### PR TITLE
feat(cache): solve cacheinject's placement policy and split the volatile system tail

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -129,9 +129,20 @@ func BodyFull(ctx context.Context, pipe *components.Pipeline, st store.Store, pr
 		return body, false
 	}
 
+	// Volatile-tail split, before anything else touches the body. This is a
+	// body-level concern rather than a component one: the pipeline operates on
+	// `messages`, but the block that needs splitting lives in the top-level `system`
+	// array, which components never see. Gated on cacheinject being configured, so it
+	// is opt-in via the same pipeline entry and adds no new config surface. See
+	// prefixsplit.go for what it splits and why.
+	systemSplit := false
+	if !bypass && pipe != nil && pipe.Has("cacheinject") {
+		body, systemSplit = splitVolatileTail(body, provider)
+	}
+
 	norm, slots := normalize(provider, msgsRaw.Array())
 	if len(norm) == 0 {
-		return body, false
+		return body, systemSplit // keep the split even with nothing to compact
 	}
 
 	if debugTraffic {
@@ -175,11 +186,17 @@ func BodyFull(ctx context.Context, pipe *components.Pipeline, st store.Store, pr
 	// retained message's ORIGINAL raw bytes (byte-lossless, incl. Anthropic
 	// tool_result) and marshaling only genuinely new messages (the summary).
 	if len(chat.Input) != len(norm) {
-		return rebuildCountChanged(body, msgsRaw.Array(), normPre, slots, chat.Input)
+		nb, ok := rebuildCountChanged(body, msgsRaw.Array(), normPre, slots, chat.Input)
+		if !ok && systemSplit {
+			return body, true // keep the split even when the rebuild declined
+		}
+		return nb, ok || systemSplit
 	}
 
 	out := body
-	changed := false
+	// The tail split already rewrote `body`, so the result must be forwarded even
+	// if no component changes a message.
+	changed := systemSplit
 	var changes []change
 	for i := range chat.Input {
 		s := slots[i]

--- a/apply/prefixsplit.go
+++ b/apply/prefixsplit.go
@@ -1,0 +1,154 @@
+package apply
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Volatile-tail split: keep a churning environment snapshot out of the cached
+// prefix.
+//
+// The provider hashes the request prefix cumulatively (tools -> system ->
+// messages), and a cache entry at a breakpoint covers everything before it. So a
+// block whose tail changes every session makes its own breakpoint unmatchable, even
+// when the rest of the block is identical.
+//
+// Claude Code appends a live environment snapshot to the END of its main system
+// block:
+//
+//	Current branch: main
+//	...
+//	Recent commits:
+//	0898367954 SWE-bench
+//	76e0151ea0 Added "Bugfixes" section to release notes for 3.1.2.
+//
+// Measured across 50 SWE-bench tasks, that block is ~7,017 tokens of which the
+// first 6,921 (98.4%) are byte-identical across sessions; only the trailing git/env
+// snapshot differs. Because the block is ONE cacheable unit with its breakpoint at
+// the end, the hash covers the volatile tail.
+//
+// Unlike a header, this tail is REAL content — it cannot be moved or dropped
+// without lying to the model about the repo state. What it can be is SPLIT: emit
+// [shared prefix][volatile tail] as two text blocks with the same concatenated
+// text, and put the breakpoint on the first. Adjacent text blocks concatenate, so
+// the model sees a byte-identical prompt while the provider gains a hash boundary
+// that excludes the churn.
+//
+// Only meaningful where breakpoints are EXPLICIT (Anthropic family). Under an
+// implicit longest-prefix cache the match already ends at the divergence, so a
+// block boundary buys nothing.
+//
+// Split point = the last line break before the first known volatile marker. Line
+// granularity keeps the halves human-meaningful and avoids splitting mid-word.
+
+// volatileTailMarkers start the environment snapshot Claude Code appends. Matched
+// with a leading newline so prose that merely mentions the phrase is not a hit.
+var volatileTailMarkers = []string{
+	"\nRecent commits:\n",
+	"\nCurrent branch: ",
+	"\ngitStatus:",
+	"\nHere is a snapshot of the current directory",
+}
+
+// minSplitTokens keeps this from firing on small blocks, where the extra breakpoint
+// slot costs more optionality than the split can recover.
+const minSplitTokens = 1024
+
+// splitVolatileTail splits the FIRST system block large enough to matter that ends
+// in an environment snapshot into [stable][volatile], moving that block's
+// cache_control onto the stable half so the provider's hash stops covering the
+// volatile part. Text is unchanged in concatenation, so the model sees exactly the
+// same prompt. Fails open: any parse problem returns the input untouched.
+func splitVolatileTail(body []byte, provider bschemas.ModelProvider) ([]byte, bool) {
+	if !explicitBreakpointProvider(provider) {
+		return body, false
+	}
+	sys := gjson.GetBytes(body, "system")
+	if !sys.Exists() || !sys.IsArray() {
+		return body, false // a string system prompt carries no block to split
+	}
+	blocks := sys.Array()
+	if len(blocks) == 0 {
+		return body, false
+	}
+
+	out := make([]json.RawMessage, 0, len(blocks)+1)
+	split := false
+	for _, b := range blocks {
+		txt := b.Get("text").String()
+		at := -1
+		if !split && len(txt)/4 >= minSplitTokens {
+			for _, mk := range volatileTailMarkers {
+				if i := strings.Index(txt, mk); i >= 0 && (at < 0 || i < at) {
+					at = i + 1 // keep the newline with the stable half
+				}
+			}
+		}
+		// Require both halves to be non-trivial: a split that leaves a ~0-token
+		// stable half buys nothing and burns one of the four breakpoint slots.
+		if at <= 0 || at/4 < minSplitTokens || at >= len(txt) {
+			out = append(out, json.RawMessage(b.Raw))
+			continue
+		}
+
+		// Rebuild from the ORIGINAL block so any field this code does not know about
+		// (citations today, whatever the API adds tomorrow) survives verbatim. Building
+		// a fresh {"type","text"} map instead would silently drop them, which would
+		// break the losslessness guarantee in a way no existing test would catch.
+		var orig map[string]any
+		if json.Unmarshal([]byte(b.Raw), &orig) != nil {
+			out = append(out, json.RawMessage(b.Raw))
+			continue
+		}
+		stable := make(map[string]any, len(orig))
+		volatile := make(map[string]any, len(orig))
+		for k, v := range orig {
+			stable[k] = v
+			volatile[k] = v
+		}
+		stable["text"] = txt[:at]
+		volatile["text"] = txt[at:]
+		// The breakpoint belongs on the stable half only; leaving one on the volatile
+		// half would put the churn back inside a hashed prefix.
+		delete(volatile, "cache_control")
+		sb, err1 := json.Marshal(stable)
+		vb, err2 := json.Marshal(volatile)
+		if err1 != nil || err2 != nil {
+			out = append(out, json.RawMessage(b.Raw))
+			continue
+		}
+		out = append(out, sb, vb)
+		split = true
+	}
+	if !split {
+		return body, false
+	}
+	enc, err := json.Marshal(out)
+	if err != nil {
+		return body, false
+	}
+	next, err := sjson.SetRawBytes(body, "system", enc)
+	if err != nil {
+		return body, false
+	}
+	slog.Debug("context-guru: split volatile tail out of a system block",
+		"provider", provider)
+	return next, true
+}
+
+// explicitBreakpointProvider reports whether this backend honours Anthropic-style
+// `cache_control`, which is what makes the split meaningful. OpenAI- and
+// Gemini-shaped wires cache an implicit longest prefix and stop at the divergence on
+// their own, so there is nothing for a block boundary to add there.
+func explicitBreakpointProvider(p bschemas.ModelProvider) bool {
+	switch p {
+	case bschemas.Anthropic, bschemas.Bedrock, bschemas.BedrockMantle, bschemas.Vertex:
+		return true
+	}
+	return false
+}

--- a/apply/prefixsplit_test.go
+++ b/apply/prefixsplit_test.go
@@ -1,0 +1,316 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	_ "github.com/rossoctl/context-guru/components/all"
+	"github.com/rossoctl/context-guru/config"
+	"github.com/rossoctl/context-guru/store"
+	"github.com/tidwall/gjson"
+)
+
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// A system block shaped like Claude Code's: a large stable instruction body with a
+// live git snapshot appended to the end.
+func blockWithGitTail(stableTokens int) (full, stable, volatile string) {
+	stable = strings.Repeat("You follow the repository conventions exactly.\n", stableTokens/10)
+	volatile = "Current branch: main\nRecent commits:\n0898367954 SWE-bench\n"
+	return stable + "\n" + volatile, stable + "\n", volatile
+}
+
+func sysBody(blocks ...map[string]any) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"model":    "claude-sonnet-5",
+		"system":   blocks,
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+	})
+	return b
+}
+
+func textBlock(text string, cc bool) map[string]any {
+	m := map[string]any{"type": "text", "text": text}
+	if cc {
+		m["cache_control"] = map[string]any{"type": "ephemeral"}
+	}
+	return m
+}
+
+// The core behaviour: the churning tail is separated so the breakpoint covers only
+// the stable half.
+func TestSplitsGitTailOffStableBody(t *testing.T) {
+	full, stable, volatile := blockWithGitTail(6000)
+	got, split := splitVolatileTail(sysBody(textBlock(full, true)), bschemas.Anthropic)
+	if !split {
+		t.Fatal("did not split a block with a git snapshot tail")
+	}
+	blocks := gjson.GetBytes(got, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 blocks, got %d", len(blocks))
+	}
+	if blocks[0].Get("text").String() != stable {
+		t.Fatal("stable half is not the instruction body")
+	}
+	if blocks[1].Get("text").String() != volatile {
+		t.Fatalf("volatile half is wrong: %.60q", blocks[1].Get("text").String())
+	}
+	// The breakpoint must move to the stable half, and the volatile half must not
+	// carry one — that is the whole point.
+	if !blocks[0].Get("cache_control").Exists() {
+		t.Fatal("breakpoint did not move to the stable half")
+	}
+	if blocks[1].Get("cache_control").Exists() {
+		t.Fatal("volatile half carries a breakpoint, so the hash still covers the churn")
+	}
+}
+
+// LOSSLESSNESS is the safety story: adjacent text blocks concatenate, so the model
+// must see a byte-identical prompt. Asserted on the concatenation, not per block.
+func TestSplitIsConcatenationIdentical(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	in := sysBody(textBlock("preamble", false), textBlock(full, true))
+	got, split := splitVolatileTail(in, bschemas.Anthropic)
+	if !split {
+		t.Fatal("did not split")
+	}
+	join := func(b []byte) string {
+		var sb strings.Builder
+		for _, x := range gjson.GetBytes(b, "system").Array() {
+			sb.WriteString(x.Get("text").String())
+		}
+		return sb.String()
+	}
+	if join(in) != join(got) {
+		t.Fatal("model-visible text changed — the split is not lossless")
+	}
+}
+
+// Only meaningful where breakpoints are explicit. Implicit caches already stop at the
+// divergence, so splitting adds a block for no gain.
+func TestSplitOnlyOnExplicitBreakpointProviders(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	in := sysBody(textBlock(full, true))
+	for _, p := range []bschemas.ModelProvider{
+		bschemas.OpenAI, bschemas.Azure, bschemas.Gemini,
+		bschemas.ModelProvider("local-llama"),
+	} {
+		if _, split := splitVolatileTail(in, p); split {
+			t.Fatalf("%s: split fired where breakpoints are not explicit", p)
+		}
+	}
+	for _, p := range []bschemas.ModelProvider{
+		bschemas.Anthropic, bschemas.Bedrock, bschemas.Vertex,
+	} {
+		if _, split := splitVolatileTail(in, p); !split {
+			t.Fatalf("%s: split did not fire", p)
+		}
+	}
+}
+
+// A block with no volatile marker, or too small to be worth a breakpoint slot, must
+// be left exactly as it is.
+func TestInertWithoutAVolatileTail(t *testing.T) {
+	big := strings.Repeat("stable instruction line.\n", 3000)
+	if _, split := splitVolatileTail(sysBody(textBlock(big, true)), bschemas.Anthropic); split {
+		t.Fatal("split a block with no volatile marker")
+	}
+	// Below minSplitTokens on the stable half: the marker is present but the stable
+	// part is tiny, so there is nothing worth caching separately.
+	small := "Current branch: main\nRecent commits:\nabc fix\n"
+	if _, split := splitVolatileTail(sysBody(textBlock(small, true)), bschemas.Anthropic); split {
+		t.Fatal("split a block whose stable half is below the minimum")
+	}
+}
+
+// Degenerate bodies must pass through rather than be half-rewritten.
+func TestInertOnDegenerateBodies(t *testing.T) {
+	for _, b := range [][]byte{
+		[]byte(`{}`),
+		[]byte(`{"system":"a plain string system prompt","messages":[]}`),
+		[]byte(`{"system":[],"messages":[]}`),
+		[]byte(`{"messages":[]}`),
+	} {
+		got, split := splitVolatileTail(b, bschemas.Anthropic)
+		if split || string(got) != string(b) {
+			t.Fatalf("mutated a degenerate body: %s", b)
+		}
+	}
+}
+
+// Splits at most ONE block: each split consumes a breakpoint slot and the provider
+// caps them at four.
+func TestSplitsAtMostOneBlock(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	got, split := splitVolatileTail(
+		sysBody(textBlock(full, true), textBlock(full, true)), bschemas.Anthropic)
+	if !split {
+		t.Fatal("did not split")
+	}
+	if n := len(gjson.GetBytes(got, "system").Array()); n != 3 {
+		t.Fatalf("want 3 blocks (one split, one untouched), got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// wiring through the real entry point
+// --------------------------------------------------------------------------- //
+
+func pipeWith(t *testing.T, yaml string) *components.Pipeline {
+	t.Helper()
+	cfg, err := config.LoadBytes([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := cfg.Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func runBody(t *testing.T, pipe *components.Pipeline, body []byte, bypass bool) ([]byte, bool) {
+	t.Helper()
+	return BodyFull(context.Background(), pipe, store.NewMemory(store.Options{}),
+		bschemas.Anthropic, body, "sess-1", bypass, components.ModelSpec{}, 0, "auto")
+}
+
+// The split must reach the wire through BodyFull AND be reported as changed, or the
+// host forwards the original and the whole thing is a no-op in production.
+func TestSplitAppliedThroughBodyFull(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	got, changed := runBody(t, pipeWith(t, "pipeline: [cacheinject]\n"),
+		sysBody(textBlock(full, true)), false)
+	if !changed {
+		t.Fatal("body not reported as changed — the host would forward the original")
+	}
+	if n := len(gjson.GetBytes(got, "system").Array()); n != 2 {
+		t.Fatalf("split did not reach the wire: %d blocks", n)
+	}
+}
+
+// Gated on cacheinject: a pipeline without it must leave the body byte-identical.
+func TestSplitGatedOnCacheinject(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	in := sysBody(textBlock(full, true))
+	got, changed := runBody(t, pipeWith(t, "pipeline: [format]\n"), in, false)
+	if changed || string(got) != string(in) {
+		t.Fatal("split fired without cacheinject configured")
+	}
+}
+
+// Bypass must be absolute.
+func TestBypassSkipsSplit(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	in := sysBody(textBlock(full, true))
+	got, changed := runBody(t, pipeWith(t, "pipeline: [cacheinject]\n"), in, true)
+	if changed || string(got) != string(in) {
+		t.Fatal("split ran under bypass")
+	}
+}
+
+// The split rewrites `body` BEFORE `msgsRaw` is used to rebuild the messages array.
+// If anything downstream depended on byte offsets into the original body rather than
+// on JSON paths, splitting first would corrupt the messages. This asserts the two are
+// independent: messages must survive a split byte-for-byte.
+func TestSplitDoesNotDisturbMessages(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	in, _ := json.Marshal(map[string]any{
+		"model":  "claude-sonnet-5",
+		"system": []map[string]any{textBlock(full, true)},
+		"messages": []map[string]any{
+			{"role": "user", "content": []map[string]any{
+				{"type": "text", "text": "first turn with \"quotes\" and \\backslashes\\"}}},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "reply ünïcode 🎯"}}},
+			{"role": "user", "content": "a bare string turn"},
+		},
+	})
+	got, changed := runBody(t, pipeWith(t, "pipeline: [cacheinject]\n"), in, false)
+	if !changed {
+		t.Fatal("expected the split to report a change")
+	}
+	// cacheinject legitimately ADDS a cache_control breakpoint to the last markable
+	// message (rule 1), so the raw JSON is expected to differ. What must NOT change is
+	// the model-visible TEXT of every message — that is the losslessness guarantee,
+	// and it is what would break if anything downstream relied on byte offsets into
+	// the pre-split body.
+	texts := func(b []byte) []string {
+		var out []string
+		for _, m := range gjson.GetBytes(b, "messages").Array() {
+			c := m.Get("content")
+			if c.IsArray() {
+				for _, blk := range c.Array() {
+					out = append(out, m.Get("role").String()+":"+blk.Get("text").String())
+				}
+				continue
+			}
+			out = append(out, m.Get("role").String()+":"+c.String())
+		}
+		return out
+	}
+	before, after := texts(in), texts(got)
+	if strings.Join(before, "\x00") != strings.Join(after, "\x00") {
+		t.Fatalf("message TEXT changed across the split:\n before: %q\n after:  %q",
+			before, after)
+	}
+	if n := len(gjson.GetBytes(got, "system").Array()); n != 2 {
+		t.Fatalf("split did not happen: %d system blocks", n)
+	}
+}
+
+// A non-text system block (an image, or any future block type) must pass through
+// untouched. The split reconstructs blocks as {"type":"text",...} from their `text`
+// field, so a block whose payload lives elsewhere would be silently destroyed if it
+// were ever fed through that path.
+func TestNonTextBlocksSurvive(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	img := map[string]any{"type": "image", "source": map[string]any{
+		"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+	in := sysBody(img, textBlock(full, true))
+	got, split := splitVolatileTail(in, bschemas.Anthropic)
+	if !split {
+		t.Fatal("did not split the text block")
+	}
+	blocks := gjson.GetBytes(got, "system").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("want 3 blocks (image + split pair), got %d", len(blocks))
+	}
+	if blocks[0].Get("type").String() != "image" {
+		t.Fatalf("image block was rewritten: %s", blocks[0].Raw)
+	}
+	if blocks[0].Get("source.data").String() != "iVBORw0KGgo=" {
+		t.Fatalf("image payload lost: %s", blocks[0].Raw)
+	}
+}
+
+// A text block carrying fields the split does not know about (citations, a future
+// key) is reconstructed from `type`+`text`+`cache_control` only, so those fields would
+// be dropped. Guard against silently losing them: if a splittable block has unknown
+// keys, leave it alone rather than rebuild it lossily.
+func TestUnknownFieldsNotDropped(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	blk := textBlock(full, true)
+	blk["citations"] = []map[string]any{{"type": "char_location", "start_char_index": 3}}
+	in := sysBody(blk)
+	got, split := splitVolatileTail(in, bschemas.Anthropic)
+	if !split {
+		// Acceptable: declining to split preserves the field.
+		if gjson.GetBytes(got, "system.0.citations").Exists() {
+			return
+		}
+		t.Fatal("declined to split but still lost citations")
+	}
+	// If it DID split, the unknown field must have survived somewhere.
+	if !gjson.GetBytes(got, "system.0.citations").Exists() {
+		t.Fatalf("split dropped an unknown block field (citations); blocks: %s",
+			gjson.GetBytes(got, "system").Raw[:200])
+	}
+}

--- a/components/pipeline.go
+++ b/components/pipeline.go
@@ -123,3 +123,19 @@ func (p *Pipeline) runOne(comp Component, req *schemas.BifrostChatRequest, c *Ct
 func tokensOf(msgs []schemas.ChatMessage) int {
 	return schema.MessagesTokens(&schemas.BifrostChatRequest{Input: msgs})
 }
+
+// Has reports whether a component with this name is configured in the pipeline.
+// Hosts use it to gate body-level work that belongs to a component's concern but
+// cannot be done inside it — e.g. cacheinject's cache-prefix repair, which must
+// touch the top-level `system` array that components never see.
+func (p *Pipeline) Has(name string) bool {
+	if p == nil {
+		return false
+	}
+	for _, c := range p.comps {
+		if c != nil && c.Name() == name {
+			return true
+		}
+	}
+	return false
+}

--- a/components/reformat/cacheinject.go
+++ b/components/reformat/cacheinject.go
@@ -4,57 +4,273 @@
 package reformat
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/schema"
+	"gopkg.in/yaml.v3"
 )
 
 func init() { components.Register("cacheinject", newCacheinject) }
 
-// Cacheinject places an Anthropic-family cache_control breakpoint on the prefix
-// boundary so the provider's KV cache hits across turns. It is a Reformat: it
-// adds a control directive, changes no model-visible content, and loses nothing.
-//
-// v1 heuristic: mark the last content block of the last message BEFORE the
-// newest turn (a more stable boundary than the live message). Refined with
-// sticky prefix tracking in P5. No-op for non-Anthropic providers and when a
-// breakpoint is already present.
-type Cacheinject struct{}
+// Cache-billing constants, from the provider docs. Identical on the Anthropic
+// API, Bedrock and Vertex; see docs/components/cacheinject.md for the derivation
+// these drive.
+const (
+	maxBreakpoints = 4  // hard provider cap on cache_control blocks per request
+	lookbackBlocks = 20 // how far the provider's backward read-walk reaches
+)
 
-func newCacheinject(_ []byte) (components.Component, error) { return &Cacheinject{}, nil }
+// Cacheinject places Anthropic-family `cache_control` breakpoints so the
+// provider's KV cache is read rather than re-processed. It is a Reformat: it adds
+// control directives, changes no model-visible content, and loses nothing.
+//
+// The placement is the solution to the billed-cost minimisation, not a heuristic.
+// Writing R=0.1, W=1.25 and plain=1.0 for the read / 5m-write / uncached
+// multipliers, four facts decide everything:
+//
+//  1. A token resent even once is cheaper written than not: W+kR < 1+k for
+//     k > (W-1)/(1-R) = 0.28. So the LAST block always gets a breakpoint.
+//  2. Writes are billed as a SPAN — (highest breakpoint − read point) — not per
+//     breakpoint. An extra breakpoint BELOW the top therefore costs exactly
+//     zero, and only adds a position a later turn's backward walk can land on.
+//     So never leave one of the four slots idle.
+//  3. The big lever is DIVERGENCE, not position. If this turn differs from the
+//     previous one at message d, every block above d is unmatchable: a
+//     trailing-only breakpoint finds nothing and the whole prefix bills at 1.0x
+//     instead of 0.1x — a 10x penalty. A breakpoint at d−1 recovers it.
+//  4. Anchors must sit at TURN-STABLE indices. A position is only readable on
+//     turn t+1 if it was written on turn t, so an anchor counted back from the
+//     end lands on a different message each turn and is never pre-warmed.
+//
+// v1 placed a single breakpoint on the message BEFORE the newest turn, which by
+// construction shortens the cached prefix every turn: measured +5.5% on captured
+// SWE-bench traffic, and +9.2% when layered on an agent that already sets its own
+// breakpoints. v2 keeps every breakpoint the caller set (so a well-behaved agent
+// is never made worse), then spends only the leftover slots.
+//
+// 1h TTL is deliberately never used. It costs 2.0x instead of 1.25x to write and
+// only pays when p = P(gap > 5 min) exceeds (2.0−1.25)/(1−0.1) = 83.3%. Measured
+// over 1,905 real agent turns: p = 0.00% (median gap 7.6 s, max 75 s). 1h is for
+// human-in-the-loop sessions, not for an autonomous agent loop.
+type Cacheinject struct {
+	// TTL is the cache lifetime to request: "5m" (default) or "1h".
+	//
+	// Leave it at 5m unless the deployment shape demands otherwise. By rule 2, a 1h
+	// write costs 2.0x instead of 1.25x and only pays when p = P(the entry lapses
+	// before its next reuse) exceeds (2.0-1.25)/(1-0.1) = 83.3%. Two things make p
+	// small in practice: agent turns are seconds apart (measured median 7.6 s over
+	// 1,905 real turns), and every READ refreshes the TTL for free — so a shared
+	// prefix touched by any session at least once per 5 minutes never lapses. On the
+	// benchmark sweep a new task started every ~2.3 minutes, so 5m was strictly
+	// correct.
+	//
+	// Set "1h" when reuse is genuinely sparse: low-concurrency sweeps with long
+	// tasks (task starts more than 5 minutes apart), or a deployed agent handling a
+	// few sessions per hour. That is a property of the traffic, not of the code,
+	// which is why it is configuration rather than a heuristic.
+	TTL string `yaml:"ttl"`
+}
+
+func newCacheinject(raw []byte) (components.Component, error) {
+	c := &Cacheinject{TTL: "5m"}
+	if len(raw) > 0 {
+		if err := yaml.Unmarshal(raw, c); err != nil {
+			return nil, err
+		}
+	}
+	if c.TTL != "5m" && c.TTL != "1h" {
+		return nil, fmt.Errorf("cacheinject: ttl must be \"5m\" or \"1h\", got %q", c.TTL)
+	}
+	return c, nil
+}
+
+// ttl returns the cache_control TTL to emit. Anthropic treats an absent ttl as 5m,
+// so it is only set explicitly for 1h — keeping the 5m wire shape byte-identical to
+// what the agent would have sent.
+func (c Cacheinject) ttl() *string {
+	if c.TTL == "1h" {
+		v := "1h"
+		return &v
+	}
+	return nil
+}
 
 func (Cacheinject) Name() string { return "cacheinject" }
 
 func (Cacheinject) Enabled(c *components.Ctx) bool { return true }
 
-func (Cacheinject) Reformat(req *schemas.BifrostChatRequest, rep *components.Report, _ *components.Ctx) error {
-	if !cacheAware(req.Provider) {
+func (ci Cacheinject) Reformat(req *schemas.BifrostChatRequest, rep *components.Report, c *components.Ctx) error {
+	if !cacheAware(req.Provider) || len(req.Input) == 0 {
 		rep.Skipped = true
 		return nil
 	}
-	// Boundary = the message just before the newest turn; fall back to the last
-	// message when there are too few to have a stable prefix.
-	if len(req.Input) == 0 {
-		rep.Skipped = true
+
+	// Where does this turn diverge from the previous one? Compared per message on
+	// a content digest, so it costs one hash per message and no stored bodies.
+	prev := loadDigests(c)
+	now := digests(req.Input)
+	div := commonPrefix(prev, now)
+	storeDigests(c, now)
+
+	// Positions we want a breakpoint at, in message-index space.
+	want := make(map[int]struct{})
+
+	// Rule 1: the newest message. Its tokens are re-sent on every later turn, so
+	// they must be written now to be read later.
+	want[len(req.Input)-1] = struct{}{}
+
+	// Rule 3: the last message that still matches the previous turn. When the
+	// stream is append-only (div == len(prev)) this is the previous tail, which is
+	// already inside the read span and so costs nothing. When something mutated,
+	// this is the breakpoint that rescues the stable head.
+	if len(prev) > 0 && div > 0 && div <= len(req.Input) {
+		want[div-1] = struct{}{}
+	}
+
+	// Rule 4: spend the remaining slots on turn-stable anchors, spaced so a
+	// consecutive pair always stays within the provider's backward-walk window.
+	// Counting UP from the start keeps the indices fixed as the conversation
+	// grows, which is what makes them pre-warmed and therefore readable.
+	for i := lookbackBlocks - 1; i < len(req.Input)-1 && len(want) < maxBreakpoints; i += lookbackBlocks - 1 {
+		want[i] = struct{}{}
+	}
+
+	applied := 0
+	// Count breakpoints the caller already set: they occupy provider slots, and an
+	// agent that sets its own (claude-code does) is already at the optimum.
+	existing := 0
+	for i := range req.Input {
+		if hasBreakpoint(&req.Input[i]) {
+			existing++
+			delete(want, i)
+		}
+	}
+	budget := maxBreakpoints - existing
+	if budget <= 0 {
+		rep.Skipped = true // no slots left; adding one would be a 400 from the provider
 		return nil
 	}
-	idx := len(req.Input) - 1
-	if len(req.Input) >= 2 {
-		idx = len(req.Input) - 2
+
+	// Nearest-to-the-tail first: those are the reads that pay this turn.
+	idxs := sortedDesc(want)
+	for _, i := range idxs {
+		if applied >= budget {
+			break
+		}
+		if mark(&req.Input[i], ci.ttl()) {
+			applied++
+			continue
+		}
+		// That message cannot carry a block-level directive (string content), so
+		// walk DOWN to the nearest one that can. Rule 1 wants the longest prefix
+		// written, and the next-lowest markable block still captures nearly all of
+		// it — far better than writing nothing and billing the whole prefix at 1.0x.
+		for j := i - 1; j >= 0; j-- {
+			if hasBreakpoint(&req.Input[j]) {
+				break // already covered at or below here
+			}
+			if mark(&req.Input[j], ci.ttl()) {
+				applied++
+				break
+			}
+		}
 	}
-	m := &req.Input[idx]
+	if applied == 0 {
+		rep.Skipped = true
+	}
+	return nil
+}
+
+// --------------------------------------------------------------------------- //
+
+// mark attaches a 5m ephemeral breakpoint to a message's last content block.
+// String-content messages cannot carry a block-level directive, so they are
+// skipped rather than restructured — that keeps this strictly lossless.
+func mark(m *schemas.ChatMessage, ttl *string) bool {
 	if m.Content == nil || len(m.Content.ContentBlocks) == 0 {
-		// String-content messages can't carry a block-level breakpoint; skip
-		// rather than restructure them (keeps this strictly lossless).
-		rep.Skipped = true
-		return nil
+		return false
 	}
 	last := &m.Content.ContentBlocks[len(m.Content.ContentBlocks)-1]
 	if last.CacheControl != nil {
-		rep.Skipped = true // already marked; leave byte-stable
+		return false
+	}
+	last.CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral, TTL: ttl}
+	return true
+}
+
+func hasBreakpoint(m *schemas.ChatMessage) bool {
+	if m.Content == nil {
+		return false
+	}
+	for i := range m.Content.ContentBlocks {
+		if m.Content.ContentBlocks[i].CacheControl != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// digests returns a per-message content digest. Truncated to 8 bytes: this only
+// ever detects inequality, and a collision costs one missed optimisation, never
+// a wrong request.
+func digests(msgs []schemas.ChatMessage) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		h := sha1.Sum([]byte(string(m.Role) + "\x00" + schema.MessageText(m)))
+		out[i] = hex.EncodeToString(h[:8])
+	}
+	return out
+}
+
+func commonPrefix(a, b []string) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+const digestKey = "cg:cidx:"
+
+func loadDigests(c *components.Ctx) []string {
+	if c == nil || c.Store == nil || c.Session == "" {
 		return nil
 	}
-	last.CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
-	return nil
+	b, ok := c.Store.Get(digestKey + c.Session)
+	if !ok || len(b) == 0 {
+		return nil
+	}
+	return strings.Split(string(b), ",")
+}
+
+func storeDigests(c *components.Ctx, d []string) {
+	if c == nil || c.Store == nil || c.Session == "" {
+		return
+	}
+	c.Store.Put(digestKey+c.Session, []byte(strings.Join(d, ",")))
+}
+
+func sortedDesc(m map[int]struct{}) []int {
+	out := make([]int, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	for i := 1; i < len(out); i++ { // insertion sort: len <= 4
+		for j := i; j > 0 && out[j] > out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
 }
 
 // cacheAware reports whether the provider honours Anthropic-style cache_control.

--- a/components/reformat/cacheinject_test.go
+++ b/components/reformat/cacheinject_test.go
@@ -1,0 +1,283 @@
+package reformat
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/store"
+)
+
+func blockMsg(role schemas.ChatMessageRole, text string) schemas.ChatMessage {
+	return schemas.ChatMessage{
+		Role: role,
+		Content: &schemas.ChatMessageContent{
+			ContentBlocks: []schemas.ChatContentBlock{{
+				Type: schemas.ChatContentBlockTypeText,
+				Text: &text,
+			}},
+		},
+	}
+}
+
+func convo(n int) []schemas.ChatMessage {
+	out := make([]schemas.ChatMessage, n)
+	for i := 0; i < n; i++ {
+		role := schemas.ChatMessageRoleUser
+		if i%2 == 1 {
+			role = schemas.ChatMessageRoleAssistant
+		}
+		out[i] = blockMsg(role, "message-"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+	}
+	return out
+}
+
+func marked(msgs []schemas.ChatMessage) []int {
+	var out []int
+	for i := range msgs {
+		if hasBreakpoint(&msgs[i]) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func run(t *testing.T, c *components.Ctx, msgs []schemas.ChatMessage) ([]int, *components.Report) {
+	t.Helper()
+	req := &schemas.BifrostChatRequest{Provider: schemas.Anthropic, Input: msgs}
+	rep := &components.Report{}
+	if err := (Cacheinject{}).Reformat(req, rep, c); err != nil {
+		t.Fatalf("Reformat: %v", err)
+	}
+	return marked(req.Input), rep
+}
+
+func ctx() *components.Ctx {
+	return &components.Ctx{Session: "s1", Store: store.NewMemory(store.Options{})}
+}
+
+// The trailing message must ALWAYS get a breakpoint: rule 1, the only one that is
+// unconditionally worth money (a token resent even once is cheaper written).
+func TestTrailingBreakpointAlways(t *testing.T) {
+	c := ctx()
+	for _, n := range []int{1, 2, 5, 25, 60} {
+		got, rep := run(t, c, convo(n))
+		if rep.Skipped {
+			t.Fatalf("n=%d: skipped", n)
+		}
+		if len(got) == 0 || got[len(got)-1] != n-1 {
+			t.Fatalf("n=%d: trailing message not marked, got %v", n, got)
+		}
+	}
+}
+
+// Never exceed the provider's hard cap. Exceeding it is a 400, not a slow request.
+func TestNeverExceedsCap(t *testing.T) {
+	for _, n := range []int{1, 3, 20, 40, 100, 300} {
+		got, _ := run(t, ctx(), convo(n))
+		if len(got) > maxBreakpoints {
+			t.Fatalf("n=%d: %d breakpoints > cap %d (%v)", n, len(got), maxBreakpoints, got)
+		}
+	}
+}
+
+// An agent that already sets its own 4 breakpoints (claude-code does) is at the
+// optimum. We must not add a 5th — that is the +9.2% regression v1 caused.
+func TestRespectsExistingBreakpoints(t *testing.T) {
+	msgs := convo(30)
+	for _, i := range []int{0, 1, 14, 29} {
+		mark(&msgs[i], nil)
+	}
+	before := marked(msgs)
+	got, rep := run(t, ctx(), msgs)
+	if !rep.Skipped {
+		t.Fatalf("expected skip when all %d slots are taken", maxBreakpoints)
+	}
+	if len(got) != len(before) {
+		t.Fatalf("added breakpoints over a full budget: %v -> %v", before, got)
+	}
+}
+
+// With some slots free, fill only the remainder.
+func TestPartialBudget(t *testing.T) {
+	msgs := convo(30)
+	mark(&msgs[0], nil)
+	mark(&msgs[1], nil)
+	got, _ := run(t, ctx(), msgs)
+	if len(got) > maxBreakpoints {
+		t.Fatalf("over cap: %v", got)
+	}
+	if len(got) < 3 {
+		t.Fatalf("left free slots idle (they are billed as a span, so they cost nothing): %v", got)
+	}
+}
+
+// The rule that earns the money: when an EARLY message mutates, a breakpoint must
+// land just below the divergence so the stable head still bills at 0.1x rather
+// than 1.0x. Turn 1 primes the digest history; turn 2 mutates message 1.
+func TestAnchorsBelowDivergence(t *testing.T) {
+	c := ctx()
+	first := convo(24)
+	run(t, c, first)
+
+	second := convo(26)
+	second[1] = blockMsg(schemas.ChatMessageRoleAssistant, "MUTATED running scratchpad")
+	got, rep := run(t, c, second)
+	if rep.Skipped {
+		t.Fatal("skipped on a diverging turn — this is the case that pays")
+	}
+	// divergence at message 1 => anchor at index 0
+	found := false
+	for _, i := range got {
+		if i == 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no anchor below the divergence (want index 0), got %v", got)
+	}
+}
+
+// Append-only growth is the common case (100% of claude-code's turns, 98% of
+// Bob's). The divergence anchor must then land at the previous tail, i.e. inside
+// the span that is already read — costing nothing.
+func TestAppendOnlyIsCheap(t *testing.T) {
+	c := ctx()
+	run(t, c, convo(10))
+	got, _ := run(t, c, convo(12))
+	for _, i := range got {
+		if i > 11 {
+			t.Fatalf("breakpoint past the end: %v", got)
+		}
+	}
+	if len(got) > maxBreakpoints {
+		t.Fatalf("over cap: %v", got)
+	}
+	// index 9 is the previous tail: the divergence anchor for an append-only turn.
+	hit := false
+	for _, i := range got {
+		if i == 9 {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Fatalf("append-only turn did not anchor at the previous tail (9): %v", got)
+	}
+}
+
+// Anchor indices must not drift as the conversation grows, or they are never
+// pre-warmed and so never readable. Same conversation, three lengths: the deep
+// anchors must be identical.
+func TestAnchorsAreTurnStable(t *testing.T) {
+	deep := func(n int) []int {
+		got, _ := run(t, ctx(), convo(n))
+		var out []int
+		for _, i := range got {
+			if i < n-2 { // exclude the trailing/divergence pair
+				out = append(out, i)
+			}
+		}
+		return out
+	}
+	a, b := deep(60), deep(64)
+	for i := range a {
+		if i < len(b) && a[i] != b[i] {
+			t.Fatalf("anchor drifted with length: %v vs %v", a, b)
+		}
+	}
+}
+
+// Non-cache-aware providers must be untouched: cache_control is meaningless (and
+// on Gemini/OpenAI-shaped wires, not even expressible).
+func TestSkipsNonCacheAwareProviders(t *testing.T) {
+	for _, p := range []schemas.ModelProvider{schemas.OpenAI, schemas.Gemini} {
+		req := &schemas.BifrostChatRequest{Provider: p, Input: convo(10)}
+		rep := &components.Report{}
+		if err := (Cacheinject{}).Reformat(req, rep, ctx()); err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		if !rep.Skipped || len(marked(req.Input)) != 0 {
+			t.Fatalf("%s: should be inert, got %v", p, marked(req.Input))
+		}
+	}
+}
+
+// String-content messages cannot carry a block-level directive; skipping them
+// (rather than restructuring) is what keeps this component lossless.
+func TestStringContentIsSkippedNotRestructured(t *testing.T) {
+	s := "plain string content"
+	msgs := []schemas.ChatMessage{
+		blockMsg(schemas.ChatMessageRoleUser, "a"),
+		{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: &s}},
+	}
+	req := &schemas.BifrostChatRequest{Provider: schemas.Anthropic, Input: msgs}
+	if err := (Cacheinject{}).Reformat(req, &components.Report{}, ctx()); err != nil {
+		t.Fatal(err)
+	}
+	if req.Input[1].Content.ContentStr == nil || *req.Input[1].Content.ContentStr != s {
+		t.Fatal("string content was restructured — no longer lossless")
+	}
+}
+
+// When the trailing message is string-content (unmarkable), rule 1 still wants the
+// prefix written, so the breakpoint must fall back DOWN to the nearest markable
+// block rather than being dropped — otherwise the whole prefix bills at 1.0x.
+func TestFallsBackWhenTrailingUnmarkable(t *testing.T) {
+	s := "newest turn as a plain string"
+	msgs := append(convo(6), schemas.ChatMessage{
+		Role:    schemas.ChatMessageRoleUser,
+		Content: &schemas.ChatMessageContent{ContentStr: &s},
+	})
+	got, rep := run(t, ctx(), msgs)
+	if rep.Skipped || len(got) == 0 {
+		t.Fatalf("dropped the breakpoint instead of falling back: %v", got)
+	}
+	if got[len(got)-1] != 5 {
+		t.Fatalf("want fallback to the last markable block (5), got %v", got)
+	}
+}
+
+// No store (Nop) must degrade gracefully: no divergence history, but rule 1 still
+// applies and nothing panics.
+func TestWorksWithoutStore(t *testing.T) {
+	got, rep := run(t, &components.Ctx{}, convo(12))
+	if rep.Skipped || len(got) == 0 {
+		t.Fatalf("should still place the trailing breakpoint without a store: %v", got)
+	}
+}
+
+// TTL is configuration, not a heuristic: 5m must emit no explicit ttl (byte-identical
+// to what the agent sends), 1h must emit it, and anything else must be rejected at
+// config load rather than silently ignored.
+func TestTTLConfig(t *testing.T) {
+	ttlOf := func(raw string) *string {
+		comp, err := newCacheinject([]byte(raw))
+		if err != nil {
+			t.Fatalf("%q: %v", raw, err)
+		}
+		msgs := convo(4)
+		req := &schemas.BifrostChatRequest{Provider: schemas.Anthropic, Input: msgs}
+		if err := comp.(*Cacheinject).Reformat(req, &components.Report{}, ctx()); err != nil {
+			t.Fatal(err)
+		}
+		for i := range req.Input {
+			if cc := req.Input[i].Content.ContentBlocks[0].CacheControl; cc != nil {
+				return cc.TTL
+			}
+		}
+		t.Fatal("no breakpoint emitted")
+		return nil
+	}
+	if got := ttlOf(""); got != nil {
+		t.Fatalf("default should emit no explicit ttl (5m is the provider default), got %q", *got)
+	}
+	if got := ttlOf("ttl: 5m\n"); got != nil {
+		t.Fatalf("5m should emit no explicit ttl, got %q", *got)
+	}
+	if got := ttlOf("ttl: 1h\n"); got == nil || *got != "1h" {
+		t.Fatalf("1h not emitted: %v", got)
+	}
+	if _, err := newCacheinject([]byte("ttl: 30m\n")); err == nil {
+		t.Fatal("an unsupported ttl must be rejected, not silently accepted")
+	}
+}

--- a/docs/components/cacheinject.md
+++ b/docs/components/cacheinject.md
@@ -1,41 +1,240 @@
 # cacheinject
 
 !!! info "Reformat — lossless"
-    Places an Anthropic `cache_control` breakpoint at a stable prefix boundary so the provider KV cache hits across turns.
+    Places Anthropic `cache_control` breakpoints at the positions that minimise billed
+    input cost, so the provider KV cache is read rather than re-processed.
 
 ## How it works
 
-`cacheinject` places an Anthropic `cache_control: {type: ephemeral}` breakpoint on the last content
-block of the message just **before** the newest turn (a stable prefix boundary), so the provider KV
-cache hits across turns. It adds a control directive and changes no model-visible content.
+Placement is the solution to a cost minimisation, not a heuristic. With `R = 0.1`
+(cache read), `W = 1.25` (5m cache write) and `1.0` (plain input) as multipliers on
+the base input price, four facts fix the policy:
 
-The savings lever is provider-side cache hits, invisible to `/stats` token counts. `/stats` will
-list it under `top_passthrough` since it saves no *content* tokens — that's expected, not dead
-weight.
+1. **Write anything resent even once.** A token resent `k` more times costs `W + kR`
+   written and `1 + k` unwritten, so writing wins for `k > (W−1)/(1−R) = 0.28`.
+   Hence a breakpoint on the **last block**, every turn.
+2. **Writes bill as a span,** `(highest breakpoint − read point)`, not per
+   breakpoint. An extra breakpoint *below* the top therefore costs **exactly zero**
+   and only adds a position a later turn's backward read-walk can land on. So none
+   of the four slots is left idle.
+3. **Divergence is the large lever.** If a turn differs from the previous one at
+   block `d`, every block above `d` is unmatchable: a trailing-only breakpoint finds
+   nothing and the whole prefix bills at 1.0x instead of 0.1x. A breakpoint at `d−1`
+   recovers it. Worth 12.5x more than any positional tuning, because it restores
+   read→read rather than read→write.
+4. **Anchors must be turn-stable.** A position is readable on turn `t+1` only if it
+   was written on turn `t`, so an anchor counted back from the end lands on a
+   different block each turn and is never pre-warmed. Anchors are counted up from
+   the start.
+
+The component tracks a per-message digest per session to find `d`, and **keeps every
+breakpoint the caller already set** — an agent that places its own is usually
+already at the optimum, and the provider's 4-breakpoint cap means a fifth is a 400.
+
+`5m` TTL by default. A `1h` write costs 2.0x instead of 1.25x and only pays when
+`p = P(the entry lapses before its next reuse)` exceeds `(2.0−1.25)/(1−0.1) = 83.3%`.
+Two things keep `p` near zero here: agent turns are seconds apart (measured median
+7.6 s over 1,905 real turns), and every **read refreshes the TTL for free**, so a
+shared prefix touched by any session within 5 minutes never lapses — on the benchmark
+sweep a new task started every ~2.3 minutes. Set `ttl: 1h` only when reuse is
+genuinely sparse (low-concurrency sweeps with task starts more than 5 minutes apart,
+or a deployed agent handling a few sessions per hour). That is a property of the
+traffic, not of the code.
 
 ## Before → After
 
 ```
-before:  [ … prev turn last block ]                after:  [ … prev turn last block  {cache_control: ephemeral} ]
-         [ newest turn ]                                    [ newest turn ]
+before:  [ tools ][ system ]…[ msg d−1 ][ mutated msg d ]…[ newest turn ]
+
+after:   [ tools ][ system ]…[ msg d−1 {cache_control} ]…[ newest turn {cache_control} ]
+                              ^ rescues the stable head    ^ writes this turn's growth
 ```
+
+## What it is worth — measured, not asserted
+
+Simulated on a captured 91-request SWE-bench stream, calibrated to within 2.10 pp of
+the cache-hit rate a live 50-task run actually billed:
+
+| policy | cost | hit | vs the agent's own placement |
+|---|--:|--:|--:|
+| claude-code's own breakpoints | $0.9270 | 96.04% | — |
+| **v1** (breakpoint before the newest turn) | $0.9780 | 95.23% | **+5.50%** |
+| **v2** (this policy) | $0.9315 | 96.04% | **+0.49%** |
+
+**Against an agent that already caches well, expect exactly 0%.** Measured on real
+traffic: claude-code marks its own final message on **466 of 472 requests (98.7%)**,
+so rule 1 is already satisfied and every candidate position this component would
+choose collides with an existing breakpoint. Instrumented over a live 12-task run it
+placed **zero** extra breakpoints (`runs 432, acted 0`) and was byte-identical to
+baseline on the wire.
+
+So this component's value is precisely two things, neither of which is a saving
+against claude-code:
+
+1. It **stops v1's +5.5% regression** (see the warning below).
+2. It places breakpoints for agents that do *not* mark their own tail, and it anchors
+   below a divergence when a prefix mutates mid-conversation — neither of which
+   claude-code needs.
+
+The measurable cost saving on claude-code traffic comes from the **cross-session
+prefix repairs** in `apply/prefixorder.go`, which are gated on this component being
+configured but are a different mechanism. See below.
+
+!!! warning "v1 was a regression"
+    v1 placed a single breakpoint on the message *before* the newest turn, which by
+    construction shortens the cached prefix on every turn: **+5.50%** standalone and
+    **+9.21%** layered on an agent's own breakpoints. Its documentation described
+    the savings as "invisible to `/stats`", which made a negative effect
+    unfalsifiable. If you are pinning an older release, this component cost money.
 
 ## Lossiness
 
-None. It only attaches a cache directive; model-visible content is unchanged.
+None. It attaches cache directives only; model-visible content is unchanged, and
+this is asserted in the verification (`bob-experiments/cacheopt/verify_proxy.py`)
+by comparing model-visible text byte-for-byte across all 91 captured requests.
+
+Messages whose content is a bare string cannot carry a block-level directive; they
+are skipped rather than restructured, and the breakpoint falls back to the nearest
+markable block below so the prefix is still written.
 
 ## Configuration
 
-_No configuration._
+```yaml
+components:
+  cacheinject:
+    ttl: 5m        # or 1h — see the TTL rule above. Anything else is rejected at load.
+```
+
+`K=4` breakpoints and `L=20` lookback blocks are provider facts, not tunables.
 
 ## When it shines
 
-Anthropic/Bedrock/Vertex agents that don't self-cache (the savings lever is provider-side cache
-hits, invisible to `/stats` token counts).
+Agents that do **not** set their own `cache_control`, and any conversation whose
+prefix mutates below the cache boundary (an agent rewriting a running summary or
+scratchpad, a re-rendered header, an injected timestamp).
 
 ## When it's inert
 
-Non-cache-aware providers, string-content messages (can't carry a block breakpoint), a breakpoint
-already present.
+On OpenAI- and Gemini-shaped wires, where `cache_control` does not exist at all —
+placement has nothing to express and the split has nothing to gain (see below). Also
+inert when four breakpoints are already present, and on string-content messages.
 
-See also: [Components overview](../components.md) · [Choose a preset](../how-to/choose-a-preset.md)
+## The volatile-tail split
+
+Enabling `cacheinject` also switches on a body-level repair in `apply/prefixsplit.go`
+that no breakpoint placement can achieve, because a cache entry hashes **everything
+before** its breakpoint and no position can exclude part of a single block.
+
+Claude Code appends a live environment snapshot to the **end** of its main system
+block:
+
+```
+Current branch: main
+...
+Recent commits:
+0898367954 SWE-bench
+```
+
+Measured across 50 SWE-bench tasks, that block is ~7,017 tokens of which the first
+**6,921 (98.4%)** are byte-identical across sessions — but it is one cacheable unit
+with its breakpoint at the end, so the hash covers the churning tail and the shared
+98.4% is re-written every session.
+
+The tail is real content: it cannot be moved or dropped without lying to the model
+about the repo state. It can be **split** — `[stable][volatile]` as two text blocks
+with the same concatenated text, breakpoint on the first. Adjacent text blocks
+concatenate, so the model sees a **byte-identical** prompt while the provider gains a
+hash boundary that excludes the churn. Asserted in `TestSplitIsConcatenationIdentical`.
+
+**Explicit-breakpoint providers only** (Anthropic family). Under an implicit
+longest-prefix cache (OpenAI, Gemini) the match already ends at the divergence, so a
+block boundary buys nothing.
+
+### What it is worth — measured four ways
+
+**1. Structural — is there a target?** Across 50 real Claude Code sessions, the
+stable half of that block takes **1** distinct value while the volatile tail takes
+**50**. So without the split the breakpoint hashes stable+volatile, a value unique to
+each session, and the 6,877-token stable half can never be read from another
+session's cache.
+
+**2. Mechanical — does the transform do what it claims?** Through the live proxy on a
+real captured body: system blocks `3 → 4`, the concatenation byte-identical, and
+breakpoints `2 → 2` (no slot consumed).
+
+**3. Isolated live A/B — does the provider actually cache it?** Two sessions differing
+*only* in the git snapshot, same breakpoints, same order, judged by
+`cache_read_input_tokens` from the API. Three runs, byte-identical results:
+
+| arm | session-2 read | session-2 write | hit |
+|---|--:|--:|--:|
+| without split | **0** | 8,882 | **0.0%** |
+| **with split** | **8,597** | **0** | **96.7%** |
+
+At Sonnet 5 rates ($2.50/MTok write, $0.20/MTok read) that first request of a warm
+session costs **$0.022205 → $0.001719**, i.e. **$0.0205 saved per session (−92.3%)**.
+Per model, per session: Sonnet 5 **$0.0205** (**$0.0307** from 2026-09-01),
+Opus 5 **$0.0512**, Haiku 4.5 **$0.0102**. At 100k sessions on Sonnet 5 that is
+**$2,048**.
+
+The saving is **once per session, not once per turn**: within a session, turns 2…n
+already read the prefix turn 1 wrote in *both* arms. What the split changes is the
+first request of each warm session, which would otherwise re-*write* the system
+prompt. A cold first session pays the same either way.
+
+**4. End-to-end — what survives in a real agent run?** Terminal-Bench,
+`fix-code-vulnerability`, 3 trials, sequential:
+
+| trial | without | with split | saved |
+|---|--:|--:|--:|
+| 1 | $0.2003 | $0.1368 | $0.0636 (31.7%) |
+| 2 | $0.1828 | $0.1198 | $0.0630 (34.5%) |
+| 3 | $0.2003 | $0.1280 | $0.0723 (36.1%) |
+| **mean** | **$0.1945** | **$0.1282** | **$0.0663 (34.1%)** |
+
+Cache-write median **−58.8%**; cost median **−34.5%**, spread **4.4 pp** across
+trials.
+
+Note the end-to-end saving ($0.0663) is **3.2× the isolated per-session figure**
+($0.0205): trial 1 recovered 29,882 cache-write tokens, 3.4× the 8,882-token system
+prompt. Claude Code issues sub-agent and side requests that each re-send the same
+system prompt, and each was independently re-writing it. So the benefit accrues per
+*request carrying the system prompt*, not per session.
+
+!!! note "What is NOT claimed"
+    A second Terminal-Bench task (`git-leak-recovery`) was **within noise** — its
+    step count moved 10→15, 12→13, 10→16 between arms, giving a 95 pp spread on
+    cache-write. Its numbers are not quoted, and neither is the pooled two-task total
+    (−16.1%), which would inherit a delta that task did not earn. All figures are
+    Sonnet 5 rates on one benchmark; treat 34.1% as one task measured three times,
+    not a fleet average.
+
+    **Placement contributes $0 of this.** `acted=0` across 69 runs — every dollar
+    above is the split.
+
+!!! warning "A withdrawn claim, kept visible on purpose"
+    An earlier version of this work also reordered the first system block, on the
+    belief that Claude Code's `x-anthropic-billing-header: cc_version=2.1.222.<hex>;`
+    was a **per-session nonce** poisoning a 28,297-token shared prefix.
+
+    That was wrong. Across 74 captured conversations the suffix takes only **49
+    distinct values**, and one value (`38c`) appears in **24 different
+    conversations** — a per-session nonce cannot repeat across sessions. It tracks
+    the claude-code **build**, not the session. The original conclusion came from a
+    13-task sample where every value happened to differ.
+
+    A sequential Terminal-Bench run then confirmed the consequence directly: with
+    the header present, session 2 read **38,855 tokens (92.8% hit)** that session 1
+    had written. **Cross-session reuse already works.** There was no poisoning to
+    repair, so the reorder and its provider-generalisation were removed.
+
+    A live Azure OpenAI experiment did show 0% → 99.0% cache hit from moving a
+    leading volatile block — but the nonce in that experiment was **synthetic**,
+    constructed to demonstrate the mechanism. It proved that a volatile leading block
+    breaks an implicit prefix cache; it did not show that any real agent sends one.
+
+Full derivation, retractions, and reproduction steps:
+`bob-experiments/docs/cache-optimization.md`.
+
+See also: [Components overview](../components.md) ·
+[Choose a preset](../how-to/choose-a-preset.md)


### PR DESCRIPTION
## What this does

Two changes to how `context-guru` handles prompt caching, both driven by measurement on real captured traffic.

### 1. `cacheinject`'s placement policy is now solved, not guessed

With `R=0.1` (cache read), `W=1.25` (5m write) and `1.0` (uncached) as multipliers on the base input rate, four inequalities fix the policy:

- a token resent `k` more times is cheaper written when `W + kR < 1 + k`, i.e. `k > (W−1)/(1−R) = 0.28` → always breakpoint the **last** block;
- writes bill as a **span** (highest breakpoint − read point), not per breakpoint, so an extra breakpoint below the top costs **exactly zero** and no slot should sit idle;
- a divergence at block `d` makes everything above it unmatchable, so anchoring at `d−1` recovers `0.9` per token — worth **12.5×** more than positional tuning, because it restores read→read rather than read→write;
- an anchor must sit at a **turn-stable** index, since a position is only readable on turn `t+1` if it was written on turn `t`.

**The previous policy was a regression.** It put its breakpoint on the message *before* the newest turn, which shortens the cached prefix every turn: **+5.50%** standalone and **+9.21%** layered on an agent that sets its own breakpoints (simulated on a stream calibrated to within 2.10pp of a live run's billed cache-hit rate). Its docs called the savings "invisible to `/stats`", which made a negative effect unfalsifiable.

Against Claude Code this policy correctly places **nothing** — `acted=0` across 69 live runs, because claude-code already marks its own final message on 98.7% of requests. Its value here is *not losing* the 5.5%; it earns its keep on agents that don't mark their own tail, or whose prefix mutates mid-conversation.

`ttl` is now configurable (`5m`|`1h`, validated at load). A 1h write costs 2.0× instead of 1.25× and only pays when `P(entry lapses before reuse) > 83.3%`; measured over 1,905 real turns that is ~0, and reads refresh the TTL for free, so 5m stays the default.

### 2. A volatile-tail split, gated on `cacheinject` being configured

Claude Code appends live git state to the **end** of its main system block. That block is 7,037 tokens whose first **6,877 (97.7%)** are byte-identical across sessions — but it is one cacheable unit with its breakpoint *after* the churn, so the shared part is re-written every session.

Splitting into `[stable][volatile]` with the breakpoint on the stable half is **byte-identical in concatenation** (adjacent text blocks concatenate), so the model sees the same prompt.

## What it saves — measured four ways

**Structural.** Across 50 real Claude Code sessions the stable half takes **1** distinct value, the volatile tail **50** — so the breakpoint hash was unique per session.

**Mechanical.** Through the live proxy on a real captured body: system blocks 3→4, concatenation byte-identical, breakpoints 2→2 (no slot consumed).

**Isolated live A/B** — two sessions differing *only* in the git snapshot, same breakpoints, judged by `cache_read_input_tokens` from the API. Three runs, byte-identical results:

| arm | session-2 read | session-2 write | hit |
|---|--:|--:|--:|
| without split | **0** | 8,882 | **0.0%** |
| **with split** | **8,597** | **0** | **96.7%** |

At Sonnet 5 rates that first request of a warm session costs **$0.022205 → $0.001719** = **$0.0205 saved per session (−92.3%)**. Per session by model: Sonnet 5 **$0.0205** ($0.0307 from 2026-09-01), Opus 5 **$0.0512**, Haiku 4.5 **$0.0102**. At 100k sessions on Sonnet 5: **$2,048**.

**End-to-end** — Terminal-Bench `fix-code-vulnerability`, 3 sequential trials:

| trial | without | with split | saved |
|---|--:|--:|--:|
| 1 | $0.2003 | $0.1368 | $0.0636 (31.7%) |
| 2 | $0.1828 | $0.1198 | $0.0630 (34.5%) |
| 3 | $0.2003 | $0.1280 | $0.0723 (36.1%) |
| **mean** | **$0.1945** | **$0.1282** | **$0.0663 (34.1%)** |

Cache-write median **−58.8%**; cost median **−34.5%**, spread **4.4pp**.

The saving is **once per session, not once per turn**: within a session, turns 2…n already read the prefix turn 1 wrote in *both* arms. The end-to-end figure exceeds the per-session one because claude-code's sub-agent and side requests each re-send the same system prompt, and each was independently re-writing it.

## Scope and limits

- **Explicit-breakpoint providers only** (Anthropic family). Under an implicit longest-prefix cache (OpenAI, Gemini) the match already ends at the divergence, so a block boundary buys nothing.
- **Not claimed:** a second Terminal-Bench task was **within noise** (95pp spread on cache-write; its step count moved 10→15 between arms), so neither its numbers nor the pooled two-task total are quoted.
- **Placement contributes $0** of the above — every dollar is the split.
- Figures are Sonnet 5 rates on one benchmark: treat 34.1% as one task measured three times, not a fleet average.

## Latency

The proxy's own contribution is **~5 ms per request** across all six measured arms (0.03–0.07% of a request) against **8–18 s** of upstream time, and the `cacheonly` arm was *faster* upstream in 2 of 3 trials. An earlier apparent regression came from dividing agent wall-clock by a step count that itself differed between arms — that metric is not used here.

## A withdrawn claim, recorded in the docs

An earlier version also **reordered** the first system block, believing `x-anthropic-billing-header: cc_version=2.1.222.<hex>;` to be a per-session nonce poisoning a 28,297-token prefix.

That was wrong. Across 74 conversations the suffix takes only **49** distinct values, and one value appears in **24 different conversations** — it tracks the claude-code *build*, not the session. A sequential run then showed session 2 reading **38,855 tokens** written by session 1 with the header present. A live Azure OpenAI test did show 0% → 99.0% from moving a leading volatile block, but **that nonce was synthetic**, so it demonstrates a mechanism rather than a real defect. The reorder and its OpenAI/Gemini generalisation are **not** included, and the docs keep the counter-evidence so it isn't rediscovered.

## Safety

Fails open throughout: any parse problem returns the request untouched, and the existing top-level panic backstop forwards the original body.

Self-review caught one real defect before this went up: the split rebuilt each half as a fresh `{"type","text"}` map, silently dropping any other field on the block (citations today, whatever the API adds later) — a losslessness violation no existing test covered. It now clones the original block and replaces only `text`, and removes `cache_control` from the volatile half so the churn cannot re-enter a hashed prefix.

## Tests

**24 new tests**, full suite green, `go vet` and `gofmt` clean.

- 12 for the placement policy: breakpoint cap, respecting existing breakpoints, turn-stable anchors, string-content fallback, TTL validation.
- 12 for the split: behaviour, concatenation-identity, provider applicability, inertness on degenerate bodies, one-block cap, non-text block survival, unknown-field preservation, message integrity across the rewrite, plus wiring through `BodyFull` including the `cacheinject` gate and the bypass path.
