### PR TITLE
fix(docs): deploy GitHub Pages via the Actions source

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -51,5 +51,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Switch the Pages source to "GitHub Actions" (build_type=workflow). Without
+      # this, deploy-pages fails with "HttpError: Not Found" when the repo's Pages
+      # is set to legacy "Deploy from a branch" mode.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -124,7 +124,7 @@ How the gateway routes Bob's traffic:
     A lossless, LLM-free pipeline (`format`, `toon`, `dedup`, `failed_run`, `cmdfilter`)
     needs no cheap-model config and leaves the transcript reversible. Verified end-to-end:
     with `[format, toon]` Bob authenticates and answers correctly through the proxy, with
-    its model call reduced. For long Bob sessions, add `mask` (see [Choose a preset](../how-to/choose-a-preset.md)).
+    its model call reduced. For long Bob sessions, add `mask` (see [Choose a preset](how-to/choose-a-preset.md)).
 
 !!! note "Bob speaks its own backend protocol"
     Unlike Claude Code (`ANTHROPIC_BASE_URL`) or OpenAI-surface agents (`OPENAI_BASE_URL`),


### PR DESCRIPTION
## Problem

`https://rossoctl.github.io/context-guru/` shows a **single page with no menu** — it's serving the raw repo `README.md` because Pages is set to legacy **Deploy from a branch (main, /root)**, not the built MkDocs site.

The `Docs` workflow already builds the site correctly, but its `deploy` job **failed on both merges to main** with:

```
##[error]Creating Pages deployment failed
##[error]HttpError: Not Found
```

That error is what `actions/deploy-pages` returns when the repo's Pages `build_type` is `legacy` rather than `workflow`.

## Fix

Add `actions/configure-pages@v5` with `enablement: true` before `deploy-pages`. On the next run it switches the Pages source to **GitHub Actions** (`build_type: workflow`) and then publishes the built site — homepage, nav, and all.

## After merging

Merging this to `main` triggers the `Docs` workflow (it touches the workflow file), which will flip the source and deploy the real site. If auto-enablement is blocked by org policy, the one-click equivalent is **Settings → Pages → Source → "GitHub Actions"**, then re-run the workflow.