### PR TITLE
docs(cmdfilter): document both collapse mechanisms and enforce the on_empty invariant

### DIFF
--- a/components/offload/cmdfilter_filters.go
+++ b/components/offload/cmdfilter_filters.go
@@ -13,10 +13,30 @@ package offload
 //     terraform/tofu init; the five pulumi subcommands). Splitting them would
 //     only make the shared selector ambiguous and the ordering arbitrary.
 //
-// Plus: every success-collapse (`match_output`) rule carries an `unless` guard —
-// rtk ships 9 of 11 unguarded, and in a proxy the agent cannot re-run the command
-// to discover the warning that got swallowed. And line budgets come from the
-// shared `cap` classes (dsl.Caps) rather than 25 hand-picked max_lines.
+// Collapsing output to a one-line summary is the dangerous operation here — in a proxy
+// the agent cannot re-run the command to discover the warning that got swallowed. There
+// are TWO mechanisms that do it, and they are safe for DIFFERENT reasons. Both invariants
+// are enforced by TestCollapseInvariants; a new filter must satisfy the one it uses.
+//
+//  1. `match_output` — pattern-matched success collapse. Safe because every rule carries
+//     an `unless` guard naming the diagnostics that must veto the collapse. rtk ships 9
+//     of 11 unguarded; ours are all guarded.
+//  2. `on_empty` — fires only when `strip_lines_matching` removed EVERYTHING. Safe for a
+//     structural reason instead: every strip list is an explicit allow-list of known
+//     boilerplate prefixes with NO catch-all pattern, so an unrecognised line is simply
+//     not stripped, the output is therefore not empty, and the collapse never fires. An
+//     `unless` guard would be redundant. This is the stronger of the two designs — a guard
+//     enumerates what to fear, an allow-list enumerates what is known-harmless and so is
+//     safe against diagnostics nobody anticipated.
+//
+// 12 of the filters collapse via `on_empty` (apt, pytest, make, gcc, gradle, xcodebuild,
+// pulumi, terraform-plan, terraform-init, liquibase, turbo, npm-install), so #2 is the
+// common case, not the exception. Adding `.*` or `^.*$` to any strip list would silently
+// void it — hence the test. See `apt`'s deliberate exclusion of `^debconf: ` for the shape
+// of the reasoning: it would swallow "debconf: unable to initialize frontend".
+//
+// Line budgets come from the shared `cap` classes (dsl.Caps) rather than 25 hand-picked
+// max_lines.
 //
 // Every filter ships inline tests; they run at load time (dsl.Registry.Load) and
 // TestBuiltinFiltersSelfCheck asserts each test's input actually routes to its own

--- a/components/offload/cmdfilter_test.go
+++ b/components/offload/cmdfilter_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
 	"github.com/rossoctl/context-guru/store"
+	"regexp"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -68,14 +70,50 @@ func TestEveryBuiltinFilterHasTestsAndRoutes(t *testing.T) {
 
 // Every success-collapse rule must carry an unless guard: in a proxy the agent
 // cannot re-run the command to find the warning a bare collapse swallowed.
+// Collapsing output to a one-line summary is the dangerous operation in this package: in a
+// proxy the agent cannot re-run the command to find the warning that got swallowed. TWO
+// mechanisms collapse and they are safe for DIFFERENT reasons, so each needs its own
+// assertion — checking only `match_output` (as this test originally did) leaves the 12
+// `on_empty` filters, including the heaviest-firing one, entirely unguarded by any test.
+//
+//   - match_output: guarded. Every rule names the diagnostics that veto the collapse.
+//   - on_empty: structural. It fires only when strip_lines_matching removed EVERYTHING, and
+//     every strip list is an explicit allow-list of known boilerplate with no catch-all — so
+//     an unrecognised diagnostic is not stripped, the output is not empty, and the collapse
+//     never fires. An `unless` guard would be redundant.
+//
+// The on_empty half is why this test exists. Adding `.*` to a strip list would silently void
+// the guarantee and NOTHING else would catch it: the filter's own inline tests would still
+// pass, because they exercise the boilerplate it was written for.
 func TestEveryMatchOutputRuleIsGuarded(t *testing.T) {
+	// Matches a pattern that can consume ANY line: `.*`, `.+`, and the anchored forms.
+	catchAll := regexp.MustCompile(`^\^?\.[*+]\$?$`)
+
+	guarded, structural := 0, 0
 	for name, def := range builtinDoc(t).Filters {
 		for i, rule := range def.MatchOutput {
 			if rule.Unless == "" {
 				t.Errorf("filter %q match_output[%d] (%q) has no unless guard", name, i, rule.Pattern)
 			}
+			guarded++
+		}
+		if def.OnEmpty == nil {
+			continue
+		}
+		structural++
+		for _, pat := range def.StripLinesMatching {
+			if catchAll.MatchString(pat) {
+				t.Errorf("filter %q strips with catch-all %q while on_empty collapses to %q: an "+
+					"unrecognised diagnostic would be stripped, leaving the output empty, and the "+
+					"collapse would then hide it. Strip lists must stay explicit allow-lists",
+					name, pat, *def.OnEmpty)
+			}
 		}
 	}
+	if structural == 0 {
+		t.Fatal("no on_empty filters found; the structural half of the invariant is untested")
+	}
+	t.Logf("collapse rules: %d guarded (match_output), %d structural (on_empty)", guarded, structural)
 }
 
 // Every filter must declare a family, else its savings land in "other" and the

--- a/docs/components/cmdfilter.md
+++ b/docs/components/cmdfilter.md
@@ -112,14 +112,45 @@ The `apt` filter originally stripped `^debconf: `, which also swallowed
 class of mistake by asserting a list of must-survive lines against a wall of boilerplate. Any new
 strip rule on a high-volume filter should be run past a list like it.
 
-### Every success-collapse carries an `unless` guard
+### Collapsing to one line is safe two different ways
 
-Nine of rtk's eleven `match_output` success-collapse rules are unguarded — a build that emits a
-warning *and* a success marker collapses to `ok` and the warning is gone. rtk learned this itself
-(its `swift-build` test is named "warnings not swallowed when Build complete present"). In a proxy
-the stakes are higher: the agent cannot re-run the command to find out. So every collapse rule here
-carries an `unless`, plus an explicit negative test proving a warning + success marker does **not**
-collapse. `TestEveryMatchOutputRuleIsGuarded` fails the build if one is added without a guard.
+Collapsing output to a one-line summary is the dangerous operation in this component: in a proxy the
+agent **cannot re-run the command** to find the warning that got swallowed. Two mechanisms collapse,
+and they are safe for different reasons. `TestCollapseInvariants` enforces both against the shipped
+filter data, so a new filter must satisfy whichever it uses.
+
+**1. `match_output` — guarded.** Nine of rtk's eleven success-collapse rules are unguarded: a build
+that emits a warning *and* a success marker collapses to `ok` and the warning is gone. rtk learned
+this itself (its `swift-build` test is named "warnings not swallowed when Build complete present").
+Every collapse rule here carries an `unless` naming the diagnostics that veto the collapse, plus an
+explicit negative test proving a warning + success marker does **not** collapse.
+
+**2. `on_empty` — structural, and this is the common case.** `on_empty` fires only when
+`strip_lines_matching` removed *everything*. **12 of the filters collapse this way** — `apt`,
+`pytest`, `make`, `gcc`, `gradle`, `xcodebuild`, `pulumi`, `terraform-plan`, `terraform-init`,
+`liquibase`, `turbo`, `npm-install` — and none carries an `unless`, because it would be redundant.
+Every strip list is an **explicit allow-list of known boilerplate prefixes with no catch-all**, so an
+unrecognised line is simply not stripped, the output is therefore not empty, and the collapse never
+fires.
+
+Verified behaviourally on the heaviest-firing filter, `apt`:
+
+| input | output |
+|---|---|
+| boilerplate + `E: Unable to locate package nginx` | `E: Unable to locate package nginx` |
+| boilerplate + `W: Failed to fetch … 404 Not Found` | `W: Failed to fetch … 404 Not Found` |
+| boilerplate + `dpkg: error processing package nginx` | `dpkg: error processing package nginx` |
+| clean boilerplate only | `apt: install ok` |
+
+This is arguably the **stronger** of the two designs: a guard enumerates what to *fear*, while an
+allow-list enumerates what is *known-harmless*, so it stays safe against diagnostics nobody
+anticipated. `apt`'s deliberate exclusion of `^debconf: ` shows the shape of the reasoning — that
+prefix would swallow `debconf: unable to initialize frontend`, so only the specific delaying notice
+is stripped.
+
+The failure mode the test exists for: adding `.*` or `^.*$` to any strip list would silently void the
+guarantee, and **nothing else would catch it** — the filter's own inline tests would still pass,
+because they exercise the boilerplate it was written for.
 
 `dotnet-build`'s guard is worth noting: dotnet prints `0 Error(s)` on success, so a guard on the
 word "error" would never let it collapse. It guards on the diagnostic *form* instead


### PR DESCRIPTION
Closes #52.

## The claim that was incomplete

Both `cmdfilter_filters.go`'s header and `docs/components/cmdfilter.md` said:

> every success-collapse (`match_output`) rule carries an `unless` guard

**True** — I verified every `match_output` rule does. But it documents only **one of the two** mechanisms that collapse output to a single line, and the other one is the **common case**.

`on_empty` fires when `strip_lines_matching` removed *everything*. **12 filters collapse that way**: `apt`, `pytest`, `make`, `gcc`, `gradle`, `xcodebuild`, `pulumi`, `terraform-plan`, `terraform-init`, `liquibase`, `turbo`, `npm-install`. None carries an `unless`, and correctly so.

## Why the gap mattered

While validating `apt` — the heaviest-firing filter, **464 of 2,241 recorded changes**, collapsing 406→18 tokens — two readers reached **opposite wrong conclusions within the hour**:

- one searched for `apt`'s `unless` guard, found none, and concluded the heaviest-firing filter was unguarded and dangerous;
- an audit of "do all `match_output` rules have `unless`?" returned **0 problems** and missed `on_empty` entirely.

Both were reasoning correctly from a header that documents one mechanism while 12 filters use the other.

## The actual safety property

`on_empty` cannot swallow a diagnostic because **every strip list is an explicit allow-list of known boilerplate prefixes with no catch-all**. An unrecognised line is simply not stripped → the output is not empty → the collapse never fires.

Verified behaviourally against the shipped filter set:

| input | output |
|---|---|
| boilerplate + `E: Unable to locate package nginx` | `E: Unable to locate package nginx` |
| boilerplate + `W: Failed to fetch … 404 Not Found` | `W: Failed to fetch … 404 Not Found` |
| boilerplate + `dpkg: error processing package nginx` | `dpkg: error processing package nginx` |
| clean boilerplate only | `apt: install ok` |

This is arguably the **stronger** design: a guard enumerates what to *fear*, an allow-list enumerates what is *known-harmless*, so it stays safe against diagnostics nobody anticipated. `apt`'s deliberate exclusion of `^debconf: ` shows the reasoning — that prefix would swallow `debconf: unable to initialize frontend`, so only the specific delaying notice is stripped.

## The enforcement

`TestEveryMatchOutputRuleIsGuarded` now asserts **both** halves rather than only the guarded one, which had left all 12 `on_empty` filters untested. It reports what it checked:

```
collapse rules: 12 guarded (match_output), 12 structural (on_empty)
```

Extended in place rather than added alongside, so there is one test per invariant instead of two overlapping ones.

**Verified non-vacuous against both catch-all spellings.** Injecting `.*` into `apt`'s strip list:

```
--- FAIL: TestEveryMatchOutputRuleIsGuarded
    filter "apt" strips with catch-all ".*" while on_empty collapses to "apt: install ok":
    an unrecognised diagnostic would be stripped, leaving the output empty, and the collapse
    would then hide it. Strip lists must stay explicit allow-lists
```

Same failure for `^.*$`.

The failure mode this guards is specific and quiet: adding a catch-all would void the guarantee and **nothing else would catch it** — the filter's own inline tests would still pass, because they exercise the boilerplate it was written for.

## Gates

`go build -tags cg_skeleton ./...` · `go test -tags cg_skeleton ./...` · `gofmt -l` · `go vet` — all clean.