### PR TITLE
docs: fix mermaid parse errors in components and design diagrams

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -78,7 +78,7 @@ signatures survive). Stashes the whole original message.
 
 ```mermaid
 flowchart LR
-  A["```go fenced block<br/>full func bodies"] --> B{tree-sitter parse<br/>lang known? body ≥ min_tokens?}
+  A["go fenced block<br/>full func bodies"] --> B{"tree-sitter parse<br/>lang known? body ≥ min_tokens?"}
   B -->|no| A
   B -->|yes| C["signatures + { … }<br/>+ <<cg:HASH>> marker"]
   C --> D[(Store: original)]
@@ -269,7 +269,7 @@ wrapping `cmdfilter` component is an Offload (it stashes the original first).
 
 ```mermaid
 flowchart LR
-  I[input] --> S1[1 strip_ansi] --> S2[2 replace[]] --> S3[3 match_output[] + unless]
+  I[input] --> S1[1 strip_ansi] --> S2["2 replace[]"] --> S3["3 match_output[] + unless"]
   S3 --> S4[4 strip / keep lines] --> S5[5 truncate_lines_at] --> S6[6 head / tail]
   S6 --> S7[7 max_lines] --> S8[8 on_empty] --> O[output + Lossiness]
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,7 +111,7 @@ sequenceDiagram
   apply->>apply: normalize → []ChatMessage + write-back slots
   apply->>Pipe: Run(chat, ctx)
   Pipe-->>apply: mutated messages
-  apply->>apply: per message: unchanged → keep bytes;<br/>changed & lossless round-trip → sjson splice
+  apply->>apply: per message: unchanged → keep bytes,<br/>changed & lossless round-trip → sjson splice
   apply-->>Host: rewritten body (or original, fail open)
 ```
 
@@ -149,7 +149,7 @@ sequenceDiagram
   Store-->>Host: original bytes
   Host->>Up: append assistant tool-call + tool_result(original), re-invoke
   Up-->>M: final answer with full content in hand
-  Note over Host,Up: capped at 3 rounds; if the model also calls another tool,<br/>the loop bails and returns the response as-is
+  Note over Host,Up: capped at 3 rounds — if the model also calls another tool,<br/>the loop bails and returns the response as-is
 ```
 
 An expired/evicted original resolves to an explicit placeholder rather than being omitted (the


### PR DESCRIPTION
## What

Four mermaid diagrams in the docs failed to render on GitHub. Fixes are label-quoting and punctuation only — no wording/content changes.

| File | Diagram | Cause | Fix |
|---|---|---|---|
| `docs/components.md` | `skeleton` flowchart | ` ```go ` backticks inside a node label broke the lexer; decision node with `<br/>`/`≥` was unquoted | drop backticks, quote both labels |
| `docs/components.md` | DSL 8-stage flowchart | nested `[]` inside `[...]` labels (`replace[]`, `match_output[]`) | quote the two labels |
| `docs/design.md` | `apply.Body` sequence | `;` is a statement separator in `sequenceDiagram`, truncating the message and erroring on the following `<br/>` | `;` → `,` |
| `docs/design.md` | expand-loop sequence | same `;` issue in a `Note` | `;` → `—` |

These match the exact GitHub render errors reported (`Lexical error ... flowchart LR A["```go fenced block<br` and `Parse error on line 10 ...keep bytes;<br/>changed`).

## Verification

No mermaid CLI available in-env; verified by grep that no remaining diagram contains the three parse-breaking constructs (backticks-in-label, nested `[]`, `;` in sequence text). The other mermaid blocks in `integrations.md`/`setup.md` were checked and are clean.