### PR TITLE
docs(components): document marker_mode on the six pages that omit it, and collapse's max_frac

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -166,7 +166,7 @@ before:  func Add(a, b int) int {          after:  func Add(a, b int) int { … 
          }                                          <<cg:9f2a…>> [full source: call context_guru_expand]
 ```
 
-- **Config:** `min_tokens` (80, per body). Grammars: go, python, js/ts/tsx, rust, java, c/cpp,
+- **Config:** `min_tokens` (80, per body), `marker_mode`. Grammars: go, python, js/ts/tsx, rust, java, c/cpp,
   ruby, php, c#, kotlin, swift, scala. **Shines:** the `coding` preset — the agent reads big
   source files but mostly needs the shape. **Inert:** no fenced blocks, unfenced file reads,
   unknown language, skeleton not smaller than the body.
@@ -184,7 +184,7 @@ before:  <big config dump>  … (later, identical) <same big config dump>
 after:   <big config dump>  … [identical to an earlier tool output] <<cg:1c8e…>>
 ```
 
-- **Config:** `min_tokens` (100). **Shines:** agents that re-read the same file/command output
+- **Config:** `min_tokens` (100), `marker_mode`. **Shines:** agents that re-read the same file/command output
   repeatedly. **Inert:** no exact repeats, small outputs.
 
 ### `collapse`
@@ -199,7 +199,8 @@ after:   <first 20 lines>
          <last 20 lines>
 ```
 
-- **Config:** `max_tokens` (2000 threshold), `head_lines` (20), `tail_lines` (20). **Shines:** a
+- **Config:** `max_tokens` (2000 threshold), `max_frac` (fraction of the context window; wins when
+  known), `head_lines` (20), `tail_lines` (20), `marker_mode`. **Shines:** a
   catch-all last stage for huge outputs. **Inert:** output ≤ `max_tokens`, or too few lines for
   head/tail to help.
 
@@ -213,7 +214,7 @@ before:  [run 1] 3 failed, 5 passed …   [run 2 after fix] 8 passed
 after:   [superseded by a later run] <<cg:7d1c…>> [full output: …]   [run 2] 8 passed
 ```
 
-- **Config:** `min_tokens` (100). Needs ≥2 run-like outputs. **Shines:** iterative fix→re-run
+- **Config:** `min_tokens` (100), `marker_mode`. Needs ≥2 run-like outputs. **Shines:** iterative fix→re-run
   loops. **Inert:** <2 runs detected, small outputs. False positives cost only an expand
   round-trip, never data.
 
@@ -295,7 +296,7 @@ before:  [ {…}, {…}, … 200 items … ]
 after:   [ item0, item1, item2, item198, item199 ] [5 of 200 items shown; full array: call …] <<cg:…>>
 ```
 
-- **Config:** `min_items` (5), `min_tokens` (200), `keep_first` (3), `keep_last` (2). **Shines:**
+- **Config:** `min_items` (5), `min_tokens` (200), `keep_first` (3), `keep_last` (2), `marker_mode`. **Shines:**
   long homogeneous JSON arrays (list endpoints, search hits) — the `mcp` preset. **Inert:**
   non-array output, fewer than `min_items`, nothing to drop. v1 uses fixed anchors (headroom's
   Kneedle adaptive-K is a documented refinement).
@@ -308,7 +309,7 @@ ones (≥ `min_tokens`) with a short marker + stash. Complementary to the conten
 after (older):  [older tool output masked; starts: 700 701 def __rmul__(self, m): 702 …] <<cg:…>> [full output: call context_guru_expand]
 ```
 
-- **Config:** `keep_recent` (3), `min_tokens` (100), `keep_head_chars` (96). **Shines:** long agent
+- **Config:** `keep_recent` (3), `min_tokens` (100), `keep_head_chars` (96), `marker_mode`. **Shines:** long agent
   trajectories where old tool results are unlikely to matter (top lever on terminal/code traffic: 27.5%
   on Terminal-Bench, 12.5% on SWE-bench; scales down to ~4% on small structured customer-service outputs).
   **Inert:** ≤ `keep_recent` tool outputs, small outputs.
@@ -333,7 +334,7 @@ The summarizer is grounded in the **current task** (first user turn + recent tur
 
 - **Config:** `summary_level` (`concise`|`regular`|`highly_detailed`), `keep_last` (3),
   `min_tokens` (500 — span floor), `include_tool_calls` (false → tool outputs masked in the
-  trajectory), `model.source`, `trigger`, `resummarize_tokens` (6000).
+  trajectory), `model.source`, `trigger`, `resummarize_tokens` (6000), `marker_mode`.
 - **Gating + reuse:** a `trigger` (`min_request_tokens`, `min_messages`; legacy `start_from_message`
   folds into `min_messages`) gates the first summary so it fires only on a large/deep transcript.
   After that, the summary is **checkpointed per session** and **reused verbatim** (no model call, and

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -30,6 +30,8 @@ Lossy but reversible — the full original is stashed and recovered via `context
 | `max_tokens` | 2000 | Threshold above which an output is collapsed. |
 | `head_lines` | 20 | Lines kept from the start. |
 | `tail_lines` | 20 | Lines kept from the end. |
+| `max_frac` | 0 (off) | Threshold as a **fraction of the model's context window**. When the window is known this wins over `max_tokens`. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 

--- a/docs/components/dedup.md
+++ b/docs/components/dedup.md
@@ -25,6 +25,7 @@ Lossy but reversible — the duplicated output is stashed and recovered via `con
 | Key | Default | Meaning |
 |---|---|---|
 | `min_tokens` | 100 | Skip outputs smaller than this token count. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 

--- a/docs/components/failed_run.md
+++ b/docs/components/failed_run.md
@@ -53,6 +53,7 @@ Lossy but reversible — superseded runs are stashed and recovered via `context_
 | Key | Default | Meaning |
 |---|---|---|
 | `min_tokens` | 100 | Skip runs smaller than this token count. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -50,6 +50,7 @@ Lossy but reversible — the full original message is stashed in the Store and r
 | Key | Default | Meaning |
 |---|---|---|
 | `min_tokens` | 80 | Minimum body size (per body) before it is skeletonized. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 

--- a/docs/components/smartcrush.md
+++ b/docs/components/smartcrush.md
@@ -30,6 +30,7 @@ Lossy but reversible — the full original array is stashed and recovered via `c
 | `min_tokens` | 200 | Output floor before crushing. |
 | `keep_first` | 3 | Leading items kept verbatim. |
 | `keep_last` | 2 | Trailing items kept verbatim. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 

--- a/docs/components/summarize.md
+++ b/docs/components/summarize.md
@@ -51,6 +51,7 @@ recovered via `context_guru_expand` / `GET /expand`.
 | `resummarize_tokens` | 6000 | Tail growth that triggers rolling the checkpoint forward. |
 | `model.source` | `incoming` | LLM source: `incoming` (proxied model+key) or `config` (cheap model). |
 | `trigger` | — | Gates the first summary: `min_request_tokens`, `min_messages`. |
+| `marker_mode` | `full` | `full` (stash + resolvable marker) / `summary` / `off`. |
 
 ## When it shines
 


### PR DESCRIPTION
## What

`marker_mode` is the per-component **reversibility** switch:

- `full` (default) — stash the original and leave a resolvable `<<cg:HASH>>` marker, so the expand tool can restore it
- `summary` / `off` — deliberate irreversible drops

Ten components accept and honor it, but only four documented it: `mask`, `cmdfilter`, `extract`, `extract_llm`. So someone assembling a pipeline around recoverability could not learn from the docs that the other six take the same knob.

This adds the row to the six pages that omitted it — `collapse`, `summarize`, `dedup`, `failed_run`, `skeleton`, `smartcrush` — reusing the exact wording already in `mask.md`, and lists it in the matching `components.md` overview entries (which omitted it for `mask` too).

It also documents **`collapse.max_frac`**, which was undocumented entirely: it sets the collapse threshold as a *fraction of the model's context window* and **wins over `max_tokens` when the window is known** (`resolveBudget`, `components/offload/common.go:47`).

Docs only — no behavior change, no defaults touched.

## How it was found

Diffing every `yaml:"..."` struct tag under `components/` against the Configuration table on each component's page. Result before → after:

| component | undocumented knobs before | after |
|---|---|---|
| `collapse` | `marker_mode`, `max_frac` | — |
| `summarize` | `marker_mode` | — |
| `dedup` | `marker_mode` | — |
| `failed_run` | `marker_mode` | — |
| `skeleton` | `marker_mode` | — |
| `smartcrush` | `marker_mode` | — |
| `mask`, `cmdfilter`, `extract`, `extract_llm`, `format`, `toon` | — | — |

## Verification

- Every `yaml:` tag on all twelve documented components now appears on its page (re-ran the same diff: 0 remaining).
- `mkdocs build --strict` passes — the check `docs.yaml` runs on any `docs/**` change.
- Confirmed each of the six actually *honors* the knob (`parseMarkerMode` → `tryMark`/`mark`), so this documents real behavior rather than a parsed-but-ignored field.

## Two follow-ups I did not put in this PR

Happy to open either if useful — flagging rather than assuming.

1. **A prior-art / baselines page.** `mask` is the *observation-masking* baseline and `summarize` is the *summary-buffer* baseline from the agent-context literature, and it would be worth saying so with citations. The closest published head-to-head is [The Complexity Trap](https://arxiv.org/abs/2508.21433) (JetBrains Research, DL4C @ NeurIPS 2025, MIT code) — SWE-bench Verified, 500 instances, five model configs — which finds observation masking **halves cost** while matching or exceeding LLM summarization's solve rate. Its [Dec-2025 follow-up](https://blog.jetbrains.com/research/2025/12/efficient-context-management) adds the mechanism: summarization makes agents run **13–15% longer**, and it reports a **10-turn** masking window as optimal (`mask.keep_recent` defaults to 3 here). That is a documentation/positioning change, not a defaults change — measuring before moving a default is the right order.
2. **A sliding-window / last-K component.** Dropping whole *messages* by age is the most common baseline in the surrounding ecosystem (`trim_messages`, `ChatMemoryBuffer`, `BufferedChatCompletionContext`, `ChatHistoryTruncationReducer`) and no component covers it today — `mask` drops tool-output *content* by age and keeps every turn, which is a different thing. It is the baseline a reviewer asks about first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)