### PR TITLE
fix(build): make the documented docker build work standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
 # context-guru-proxy: the LLM-proxy integration and eval-containers gateway.
 #
-# The module uses a local `replace github.com/maximhq/bifrost/core => ../bifrost/core`,
-# so the build context MUST be the PARENT directory that contains both repos:
+# bifrost is an ordinary published dependency, so the build context is just this
+# repo:
 #
-#   docker build -f lab-context-engineering/Dockerfile -t context-guru-proxy .
+#   docker build -t context-guru-proxy .
 #
-# (run from .../context-engineering/). CI that builds standalone should either
-# `go mod vendor` first or switch the replace to a pinned published bifrost.
-#
-# CGO is required (tree-sitter for the skeleton component), so the final image is
-# glibc-based. It also carries a shell + curl for the eval-containers
-# start/health scripts under /opt/gateway.
+# The image is glibc-based because CGO is enabled below. It also carries a shell +
+# curl for the eval-containers start/health scripts under /opt/gateway.
 FROM golang:1.26 AS build
 WORKDIR /src
-COPY bifrost/ ./bifrost/
-COPY lab-context-engineering/ ./lab-context-engineering/
-WORKDIR /src/lab-context-engineering
+COPY . .
 ARG VERSION=dev
 ARG COMMIT=none
 RUN CGO_ENABLED=1 go build \
@@ -26,8 +20,8 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /out/context-guru-proxy /opt/gateway/main
-COPY lab-context-engineering/deploy/eval-containers/start /opt/gateway/start
-COPY lab-context-engineering/deploy/eval-containers/health /opt/gateway/health
+COPY deploy/eval-containers/start /opt/gateway/start
+COPY deploy/eval-containers/health /opt/gateway/health
 RUN chmod +x /opt/gateway/start /opt/gateway/health
 EXPOSE 4000
 # Default entrypoint is the eval-containers gateway wrapper; override with

--- a/deploy/eval-containers/README.md
+++ b/deploy/eval-containers/README.md
@@ -6,12 +6,11 @@ provider. Swap it in with `EVAL_GATEWAY_IMAGE` — no agent or benchmark changes
 
 ## Build
 
-The module uses a local `replace` to `../bifrost/core`, so build from the parent
-directory that holds both repos:
+The build context is this repo — bifrost is an ordinary published dependency, so no
+sibling checkout is needed:
 
 ```sh
-cd .../context-engineering
-docker build -f lab-context-engineering/Dockerfile -t context-guru-proxy:latest .
+docker build -t context-guru-proxy:latest .
 ```
 
 ## Run under eval-containers
@@ -41,5 +40,3 @@ savings per component; per-task attribution improves once a session id is stampe
 
 - OTel `gen_ai` spans are not yet emitted (eval-containers' otelcol ingests them);
   today savings come from `/stats`.
-- The image build needs the parent-dir context (or `go mod vendor`) until bifrost
-  is pinned to a published version.

--- a/examples/llm-d-service/README.md
+++ b/examples/llm-d-service/README.md
@@ -73,13 +73,8 @@ See a real run of all three on one input, with the full `messages` before and af
 ## 3. Prerequisites
 
 - **Go 1.26** and a **C toolchain** (`CGO_ENABLED=1` — the `skeleton` component links tree-sitter via cgo).
-- A sibling **bifrost** checkout next to this repo (the module pins it with a local `replace` to
-  `../bifrost/core`). Directory layout:
-  ```
-  <parent>/
-    context-guru/     ← this repo
-    bifrost/          ← https://github.com/maximhq/bifrost
-  ```
+- Nothing else: **bifrost** is an ordinary published module dependency (`go.mod`), so this repo
+  builds standalone from a plain clone.
 - For the two **LLM** configs only: access to an LLM endpoint (any OpenAI- or Anthropic-compatible
   API, including a gateway) and its credentials.
 

--- a/examples/llm-d-service/build.sh
+++ b/examples/llm-d-service/build.sh
@@ -2,9 +2,8 @@
 # Build the context-guru compaction service (bin/context-guru-proxy).
 #
 # Requires Go 1.26 and a C toolchain: CGO_ENABLED=1 is set below because the
-# `skeleton` component links tree-sitter via cgo. The module pins bifrost with a
-# local `replace` to ../bifrost/core, so a sibling bifrost checkout must exist
-# next to the context-guru repo (see the repo README "Install").
+# `skeleton` component links tree-sitter via cgo. bifrost is an ordinary published
+# dependency, so this repo builds standalone — no sibling checkout needed.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
README.md and docs/setup.md both tell you to build the image with

    docker build -t context-guru:local .

from the repo root. That command cannot work, and this PR makes it work.

go.mod pins bifrost as an ordinary published dependency:

    require github.com/maximhq/bifrost/core v1.7.0

There is no replace directive, and docs/setup.md already says so. But the
Dockerfile was still written for the old layout, and not only in comments:

    COPY bifrost/ ./bifrost/                    # a directory that need not exist
    COPY lab-context-engineering/ ./lab-context-engineering/
    WORKDIR /src/lab-context-engineering

So the image could only be built from a PARENT directory holding a sibling
bifrost checkout, while two places in the repo documented the opposite. Run the
documented command today and the first COPY fails. That is the justification for
this change: the two halves of the repo disagreed, and the documented path was
the losing one.

What changes, per file:

- Dockerfile, the only functional change. The build context becomes the repo
  (COPY . .), the WORKDIR /src/lab-context-engineering line goes away, and the
  two runtime-stage COPY lab-context-engineering/deploy/... paths become
  deploy/.... The header comment now documents the same command README does.
- deploy/eval-containers/README.md drops the
  `cd .../context-engineering` + `-f lab-context-engineering/Dockerfile`
  incantation for a plain `docker build -t context-guru-proxy:latest .`. It also
  deletes a "Known gaps (tracked, P5)" bullet that is now factually resolved:
  "The image build needs the parent-dir context (or go mod vendor) until bifrost
  is pinned to a published version." bifrost IS pinned, so the gap no longer
  exists. If that bullet maps to a real P5 ticket, the ticket should be closed
  too.
- examples/llm-d-service/README.md removes the sibling-checkout prerequisite and
  its ASCII directory-layout block, replaced by one line saying the repo builds
  standalone from a plain clone.
- examples/llm-d-service/build.sh is a comment-only change. The go build line
  always worked; the comment just told you to go set up a sibling checkout first.

Net -15 lines. It deletes stale claims and corrects paths; it adds no new
mechanism, no Go code, and nothing that can move a benchmark number.

Verification, both directions executed rather than reasoned about:

    new Dockerfile, docker build from the repo root   rc=0, 14/14 steps, 192 MB
    OLD Dockerfile, same command                      rc=1, COPY failed:
                                                      stat bifrost/: file does
                                                      not exist
    /opt/gateway/{main,start,health} in the image      all three, executable
    CGO binary runs on debian:bookworm-slim            yes (no missing libs)
    default ENTRYPOINT /opt/gateway/start              runs, demands EVAL_MODEL
                                                       (its own contract)
    /opt/gateway/main + GET /healthz                   ok
    the image's own /opt/gateway/health                rc=0
    make lint / make test / make build                 pass

Also checked against the current tree rather than the tree this was written on:
the dashboard added in #30/#58 ships its UI through //go:embed in dash/ui.go, so
COPY . . covers it and the runtime stage needs nothing extra.

Two things deliberately left out, both reasonable review requests:

- There is still no .dockerignore, so COPY . . sends the whole working tree to
  the daemon (including bin/ and coverage.out if present). Harmless for a
  multi-stage build -- the final image receives only the compiled binary plus the
  two scripts -- but adding one would speed the build. Left out to keep this
  commit to one concern.
- CI does not build the image at all: .github/workflows/ci.yaml runs make lint,
  make cover, make build and a Trivy scan. So nothing in CI would have caught the
  original breakage, and nothing will validate this fix automatically either.
