### PR TITLE
test(dash): compare prices with a tolerance so the suite passes on arm64

### DIFF
--- a/dash/capture_test.go
+++ b/dash/capture_test.go
@@ -276,11 +276,21 @@ func TestPriceNeverReportsUnknownCostAsFree(t *testing.T) {
 	if e.TokenAccounting != AccountingComplete {
 		t.Errorf("accounting = %q; want complete", e.TokenAccounting)
 	}
+	// Compare with a tolerance, not ==. Price.Cost is a sum of four products, and
+	// Go PERMITS the compiler to contract `x*y + z` into a fused multiply-add (FMA),
+	// which rounds once instead of twice. Whether it does so differs between the two
+	// evaluations here — the test's literal arguments fold differently from the
+	// struct-field loads inside Price — so on arm64 the two mathematically identical
+	// sums land one bit apart (0.00327 vs 0.0032700000000000003) and an exact
+	// comparison fails. amd64 has no FMA contraction for this shape, so CI is green
+	// and the failure only appears on Apple Silicon. The property under test is the
+	// accounting, which a 1-ULP difference does not affect.
+	const eps = 1e-12
 	wantCost := p.Cost(10, 5000, 500, 100)
-	if e.CostUSD != wantCost {
+	if math.Abs(e.CostUSD-wantCost) > eps {
 		t.Errorf("cost = %v; want %v", e.CostUSD, wantCost)
 	}
-	if e.BaselineCostUSD != wantCost+200*p.CacheWrite {
+	if math.Abs(e.BaselineCostUSD-(wantCost+200*p.CacheWrite)) > eps {
 		t.Errorf("baseline = %v; want cost + 200 unique removed tokens at the cache-write rate", e.BaselineCostUSD)
 	}
 	if e.BaselineCostUSD <= e.CostUSD {


### PR DESCRIPTION
TestPriceNeverReportsUnknownCostAsFree fails on darwin/arm64 at current main,
before any other change:

    capture_test.go:281: cost = 0.00327; want 0.0032700000000000003
    capture_test.go:284: baseline = 0.00377; want cost + 200 unique removed
                         tokens at the cache-write rate

Both sides call the same modelinfo.Price.Cost with the same arguments, and
nothing in Price or Event.Price rounds. The difference is FMA. Price.Cost is a sum
of four products:

    float64(fresh)*p.Input + float64(cacheRead)*p.CacheRead +
        float64(cacheWrite)*p.CacheWrite + float64(output)*p.Output

and the Go spec PERMITS an implementation to contract x*y + z into a fused
multiply-add, which rounds once instead of twice. The contraction is applied
inconsistently between the two evaluations in the test -- the literal arguments in
the assertion fold differently from the struct-field loads inside Price -- so the
two mathematically identical sums land one bit apart, and == fails.

arm64 has an FMA instruction the compiler will use for this shape; amd64 does not
contract it. So the failure is invisible in CI (ubuntu-latest, amd64) and
reproduces for every contributor on Apple Silicon. Confirmed both ways:

    GOARCH=amd64 go test -run TestPriceNeverReportsUnknownCostAsFree ./dash/   ok
    native arm64, same test, -count=3                                         FAIL x3

The fix compares within 1e-12 instead of exact equality, with the reason recorded
in a comment so nobody "simplifies" it back. The property under test is the
accounting -- a cost we cannot compute must read as unknown, never as zero -- and a
1-ULP difference does not affect it. The surrounding exact assertions are left
alone: TokenAccounting is still compared with ==, and the ordering assertion
(baseline must exceed actual when tokens were removed) is untouched, so the test
still fails if the accounting logic regresses.

Test-only change, 12 insertions, 2 deletions, no production code. make lint,
go test -race ./... and go test -race -tags cg_skeleton ./... all pass on arm64
after it; before it, ./dash/ fails.

Worth noting for whoever owns pricing: the same pattern (comparing a float64
against a re-computation of the same expression) will keep producing
platform-dependent failures wherever it appears. This PR only fixes the one
occurrence that is failing today.
