### PR TITLE
feat(tenant): enable textclean in the default pipeline for every tracking account

### DIFF
--- a/docs/hosted.md
+++ b/docs/hosted.md
@@ -612,12 +612,30 @@ Every new tenant starts on `codesmart` minus the LLM extractor (and minus `codes
 blind `collapse`):
 
 ```yaml
-pipeline: [format, toon, dedup, cmdfilter, extract, cachesplit]
+pipeline: [format, toon, textclean, dedup, cmdfilter, extract, cachesplit]
 components:
   extract:
     min_tokens: 400
 mode: sync
 ```
+
+`textclean` was added on 2026-08-20 and is the reason to re-read this section if you last
+saw it earlier. It strips ANSI escapes and carriage-return redraws from tool output, which
+is display noise your agent never saw rendered — so it is **lossless**, needs no marker, no
+stash and no minimum size, and is a pure function of the content, meaning it produces the
+same bytes on every turn and never invalidates your prompt cache. It exists because
+`format` and `toon` only understand JSON, and 1,724 of 1,748 distinct tool outputs measured
+on this service are not JSON. Measured saving on that corpus: −17,219 tokens, 1.73%, at zero
+upstream spend.
+
+**Whether this reached you** depends on one thing: an account with an EMPTY config tracks
+the server default and picked this up at the restart, with nothing to do. An account that
+has ever saved its own config on the settings page keeps exactly what it saved — including a
+config that happens to be identical to the old default. That is deliberate (a saved config
+is a choice, and this service does not rewrite choices), but it does mean the upgrade is not
+automatic for everyone. To take it: either add `textclean` to your own pipeline after
+`toon`, or press **Track the server default**, which hands you this document and every
+future improvement to it.
 
 `failed_run` used to be in that list and is not any more. It acted **zero** times on every
 workload measured here — 251 requests on one account (843 ms spent scanning), and 28.8 s on

--- a/tenant/supersededdefaults_test.go
+++ b/tenant/supersededdefaults_test.go
@@ -1,0 +1,40 @@
+package tenant
+
+// Internal test on purpose: supersededDefaults is unexported and stays that way. It also
+// needs no `config` import, so the rule that `tenant` does not depend on the pipeline
+// holds for the test binary too (see defaultconfig_test.go).
+
+import "testing"
+
+// The live default must never appear in the superseded list. Everything the list is for
+// depends on "matches an entry" meaning "is running an OLD default": if the current one
+// were in there, every tenant tracking today's recommendation would be classified as
+// running something stale, and any future sweep built on it would rewrite configurations
+// that are already correct.
+func TestSupersededDefaultsExcludesTheLiveDefault(t *testing.T) {
+	for i, old := range supersededDefaults {
+		if old == DefaultConfigYAML {
+			t.Errorf("supersededDefaults[%d] is byte-identical to the CURRENT "+
+				"DefaultConfigYAML; an entry means 'this value is no longer the default'", i)
+		}
+	}
+}
+
+// Duplicates are a symptom, not a bug in themselves: the same literal recorded twice means
+// a default was reverted and re-superseded, or that a commit added an entry without
+// checking. Either way the list stopped being a faithful history, which is its only job.
+func TestSupersededDefaultsHasNoDuplicatesOrBlanks(t *testing.T) {
+	seen := map[string]int{}
+	for i, old := range supersededDefaults {
+		if old == "" {
+			t.Errorf("supersededDefaults[%d] is empty; an empty stored config already means "+
+				"'tracks the server default' and must never be matched as a superseded one", i)
+			continue
+		}
+		if prev, dup := seen[old]; dup {
+			t.Errorf("supersededDefaults[%d] duplicates [%d]", i, prev)
+			continue
+		}
+		seen[old] = i
+	}
+}

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -109,12 +109,41 @@ const (
 // acted ZERO times while spending real wall clock scanning every request for superseded
 // failures (843 ms across 251 requests on one account, 28.8 s on the Terminal-Bench arm).
 // A component that has never once fired on agentic traffic is latency with a name.
-const DefaultConfigYAML = `pipeline: [format, toon, dedup, cmdfilter, extract, cachesplit]
+//
+// textclean is here because it is the cheapest thing in the catalogue that actually
+// fires. It is a Reformat, so it is LOSSLESS — no marker, no stash, no floor, a pure
+// function of the content and therefore byte-stable across turns and restarts, which is
+// the same cache posture as `format`. It handles the shape `format` and `toon` never see:
+// 1,724 of 1,748 distinct tool outputs measured on this box are not JSON. Measured
+// −17,219 tokens = 1.73% of the capture corpus, at no upstream spend and no cache churn,
+// which is why it is safe to turn on for everyone rather than offer as an opt-in.
+// Ordered after toon per the pipeline's "lossless repack first" rule, so every downstream
+// component's token counts are honest (see config.presets["general"]).
+const DefaultConfigYAML = `pipeline: [format, toon, textclean, dedup, cmdfilter, extract, cachesplit]
 components:
   extract:
     min_tokens: 400
 mode: sync
 `
+
+// supersededDefaults are the exact literals DefaultConfigYAML has previously held, newest
+// first. A tenant whose stored config matches one of these byte-for-byte is running an old
+// server default rather than a configuration they chose, so it is safe to identify — which
+// is the one thing the absence of this list made impossible (see the note on migrations).
+//
+// Recorded here at the commit that supersedes each value, while it is still known to be
+// exactly what Register wrote, because after that commit ships the knowledge is gone. It is
+// a record, not a mechanism: nothing rewrites a stored config on the strength of it. A
+// sweep, if one is ever wanted, gets to be a separate and reversible decision.
+var supersededDefaults = []string{
+	// Superseded 2026-08-20 by the addition of textclean.
+	`pipeline: [format, toon, dedup, cmdfilter, extract, cachesplit]
+components:
+  extract:
+    min_tokens: 400
+mode: sync
+`,
+}
 
 // Tenant is one user of the service.
 type Tenant struct {
@@ -1071,7 +1100,8 @@ const stampInUseAccounts = `
 // previous defaults were never recorded anywhere — no constant, no schema row, and
 // this package predates its first commit — so the match list would be a guess.
 // A guess that misses does nothing; a guess that hits deletes a configuration
-// somebody chose. Existing rows therefore keep exactly what they have, and the
+// somebody chose. supersededDefaults below is that list, started at the first commit
+// that could honestly contribute to it. Existing rows therefore keep exactly what they have, and the
 // settings page offers "Track the server default" as a one-click, audited way out,
 // pointing out when a saved config is identical to the current default. If a future
 // change to DefaultConfigYAML wants to sweep tracking tenants forward, add the


### PR DESCRIPTION
## What

Adds `textclean` to `tenant.DefaultConfigYAML`, after `toon`:

```
pipeline: [format, toon, textclean, dedup, cmdfilter, extract, cachesplit]
```

## Why this one is safe to turn on for everybody

`textclean` is a **Reformat**, not an Offload. That is the whole argument:

- **Lossless** — strips ANSI escape sequences and carriage-return redraws, which are
  display noise the agent never saw rendered. No marker, no stash, no expand-tool
  round trip, no minimum size.
- **Cache-neutral** — a pure function of the content, so it emits the same bytes on
  every turn and across process restarts. Same cache posture as `format`. It cannot
  cause the re-anchor that makes a prefix-affecting transform expensive.
- **No upstream spend** — deterministic, makes no cheap-model call, so it adds nothing
  to the shared credential and contends for no shared LLM budget. That is the bar the
  default pipeline has always been held to.
- **It covers the shape the existing lossless pair cannot see.** `format` and `toon`
  only understand JSON, and 1,724 of 1,748 distinct tool outputs measured on this
  service are not JSON.

Measured on the capture corpus: **-17,219 tokens, 1.73%**.

Ordered after `toon` per the pipeline's lossless-repack-first rule, so every downstream
component's token counts stay honest — the same order `config.presets["general"]` uses.

## Who this actually reaches

An account with an **empty** `config_yaml` tracks the server default and picked this up
at restart with nothing to do. An account that has **saved** its own config keeps exactly
what it saved — including a config byte-identical to the old default. That is deliberate:
a saved config is a choice, and this service does not rewrite choices. It does mean the
change is not automatic for all 12 accounts, and `docs/hosted.md` now says so and gives
both ways to take it.

## supersededDefaults

`migrations` carries a long-standing note: there is no data migration for stored configs
because no previous default was ever recorded anywhere, so a match list would be a guess —
and a guess that hits deletes a configuration somebody chose. The note asks that any
commit which changes `DefaultConfigYAML` record the **outgoing** literal at that commit,
while it is still known to be exactly what `Register` wrote.

This is the first commit that can honestly contribute, so it starts the list. It is a
**record, not a mechanism**: nothing rewrites a stored config on the strength of it. A
sweep, if ever wanted, stays a separate and reversible decision.

Note the linker drops it from the binary (referenced only by tests), which is fine — its
value is at source level.

## Verification

- `go test -race ./tenant/... ./dash/...` — pass
- `go test ./proxy/... ./config/... ./components/...` — pass
- `go vet ./...` — clean
- `mkdocs build --strict` — clean
- New default compiled into the shipped binary, confirmed by string match
- Two new tests: the live default must never appear in `supersededDefaults`, and the
  list must hold no duplicates or blanks

## Deployed

Live on the hosted service since 2026-08-20 10:08:27 UTC, binary md5
`eb629871c8aec6258f3eae85ca268a27`, 0 error/panic lines. `schema_version` still 6 and
all 17,177 `requests` rows plus 912 `archived_sessions` intact across the restart — this
touches no schema.