### PR TITLE
fix(observe): serve the off-path pool's counters at /stats

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -491,6 +491,26 @@ type Snapshot struct {
 	// mode it correctly reads ~0 because that path does no pipeline work. Zeroing either
 	// would hide a true number rather than protect anyone.
 	ObserveLLMNotice string `json:"observe_llm_notice,omitempty"`
+
+	// ObserveQueue is the off-path worker pool's counter tuple, filled by the host at
+	// serve time (the pool lives in `modes`, which sits above this package). All five
+	// counters are exposed rather than just `queued` because `dropped` is the one that
+	// changes a reader's conclusion: a drop is an observation silently given up, so a
+	// rising `dropped` means the potential_*/projected_* figures UNDERSTATE what
+	// compaction would have saved. Reporting the queue depth while hiding the drops is
+	// exactly the gap noted in headroom's dashboard. Omitted when no pool is running, so
+	// a sync-only deployment shows no phantom queue.
+	ObserveQueue *QueueStats `json:"observe_queue,omitempty"`
+}
+
+// QueueStats mirrors modes.Stats. Declared here as a plain struct rather than importing
+// modes because the dependency runs the other way (modes uses metrics, not vice versa).
+type QueueStats struct {
+	Queued    int64 `json:"queued"`
+	Pending   int64 `json:"pending"`
+	Processed int64 `json:"processed"`
+	Dropped   int64 `json:"dropped"`
+	Errors    int64 `json:"errors"`
 }
 
 // SelectorMiss is one output shape that matched no filter, with how often it appeared.

--- a/proxy/modes_test.go
+++ b/proxy/modes_test.go
@@ -541,3 +541,37 @@ func settleGoroutines() {
 		time.Sleep(5 * time.Millisecond)
 	}
 }
+
+// The observe-mode docs tell operators to watch `dropped` and `errors`, and make a point
+// of contrasting that against a dashboard which reports only queue depth. The pool tracked
+// all five counters correctly and NOTHING SERVED THEM: metrics.Snapshot had no field and
+// the /stats handler never called Stats(), so the documented counter was unreachable. This
+// asserts the wiring, not the pool.
+func TestObserveQueueCountersReachStats(t *testing.T) {
+	up, _ := captureUpstream(t)
+	h, agg := modeHandler(t, modePipeline, up.URL, components.ModeObserve)
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	for i := 0; i < 3; i++ {
+		post(t, srv, dupBody())
+	}
+	awaitSnapshot(t, agg, func(s metrics.Snapshot) bool { return s.ObserveRequests > 0 })
+
+	var got metrics.Snapshot
+	res, err := http.Get(srv.URL + "/stats")
+	if err != nil {
+		t.Fatalf("GET /stats: %v", err)
+	}
+	defer res.Body.Close()
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode /stats: %v", err)
+	}
+	if got.ObserveQueue == nil {
+		t.Fatal("observe_queue absent from /stats: the pool's counters are still unreachable, " +
+			"so the documented `dropped` cannot be read by any consumer")
+	}
+	if got.ObserveQueue.Processed == 0 && got.ObserveQueue.Queued == 0 && got.ObserveQueue.Pending == 0 {
+		t.Fatalf("observe_queue served but empty after 3 observed requests: %+v", got.ObserveQueue)
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -654,6 +654,17 @@ func (h *Handler) stats(w http.ResponseWriter, _ *http.Request) {
 		snap.FrozenDropped, snap.FrozenRepaired = fl.FrozenLossStats()
 		snap.FrozenFlips = snap.FrozenDropped - snap.FrozenRepaired
 	}
+	// Off-path pool counters, same layering: the pool lives in `modes`, so `metrics` cannot
+	// read it and the host merges it here. Without this the observe-mode docs describe a
+	// `dropped` counter no consumer can reach — the pool tracked it correctly and nothing
+	// served it.
+	if h.pool != nil {
+		q := h.pool.Stats()
+		snap.ObserveQueue = &metrics.QueueStats{
+			Queued: q.Queued, Pending: q.Pending,
+			Processed: q.Processed, Dropped: q.Dropped, Errors: q.Errors,
+		}
+	}
 	json.NewEncoder(w).Encode(snap)
 }
 


### PR DESCRIPTION
Found by the docs audit in #49, which diffed every documented `/stats` field against the actual `Snapshot` struct.

## Problem

`modes.Pool` tracked `queued`/`pending`/`processed`/`dropped`/`errors` correctly — and **nothing ever read them.** `metrics.Snapshot` had no field for them and `proxy.Handler.stats` never called `Stats()`.

Meanwhile `docs/how-to/operating-modes.md` (added by #43) instructs operators to watch `dropped` and `errors`, and makes a point of contrasting that with a dashboard which reports only queue depth. **The doc described a counter no consumer could reach.**

Both halves were individually correct, which is why neither the code review nor the docs review caught it — the gap only exists between them.

## Why `dropped` in particular matters

A drop is an observation **silently given up**. So a rising `dropped` means the `potential_*`/`projected_*` figures **understate** what compaction would have saved. Serving queue depth while hiding drops is exactly the failure the doc calls out in the competitor's dashboard.

## Fix

Exposed as `observe_queue`, filled by the host at serve time (the pool lives in `modes`, which sits above `metrics`, so `metrics` cannot read it). `omitempty`, so a sync-only deployment shows no phantom queue.

`metrics` declares its own `QueueStats` rather than importing `modes` — the dependency runs the other way and importing it would invert the layering.

**Purely additive:** no existing `/stats` key renamed or removed, so `deploy/harbor/*.py` keeps parsing.

## Test

`TestObserveQueueCountersReachStats` asserts the counters arrive **over HTTP** — it tests the wiring, not the pool, which already had coverage.

Verified non-vacuous. With the wiring removed:

```
modes_test.go:571: observe_queue absent from /stats: the pool's counters are still
unreachable, so the documented `dropped` cannot be read by any consumer
```

## Gates

`go build -tags cg_skeleton ./...` · `go test -tags cg_skeleton ./...` · `go test -race ./proxy/... ./metrics/...` · `gofmt -l` · `go vet` — all clean.