### PR TITLE
fix(cache): delete both breakpoint spellings from the split's volatile half

### DIFF
--- a/apply/prefixsplit.go
+++ b/apply/prefixsplit.go
@@ -114,8 +114,14 @@ func splitVolatileTail(body []byte, provider bschemas.ModelProvider) ([]byte, bo
 		stable["text"] = txt[:at]
 		volatile["text"] = txt[at:]
 		// The breakpoint belongs on the stable half only; leaving one on the volatile
-		// half would put the churn back inside a hashed prefix.
+		// half would put the churn back inside a hashed prefix. BOTH spellings must go:
+		// Bedrock/Vertex write `cachePoint` where Anthropic writes `cache_control`, and
+		// wireBreakpoints counts both (metawrite.go). Deleting only one DUPLICATES the
+		// other — the split copies the block, so a system block carrying an inline
+		// cachePoint turns 1 breakpoint into 2 and can push the wire past the provider's
+		// cap of four (measured: 4 inbound -> 5 on the wire -> 400).
 		delete(volatile, "cache_control")
+		delete(volatile, "cachePoint")
 		sb, err1 := json.Marshal(stable)
 		vb, err2 := json.Marshal(volatile)
 		if err1 != nil || err2 != nil {

--- a/apply/prefixsplit_test.go
+++ b/apply/prefixsplit_test.go
@@ -333,3 +333,31 @@ func TestUnknownFieldsNotDropped(t *testing.T) {
 			gjson.GetBytes(got, "system").Raw[:200])
 	}
 }
+
+// A Bedrock/Vertex system block can carry `cachePoint` where Anthropic writes
+// `cache_control`. The split COPIES the block, so deleting only one spelling leaves the
+// other on BOTH halves and turns one breakpoint into two. wireBreakpoints counts both
+// spellings, so that silently eats a slot from the provider's cap of four — and from a
+// request already at the cap it pushes the wire to five and takes a 400.
+func TestSplitDoesNotDuplicateBedrockCachePoint(t *testing.T) {
+	full, _, _ := blockWithGitTail(6000)
+	block := map[string]any{"type": "text", "text": full, "cachePoint": map[string]any{"type": "default"}}
+	in := sysBody(block)
+
+	before := wireBreakpoints(in)
+	got, split := splitVolatileTail(in, bschemas.Bedrock)
+	if !split {
+		t.Fatal("expected the git-tail block to split")
+	}
+	if after := wireBreakpoints(got); after != before {
+		t.Fatalf("split changed the wire breakpoint count %d -> %d; a copied cachePoint "+
+			"burns a slot from the provider's cap of four", before, after)
+	}
+	// and the churning half must not carry a breakpoint at all
+	for _, b := range gjson.GetBytes(got, "system").Array() {
+		if strings.Contains(b.Get("text").String(), "Recent commits:") &&
+			(b.Get("cachePoint").Exists() || b.Get("cache_control").Exists()) {
+			t.Fatal("the volatile half kept a breakpoint — the churn is back inside a hashed prefix")
+		}
+	}
+}


### PR DESCRIPTION
Closes nothing on its own — this is a **blocker found by integration review** of the five cache/filter/observe merges (#33, #36, #40, #42, #43). Neither per-PR review could see it.

## The defect

`splitVolatileTail` **copies** the system block it splits, then deletes `cache_control` from the churning half so the breakpoint covers only the stable text (`apply/prefixsplit.go:118`).

It did not delete **`cachePoint`** — the Bedrock/Vertex spelling of the same thing, which `wireBreakpoints` counts alongside `cache_control` (`apply/metawrite.go:117`).

So on those providers, a splittable system block carrying an inline `cachePoint` gets its breakpoint **duplicated** — one on each half, **1 → 2**. That silently spends a slot from the provider's cap of four, and from a request already at the cap it puts **5 on the wire → 400**.

## Why both reviews missed it

The two halves landed in the *same* PR (#36) but in *different files*: the split predates it, the `cachePoint` counting was added by it. And the **Anthropic path — the only one the benchmarks exercise — has no `cachePoint` to duplicate**, so no run could have surfaced it.

This is the same shape as the bug #36 was written to fix (46 breakpoints applied, 0 forwarded): a provider-specific wire detail invisible to the code path under test.

## Fix

One line, plus a comment explaining why both spellings must go.

```go
delete(volatile, "cache_control")
delete(volatile, "cachePoint")
```

## Test

`TestSplitDoesNotDuplicateBedrockCachePoint` asserts the wire breakpoint count is **unchanged across the split**, and that the volatile half keeps no breakpoint in **either** spelling.

Verified non-vacuous — with the fix reverted it fails with the exact reported symptom:

```
--- FAIL: TestSplitDoesNotDuplicateBedrockCachePoint
    prefixsplit_test.go:353: split changed the wire breakpoint count 1 -> 2;
    a copied cachePoint burns a slot from the provider's cap of four
```

## Gates

`go build -tags cg_skeleton ./...` · `go test -tags cg_skeleton ./...` · `go test -race ./apply/...` · `gofmt -l` · `go vet` — all clean.

## Related findings from the same review, NOT fixed here

Tracked separately so this stays a one-line blocker fix:

1. **The volatile-tail split is a silent no-op on Bedrock Converse.** `explicitBreakpointProvider` admits Bedrock/Vertex, but on real Converse shape `cachePoint` is its *own array entry after* the block it terminates — so the split inserts the volatile half *before* it and the breakpoint still covers the churn. The split reports `Changed: true` and `cachesplit` looks active in `/stats`, yet the −34.1% win it is credited with cannot materialize there. Same class of defect, one provider over.
2. **Observe mode leaks hypotheticals into unlabelled `/stats` fields.** `cmdfilter`'s `FilterStats` sink has no `Mode` check, so an observe-only run reports real `cmdfilter_families`/`cmdfilter_filters`/`cmdfilter_selector_misses` with **no mode label and no `potential_*` counterpart** — a consumer cannot tell enforced from hypothetical. New leakage from #42 × #43 composing.
3. **Pin-budget exhaustion can reopen the `TailOnly` fail-open** on the `/compact` route only (the chat path uses `modes.Tracker` and never consults `cg:len:`). Measurement-accuracy risk for offline eval, not live traffic.
4. **The selector-miss ledger bounds count, not key size** — replaying multimodal traffic filled the top slots with base64 PNG blobs, making the "which filter to write next" ledger unusable on that traffic.