### PR TITLE
feat: add /compact endpoint and llm-d compaction service example

### DIFF
--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -11,10 +11,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/kagenti/context-guru/components"
 	_ "github.com/kagenti/context-guru/components/all"
@@ -31,12 +33,16 @@ func main() {
 		preset    = flag.String("preset", envOr("PRESET", "balanced"), "preset to use when --config is absent")
 		openai    = flag.String("openai-upstream", envOr("OPENAI_UPSTREAM", "https://api.openai.com"), "OpenAI upstream base URL")
 		anthropic = flag.String("anthropic-upstream", envOr("ANTHROPIC_UPSTREAM", "https://api.anthropic.com"), "Anthropic upstream base URL")
+		storeFlag = flag.String("store", envOr("STORE", ""), "override state store: true|false (default: config store.enabled, else on)")
 	)
 	flag.Parse()
 
 	cfg, err := loadConfig(*cfgPath, *preset)
 	if err != nil {
 		log.Fatalf("config: %v", err)
+	}
+	if v, ok := parseBool(*storeFlag); ok {
+		cfg.Store.Enabled = &v // flag/env wins over the config file when set
 	}
 
 	agg := metrics.NewAggregator()
@@ -55,6 +61,22 @@ func main() {
 		AnthropicKey: os.Getenv("ANTHROPIC_API_KEY"),
 		ForceModel:   os.Getenv("FORCE_MODEL"), // eval-containers pins EVAL_MODEL's model here
 		CheapModel:   cheapModelFromEnv(),      // static "config"-source LLM for NeedsModel components
+		// Per-request /compact override: swap the pipeline (?preset / header) while
+		// keeping this config's component blocks. nil-safe in the handler.
+		PipelineFor: func(preset string, names []string) (*components.Pipeline, error) {
+			oc := *cfg // override Pipeline only; component blocks + store carry over
+			switch {
+			case len(names) > 0:
+				oc.Pipeline = names
+			case preset != "":
+				p, ok := config.PresetPipeline(preset) // map lookup, not YAML from request input
+				if !ok {
+					return nil, fmt.Errorf("unknown preset %q", preset)
+				}
+				oc.Pipeline = p
+			}
+			return oc.Build(emitter)
+		},
 	})
 
 	slog.Info("context-guru-proxy listening", "addr", addr, "pipeline", cfg.Pipeline)
@@ -75,6 +97,18 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// parseBool reads a permissive bool override; ok=false for an empty/unknown
+// value so the config file's setting is left untouched.
+func parseBool(s string) (v, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "on", "yes":
+		return true, true
+	case "false", "0", "off", "no":
+		return false, true
+	}
+	return false, false
 }
 
 // cheapModelFromEnv builds the static "config"-source LLM client for NeedsModel

--- a/components/offload/cmdfilter.go
+++ b/components/offload/cmdfilter.go
@@ -87,8 +87,10 @@ func (f *Cmdfilter) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 		// original — the marker costs tokens too, so filtering that barely wins can
 		// still make the message larger (rtk never_worse, at the message level).
 		key := hashKey(content)
+		// degrade full→off when the store can't persist (no unresolvable marker).
+		mode := effectiveMode(c, f.mode)
 		var token string
-		switch f.mode {
+		switch mode {
 		case markerFull:
 			token = expand.Marker(key) + recoveryHint(loss)
 		case markerSummary:
@@ -101,7 +103,7 @@ func (f *Cmdfilter) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 		if schema.TextTokens(newText) >= schema.TextTokens(content) {
 			continue
 		}
-		if f.mode == markerFull {
+		if mode == markerFull {
 			c.Store.Put(key, []byte(content))
 			keys = append(keys, key)
 		} else {

--- a/components/offload/extract.go
+++ b/components/offload/extract.go
@@ -39,19 +39,18 @@ type Extract struct {
 	tail        int
 	strategy    string
 	modelSource string
+	modelClient components.Model // config-pinned client (model: block), or nil
 	trigger     components.Trigger
 	mode        markerMode
 	rewrite     bool
 }
 
 type extractConfig struct {
-	MinTokens int    `yaml:"min_tokens"`
-	Head      int    `yaml:"head_lines"`
-	Tail      int    `yaml:"tail_lines"`
-	Strategy  string `yaml:"strategy"` // deterministic | code | rlm
-	Model     struct {
-		Source string `yaml:"source"` // incoming (default) | config
-	} `yaml:"model"`
+	MinTokens  int                `yaml:"min_tokens"`
+	Head       int                `yaml:"head_lines"`
+	Tail       int                `yaml:"tail_lines"`
+	Strategy   string             `yaml:"strategy"` // deterministic | code | rlm
+	Model      modelConfig        `yaml:"model"`
 	Trigger    components.Trigger `yaml:"trigger"`
 	MarkerMode string             `yaml:"marker_mode"` // full (default) | summary | off
 	// Rewrite (code strategy only): drop the deletion-only containment proof so the
@@ -72,7 +71,7 @@ func newExtract(raw []byte) (components.Component, error) {
 	if cfg.Trigger.MinOutputTokens == 0 {
 		cfg.Trigger.MinOutputTokens = cfg.MinTokens
 	}
-	return &Extract{minTokens: cfg.MinTokens, head: cfg.Head, tail: cfg.Tail, strategy: cfg.Strategy, modelSource: cfg.Model.Source, trigger: cfg.Trigger, mode: parseMarkerMode(cfg.MarkerMode), rewrite: cfg.Rewrite}, nil
+	return &Extract{minTokens: cfg.MinTokens, head: cfg.Head, tail: cfg.Tail, strategy: cfg.Strategy, modelSource: cfg.Model.Source, modelClient: cfg.Model.Client(), trigger: cfg.Trigger, mode: parseMarkerMode(cfg.MarkerMode), rewrite: cfg.Rewrite}, nil
 }
 
 // outputFloor is the minimum tokens a single tool output must have to be worth
@@ -106,7 +105,9 @@ func (e *Extract) Offload(req *bschemas.BifrostChatRequest, rep *components.Repo
 	}
 	var model components.Model
 	if e.NeedsModel() {
-		model = c.Model.For(e.modelSource)
+		if model = e.modelClient; model == nil { // config-pinned client wins
+			model = c.Model.For(e.modelSource)
+		}
 	}
 	floor := e.outputFloor()
 	keepIDs := extract.HarvestIdentifiers(goal, 40)

--- a/components/offload/marker.go
+++ b/components/offload/marker.go
@@ -40,6 +40,17 @@ func parseMarkerMode(s string) markerMode {
 	}
 }
 
+// effectiveMode degrades a full (reversible) marker to off when the store cannot
+// persist the stash (store disabled). Without this, a full marker would leave an
+// unresolvable <<cg:HASH>> in the request and silently lose the dropped content.
+// Every Offload that honors marker_mode routes its mode through this first.
+func effectiveMode(c *components.Ctx, mode markerMode) markerMode {
+	if mode == markerFull && !c.Store.Persists() {
+		return markerOff
+	}
+	return mode
+}
+
 // mark centralizes the three marker_modes for the spot where an Offload component
 // would write its restoration marker. It returns the token to splice there and
 // the store key to append to the component's cacheKeys (empty in summary/off).
@@ -51,7 +62,7 @@ func parseMarkerMode(s string) markerMode {
 // hint is the component-specific recovery hint (e.g. " [full output: call
 // context_guru_expand]"); it is only emitted in full mode, where expand works.
 func mark(c *components.Ctx, rep *components.Report, mode markerMode, original, hint string) (token, key string) {
-	if mode == markerFull {
+	if effectiveMode(c, mode) == markerFull {
 		key = hashKey(original)
 		c.Store.Put(key, []byte(original))
 		return expand.Marker(key) + hint, key

--- a/components/offload/marker_test.go
+++ b/components/offload/marker_test.go
@@ -1,0 +1,34 @@
+package offload
+
+import (
+	"testing"
+
+	"github.com/kagenti/context-guru/components"
+	"github.com/kagenti/context-guru/store"
+)
+
+// A full (reversible) marker must degrade to an irreversible off-style drop when
+// the store cannot persist the stash — otherwise it leaves an unresolvable
+// <<cg:HASH>> marker in the request and silently loses the dropped content.
+func TestMarkDegradesWhenStoreCannotPersist(t *testing.T) {
+	rep := &components.Report{}
+	c := &components.Ctx{Store: store.Nop{}}
+	tok, key := mark(c, rep, markerFull, "original content", " [hint]")
+	if tok != "" || key != "" {
+		t.Fatalf("non-persisting store: want no marker/key, got tok=%q key=%q", tok, key)
+	}
+	if !rep.Irreversible {
+		t.Fatal("degraded drop must set Irreversible so the pipeline keeps it (not reverted)")
+	}
+
+	// With a persisting store, full mode still stashes and emits a marker+key.
+	rep2 := &components.Report{}
+	c2 := &components.Ctx{Store: store.NewMemory(store.Options{})}
+	tok2, key2 := mark(c2, rep2, markerFull, "original content", "")
+	if tok2 == "" || key2 == "" {
+		t.Fatalf("persisting store: want marker+key, got tok=%q key=%q", tok2, key2)
+	}
+	if got, ok := c2.Store.Get(key2); !ok || string(got) != "original content" {
+		t.Fatalf("persisting store must retain the original, got %q ok=%v", got, ok)
+	}
+}

--- a/components/offload/modelcfg.go
+++ b/components/offload/modelcfg.go
@@ -1,0 +1,47 @@
+package offload
+
+import (
+	"os"
+
+	"github.com/kagenti/context-guru/components"
+	"github.com/kagenti/context-guru/internal/cheapmodel"
+)
+
+// modelConfig is the shared `model:` block for the NeedsModel components
+// (extract code/rlm, summarize). `source` picks the host-resolved client at run
+// time (incoming vs config, via Ctx.Model.For). Setting base_url/model/api_key
+// instead pins a dedicated endpoint+credentials right in the config: Client()
+// then returns that client and the component uses it directly, no CHEAP_MODEL_*
+// env required.
+type modelConfig struct {
+	Source   string `yaml:"source"`   // incoming (default) | config
+	Provider string `yaml:"provider"` // anthropic (default) | openai
+	BaseURL  string `yaml:"base_url"` // e.g. http://llm-d-gateway:8000 (default: provider public API)
+	APIKey   string `yaml:"api_key"`  // empty => provider env key (see Client)
+	Model    string `yaml:"model"`    // e.g. gpt-4o-mini; empty => not a config-pinned client
+	Auth     string `yaml:"auth"`     // anthropic only: "" | x-api-key (default) | bearer (LiteLLM/gateway)
+}
+
+// Client builds the LLM client this block pins, or nil when no model is named
+// (the component then falls back to the host-resolved Ctx.Model.For(source)).
+// An empty api_key falls back to the provider's env key: OPENAI_API_KEY for
+// OpenAI; ANTHROPIC_API_KEY then ANTHROPIC_AUTH_TOKEN (bearer gateways) for
+// Anthropic — so secrets can stay in the environment, out of the config file.
+func (m modelConfig) Client() components.Model {
+	if m.Model == "" {
+		return nil
+	}
+	key := m.APIKey
+	if m.Provider == "openai" {
+		if key == "" {
+			key = os.Getenv("OPENAI_API_KEY")
+		}
+		return cheapmodel.OpenAI{BaseURL: m.BaseURL, Model: m.Model, APIKey: key}
+	}
+	if key == "" {
+		if key = os.Getenv("ANTHROPIC_API_KEY"); key == "" {
+			key = os.Getenv("ANTHROPIC_AUTH_TOKEN")
+		}
+	}
+	return cheapmodel.Anthropic{BaseURL: m.BaseURL, Model: m.Model, APIKey: key, AuthScheme: m.Auth}
+}

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -43,6 +43,7 @@ type Summarize struct {
 	resummarizeTokens int
 	includeToolCalls  bool
 	modelSource       string
+	modelClient       components.Model // config-pinned client (model: block), or nil
 	trigger           components.Trigger
 	mode              markerMode
 }
@@ -56,13 +57,11 @@ type summarizeConfig struct {
 	// un-summarized tail since the last checkpoint grows past this many tokens,
 	// then roll the checkpoint forward with a fresh summary. 0 = re-summarize
 	// every eligible turn (old behavior).
-	ResummarizeTokens int  `yaml:"resummarize_tokens"`
-	IncludeToolCalls  bool `yaml:"include_tool_calls"`
-	Model             struct {
-		Source string `yaml:"source"` // incoming (default) | config
-	} `yaml:"model"`
-	Trigger    components.Trigger `yaml:"trigger"`
-	MarkerMode string             `yaml:"marker_mode"` // full (default) | summary | off
+	ResummarizeTokens int                `yaml:"resummarize_tokens"`
+	IncludeToolCalls  bool               `yaml:"include_tool_calls"`
+	Model             modelConfig        `yaml:"model"`
+	Trigger           components.Trigger `yaml:"trigger"`
+	MarkerMode        string             `yaml:"marker_mode"` // full (default) | summary | off
 }
 
 func newSummarize(raw []byte) (components.Component, error) {
@@ -80,7 +79,7 @@ func newSummarize(raw []byte) (components.Component, error) {
 	return &Summarize{
 		level: cfg.SummaryLevel, keepLast: cfg.KeepLast,
 		minTokens: cfg.MinTokens, resummarizeTokens: cfg.ResummarizeTokens,
-		includeToolCalls: cfg.IncludeToolCalls, modelSource: cfg.Model.Source, trigger: cfg.Trigger,
+		includeToolCalls: cfg.IncludeToolCalls, modelSource: cfg.Model.Source, modelClient: cfg.Model.Client(), trigger: cfg.Trigger,
 		mode: parseMarkerMode(cfg.MarkerMode),
 	}, nil
 }
@@ -99,7 +98,10 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 		rep.Skipped = true
 		return nil, nil
 	}
-	model := c.Model.For(s.modelSource)
+	model := s.modelClient // config-pinned client wins
+	if model == nil {
+		model = c.Model.For(s.modelSource)
+	}
 	if model == nil {
 		rep.Skipped = true // NeedsModel but none available → degrade gracefully
 		return nil, nil
@@ -137,8 +139,11 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// Stash the replaced span so expand can restore it — full mode only. In
 	// summary/off there is no restoration; flag the deliberate lossy drop so the
 	// pipeline's dropped-without-stash guard permits it.
+	// full is reversible only if the store persists the stash; otherwise degrade
+	// to an irreversible off-style drop (no unresolvable marker).
+	mode := effectiveMode(c, s.mode)
 	var key string
-	if s.mode == markerFull {
+	if mode == markerFull {
 		spanJSON, err := json.Marshal(span)
 		if err != nil {
 			return nil, err
@@ -149,7 +154,7 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 		rep.Irreversible = true
 	}
 
-	summaryText := summaryWrapper(summary, key, s.mode)
+	summaryText := summaryWrapper(summary, key, mode)
 	summaryMsg := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleSystem}
 	schema.SetMessageText(&summaryMsg, summaryText)
 

--- a/components/reformat/format.go
+++ b/components/reformat/format.go
@@ -14,8 +14,8 @@ func init() { components.Register("format", newFormat) }
 
 // Format re-encodes JSON tool outputs denser without losing data (a Reformat):
 // pretty-printed JSON is re-marshaled compact. It's strictly lossless — same
-// value, fewer whitespace tokens — so no stash is needed. (A TOON encoder is a
-// planned future option; v1 ships json-compact only.)
+// value, fewer whitespace tokens — so no stash is needed. (For a denser tabular
+// re-encoding of uniform object arrays, see the `toon` component.)
 type Format struct{ minTokens int }
 
 type formatConfig struct {

--- a/components/reformat/toon.go
+++ b/components/reformat/toon.go
@@ -1,0 +1,154 @@
+package reformat
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/kagenti/context-guru/components"
+	"github.com/kagenti/context-guru/schema"
+	"github.com/maximhq/bifrost/core/schemas"
+	"gopkg.in/yaml.v3"
+)
+
+func init() { components.Register("toon", newToon) }
+
+// Toon re-encodes a JSON array of uniform, flat objects as TOON (Token-Oriented
+// Object Notation): one header listing the field names once, then one
+// comma-separated row per element. It drops the braces, repeated keys, and
+// quotes that dominate a JSON array's token cost. It's a Reformat (repack in
+// place, nothing stashed): every scalar value is preserved, with one small
+// representational simplification — JSON null renders as an empty cell
+// (indistinguishable from ""). Only arrays whose elements share one key set and
+// hold scalar values are encoded; anything nested, ragged, or non-array is left
+// untouched, and the pipeline's never-worse guard reverts any case that fails to
+// shrink.
+//
+//	[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]
+//	=>
+//	[2]{id,name}:
+//	1,Alice
+//	2,Bob
+type Toon struct{ minTokens int }
+
+type toonConfig struct {
+	MinTokens int `yaml:"min_tokens"`
+}
+
+func newToon(raw []byte) (components.Component, error) {
+	cfg := toonConfig{MinTokens: 50}
+	if len(raw) > 0 {
+		if err := yaml.Unmarshal(raw, &cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &Toon{minTokens: cfg.MinTokens}, nil
+}
+
+func (Toon) Name() string                 { return "toon" }
+func (Toon) Enabled(*components.Ctx) bool { return true }
+
+func (t *Toon) Reformat(req *schemas.BifrostChatRequest, rep *components.Report, _ *components.Ctx) error {
+	acted := false
+	for i := range req.Input {
+		m := &req.Input[i]
+		if m.Role != schemas.ChatMessageRoleTool {
+			continue
+		}
+		if !schema.Rewritable(*m) {
+			continue // non-text blocks would be dropped by a text rewrite
+		}
+		content := schema.MessageText(*m)
+		if schema.TextTokens(content) < t.minTokens {
+			continue
+		}
+		toon, ok := encodeTOON(content)
+		if !ok {
+			continue
+		}
+		if schema.TextTokens(toon) >= schema.TextTokens(content) {
+			continue // already dense / no win
+		}
+		schema.SetMessageText(m, toon)
+		acted = true
+	}
+	if !acted {
+		rep.Skipped = true
+	}
+	return nil
+}
+
+// encodeTOON renders a JSON array of uniform scalar-valued objects as TOON.
+// ok=false (leave the content untouched) for anything else: non-array, empty,
+// ragged key sets, or a nested/complex value.
+func encodeTOON(content string) (string, bool) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" || trimmed[0] != '[' {
+		return "", false
+	}
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	dec.UseNumber() // keep numbers byte-exact rather than float64
+	var arr []map[string]any
+	if err := dec.Decode(&arr); err != nil || len(arr) == 0 {
+		return "", false
+	}
+
+	keys := make([]string, 0, len(arr[0]))
+	for k := range arr[0] {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic column order; header preserves the mapping
+
+	var b strings.Builder
+	b.WriteString("[")
+	b.WriteString(strconv.Itoa(len(arr)))
+	b.WriteString("]{")
+	b.WriteString(strings.Join(keys, ","))
+	b.WriteString("}:\n")
+
+	for _, row := range arr {
+		if len(row) != len(keys) {
+			return "", false // ragged: a row has extra/missing keys
+		}
+		cells := make([]string, len(keys))
+		for j, k := range keys {
+			v, ok := row[k]
+			if !ok {
+				return "", false
+			}
+			cell, ok := scalarCell(v)
+			if !ok {
+				return "", false // nested object/array — not a flat table
+			}
+			cells[j] = cell
+		}
+		b.WriteString(strings.Join(cells, ","))
+		b.WriteByte('\n')
+	}
+	return b.String(), true
+}
+
+// scalarCell renders one JSON scalar as a TOON cell, quoting CSV-style when the
+// value contains a delimiter. ok=false for objects/arrays (a non-flat value).
+// ponytail: null renders as an empty cell — acceptable for a display-oriented
+// reformat; a strict round-trip is not a goal here.
+func scalarCell(v any) (string, bool) {
+	var s string
+	switch x := v.(type) {
+	case nil:
+		s = ""
+	case bool:
+		s = strconv.FormatBool(x)
+	case json.Number:
+		s = x.String()
+	case string:
+		s = x
+	default:
+		return "", false
+	}
+	if strings.ContainsAny(s, ",\"\n\r") || s != strings.TrimSpace(s) {
+		s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	}
+	return s, true
+}

--- a/components/reformat/toon_test.go
+++ b/components/reformat/toon_test.go
@@ -1,0 +1,51 @@
+package reformat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeTOON_UniformArrayShrinks(t *testing.T) {
+	in := `[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"}]`
+	out, ok := encodeTOON(in)
+	if !ok {
+		t.Fatal("expected uniform scalar array to encode")
+	}
+	// Header lists count + sorted keys once; each row is comma-separated.
+	if !strings.HasPrefix(out, "[2]{id,name,role}:\n") {
+		t.Fatalf("unexpected header, got:\n%s", out)
+	}
+	for _, want := range []string{"1,Alice,admin", "2,Bob,user"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing row %q in:\n%s", want, out)
+		}
+	}
+	if len(out) >= len(in) {
+		t.Fatalf("TOON (%d) not smaller than JSON (%d)", len(out), len(in))
+	}
+}
+
+func TestEncodeTOON_QuotesDelimiters(t *testing.T) {
+	out, ok := encodeTOON(`[{"a":"x,y"},{"a":"he said \"hi\""}]`)
+	if !ok {
+		t.Fatal("expected encode")
+	}
+	if !strings.Contains(out, `"x,y"`) || !strings.Contains(out, `"he said ""hi"""`) {
+		t.Fatalf("bad CSV quoting:\n%s", out)
+	}
+}
+
+func TestEncodeTOON_SkipsNonTable(t *testing.T) {
+	cases := map[string]string{
+		"object":       `{"id":1}`,
+		"empty array":  `[]`,
+		"nested value": `[{"a":{"b":1}}]`,
+		"ragged keys":  `[{"a":1},{"a":1,"b":2}]`,
+		"not json":     `just some log output`,
+	}
+	for name, in := range cases {
+		if _, ok := encodeTOON(in); ok {
+			t.Errorf("%s: expected ok=false (leave untouched)", name)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,15 @@ var presets = map[string][]string{
 	"summarize": {"summarize"},
 }
 
+// PresetPipeline returns the default pipeline (ordered component names) for a
+// named preset. It's the safe way to resolve a caller-supplied preset name (e.g.
+// a /compact ?preset= query param) — a plain map lookup, no YAML parsing of
+// untrusted input.
+func PresetPipeline(name string) ([]string, bool) {
+	p, ok := presets[name]
+	return append([]string(nil), p...), ok
+}
+
 // Build constructs the ordered pipeline from the config, wiring each named
 // component with its raw config block.
 func (c *Config) Build(e components.Emitter) (*components.Pipeline, error) {
@@ -113,5 +122,11 @@ func (c *Config) Build(e components.Emitter) (*components.Pipeline, error) {
 	return components.NewPipeline(comps, e), nil
 }
 
-// NewStore builds the configured state store (in-memory for v1).
-func (c *Config) NewStore() store.Store { return store.NewMemory(c.Store) }
+// NewStore builds the configured state store: an in-memory TTL+LRU by default,
+// or a no-op store when store.enabled is false (disables offload reversibility).
+func (c *Config) NewStore() store.Store {
+	if c.Store.Enabled != nil && !*c.Store.Enabled {
+		return store.Nop{}
+	}
+	return store.NewMemory(c.Store)
+}

--- a/examples/llm-d-service/README.md
+++ b/examples/llm-d-service/README.md
@@ -1,0 +1,256 @@
+# context-guru as an llm-d-router compaction service
+
+A ready-to-run example that turns **context-guru** into a standalone HTTP **compaction service**
+for [`llm-d-router`](https://github.com/ronenkat/llm-d-router). You don't need to know
+context-guru to use this — everything you need is below.
+
+---
+
+## 1. What this is (for newcomers)
+
+Large-language-model requests carry a lot of text: system prompts, past turns, and especially
+**tool outputs** (file reads, command logs, API responses) that get re-sent on every turn. That
+text costs tokens — money and latency — and pushes against the context window.
+
+**context-guru** shrinks that text *before* it reaches the model, without changing the agent.
+It parses the request's `messages` array, rewrites the bulky parts (compacting JSON, filtering
+irrelevant lines, summarizing old turns), and hands back a **smaller request of the exact same
+shape**. It is **fail-open**: if anything goes wrong, it returns your original request unchanged.
+
+`llm-d-router`'s `request-inline-compaction` step (PR #1) is designed to call an external
+service with exactly this contract:
+
+```
+POST <service>/compact         body = the inference request JSON
+  200 + non-empty JSON  ->  router swaps that body in (now smaller)
+  anything else          ->  router keeps the original (passthrough)
+```
+
+This example is that service. It runs with **no state storage** and **no markers**, so the body
+it returns is a clean, directly-usable inference request.
+
+```
+             ┌─────────────────────── /compact ───────────────────────┐
+ request ───▶│  parse messages[] ─▶ run pipeline ─▶ splice back  ─▶ 200 │───▶ smaller request
+   (JSON)    │       (format · toon · extract · summarize · …)          │        (same schema)
+             └──────────────────────────────────────────────────────────┘
+                         no upstream call · fail-open · no markers
+```
+
+### A few terms you'll see
+
+- **Component** — one compaction step (e.g. `toon`, `extract`, `summarize`). You pick which run,
+  and in what order, in a small YAML config.
+- **Pipeline** — the ordered list of components applied to a request.
+- **Reformat vs Offload** — a *reformat* component (like `toon`) repacks text losslessly; an
+  *offload* component (like `extract`/`summarize`) drops bulk and can leave a `<<cg:…>>` **marker**
+  that a companion store could later expand. **This example disables the store and sets
+  `marker_mode: off`**, so nothing is stored and no markers appear — compaction is one-way.
+- **Cheap model** — the small LLM the LLM-based components call. You configure it (endpoint +
+  credentials + model id); the example configs use `gpt-4o-mini` as a placeholder, but any
+  OpenAI- or Anthropic-compatible model works (e.g. `claude-haiku-4-5`).
+
+Deeper docs live in the repo: [`docs/components.md`](../../docs/components.md) (every component)
+and [`docs/design.md`](../../docs/design.md) (the pipeline, store, fail-open model).
+
+---
+
+## 2. The three example configs
+
+| Config | Component(s) | Uses an LLM? | What it does | Best for |
+|---|---|:--:|---|---|
+| [`configs/toon.yaml`](configs/toon.yaml) | `format` + `toon` | no | Re-encodes uniform JSON object-arrays in tool outputs as **TOON** (field names once, then one row per element). | Deterministic, zero-cost, zero-latency wins on structured/tabular tool output. |
+| [`configs/extract-code.yaml`](configs/extract-code.yaml) | `extract` (`strategy: code`) | yes | A cheap LLM writes a sandboxed filter that **deletes irrelevant lines** from large tool outputs (verified deletion-only — never invents text). | Big, noisy tool outputs where only a slice is relevant to the current goal. |
+| [`configs/summarize.yaml`](configs/summarize.yaml) | `summarize` | yes | A cheap LLM **summarizes the middle** of a long transcript into one message, keeping the head + last few turns. | Long agentic sessions where the transcript itself is the token cost. |
+
+All three set `store: { enabled: false }` and `marker_mode: "off"` — irreversible, marker-free output.
+
+See a real run of all three on one input, with the full `messages` before and after, in
+[`sample/BEFORE-AFTER.md`](sample/BEFORE-AFTER.md).
+
+---
+
+## 3. Prerequisites
+
+- **Go 1.26** and a **C toolchain** (`CGO_ENABLED=1` — the `skeleton` component links tree-sitter via cgo).
+- A sibling **bifrost** checkout next to this repo (the module pins it with a local `replace` to
+  `../bifrost/core`). Directory layout:
+  ```
+  <parent>/
+    context-guru/     ← this repo
+    bifrost/          ← https://github.com/maximhq/bifrost
+  ```
+- For the two **LLM** configs only: access to an LLM endpoint (any OpenAI- or Anthropic-compatible
+  API, including a gateway) and its credentials.
+
+---
+
+## 4. Build
+
+```sh
+./examples/llm-d-service/build.sh        # -> bin/context-guru-proxy
+```
+
+---
+
+## 5. Run
+
+The deterministic config needs no credentials:
+
+```sh
+bin/context-guru-proxy --config examples/llm-d-service/configs/toon.yaml
+# listens on :4000 (set LISTEN_ADDR to change)
+```
+
+The LLM configs need a model. Put the endpoint + credentials in the config's `model:` block, or
+leave `api_key: ""` and supply the key via the environment:
+
+```sh
+# Option A — credentials in the environment (recommended; keeps secrets out of files)
+export OPENAI_API_KEY=sk-...            # or ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
+bin/context-guru-proxy --config examples/llm-d-service/configs/extract-code.yaml
+
+# Option B — a shared "cheap model" via env, and set model.source: config with an empty block
+export CHEAP_MODEL=claude-haiku-4-5 CHEAP_MODEL_PROVIDER=anthropic \
+       CHEAP_MODEL_BASE=https://your-gateway CHEAP_MODEL_KEY=... CHEAP_MODEL_AUTH=bearer
+bin/context-guru-proxy --config examples/llm-d-service/configs/summarize.yaml
+```
+
+Edit the `model:` block in each LLM config to point at your endpoint (see the reference in §9).
+
+---
+
+## 6. Try it
+
+### With curl (deterministic `toon`)
+
+```sh
+curl -s -XPOST localhost:4000/compact -H 'content-type: application/json' -d '{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {"role": "user", "content": "list users"},
+    {"role": "tool", "tool_call_id": "c1",
+     "content": "[{\"id\":1,\"name\":\"Alice\",\"role\":\"admin\"},{\"id\":2,\"name\":\"Bob\",\"role\":\"user\"},{\"id\":3,\"name\":\"Carol\",\"role\":\"admin\"},{\"id\":4,\"name\":\"Dave\",\"role\":\"user\"},{\"id\":5,\"name\":\"Eve\",\"role\":\"admin\"},{\"id\":6,\"name\":\"Frank\",\"role\":\"user\"}]"}
+  ]
+}'
+```
+
+The response is the same request with the tool output rewritten to TOON (smaller, no markers):
+
+```
+[6]{id,name,role}:
+1,Alice,admin
+2,Bob,user
+...
+```
+
+> Outputs below a component's `min_tokens` gate (or below an LLM config's `trigger`) pass through
+> unchanged — that's expected. Use a few-row array (or the Go client below) to see it act.
+
+### From Go — the exact pattern llm-d uses
+
+[`client/main.go`](client/main.go) is dependency-free. It builds a sample request, POSTs it to
+`/compact`, and applies the returned body **only** on a `200`-with-JSON (passthrough otherwise) —
+the same contract as the router step. Copy `compact()` into your own step and adapt.
+
+```sh
+go run ./examples/llm-d-service/client                 # default http://localhost:4000
+go run ./examples/llm-d-service/client -addr http://compactor:4000
+```
+
+---
+
+## 7. Wire it into llm-d-router
+
+Point the `request-inline-compaction` step's `address` parameter at this service; the step appends
+its path so requests land on `/compact`:
+
+```yaml
+# llm-d-router pipeline step params
+address: http://context-guru:4000      # this service's base URL
+```
+
+Send the step's opt-in header on requests you want compacted:
+
+```
+x-llm-d-optimization: compaction
+```
+
+Run one service instance per config, or one instance plus per-request overrides (§8).
+
+---
+
+## 8. Per-request overrides
+
+The router forwards the request body verbatim, so overrides ride on **headers / query params**:
+
+| Override | Effect |
+|---|---|
+| `?provider=anthropic` | Treat the body as Anthropic Messages instead of OpenAI (the default). |
+| `?preset=<name>` | Swap the pipeline for a built-in preset (e.g. `summarize`), keeping this config's component blocks. |
+| `x-context-guru-pipeline: format,toon` | Run exactly these components, in order. |
+| `x-context-guru-session: <id>` | Explicit session key (otherwise a content hash). |
+| `x-context-guru-bypass: true` | Skip the pipeline entirely (returns the body unchanged). |
+
+> `/compact` has no authentication — it's meant to run as an in-cluster sidecar reachable only by
+> the router. Note that a caller can use `?preset=`/`x-context-guru-pipeline` to invoke the
+> LLM-backed components, which spend the service's configured credentials. Front it accordingly
+> (or omit the LLM configs) if the endpoint is exposed more broadly.
+
+---
+
+## 9. Configuration reference
+
+**Store flag** — top-level `store:` block:
+
+```yaml
+store:
+  enabled: false     # disable the state store (this example). Omit/true = on.
+```
+
+You can also override at launch: `--store=false` or `STORE=false` (wins over the file).
+
+**Model block** — on `extract` / `summarize` under `components:`:
+
+```yaml
+model:
+  source: config          # "config" = use the block below; "incoming" = reuse the request's own model+key
+  provider: openai        # openai | anthropic
+  base_url: http://your-llm-endpoint:8000   # your endpoint (default: provider public API)
+  model: gpt-4o-mini      # model id the cheap calls use
+  api_key: ""             # empty => env: OPENAI_API_KEY, or ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
+  auth: bearer            # anthropic only: x-api-key (default) | bearer (LiteLLM/gateways)
+```
+
+**Other knobs** (see [`docs/components.md`](../../docs/components.md) for the full set):
+
+- `marker_mode: full | summary | "off"` — this example uses `"off"` (must be quoted in YAML).
+- `trigger: { min_request_tokens, min_output_tokens, min_messages }` — gates when a (costly) LLM
+  component fires; zero means "always". The committed LLM configs use production-scale triggers.
+
+---
+
+## 10. Troubleshooting
+
+- **The response is identical to the input.** The request didn't meet a gate: below `min_tokens`
+  (toon/format), or below the LLM config's `trigger`. Send a larger tool output / longer transcript,
+  or lower the thresholds (see [`sample/configs/`](sample/configs) for lowered-trigger demo copies).
+- **LLM config does nothing / logs "no model".** No reachable model: check `base_url`, the key
+  (`api_key` or the env fallback), and `auth` (bearer vs x-api-key). With no model, `extract`
+  degrades to a deterministic line projection and `summarize` no-ops — the request still returns `200`.
+- **`summarize` output says tool outputs are "masked".** `include_tool_calls` defaults to `false`,
+  so the summarizer sees the transcript shape, not tool bodies. Set `include_tool_calls: true` to fold them in.
+- **`/compact` never errors your caller.** Unparseable bodies, bodies without a `messages` array,
+  or any component failure return the **original body with `200`** — the router's passthrough
+  contract always holds.
+
+---
+
+## 11. Notes
+
+- **Fail-open by design** — a component that errors, panics, or would *grow* the request is reverted;
+  the original request is always a valid fallback.
+- **Secrets** — prefer leaving `api_key: ""` and supplying the key via the environment rather than
+  committing it into a config file.
+- **Files in this example:** [`configs/`](configs) (the 3 configs), [`build.sh`](build.sh),
+  [`client/main.go`](client/main.go), [`sample/`](sample) (a captured before/after run).

--- a/examples/llm-d-service/build.sh
+++ b/examples/llm-d-service/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build the context-guru compaction service (bin/context-guru-proxy).
+#
+# Requires Go 1.26 and a C toolchain: CGO_ENABLED=1 is set below because the
+# `skeleton` component links tree-sitter via cgo. The module pins bifrost with a
+# local `replace` to ../bifrost/core, so a sibling bifrost checkout must exist
+# next to the context-guru repo (see the repo README "Install").
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+CGO_ENABLED=1 go build -o bin/context-guru-proxy ./cmd/context-guru-proxy
+echo "built: $repo_root/bin/context-guru-proxy"

--- a/examples/llm-d-service/client/main.go
+++ b/examples/llm-d-service/client/main.go
@@ -1,0 +1,107 @@
+// Command client is a minimal, dependency-free example of calling the
+// context-guru compaction service the way the llm-d-router
+// request-inline-compaction step does: POST the inference request body to the
+// service and, on a 200 with a non-empty JSON object, use the returned (smaller)
+// body in place of the original. Any other outcome is passthrough (keep the
+// original). Copy compact() into your own router step and adapt as needed.
+//
+//	go run ./examples/llm-d-service/client            # default http://localhost:4000
+//	go run ./examples/llm-d-service/client -addr http://compactor:4000
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	addr := flag.String("addr", envOr("COMPACTOR_ADDR", "http://localhost:4000"), "compaction service base URL")
+	flag.Parse()
+
+	original := sampleRequest() // an OpenAI request whose tool output is a big JSON array
+
+	compacted, ok := compact(*addr, original)
+	if !ok {
+		fmt.Println("compaction skipped (passthrough) — using the original body")
+		compacted = original
+	}
+	fmt.Printf("original  : %d bytes\n", len(original))
+	fmt.Printf("compacted : %d bytes  (%.0f%% of original)\n",
+		len(compacted), 100*float64(len(compacted))/float64(len(original)))
+	fmt.Printf("cg markers present: %v (want false)\n", bytes.Contains(compacted, []byte("<<cg:")))
+}
+
+// compact POSTs body to {addr}/compact and returns the replacement body. It
+// mirrors the llm-d step's contract exactly: only a 200 with a non-empty JSON
+// object counts as a successful compaction; every failure mode (network error,
+// non-200, empty/invalid JSON) is passthrough — return ok=false and keep the
+// original body.
+func compact(addr string, body []byte) ([]byte, bool) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodPost, addr+"/compact", bytes.NewReader(body))
+	if err != nil {
+		return nil, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Optional per-request override (leave off to use the service's loaded config):
+	//   req.URL.RawQuery = "preset=summarize"
+	//   req.Header.Set("x-context-guru-pipeline", "format,toon")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false
+	}
+	var probe map[string]any
+	if err := json.Unmarshal(out, &probe); err != nil || len(probe) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// sampleRequest builds an OpenAI chat request whose single tool output is a large
+// uniform JSON array — exactly the shape the TOON config compacts deterministically.
+func sampleRequest() []byte {
+	rows := make([]map[string]any, 0, 40)
+	for i := 1; i <= 40; i++ {
+		rows = append(rows, map[string]any{
+			"id":     i,
+			"name":   fmt.Sprintf("User %d", i),
+			"email":  fmt.Sprintf("user%d@example.com", i),
+			"role":   "member",
+			"active": i%2 == 0,
+		})
+	}
+	toolOutput, _ := json.Marshal(rows)
+
+	req := map[string]any{
+		"model": "gpt-4o-mini",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are a helpful assistant."},
+			map[string]any{"role": "user", "content": "List the active users."},
+			map[string]any{"role": "tool", "tool_call_id": "call_1", "content": string(toolOutput)},
+		},
+	}
+	b, _ := json.Marshal(req)
+	return b
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/examples/llm-d-service/configs/extract-code.yaml
+++ b/examples/llm-d-service/configs/extract-code.yaml
@@ -1,0 +1,29 @@
+# Config 2 — LLM code extraction (the extract component, strategy: code).
+#
+# A cheap LLM writes a sandboxed Starlark filter that deletes irrelevant lines
+# from large tool outputs, keeping only what the current goal needs. The output
+# is verified to be a deletion-only subsequence of the input (rewrite: false), so
+# it never hallucinates content. Irreversible here: marker_mode "off" drops the
+# removed lines with no <<cg:…>> marker and no stash, and the store is disabled.
+pipeline: [extract]
+
+components:
+  extract:
+    strategy: code
+    marker_mode: "off"        # no markers; irreversible drop (pairs with store off)
+    rewrite: false            # keep the verified deletion-only guarantee
+    trigger:
+      min_request_tokens: 20000   # only spend an LLM call on genuinely large requests
+      min_output_tokens: 2000     # …and only on genuinely large individual tool outputs
+    # Model endpoint + credentials live here (source: config). Point base_url at
+    # your LLM (e.g. the llm-d gateway or any OpenAI-compatible endpoint). Leave
+    # api_key empty to fall back to OPENAI_API_KEY / ANTHROPIC_API_KEY from env.
+    model:
+      source: config
+      provider: openai
+      base_url: http://your-llm-endpoint:8000
+      model: gpt-4o-mini
+      api_key: ""
+
+store:
+  enabled: false

--- a/examples/llm-d-service/configs/summarize.yaml
+++ b/examples/llm-d-service/configs/summarize.yaml
@@ -1,0 +1,28 @@
+# Config 3 — whole-transcript summarizer (the summarize component).
+#
+# A cheap LLM compresses the middle of a long conversation into a single summary
+# message, keeping msg0 (system/first) plus the last few turns verbatim. Best for
+# long agentic sessions where the transcript itself is the token cost. Marker
+# mode "off" + store disabled makes it irreversible: the summarized span is
+# replaced outright, no <<cg:…>> markers, nothing stashed.
+pipeline: [summarize]
+
+components:
+  summarize:
+    summary_level: regular    # concise | regular | highly_detailed
+    keep_last: 3              # turns kept verbatim at the tail
+    min_tokens: 500           # min span size worth summarizing
+    resummarize_tokens: 6000  # roll the summary forward once the fresh tail exceeds this
+    marker_mode: "off"
+    trigger:
+      min_messages: 12            # don't summarize short conversations
+      min_request_tokens: 40000   # …or small ones
+    model:
+      source: config
+      provider: openai
+      base_url: http://your-llm-endpoint:8000
+      model: gpt-4o-mini
+      api_key: ""
+
+store:
+  enabled: false

--- a/examples/llm-d-service/configs/toon.yaml
+++ b/examples/llm-d-service/configs/toon.yaml
@@ -1,0 +1,19 @@
+# Config 1 — deterministic reformatter (no LLM, no store, no markers).
+#
+# Re-encodes uniform JSON object-arrays in tool outputs as TOON (Token-Oriented
+# Object Notation): the field names are listed once, then one comma-separated row
+# per element — dropping the braces/keys/quotes that dominate a JSON array's token
+# cost. `format` first collapses pretty-printed JSON to compact JSON. Both are
+# lossless Reformats, so nothing is stashed and the store stays off.
+pipeline: [format, toon]
+
+components:
+  format:
+    min_tokens: 50
+  toon:
+    min_tokens: 50
+
+# No reversibility needed: this endpoint hands the compacted body straight back
+# to the caller, so the state store is disabled entirely.
+store:
+  enabled: false

--- a/examples/llm-d-service/sample/BEFORE-AFTER.md
+++ b/examples/llm-d-service/sample/BEFORE-AFTER.md
@@ -1,0 +1,226 @@
+# Sample run — before / after full context
+
+A single input context ([`context.before.json`](context.before.json)) run through each of the three configs, showing the complete `messages` array in and out. Captured with the store disabled and `marker_mode: off`, so outputs carry no `<<cg:…>>` markers and are drop-in inference-request bodies.
+
+> The [`configs/`](configs) here are the committed [`../configs`](../configs) with triggers lowered so this small readable example actually fires. The LLM configs used `claude-haiku-4-5` via `model.source: config` (CHEAP_MODEL_* env).
+
+| Config | messages | body bytes | output file |
+|---|---|---|---|
+| Config 1 | 11 → 11 | 2667 → 2376 | [`context.after.toon.json`](context.after.toon.json) |
+| Config 2 | 11 → 11 | 2667 → 2145 | [`context.after.extract.json`](context.after.extract.json) |
+| Config 3 | 11 → 4 | 2667 → 1298 | [`context.after.summarize.json`](context.after.summarize.json) |
+
+## BEFORE — shared input (11 messages, 2667 bytes)
+
+```
+[0] system:
+    You are a coding assistant.
+[1] user:
+    List the admins, then fix the failing test_col_insert.
+[2] assistant:
+    Listing users.
+[3] tool (id=c1):
+    [{"id": 1, "name": "Alice", "role": "admin", "active": true}, {"id": 2, "name": "Bob", "role": "member", "active": false}, {"id": 3, "name": "Carol", "role": "admin", "active": true}, {"id": 4, "name": "Dave", "role": "member", "active": true}, {"id": 5, "name": "Eve", "role": "admin", "active": false}, {"id": 6, "name": "Frank", "role": "member", "active": true}]
+[4] assistant:
+    Searching for col_insert references.
+[5] tool (id=c2):
+    sympy/matrices/common.py:80:    # ref to col_insert usage #0
+    sympy/matrices/common.py:81:    # ref to col_insert usage #1
+    sympy/matrices/common.py:82:    # ref to col_insert usage #2
+    sympy/matrices/common.py:83:    # ref to col_insert usage #3
+    sympy/matrices/common.py:84:    # ref to col_insert usage #4
+    sympy/matrices/common.py:85:    # ref to col_insert usage #5
+    sympy/matrices/common.py:86:    # ref to col_insert usage #6
+    sympy/matrices/common.py:87:    # ref to col_insert usage #7
+    sympy/matrices/common.py:88:    # ref to col_insert usage #8
+    sympy/matrices/common.py:89:    # ref to col_insert usage #9
+    sympy/matrices/common.py:90:    # ref to col_insert usage #10
+    sympy/matrices/common.py:91:    # ref to col_insert usage #11
+    sympy/matrices/common.py:92:    # ref to col_insert usage #12
+    sympy/matrices/common.py:93:    # ref to col_insert usage #13
+[6] assistant:
+    Reading the implementation.
+[7] tool (id=c3):
+    def col_insert(self, pos, other):
+        if pos < 0:
+            pos = self.cols + pos
+        # BUG: no upper clamp -> pos may exceed self.cols
+        return self._eval_col_insert(pos, other)
+        # helper line 0
+        # helper line 1
+        # helper line 2
+        # helper line 3
+        # helper line 4
+        # helper line 5
+        # helper line 6
+        # helper line 7
+        # helper line 8
+        # helper line 9
+        # helper line 10
+        # helper line 11
+[8] assistant:
+    Running the failing test.
+[9] tool (id=c4):
+    $ pytest tests/test_matrices.py::test_col_insert
+    tests/test_matrices.py::test_col_insert FAILED
+    E   IndexError: Index out of range: a[2]
+    sympy/matrices/common.py:86: IndexError
+    1 failed, 180 passed in 2.14s
+[10] user:
+    Which users are admins, and what's the fix?
+```
+
+## AFTER — Config 1 — toon (deterministic reformatter, no LLM)
+
+`11 → 11 messages, 2667 → 2376 bytes`
+
+```
+[0] system:
+    You are a coding assistant.
+[1] user:
+    List the admins, then fix the failing test_col_insert.
+[2] assistant:
+    Listing users.
+[3] tool (id=c1):
+    [6]{active,id,name,role}:
+    true,1,Alice,admin
+    false,2,Bob,member
+    true,3,Carol,admin
+    true,4,Dave,member
+    false,5,Eve,admin
+    true,6,Frank,member
+
+[4] assistant:
+    Searching for col_insert references.
+[5] tool (id=c2):
+    sympy/matrices/common.py:80:    # ref to col_insert usage #0
+    sympy/matrices/common.py:81:    # ref to col_insert usage #1
+    sympy/matrices/common.py:82:    # ref to col_insert usage #2
+    sympy/matrices/common.py:83:    # ref to col_insert usage #3
+    sympy/matrices/common.py:84:    # ref to col_insert usage #4
+    sympy/matrices/common.py:85:    # ref to col_insert usage #5
+    sympy/matrices/common.py:86:    # ref to col_insert usage #6
+    sympy/matrices/common.py:87:    # ref to col_insert usage #7
+    sympy/matrices/common.py:88:    # ref to col_insert usage #8
+    sympy/matrices/common.py:89:    # ref to col_insert usage #9
+    sympy/matrices/common.py:90:    # ref to col_insert usage #10
+    sympy/matrices/common.py:91:    # ref to col_insert usage #11
+    sympy/matrices/common.py:92:    # ref to col_insert usage #12
+    sympy/matrices/common.py:93:    # ref to col_insert usage #13
+[6] assistant:
+    Reading the implementation.
+[7] tool (id=c3):
+    def col_insert(self, pos, other):
+        if pos < 0:
+            pos = self.cols + pos
+        # BUG: no upper clamp -> pos may exceed self.cols
+        return self._eval_col_insert(pos, other)
+        # helper line 0
+        # helper line 1
+        # helper line 2
+        # helper line 3
+        # helper line 4
+        # helper line 5
+        # helper line 6
+        # helper line 7
+        # helper line 8
+        # helper line 9
+        # helper line 10
+        # helper line 11
+[8] assistant:
+    Running the failing test.
+[9] tool (id=c4):
+    $ pytest tests/test_matrices.py::test_col_insert
+    tests/test_matrices.py::test_col_insert FAILED
+    E   IndexError: Index out of range: a[2]
+    sympy/matrices/common.py:86: IndexError
+    1 failed, 180 passed in 2.14s
+[10] user:
+    Which users are admins, and what's the fix?
+```
+
+## AFTER — Config 2 — extract strategy=code (LLM: claude-haiku-4-5)
+
+`11 → 11 messages, 2667 → 2145 bytes`
+
+```
+[0] system:
+    You are a coding assistant.
+[1] user:
+    List the admins, then fix the failing test_col_insert.
+[2] assistant:
+    Listing users.
+[3] tool (id=c1):
+    [{"active":true,"id":1,"name":"Alice","role":"admin"},{"active":true,"id":3,"name":"Carol","role":"admin"},{"active":false,"id":5,"name":"Eve","role":"admin"}]
+
+[4] assistant:
+    Searching for col_insert references.
+[5] tool (id=c2):
+    sympy/matrices/common.py:80:    # ref to col_insert usage #0
+    sympy/matrices/common.py:81:    # ref to col_insert usage #1
+    sympy/matrices/common.py:82:    # ref to col_insert usage #2
+    sympy/matrices/common.py:83:    # ref to col_insert usage #3
+    sympy/matrices/common.py:84:    # ref to col_insert usage #4
+    sympy/matrices/common.py:85:    # ref to col_insert usage #5
+    sympy/matrices/common.py:86:    # ref to col_insert usage #6
+    sympy/matrices/common.py:87:    # ref to col_insert usage #7
+    sympy/matrices/common.py:88:    # ref to col_insert usage #8
+    sympy/matrices/common.py:89:    # ref to col_insert usage #9
+    sympy/matrices/common.py:90:    # ref to col_insert usage #10
+    sympy/matrices/common.py:91:    # ref to col_insert usage #11
+    sympy/matrices/common.py:92:    # ref to col_insert usage #12
+    sympy/matrices/common.py:93:    # ref to col_insert usage #13
+[6] assistant:
+    Reading the implementation.
+[7] tool (id=c3):
+    def col_insert(self, pos, other):
+        if pos < 0:
+            pos = self.cols + pos
+        # BUG: no upper clamp -> pos may exceed self.cols
+        return self._eval_col_insert(pos, other)
+
+[8] assistant:
+    Running the failing test.
+[9] tool (id=c4):
+    $ pytest tests/test_matrices.py::test_col_insert
+    tests/test_matrices.py::test_col_insert FAILED
+    E   IndexError: Index out of range: a[2]
+    sympy/matrices/common.py:86: IndexError
+
+[10] user:
+    Which users are admins, and what's the fix?
+```
+
+## AFTER — Config 3 — summarize (LLM: claude-haiku-4-5)
+
+`11 → 4 messages, 2667 → 1298 bytes`
+
+```
+[0] system:
+    You are a coding assistant.
+[1] system:
+    === History Summary ===
+    The earlier trajectory is summarized below.
+
+    <summary>
+    • Essential Information:
+      - The user requested two tasks: (1) list the admins, and (2) fix the failing test_col_insert
+      - The assistant took the following actions in sequence:
+        1. Listed users
+        2. Searched for col_insert references
+        3. Read the implementation
+        4. Ran the failing test
+      - All tool outputs have been masked/removed from the trajectory, making the specific results of these actions unavailable
+      - No explicit information about which users are admins or what the test failure is or its fix has been provided in the visible conversation
+    </summary>
+
+    Use this summary as the older context, and use the following messages as the most recent context. Continue the task accordingly. Do not summarize the conversation again.
+[2] tool (id=c4):
+    $ pytest tests/test_matrices.py::test_col_insert
+    tests/test_matrices.py::test_col_insert FAILED
+    E   IndexError: Index out of range: a[2]
+    sympy/matrices/common.py:86: IndexError
+    1 failed, 180 passed in 2.14s
+[3] user:
+    Which users are admins, and what's the fix?
+```

--- a/examples/llm-d-service/sample/configs/extract.demo.yaml
+++ b/examples/llm-d-service/sample/configs/extract.demo.yaml
@@ -1,0 +1,7 @@
+# = configs/extract-code.yaml with triggers lowered for the small sample.
+pipeline: [extract]
+components:
+  extract: { strategy: code, marker_mode: "off", rewrite: false,
+             trigger: { min_request_tokens: 0, min_output_tokens: 50 },
+             model: { source: config } }
+store: { enabled: false }

--- a/examples/llm-d-service/sample/configs/summarize.demo.yaml
+++ b/examples/llm-d-service/sample/configs/summarize.demo.yaml
@@ -1,0 +1,6 @@
+# = configs/summarize.yaml with triggers lowered for the small sample.
+pipeline: [summarize]
+components:
+  summarize: { summary_level: concise, keep_last: 2, min_tokens: 50, marker_mode: "off",
+               trigger: { min_messages: 4 }, model: { source: config } }
+store: { enabled: false }

--- a/examples/llm-d-service/sample/configs/toon.demo.yaml
+++ b/examples/llm-d-service/sample/configs/toon.demo.yaml
@@ -1,0 +1,4 @@
+# = configs/toon.yaml with min_tokens lowered so the small sample array acts.
+pipeline: [format, toon]
+components: { format: { min_tokens: 20 }, toon: { min_tokens: 20 } }
+store: { enabled: false }

--- a/examples/llm-d-service/sample/context.after.extract.json
+++ b/examples/llm-d-service/sample/context.after.extract.json
@@ -1,0 +1,53 @@
+{
+    "model": "gpt-4o-mini",
+    "messages": [
+        {
+            "role": "system",
+            "content": "You are a coding assistant."
+        },
+        {
+            "role": "user",
+            "content": "List the admins, then fix the failing test_col_insert."
+        },
+        {
+            "role": "assistant",
+            "content": "Listing users."
+        },
+        {
+            "role": "tool",
+            "content": "[{\"active\":true,\"id\":1,\"name\":\"Alice\",\"role\":\"admin\"},{\"active\":true,\"id\":3,\"name\":\"Carol\",\"role\":\"admin\"},{\"active\":false,\"id\":5,\"name\":\"Eve\",\"role\":\"admin\"}]\n",
+            "tool_call_id": "c1"
+        },
+        {
+            "role": "assistant",
+            "content": "Searching for col_insert references."
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c2",
+            "content": "sympy/matrices/common.py:80:    # ref to col_insert usage #0\nsympy/matrices/common.py:81:    # ref to col_insert usage #1\nsympy/matrices/common.py:82:    # ref to col_insert usage #2\nsympy/matrices/common.py:83:    # ref to col_insert usage #3\nsympy/matrices/common.py:84:    # ref to col_insert usage #4\nsympy/matrices/common.py:85:    # ref to col_insert usage #5\nsympy/matrices/common.py:86:    # ref to col_insert usage #6\nsympy/matrices/common.py:87:    # ref to col_insert usage #7\nsympy/matrices/common.py:88:    # ref to col_insert usage #8\nsympy/matrices/common.py:89:    # ref to col_insert usage #9\nsympy/matrices/common.py:90:    # ref to col_insert usage #10\nsympy/matrices/common.py:91:    # ref to col_insert usage #11\nsympy/matrices/common.py:92:    # ref to col_insert usage #12\nsympy/matrices/common.py:93:    # ref to col_insert usage #13"
+        },
+        {
+            "role": "assistant",
+            "content": "Reading the implementation."
+        },
+        {
+            "role": "tool",
+            "content": "def col_insert(self, pos, other):\n    if pos < 0:\n        pos = self.cols + pos\n    # BUG: no upper clamp -> pos may exceed self.cols\n    return self._eval_col_insert(pos, other)\n",
+            "tool_call_id": "c3"
+        },
+        {
+            "role": "assistant",
+            "content": "Running the failing test."
+        },
+        {
+            "role": "tool",
+            "content": "$ pytest tests/test_matrices.py::test_col_insert\ntests/test_matrices.py::test_col_insert FAILED\nE   IndexError: Index out of range: a[2]\nsympy/matrices/common.py:86: IndexError\n",
+            "tool_call_id": "c4"
+        },
+        {
+            "role": "user",
+            "content": "Which users are admins, and what's the fix?"
+        }
+    ]
+}

--- a/examples/llm-d-service/sample/context.after.summarize.json
+++ b/examples/llm-d-service/sample/context.after.summarize.json
@@ -1,0 +1,22 @@
+{
+    "model": "gpt-4o-mini",
+    "messages": [
+        {
+            "role": "system",
+            "content": "You are a coding assistant."
+        },
+        {
+            "role": "system",
+            "content": "=== History Summary ===\nThe earlier trajectory is summarized below.\n\n<summary>\n\u2022 Essential Information: \n  - The user requested two tasks: (1) list the admins, and (2) fix the failing test_col_insert\n  - The assistant took the following actions in sequence:\n    1. Listed users\n    2. Searched for col_insert references\n    3. Read the implementation\n    4. Ran the failing test\n  - All tool outputs have been masked/removed from the trajectory, making the specific results of these actions unavailable\n  - No explicit information about which users are admins or what the test failure is or its fix has been provided in the visible conversation\n</summary>\n\nUse this summary as the older context, and use the following messages as the most recent context. Continue the task accordingly. Do not summarize the conversation again."
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c4",
+            "content": "$ pytest tests/test_matrices.py::test_col_insert\ntests/test_matrices.py::test_col_insert FAILED\nE   IndexError: Index out of range: a[2]\nsympy/matrices/common.py:86: IndexError\n1 failed, 180 passed in 2.14s"
+        },
+        {
+            "role": "user",
+            "content": "Which users are admins, and what's the fix?"
+        }
+    ]
+}

--- a/examples/llm-d-service/sample/context.after.toon.json
+++ b/examples/llm-d-service/sample/context.after.toon.json
@@ -1,0 +1,53 @@
+{
+    "model": "gpt-4o-mini",
+    "messages": [
+        {
+            "role": "system",
+            "content": "You are a coding assistant."
+        },
+        {
+            "role": "user",
+            "content": "List the admins, then fix the failing test_col_insert."
+        },
+        {
+            "role": "assistant",
+            "content": "Listing users."
+        },
+        {
+            "role": "tool",
+            "content": "[6]{active,id,name,role}:\ntrue,1,Alice,admin\nfalse,2,Bob,member\ntrue,3,Carol,admin\ntrue,4,Dave,member\nfalse,5,Eve,admin\ntrue,6,Frank,member\n",
+            "tool_call_id": "c1"
+        },
+        {
+            "role": "assistant",
+            "content": "Searching for col_insert references."
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c2",
+            "content": "sympy/matrices/common.py:80:    # ref to col_insert usage #0\nsympy/matrices/common.py:81:    # ref to col_insert usage #1\nsympy/matrices/common.py:82:    # ref to col_insert usage #2\nsympy/matrices/common.py:83:    # ref to col_insert usage #3\nsympy/matrices/common.py:84:    # ref to col_insert usage #4\nsympy/matrices/common.py:85:    # ref to col_insert usage #5\nsympy/matrices/common.py:86:    # ref to col_insert usage #6\nsympy/matrices/common.py:87:    # ref to col_insert usage #7\nsympy/matrices/common.py:88:    # ref to col_insert usage #8\nsympy/matrices/common.py:89:    # ref to col_insert usage #9\nsympy/matrices/common.py:90:    # ref to col_insert usage #10\nsympy/matrices/common.py:91:    # ref to col_insert usage #11\nsympy/matrices/common.py:92:    # ref to col_insert usage #12\nsympy/matrices/common.py:93:    # ref to col_insert usage #13"
+        },
+        {
+            "role": "assistant",
+            "content": "Reading the implementation."
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c3",
+            "content": "def col_insert(self, pos, other):\n    if pos < 0:\n        pos = self.cols + pos\n    # BUG: no upper clamp -> pos may exceed self.cols\n    return self._eval_col_insert(pos, other)\n    # helper line 0\n    # helper line 1\n    # helper line 2\n    # helper line 3\n    # helper line 4\n    # helper line 5\n    # helper line 6\n    # helper line 7\n    # helper line 8\n    # helper line 9\n    # helper line 10\n    # helper line 11"
+        },
+        {
+            "role": "assistant",
+            "content": "Running the failing test."
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c4",
+            "content": "$ pytest tests/test_matrices.py::test_col_insert\ntests/test_matrices.py::test_col_insert FAILED\nE   IndexError: Index out of range: a[2]\nsympy/matrices/common.py:86: IndexError\n1 failed, 180 passed in 2.14s"
+        },
+        {
+            "role": "user",
+            "content": "Which users are admins, and what's the fix?"
+        }
+    ]
+}

--- a/examples/llm-d-service/sample/context.before.json
+++ b/examples/llm-d-service/sample/context.before.json
@@ -1,0 +1,53 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a coding assistant."
+    },
+    {
+      "role": "user",
+      "content": "List the admins, then fix the failing test_col_insert."
+    },
+    {
+      "role": "assistant",
+      "content": "Listing users."
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "c1",
+      "content": "[{\"id\": 1, \"name\": \"Alice\", \"role\": \"admin\", \"active\": true}, {\"id\": 2, \"name\": \"Bob\", \"role\": \"member\", \"active\": false}, {\"id\": 3, \"name\": \"Carol\", \"role\": \"admin\", \"active\": true}, {\"id\": 4, \"name\": \"Dave\", \"role\": \"member\", \"active\": true}, {\"id\": 5, \"name\": \"Eve\", \"role\": \"admin\", \"active\": false}, {\"id\": 6, \"name\": \"Frank\", \"role\": \"member\", \"active\": true}]"
+    },
+    {
+      "role": "assistant",
+      "content": "Searching for col_insert references."
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "c2",
+      "content": "sympy/matrices/common.py:80:    # ref to col_insert usage #0\nsympy/matrices/common.py:81:    # ref to col_insert usage #1\nsympy/matrices/common.py:82:    # ref to col_insert usage #2\nsympy/matrices/common.py:83:    # ref to col_insert usage #3\nsympy/matrices/common.py:84:    # ref to col_insert usage #4\nsympy/matrices/common.py:85:    # ref to col_insert usage #5\nsympy/matrices/common.py:86:    # ref to col_insert usage #6\nsympy/matrices/common.py:87:    # ref to col_insert usage #7\nsympy/matrices/common.py:88:    # ref to col_insert usage #8\nsympy/matrices/common.py:89:    # ref to col_insert usage #9\nsympy/matrices/common.py:90:    # ref to col_insert usage #10\nsympy/matrices/common.py:91:    # ref to col_insert usage #11\nsympy/matrices/common.py:92:    # ref to col_insert usage #12\nsympy/matrices/common.py:93:    # ref to col_insert usage #13"
+    },
+    {
+      "role": "assistant",
+      "content": "Reading the implementation."
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "c3",
+      "content": "def col_insert(self, pos, other):\n    if pos < 0:\n        pos = self.cols + pos\n    # BUG: no upper clamp -> pos may exceed self.cols\n    return self._eval_col_insert(pos, other)\n    # helper line 0\n    # helper line 1\n    # helper line 2\n    # helper line 3\n    # helper line 4\n    # helper line 5\n    # helper line 6\n    # helper line 7\n    # helper line 8\n    # helper line 9\n    # helper line 10\n    # helper line 11"
+    },
+    {
+      "role": "assistant",
+      "content": "Running the failing test."
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "c4",
+      "content": "$ pytest tests/test_matrices.py::test_col_insert\ntests/test_matrices.py::test_col_insert FAILED\nE   IndexError: Index out of range: a[2]\nsympy/matrices/common.py:86: IndexError\n1 failed, 180 passed in 2.14s"
+    },
+    {
+      "role": "user",
+      "content": "Which users are admins, and what's the fix?"
+    }
+  ]
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -49,6 +49,11 @@ type Options struct {
 	// components (nil = none). The "incoming"-source client is built per request
 	// from the route's upstream + the gateway's real key.
 	CheapModel components.Model
+	// PipelineFor builds a pipeline for a per-request override on /compact
+	// (?preset=… or x-context-guru-pipeline: a,b,c). nil = overrides ignored, the
+	// handler always uses the configured pipeline. Supplied by main (which holds
+	// the config + emitter) so proxy stays decoupled from the config package.
+	PipelineFor func(preset string, names []string) (*components.Pipeline, error)
 }
 
 // upstream binds a provider to its base URL, the canonical provider path to POST
@@ -91,10 +96,71 @@ func (h *Handler) Mux() *http.ServeMux {
 		path:   "/v1/messages",
 		setKey: headerKey("x-api-key", h.opts.AnthropicKey),
 	}))
+	m.HandleFunc("POST /compact", h.compact)
 	m.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.Write([]byte("ok")) })
 	m.HandleFunc("GET /stats", h.stats)
 	m.HandleFunc("GET /expand", h.expand)
 	return m
+}
+
+// compact runs the pipeline over the request body's messages and returns the
+// rewritten body — without forwarding upstream. This is the "compact a context,
+// hand it back" endpoint: a caller (e.g. the llm-d-router request-inline-
+// compaction step) POSTs an inference request body and gets a smaller body of
+// the same shape back. Fail-open: any parse/serialize trouble returns the
+// original body with 200, so the caller's passthrough contract always holds.
+//
+// Provider defaults to OpenAI; ?provider=anthropic switches dialects. Config
+// overrides (when Options.PipelineFor is set): ?preset=<name> or header
+// x-context-guru-pipeline: comp1,comp2. Session/bypass honor the usual headers.
+func (h *Handler) compact(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	provider := bschemas.OpenAI
+	if strings.EqualFold(r.URL.Query().Get("provider"), "anthropic") {
+		provider = bschemas.Anthropic
+	}
+
+	pipe := h.pipe
+	if h.opts.PipelineFor != nil {
+		preset := r.URL.Query().Get("preset")
+		var names []string
+		if hp := r.Header.Get("x-context-guru-pipeline"); hp != "" {
+			names = splitComma(hp)
+		}
+		if preset != "" || len(names) != 0 {
+			// ponytail: rebuild per override request; add an LRU cache if override QPS ever matters.
+			if p, err := h.opts.PipelineFor(preset, names); err == nil {
+				pipe = p
+			} // build error => fall back to the configured pipeline (fail open)
+		}
+	}
+
+	// No upstream here, so there is no "incoming" model; only the static
+	// "config"-source client (and any endpoint pinned in a component's model: block).
+	models := components.ModelSpec{Static: h.opts.CheapModel}
+	out, _ := apply.BodyWithModel(
+		r.Context(), pipe, h.store, provider, body,
+		r.Header.Get("x-context-guru-session"),
+		strings.EqualFold(r.Header.Get("x-context-guru-bypass"), "true"),
+		models,
+	)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(out)
+}
+
+// splitComma splits a comma-separated header value into trimmed, non-empty names.
+func splitComma(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func bearerKey(key string) func(http.Header) {

--- a/store/store.go
+++ b/store/store.go
@@ -28,6 +28,10 @@ type Store interface {
 	Sticky(session string) map[string]struct{}
 	// MarkSticky records that id was reduced in this session.
 	MarkSticky(session, id string)
+	// Persists reports whether Put actually retains payloads. false (the Nop
+	// store) means offloads cannot be made reversible, so a full marker_mode must
+	// degrade to an irreversible drop rather than leave an unresolvable marker.
+	Persists() bool
 }
 
 type entry struct {
@@ -53,10 +57,25 @@ type Memory struct {
 // Options configures a Memory store; the zero value yields sane defaults.
 // yaml tags let it drop straight into the config file's store: block.
 type Options struct {
-	TTLSeconds  int `yaml:"ttl_seconds"`
-	MaxEntries  int `yaml:"max_entries"`
-	MaxSessions int `yaml:"max_sessions"`
+	// Enabled toggles the state store. nil/absent => on (backward-compatible).
+	// false => no store: reversibility is off, so offload components must run
+	// marker_mode: off (a full-marker offload would leave dangling markers).
+	Enabled     *bool `yaml:"enabled"`
+	TTLSeconds  int   `yaml:"ttl_seconds"`
+	MaxEntries  int   `yaml:"max_entries"`
+	MaxSessions int   `yaml:"max_sessions"`
 }
+
+// Nop is a Store that persists nothing: Put discards, Get/Sticky always miss.
+// Used when the store is disabled — the expand loop resolves nothing and lossy
+// offloads become irreversible, which is why they must use marker_mode: off.
+type Nop struct{}
+
+func (Nop) Put(string, []byte)                {}
+func (Nop) Get(string) ([]byte, bool)         { return nil, false }
+func (Nop) Sticky(string) map[string]struct{} { return nil }
+func (Nop) MarkSticky(string, string)         {}
+func (Nop) Persists() bool                    { return false }
 
 // NewMemory builds an in-memory store. Zero/negative option fields fall back to
 // defaults (1800s TTL, 1000 entries, 100 sessions of sticky sets).
@@ -80,6 +99,8 @@ func NewMemory(o Options) *Memory {
 		now:    time.Now,
 	}
 }
+
+func (*Memory) Persists() bool { return true }
 
 func (m *Memory) Put(key string, payload []byte) {
 	m.mu.Lock()


### PR DESCRIPTION
## What

Makes context-guru usable as a standalone **compaction service** for
[`llm-d-router`](https://github.com/ronenkat/llm-d-router)'s
`request-inline-compaction` step (PR #1). That step POSTs the raw inference
request body to a compaction server and, on `200` + non-empty JSON, swaps that
body in. Contract: **request body in → smaller body of the same shape out**.

The proxy was forward-only (routes proxy to OpenAI/Anthropic and return a
completion), so this adds a compact-and-return endpoint plus the pieces needed
to run it cleanly without the store.

## Changes

- **`POST /compact`** (`proxy/`): runs the pipeline over the request `messages`
  and returns the rewritten body without forwarding upstream. OpenAI by default,
  `?provider=anthropic`; per-request overrides via `?preset=` and
  `x-context-guru-pipeline`. Fail-open (bad input → original body, `200`).
- **Store enable/disable flag**: `store.enabled` in YAML, plus `--store` /
  `STORE`. Adds a `Nop` store and `Store.Persists()`, so a `full` `marker_mode`
  automatically degrades to an irreversible drop when the store can't persist —
  instead of leaving an unresolvable `<<cg:HASH>>` marker (applied in
  `mark`/`summarize`/`cmdfilter`).
- **`toon` component** (`components/reformat/`): deterministic re-encoding of
  uniform JSON object-arrays into tabular TOON. Lossless repack; tests included.
- **Config-driven model creds**: the `model:` block on `extract`/`summarize` now
  takes `provider`/`base_url`/`api_key`/`model`/`auth`; empty `api_key` falls
  back to env keys (incl. `ANTHROPIC_AUTH_TOKEN` for bearer gateways).
- **`examples/llm-d-service/`**: three configs (toon, extract-code, summarize;
  store off, `marker_mode: off`), `build.sh`, a dependency-free Go client
  mirroring the router's call, a self-contained README, and a captured
  before/after sample run.

## Testing

- `CGO_ENABLED=1 go build ./...`, `go vet ./...`, `go test ./...` — all pass;
  gofmt clean. New tests: `toon` encoder + the store-disabled marker degrade.
- End-to-end: ran the service for each config against a shared context.
  Deterministic `toon` reduced a sample request ~46%. The two LLM configs ran a
  real `claude-haiku-4-5` call through a bearer gateway (`extract` filtered to
  the relevant lines deletion-only; `summarize` collapsed the transcript ~81%),
  all with the store disabled and no markers in the output.

## Note

The commit skips the repo's dnephin `go-vet` pre-commit hook (`SKIP=go-vet`): it
passes individual filenames to `go vet`, which errors on a multi-package commit
("no Go files in ..."). `go vet ./...` is clean; all other hooks (gofmt,
go-mod-tidy, gitlint, DCO) ran.
