### PR TITLE
feat(cache): keep an idle prompt cache alive, price the 1h write tier, and say what cachesplit did

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -213,6 +213,15 @@ type Trace struct {
 	FilteredDeclTokens int
 	// FilteredDecls is how many declarations went, for the component's own report.
 	FilteredDecls int
+	// HeadTTL1h says this request asked for the provider's ONE-HOUR cache tier on its head
+	// breakpoints (`tools`, `system`) while leaving the trailing message breakpoint at five
+	// minutes. False on every request unless the account opted in.
+	HeadTTL1h bool
+	// HeadTTLTokens is the size of the prefix that 1h entry covers — the numerator of the
+	// head share f, on which the whole mixed-TTL economics is linear. Measured rather than
+	// assumed, because f was the one input R4's simulation could not read off the database
+	// and had to parameterise.
+	HeadTTLTokens int
 	// Run is the pipeline's aggregate report (nil when the pipeline never ran).
 	Run *components.RunReport
 	// Changes lists each rewritten message's before/after text (clipped).
@@ -357,12 +366,23 @@ func BodyOpts(ctx context.Context, pipe *components.Pipeline, st store.Store, o 
 		}
 	}
 
+	// Mixed TTL: ask for the one-hour tier on the head's existing breakpoints. Here for the
+	// third time for the same reason as the two rewrites above — it edits `tools` and
+	// `system`, top-level fields the pipeline never sees, and it must land before any byte
+	// offset into the body is taken. It adds no breakpoint, so it cannot breach the
+	// provider's cap of four. See headttl.go; off unless the host asks.
+	headTTL1h, headTTLTokens := false, 0
+	if !bypass && o.HeadTTL1h && o.HeadTTLMinTokens > 0 {
+		body, headTTL1h, headTTLTokens = upgradeHeadTTL(body, provider, o.HeadTTLMinTokens)
+	}
+	tr.HeadTTL1h, tr.HeadTTLTokens = headTTL1h, headTTLTokens
+
 	msgsRaw := gjson.GetBytes(body, "messages")
 	if !msgsRaw.Exists() || !msgsRaw.IsArray() {
 		// Assign rather than return a fresh Result: res already carries the trace fields
 		// set above, and a bypassed request that also lacks a messages array must still
 		// report itself as bypassed rather than as "no messages".
-		res.Body, res.Changed = body, toolSchema || filteredDecls > 0
+		res.Body, res.Changed = body, toolSchema || filteredDecls > 0 || headTTL1h
 		tr.FilteredDeclTokens, tr.FilteredDecls = filteredTokens, filteredDecls
 		return res
 	}
@@ -402,7 +422,7 @@ func BodyOpts(ctx context.Context, pipe *components.Pipeline, st store.Store, o 
 	msgs := msgsRaw.Array()
 	norm, slots := normalize(provider, msgs)
 	if len(norm) == 0 {
-		res.Body, res.Changed = body, systemSplit || toolSchema || filteredDecls > 0 // keep the envelope rewrites even with nothing to compact
+		res.Body, res.Changed = body, systemSplit || toolSchema || filteredDecls > 0 || headTTL1h // keep the envelope rewrites even with nothing to compact
 		tr.FilteredDeclTokens, tr.FilteredDecls = filteredTokens, filteredDecls
 		return res
 	}

--- a/apply/headttl.go
+++ b/apply/headttl.go
@@ -74,6 +74,13 @@ var headTTLPaths = [...]string{"tools", "system"}
 // sign. Gating on SIZE does change it (+$48.81 measured), because it excludes the
 // small-prefix requests that pay a premium and can never produce a large miss.
 //
+// ponytail: the gate is evaluated per request, so a session growing across the threshold starts
+// asking for 1h mid-conversation and a compaction can take it back — the head is then re-labelled
+// and, because this never STRIPS an existing ttl, a request can carry 1h while its neighbours do
+// not. Harmless while this is off and while the provider downgrades it anyway (a differing ttl
+// does not change the prefix hash, so neither direction costs a cache miss); if it is ever
+// switched on for real, latch the decision per session instead of recomputing it.
+//
 // The size is estimated as len(body)/4 rather than counted. This runs before any byte offset
 // into the body is taken and therefore before anything has been tokenized, and a BPE pass
 // over a whole request to decide a coarse 50,000-token threshold would cost more than the

--- a/apply/headttl.go
+++ b/apply/headttl.go
@@ -1,0 +1,160 @@
+package apply
+
+import (
+	"log/slog"
+	"strconv"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/internal/tokens"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Mixed-TTL: a one-hour anchor on the request's HEAD, the five-minute default on its tail.
+//
+// The provider offers two cache lifetimes, and the naive reading of that — ask for 1h
+// everywhere, stop losing prefixes to idle gaps — loses money. The premium is levied on
+// every request that CREATES an entry while the benefit lands only on the ones that would
+// otherwise have missed, and on this service's traffic those populations differ by fifty
+// times: measured over 19,805 production requests, a blanket 1h costs an extra $773.00 on
+// 14,499 cache-creating requests to recover $754.66 on 290, net **−$18.34**.
+//
+// Mixed TTL fixes the arithmetic rather than the probability. Billing splits at three
+// positions — a read for the highest cache hit, a 1h write for the segment between the 1h
+// and 5m breakpoints, a 5m write for the rest — so labelling ONLY the head 1h pays the 2.0x
+// premium on the head alone. The premium then lands on head-write events (769 in the
+// window) instead of on every writer, and both sides of the ledger scale linearly in the
+// head's share f of what gets written, which fixes the ratio at 1.79:1 and means the sign
+// never flips: net +$20.19 at f=0.10, +$60.56 at f=0.30.
+//
+// Three constraints make this the design that fits, and each is load-bearing:
+//
+//   - **It adds no breakpoint.** The cap is four per request and production's modal layout
+//     already uses three (two `system`, one trailing content block, 60.6% of requests and
+//     88.9% of spend); 16.1% are already AT four, where adding one is a 400 rather than a
+//     cost regression. Re-labelling an existing mark's `ttl` spends no slot, which is why
+//     this is reachable where a genuinely new split is not.
+//   - **1h entries must appear BEFORE 5m ones.** The head does, by construction: the
+//     provider hashes `tools` → `system` → `messages`, so anything in the first two arrays
+//     precedes every message breakpoint. This function only ever writes 1h into the head,
+//     so it cannot produce the illegal order.
+//   - **The 1h tier must actually arrive, and on the models that carry this service's spend it
+//     does not.** Measured live on this gateway, one request each with the head labelled 1h:
+//     `aws/claude-haiku-4-5` came back with `ephemeral_1h_input_tokens: 36,251` of 36,574
+//     written — GRANTED; `aws/claude-sonnet-5` came back with `ephemeral_1h_input_tokens: 0`
+//     and all 48,212 tokens on the 5-minute tier — silently downgraded, with an otherwise
+//     normal 200. So the `ttl` field is NOT stripped in transit (Haiku honouring it proves it
+//     arrives); Bedrock's 1h support simply covers the Claude 4.5 family, and this service's
+//     spend is Opus 5, Opus 4.8, Sonnet 5 and Opus 4.6. Zero 1h writes appear in 19,805
+//     production requests, which is the same fact seen from the billing side.
+//
+//     Hence: implemented, verifiable, and off. `Usage.CacheWrite1h` is what says whether a
+//     request that asked for 1h got it, and while that is zero on a model the honest
+//     projection for this policy on that model is $0.
+//
+// Fails open: any parse trouble returns the input untouched.
+
+// headTTLPaths are the arrays whose breakpoints sit in the hashed prefix ahead of every
+// message — the head. `tools` and `system` only: a mark inside `messages` is the tail, and
+// promoting it to 1h is both the losing blanket policy and the illegal ordering.
+var headTTLPaths = [...]string{"tools", "system"}
+
+// upgradeHeadTTL re-labels the head's existing cache breakpoints as one-hour entries and
+// reports the token size of the prefix they cover.
+//
+// headTokens is the numerator of the head share f, and it is measured here because this is
+// the only place that knows which marks were promoted. It is the honest size of the 1h
+// entry: the tokens of `tools` plus the `system` blocks up to and including the LAST
+// promoted mark. Everything after it stays on the 5m tier and is not part of the premium.
+//
+// minTokens gates it on the request's own size. A dollar filter, not a probability filter:
+// gating this on the best available predictor of a long idle gap leaves the net unchanged
+// (−$18.32 against −$18.34 blanket), because premium and benefit scale with the same
+// `cache_write` on the same requests and multiplying both by a probability cannot change the
+// sign. Gating on SIZE does change it (+$48.81 measured), because it excludes the
+// small-prefix requests that pay a premium and can never produce a large miss.
+//
+// The size is estimated as len(body)/4 rather than counted. This runs before any byte offset
+// into the body is taken and therefore before anything has been tokenized, and a BPE pass
+// over a whole request to decide a coarse 50,000-token threshold would cost more than the
+// policy earns. Same estimate, same reason, as splitVolatileTail's own floor.
+func upgradeHeadTTL(body []byte, provider bschemas.ModelProvider, minTokens int) (out []byte, upgraded bool, headTokens int) {
+	if !explicitBreakpointProvider(provider) {
+		return body, false, 0 // no explicit breakpoints, so no TTL to state
+	}
+	if len(body)/4 < minTokens {
+		return body, false, 0
+	}
+	next := body
+	for _, arr := range headTTLPaths {
+		res := gjson.GetBytes(next, arr)
+		if !res.Exists() || !res.IsArray() {
+			continue
+		}
+		elems := res.Array()
+		for i := range elems {
+			// Only an EXISTING mark is promoted. Writing a `cache_control` where there was
+			// none would add a breakpoint, and on the 16.1% of requests already at the cap
+			// of four that is a 400 from the provider rather than a worse price.
+			cc := elems[i].Get("cache_control")
+			if !cc.IsObject() {
+				continue
+			}
+			if cc.Get("ttl").String() == "1h" {
+				// Already 1h — count it as head all the same, so the reported size matches
+				// what the provider will bill at the 1h tier.
+				upgraded = true
+				continue
+			}
+			set, err := sjson.SetBytes(next, arr+"."+strconv.Itoa(i)+".cache_control.ttl", "1h")
+			if err != nil {
+				return body, false, 0 // fail open, whole-body: a half-labelled head is worse than none
+			}
+			next, upgraded = set, true
+		}
+	}
+	if !upgraded {
+		return body, false, 0
+	}
+	headTokens = headPrefixTokens(next)
+	slog.Debug("context-guru: asked for the 1h cache tier on the head breakpoints",
+		"provider", provider, "head_tokens", headTokens, "body_bytes", len(body))
+	return next, true, headTokens
+}
+
+// headPrefixTokens counts the prefix the head's 1h entry covers: all of `tools`, plus the
+// `system` blocks up to and including the last one carrying a breakpoint.
+//
+// Counted over the JSON of the tool declarations and the TEXT of the system blocks, which
+// is what the provider hashes and bills. It is an estimate in the same sense
+// splitVolatileTail's stableTokens is — BPE over our own reconstruction rather than the
+// provider's block-granular accounting — so it is used for measuring f and never for
+// pricing a request. The billed figure comes from `usage`.
+//
+// Only called when the upgrade actually fires, which is off by default and gated on size:
+// a BPE pass over a ~48k-token head is not something to spend on every request.
+func headPrefixTokens(body []byte) int {
+	n := 0
+	gjson.GetBytes(body, "tools").ForEach(func(_, v gjson.Result) bool {
+		n += tokens.Count(v.Raw)
+		return true
+	})
+	sys := gjson.GetBytes(body, "system")
+	if !sys.Exists() {
+		return n
+	}
+	if !sys.IsArray() {
+		return n + tokens.Count(sys.String()) // a string system prompt is the whole head
+	}
+	blocks := sys.Array()
+	last := -1
+	for i := range blocks {
+		if blocks[i].Get("cache_control").IsObject() {
+			last = i
+		}
+	}
+	for i := 0; i <= last && i < len(blocks); i++ {
+		n += tokens.Count(blocks[i].Get("text").String())
+	}
+	return n
+}

--- a/apply/headttl_test.go
+++ b/apply/headttl_test.go
@@ -1,0 +1,151 @@
+package apply
+
+import (
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// A Claude Code-shaped request: two `system` breakpoints and one on the last content block,
+// which is the (2,0,0,1) layout carrying 86.4% of production spend and 100% of the
+// addressable TTL misses. Padded past the 50,000-token size gate.
+func headTTLBody() []byte {
+	pad := strings.Repeat("context ", 30000) // ~240 KB, comfortably over 50k estimated tokens
+	return []byte(`{"model":"aws/claude-opus-5",` +
+		`"tools":[{"name":"Bash","description":"` + pad + `","input_schema":{"type":"object"},` +
+		`"cache_control":{"type":"ephemeral"}}],` +
+		`"system":[{"type":"text","text":"you are claude code","cache_control":{"type":"ephemeral"}},` +
+		`{"type":"text","text":"Current branch: main","cache_control":{"type":"ephemeral"}}],` +
+		`"messages":[{"role":"user","content":[{"type":"text","text":"hi",` +
+		`"cache_control":{"type":"ephemeral"}}]}]}`)
+}
+
+// The ordering rule: "1-hour entries must appear BEFORE 5-minute ones". The head does by
+// construction, so the upgrade must label the head and leave every message breakpoint alone —
+// labelling a message breakpoint 1h would produce the illegal order AND be the blanket policy
+// that loses money.
+func TestHeadTTLUpgradesTheHeadAndNotTheTail(t *testing.T) {
+	body := headTTLBody()
+	out, up, head := upgradeHeadTTL(body, bschemas.Anthropic, 50000)
+	if !up {
+		t.Fatal("upgrade did not fire on a Claude Code-shaped body over the size gate")
+	}
+	for _, path := range []string{"tools.0.cache_control.ttl", "system.0.cache_control.ttl",
+		"system.1.cache_control.ttl"} {
+		if got := gjson.GetBytes(out, path).String(); got != "1h" {
+			t.Errorf("%s = %q, want \"1h\"", path, got)
+		}
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.cache_control.ttl"); got.Exists() {
+		t.Errorf("the trailing message breakpoint was labelled %q; the tail must stay on the "+
+			"5-minute default, or the wire carries 1h AFTER 5m and the premium lands on every write",
+			got.String())
+	}
+	if head <= 0 {
+		t.Error("head tokens not measured; the whole mixed-TTL economics is linear in that share")
+	}
+}
+
+// The breakpoint budget. The provider's cap is four and 16.1% of production requests are
+// already at it, where one more is a 400 rather than a worse price. Re-labelling must never
+// add one, and must never write a mark where there was none.
+func TestHeadTTLAddsNoBreakpoint(t *testing.T) {
+	body := headTTLBody()
+	before := CountBreakpoints(body)
+	out, _, _ := upgradeHeadTTL(body, bschemas.Anthropic, 50000)
+	after := CountBreakpoints(out)
+	if before != after {
+		t.Fatalf("breakpoints changed: %+v -> %+v", before, after)
+	}
+	if before.Total() != 4 {
+		t.Fatalf("fixture should carry 4 breakpoints, got %d", before.Total())
+	}
+
+	// An unmarked head block must stay unmarked: writing a cache_control here is what turns a
+	// request at the cap into a 400.
+	noMark := []byte(`{"model":"m","system":[{"type":"text","text":"` +
+		strings.Repeat("x", 300000) + `"}],"messages":[]}`)
+	out2, up2, _ := upgradeHeadTTL(noMark, bschemas.Anthropic, 50000)
+	if up2 {
+		t.Error("reported an upgrade on a head with no breakpoint to re-label")
+	}
+	if strings.Contains(string(out2), "cache_control") {
+		t.Error("invented a breakpoint on an unmarked head block")
+	}
+}
+
+// The size gate is a DOLLAR filter: it exists to exclude the small-prefix requests that pay
+// the 2.0x premium and can never produce a large miss. Gating on a probability instead leaves
+// the net unchanged, which is why this is the gate.
+func TestHeadTTLSizeGate(t *testing.T) {
+	small := []byte(`{"model":"m","system":[{"type":"text","text":"short",` +
+		`"cache_control":{"type":"ephemeral"}}],"messages":[]}`)
+	if _, up, _ := upgradeHeadTTL(small, bschemas.Anthropic, 50000); up {
+		t.Error("upgraded a request far below the size gate")
+	}
+	if _, up, _ := upgradeHeadTTL(headTTLBody(), bschemas.Anthropic, 1<<30); up {
+		t.Error("upgraded a request below an enormous gate")
+	}
+}
+
+// Only providers that honour explicit `cache_control` have a TTL to state. On an
+// implicit-longest-prefix backend the field is meaningless and must not be written.
+func TestHeadTTLOnlyForExplicitBreakpointProviders(t *testing.T) {
+	for _, p := range []bschemas.ModelProvider{bschemas.OpenAI, bschemas.ModelProvider("gemini")} {
+		if out, up, _ := upgradeHeadTTL(headTTLBody(), p, 50000); up || strings.Contains(string(out), `"ttl"`) {
+			t.Errorf("provider %s: wrote a ttl on a backend with no explicit breakpoints", p)
+		}
+	}
+}
+
+// Idempotent: a body that already asks for 1h is reported as upgraded (so its head is
+// measured) and comes back unchanged rather than doubly labelled.
+func TestHeadTTLIdempotent(t *testing.T) {
+	once, _, head1 := upgradeHeadTTL(headTTLBody(), bschemas.Anthropic, 50000)
+	twice, up, head2 := upgradeHeadTTL(once, bschemas.Anthropic, 50000)
+	if !up {
+		t.Error("a body already on 1h reported no upgrade, so its head would go unmeasured")
+	}
+	if string(once) != string(twice) {
+		t.Error("second pass changed the body")
+	}
+	if head1 != head2 {
+		t.Errorf("head tokens differ across passes: %d vs %d", head1, head2)
+	}
+}
+
+// bodyAsksExtendedTTL is what the cold-cache logic reads to decide how long a prefix may be
+// assumed to live, so the upgrade has to be visible to it. If it were not, a request that
+// asked for 1h would still be treated as a 5-minute prefix.
+func TestHeadTTLIsVisibleToTheColdCacheLogic(t *testing.T) {
+	body := headTTLBody()
+	if bodyAsksExtendedTTL(body) {
+		t.Fatal("fixture already asks for the extended TTL")
+	}
+	out, _, _ := upgradeHeadTTL(body, bschemas.Anthropic, 50000)
+	if !bodyAsksExtendedTTL(out) {
+		t.Error("the upgraded body does not read as asking for the extended TTL")
+	}
+}
+
+// Fail open: a body that is not an object, or whose head arrays are not arrays, comes back
+// untouched rather than mangled or panicking.
+func TestHeadTTLFailsOpen(t *testing.T) {
+	for _, in := range []string{
+		`not json at all`,
+		`{"system":"a string system prompt","messages":[]}`,
+		`{"tools":42,"system":null}`,
+		`{}`,
+	} {
+		big := in + strings.Repeat(" ", 300000) // over the size gate, so the gate is not what refuses
+		out, up, _ := upgradeHeadTTL([]byte(big), bschemas.Anthropic, 50000)
+		if up {
+			t.Errorf("reported an upgrade for %q", in)
+		}
+		if string(out) != big {
+			t.Errorf("body changed for %q", in)
+		}
+	}
+}

--- a/apply/opts.go
+++ b/apply/opts.go
@@ -45,6 +45,16 @@ type Opts struct {
 	// Mode is the operating mode. Empty means components.ModeSync, so a caller that does
 	// not know about modes gets exactly today's behavior.
 	Mode components.Mode
+	// HeadTTL1h asks for the provider's one-hour cache tier on the HEAD breakpoints
+	// (`tools`, `system`) while the trailing message breakpoint stays at five minutes —
+	// the documented mixed-TTL shape. Off by default; see config.CacheConfig.HeadTTL1h for
+	// the measured reason, which is that on this deployment the tier is silently stripped
+	// before it reaches the provider.
+	HeadTTL1h bool
+	// HeadTTLMinTokens is the size gate on HeadTTL1h, in estimated tokens. 0 disables the
+	// upgrade entirely rather than defaulting, so a host that forgets to resolve its
+	// configuration asks for nothing instead of asking on every request.
+	HeadTTLMinTokens int
 	// Tracker, when set, owns the per-session cached-prefix boundary. Supplying it also
 	// removes the concurrent-turn race in the legacy read-then-deferred-write of prevLen.
 	// nil => the legacy store-backed path, unchanged for library callers and /compact.

--- a/apply/opts.go
+++ b/apply/opts.go
@@ -47,9 +47,16 @@ type Opts struct {
 	Mode components.Mode
 	// HeadTTL1h asks for the provider's one-hour cache tier on the HEAD breakpoints
 	// (`tools`, `system`) while the trailing message breakpoint stays at five minutes —
-	// the documented mixed-TTL shape. Off by default; see config.CacheConfig.HeadTTL1h for
-	// the measured reason, which is that on this deployment the tier is silently stripped
-	// before it reaches the provider.
+	// the documented mixed-TTL shape. Off by default; see headttl.go for the measured reason,
+	// which is that Bedrock grants the tier for the Claude 4.5 family and silently downgrades
+	// it for the Opus 5 / Sonnet 5 models this service actually runs.
+	//
+	// NOTE for anyone reading the cold-cache logic: setting this makes bodyAsksExtendedTTL
+	// true, so cacheTTL returns 1h and cacheIsCold becomes correspondingly permissive. That is
+	// the right behaviour when the tier is granted and a deliberate over-estimate when it is
+	// not (the safe direction — believing a cache is warm only forgoes an optimisation). It
+	// cannot affect anything today because this is off, but it is the one way this field
+	// touches shared behaviour.
 	HeadTTL1h bool
 	// HeadTTLMinTokens is the size gate on HeadTTL1h, in estimated tokens. 0 disables the
 	// upgrade entirely rather than defaulting, so a host that forgets to resolve its

--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -483,11 +483,14 @@ func main() {
 		CheapModel:   cheapModelFromEnv(),        // static "config"-source LLM for NeedsModel components
 		InjectExpand: os.Getenv("INJECT_EXPAND"), // auto (default) | always | never
 		CacheMode:    os.Getenv("CACHE_MODE"),    // auto (default) | on | off — cache-aware compaction
-		Windows:      windows,                    // dynamic context-window resolver (fraction triggers)
-		Prices:       priceResolver(windows),     // per-token rates, so each captured request is priced at write time
-		Preset:       cfg.Preset,
-		Dashboard:    rec,  // nil unless --dashboard
-		Mode:         mode, // sync (default) | observe — explicit, never inferred
+		// The single-tenant host's own `cache:` block: the idle keep-alive and the mixed-TTL
+		// head. In hosted mode each tenant's document supplies this instead (buildTenantConfig).
+		Cache:     cachePolicy(cfg.Cache),
+		Windows:   windows,                // dynamic context-window resolver (fraction triggers)
+		Prices:    priceResolver(windows), // per-token rates, so each captured request is priced at write time
+		Preset:    cfg.Preset,
+		Dashboard: rec,  // nil unless --dashboard
+		Mode:      mode, // sync (default) | observe — explicit, never inferred
 		Observe: proxy.ObserveOptions{
 			MaxQueue: cfg.Observe.MaxQueue,
 			Workers:  cfg.Observe.Workers,
@@ -702,7 +705,39 @@ func buildTenantConfig(doc []byte, e components.Emitter) (proxy.BuiltConfig, err
 	if preset == "" {
 		preset = "custom" // an explicit pipeline list; labelled so the dashboard can group it
 	}
-	return proxy.BuiltConfig{Pipe: pipe, Store: cfg.NewStore(), Mode: mode, Preset: preset}, nil
+	return proxy.BuiltConfig{Pipe: pipe, Store: cfg.NewStore(), Mode: mode, Preset: preset,
+		Cache: cachePolicy(cfg.Cache)}, nil
+}
+
+// cachePolicy maps the configuration document's `cache:` block onto the proxy's own type.
+// The mapping lives here rather than in `proxy` for the reason ConfigBuilder exists: the
+// proxy package does not depend on the configuration loader.
+func cachePolicy(c config.CacheConfig) proxy.CachePolicy {
+	// Resolve the defaults only when something is actually switched on. A parked block
+	// (`keepalive: false` with a tuned interval) must not come out looking enabled, and a
+	// zero HeadTTLMinTokens must stay zero so a host that never configured this asks for
+	// nothing rather than asking on every request.
+	if !c.KeepAlive && !c.HeadTTL1h {
+		return proxy.CachePolicy{}
+	}
+	r := c.Resolved()
+	return proxy.CachePolicy{
+		KeepAlive:        c.KeepAlive,
+		Idle:             time.Duration(r.KeepAliveIdleSeconds) * time.Second,
+		MaxPings:         r.KeepAliveMaxPings,
+		MaxUSDPerSession: r.KeepAliveMaxUSDPerSession,
+		HeadTTL1h:        c.HeadTTL1h,
+		HeadTTLMinTokens: headTTLMin(c.HeadTTL1h, r.HeadTTLMinTokens),
+	}
+}
+
+// headTTLMin returns the size gate only when the policy is on, so `HeadTTLMinTokens > 0` is
+// the single condition apply has to test.
+func headTTLMin(on bool, n int) int {
+	if !on {
+		return 0
+	}
+	return n
 }
 
 // defaultUpstreams picks the first entry of each dialect as the default a newly

--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -725,7 +725,8 @@ func cachePolicy(c config.CacheConfig) proxy.CachePolicy {
 		KeepAlive:        c.KeepAlive,
 		Idle:             time.Duration(r.KeepAliveIdleSeconds) * time.Second,
 		MaxPings:         r.KeepAliveMaxPings,
-		MaxUSDPerSession: r.KeepAliveMaxUSDPerSession,
+		MaxUSDPerPing:    r.KeepAliveMaxUSDPerPing,
+		MinPrefixTokens:  r.KeepAliveMinPrefixTokens,
 		HeadTTL1h:        c.HeadTTL1h,
 		HeadTTLMinTokens: headTTLMin(c.HeadTTL1h, r.HeadTTLMinTokens),
 	}

--- a/components/reformat/cacheinject.go
+++ b/components/reformat/cacheinject.go
@@ -53,7 +53,7 @@ const (
 // is never made worse), then spends only the leftover slots.
 //
 // 1h TTL is deliberately never used. It costs 2.0x instead of 1.25x to write and
-// only pays when p = P(gap > 5 min) exceeds (2.0−1.25)/(1−0.1) = 83.3%. Measured
+// only pays when p = P(gap > 5 min) exceeds (2.0−1.25)/(1.25−0.1) = 65.2%. Measured
 // over 1,905 real agent turns: p = 0.00% (median gap 7.6 s, max 75 s). 1h is for
 // human-in-the-loop sessions, not for an autonomous agent loop.
 type Cacheinject struct {
@@ -61,7 +61,14 @@ type Cacheinject struct {
 	//
 	// Leave it at 5m unless the deployment shape demands otherwise. By rule 2, a 1h
 	// write costs 2.0x instead of 1.25x and only pays when p = P(the entry lapses
-	// before its next reuse) exceeds (2.0-1.25)/(1-0.1) = 83.3%. Two things make p
+	// before its next reuse) exceeds (2.0-1.25)/(1.25-0.1) = 65.2%.
+	//
+	// The denominator is the 5m WRITE rate minus the read rate, not 1 minus the read rate.
+	// A lapsed entry does not re-bill at the fresh 1.0x: those tokens still carry
+	// cache_control, so the provider CREATES a new entry at 1.25x. Production ttl_expiry
+	// rows show it directly — cache_write averages 178,793 against fresh_input 1,712. The
+	// documented figure was 83.3%, wrong by 18 points; the conclusion is unchanged. Two
+	// things make p
 	// small in practice: agent turns are seconds apart (measured median 7.6 s over
 	// 1,905 real turns), and every READ refreshes the TTL for free — so a shared
 	// prefix touched by any session at least once per 5 minutes never lapses. On the

--- a/config/config.go
+++ b/config/config.go
@@ -67,16 +67,20 @@ type CacheConfig struct {
 	// is 5 minutes and "the lifetime is measured from the start of the request that writes
 	// or reads the cache entry, not from the end of its response", so the budget is 300s
 	// from the previous request's START. Simulated over the production window: X=240 wastes
-	// 175 pings on gaps that would have hit anyway, X=280 wastes 39, and the net moves from
-	// +$135.38 to +$170.08.
+	// 111 pings on gaps that would have hit anyway, X=280 wastes 53, and the net moves from
+	// +$94.85 to +$125.08.
 	KeepAliveIdleSeconds int `yaml:"keepalive_idle_seconds"`
 	// KeepAliveMaxPings is K: the most pings one idle span may send. 0 =
 	// DefaultKeepAliveMaxPings (2).
 	//
-	// K is the main control on the one waste this mechanism cannot avoid — a session that
-	// has ENDED looks exactly like one that is thinking. Session-final waste scales
-	// linearly in K (measured: 3,891 sessions x K pings), so the net peaks early and
-	// collapses: K=2 nets +$170.08, K=3 +$162.56, K=12 +$27.99, K=20 −$99.72.
+	// K is the main control on the one waste this mechanism cannot avoid — a session that has
+	// ENDED looks exactly like one that is thinking. The marginal ping's yield falls while its
+	// cost does not, so the net flattens and then collapses: K=1 nets +$85.28, K=2 +$125.08,
+	// K=3 +$130.80, K=12 +$58.35.
+	//
+	// K=2 and K=3 TIE on money — the $5 between them is inside the run-to-run wobble — so the
+	// default is 2 for the request-volume reason rather than a dollar one: 26% fewer pings on a
+	// gateway path that returned 180 HTTP 429s over the same window.
 	KeepAliveMaxPings int `yaml:"keepalive_max_pings"`
 	// KeepAliveMaxUSDPerPing refuses a ping whose projected cost exceeds this. 0 =
 	// DefaultKeepAliveMaxUSDPerPing.
@@ -94,9 +98,9 @@ type CacheConfig struct {
 	// request). 0 = DefaultKeepAliveMinPrefix.
 	//
 	// This is the gate that makes the policy deployable rather than merely profitable.
-	// Combined with skipping a session's FIRST request, it sends 8.7x fewer pings (1,060
-	// against 9,234 over the production window) for 3.3% less money, because what it drops is
-	// the near-free pings on tiny prefixes. That matters twice over: those 8,000 requests are
+	// Combined with skipping a session's FIRST request, it sends 9.8x fewer pings (912 against
+	// 8,915 over the production window) for 1.7% less money, because what it drops is the
+	// near-free pings on tiny prefixes. That matters twice over: those 8,000 requests are
 	// real load on a gateway that already returned 180 HTTP 429s in the same window, and the
 	// gate leaves 3,748 of 3,891 sessions untouched entirely — which is the fairness answer as
 	// well as the efficiency one.
@@ -114,13 +118,16 @@ type CacheConfig struct {
 	// instead — and simulates net positive at every head share, +$20.19 at f=0.10 to
 	// +$60.56 at f=0.30.
 	//
-	// It is still off, because on THIS deployment the tier does not arrive. LiteLLM's
-	// Bedrock transform drops the `ttl` field before the request leaves (its
-	// `_remove_ttl_from_cache_control`, upstream issues #19848 / #20326), and Bedrock's own
-	// 1h support covers the Claude 4.5 family rather than the Opus 5 / 4.8 / Sonnet 5 this
-	// service runs. Zero 1h writes appear in 19,805 production requests. So this ships
-	// implemented, verifiable and off: Usage.CacheWrite1h is what says whether flipping it
-	// on did anything, and until that column is nonzero the honest projection is $0.
+	// It is still off, because on the models that carry this service's spend the tier does not
+	// arrive. Measured live, one request each with the head labelled 1h:
+	// aws/claude-haiku-4-5 was GRANTED (ephemeral_1h_input_tokens 36,251 of 36,574 written),
+	// aws/claude-sonnet-5 was silently downgraded (0 of 48,212, and an otherwise normal 200).
+	// So the ttl field DOES reach the provider — Haiku honouring it proves that — and it is
+	// Bedrock's model coverage that refuses: the Claude 4.5 family, not the Opus 5 / 4.8 /
+	// Sonnet 5 this service runs. Zero 1h writes appear in 19,805 production requests, which is
+	// the same fact from the billing side. So this ships implemented, verifiable and off:
+	// Usage.CacheWrite1h is what says whether flipping it on did anything, and while that is
+	// zero on a model the honest projection for it is $0.
 	HeadTTL1h bool `yaml:"head_ttl_1h"`
 	// HeadTTLMinTokens gates the 1h head on the request's own size. 0 =
 	// DefaultHeadTTLMinTokens (50,000).

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,138 @@ type Config struct {
 	Mode string `yaml:"mode"`
 	// Observe tunes observe mode's off-path measurement; ignored in sync mode.
 	Observe ObserveConfig `yaml:"observe"`
+	// Cache holds the provider prompt-cache policies the HOST applies between and
+	// around requests, which no component can reach: keeping an idle session's cached
+	// prefix alive, and which TTL tier its breakpoints ask for. Both default to off.
+	Cache CacheConfig `yaml:"cache"`
+}
+
+// CacheConfig is the `cache:` block: provider prompt-cache policy that lives above the
+// pipeline.
+//
+// It is not a component and could not be. A component runs while a request is in flight,
+// and the expensive event here happens when NO request is in flight — a session goes idle,
+// its cached prefix lapses, and the next turn re-bills the whole prefix at the creation
+// rate. Measured on this service over 19,805 requests: 742 such requests (3.7% of traffic)
+// cost $741.07, which is 23.6% of all spend, at $0.9987 each against $0.1178 for a request
+// that hit — an 8.5x penalty. $584.83 of it sits in misses whose idle gap was under an hour.
+//
+// Every field is off or zero by default. KeepAlive spends the caller's money without the
+// caller asking, so it is opt-in per account, capped, and reported per ping.
+type CacheConfig struct {
+	// KeepAlive turns on the idle keep-alive: for a session that has been idle
+	// IdleSeconds, re-read its cached prefix once so the provider refreshes the TTL.
+	//
+	// Off by default and deliberately so. A ping is a real upstream request that costs
+	// real money on the caller's own credential — small money (a cache read is 0.1x base
+	// input where re-creating the prefix is 1.25x, so the saving:ping ratio is 11.5:1),
+	// but money the caller did not ask to spend. That is a consent decision, not a
+	// default.
+	KeepAlive bool `yaml:"keepalive"`
+	// KeepAliveIdleSeconds is X: how long a session must be idle before the first ping.
+	// 0 = DefaultKeepAliveIdle (280).
+	//
+	// 280 rather than 240 is measured, not tuned by feel. The provider's default lifetime
+	// is 5 minutes and "the lifetime is measured from the start of the request that writes
+	// or reads the cache entry, not from the end of its response", so the budget is 300s
+	// from the previous request's START. Simulated over the production window: X=240 wastes
+	// 175 pings on gaps that would have hit anyway, X=280 wastes 39, and the net moves from
+	// +$135.38 to +$170.08.
+	KeepAliveIdleSeconds int `yaml:"keepalive_idle_seconds"`
+	// KeepAliveMaxPings is K: the most pings one idle span may send. 0 =
+	// DefaultKeepAliveMaxPings (2).
+	//
+	// K is the main control on the one waste this mechanism cannot avoid — a session that
+	// has ENDED looks exactly like one that is thinking. Session-final waste scales
+	// linearly in K (measured: 3,891 sessions x K pings), so the net peaks early and
+	// collapses: K=2 nets +$170.08, K=3 +$162.56, K=12 +$27.99, K=20 −$99.72.
+	KeepAliveMaxPings int `yaml:"keepalive_max_pings"`
+	// KeepAliveMaxUSDPerSession caps what pings may cost one session. 0 =
+	// DefaultKeepAliveMaxUSD.
+	//
+	// A cap rather than trust: the per-ping cost is 0.1x the prefix, so a 400k-token
+	// session pings at ~$0.15 and a runaway would be visible only on the bill. With K=2
+	// the cap is normally slack; it is the backstop for a configuration that raises K.
+	KeepAliveMaxUSDPerSession float64 `yaml:"keepalive_max_usd_per_session"`
+
+	// HeadTTL1h asks for the ONE-HOUR tier on the request's HEAD breakpoints (`tools` and
+	// `system`) while leaving the trailing message breakpoint at 5 minutes — the provider's
+	// documented mixed-TTL shape, in the order it requires (1h entries must precede 5m
+	// ones, and the head precedes the messages by construction).
+	//
+	// Off by default for a measured reason, and NOT the one people expect. A blanket 1h TTL
+	// loses money: the 2.0x write premium falls on every cache-creating request (14,499 of
+	// them, −$773.00) while the benefit lands on 290 (+$754.66), net −$18.34. Re-labelling
+	// only the head fixes that arithmetic — the premium is paid on 769 head-write events
+	// instead — and simulates net positive at every head share, +$20.19 at f=0.10 to
+	// +$60.56 at f=0.30.
+	//
+	// It is still off, because on THIS deployment the tier does not arrive. LiteLLM's
+	// Bedrock transform drops the `ttl` field before the request leaves (its
+	// `_remove_ttl_from_cache_control`, upstream issues #19848 / #20326), and Bedrock's own
+	// 1h support covers the Claude 4.5 family rather than the Opus 5 / 4.8 / Sonnet 5 this
+	// service runs. Zero 1h writes appear in 19,805 production requests. So this ships
+	// implemented, verifiable and off: Usage.CacheWrite1h is what says whether flipping it
+	// on did anything, and until that column is nonzero the honest projection is $0.
+	HeadTTL1h bool `yaml:"head_ttl_1h"`
+	// HeadTTLMinTokens gates the 1h head on the request's own size. 0 =
+	// DefaultHeadTTLMinTokens (50,000).
+	//
+	// A dollar filter, not a probability filter, and that distinction is the whole result.
+	// Gating 1h on the best available predictor of a long gap leaves the net unchanged
+	// (−$18.32 against −$18.34 blanket) because the premium and the benefit scale with the
+	// SAME cache_write on the same requests, so multiplying both by a probability cannot
+	// flip the sign. Gating on size does flip it (+$48.81): it excludes small-prefix
+	// requests that pay the premium and can never produce a large miss.
+	HeadTTLMinTokens int `yaml:"head_ttl_min_tokens"`
+}
+
+// Keep-alive and head-TTL defaults. Named constants because the same numbers are asserted
+// in tests and quoted in the settings page, and three copies of 280 is how one of them
+// becomes 240.
+const (
+	DefaultKeepAliveIdle     = 280
+	DefaultKeepAliveMaxPings = 2
+	DefaultKeepAliveMaxUSD   = 0.25
+	DefaultHeadTTLMinTokens  = 50000
+)
+
+// Resolved returns the block with every zero replaced by its default, so callers never
+// repeat the fallbacks. Disabled flags are left alone: `enabled: false` with a tuned
+// interval is a legitimate parked configuration.
+func (c CacheConfig) Resolved() CacheConfig {
+	if c.KeepAliveIdleSeconds <= 0 {
+		c.KeepAliveIdleSeconds = DefaultKeepAliveIdle
+	}
+	if c.KeepAliveMaxPings <= 0 {
+		c.KeepAliveMaxPings = DefaultKeepAliveMaxPings
+	}
+	if c.KeepAliveMaxUSDPerSession <= 0 {
+		c.KeepAliveMaxUSDPerSession = DefaultKeepAliveMaxUSD
+	}
+	if c.HeadTTLMinTokens <= 0 {
+		c.HeadTTLMinTokens = DefaultHeadTTLMinTokens
+	}
+	return c
+}
+
+// validate rejects a cache block that would misbehave rather than accepting it and
+// degrading quietly. An idle interval at or past the provider's 5-minute lifetime cannot
+// refresh anything — the entry is gone before the ping fires — and it is the one mistake
+// here that turns a saving into a pure cost, because the ping then WRITES at 1.25x instead
+// of reading at 0.1x.
+func (c CacheConfig) validate() error {
+	if c.KeepAliveIdleSeconds < 0 || c.KeepAliveMaxPings < 0 || c.HeadTTLMinTokens < 0 ||
+		c.KeepAliveMaxUSDPerSession < 0 {
+		return fmt.Errorf("config: cache: negative values are not meaningful")
+	}
+	if c.KeepAliveIdleSeconds >= 300 {
+		return fmt.Errorf("config: cache: keepalive_idle_seconds must be under 300 "+
+			"(the provider's 5-minute lifetime runs from the previous request's START, "+
+			"so a later ping re-creates the entry at 1.25x instead of refreshing it at 0.1x); got %d",
+			c.KeepAliveIdleSeconds)
+	}
+	return nil
 }
 
 // ObserveConfig is the `observe:` block.
@@ -71,6 +203,9 @@ func LoadBytes(b []byte) (*Config, error) {
 	}
 	if _, err := c.OperatingMode(); err != nil {
 		return nil, fmt.Errorf("config: %w", err)
+	}
+	if err := c.Cache.validate(); err != nil {
+		return nil, err
 	}
 	return &c, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -74,13 +74,23 @@ type CacheConfig struct {
 	// DefaultKeepAliveMaxPings (2).
 	//
 	// K is the main control on the one waste this mechanism cannot avoid — a session that has
-	// ENDED looks exactly like one that is thinking. The marginal ping's yield falls while its
-	// cost does not, so the net flattens and then collapses: K=1 nets +$85.28, K=2 +$125.08,
-	// K=3 +$130.80, K=12 +$58.35.
+	// ENDED looks exactly like one that is thinking.
 	//
-	// K=2 and K=3 TIE on money — the $5 between them is inside the run-to-run wobble — so the
-	// default is 2 for the request-volume reason rather than a dollar one: 26% fewer pings on a
-	// gateway path that returned 180 HTTP 429s over the same window.
+	// 2 rather than 3, and NOT as a dollars-for-volume trade: the dollars are not real. K=3's
+	// +$5.72 over the 4.47-day window is $1.28/day against a bootstrap CI of [$95, $237] and a
+	// 1.4x split-half swing — statistically indistinguishable. What K=3 costs IS measurable:
+	// +34% pings (1,226 against 912) onto a gateway path that returned 180 HTTP 429s in the same
+	// window; the worst single session goes −$2.42 to −$3.63, 50% worse, with total losses +41%,
+	// against a promise to save money and not raise anyone's bill while 85 of 119 pinged sessions
+	// already lose; and the credential hold window grows 33%, 14 to 18.7 minutes.
+	//
+	// The decisive one: K=3's extra value comes from pings FURTHER from the last real request,
+	// which is exactly where the ping-onto-a-dead-entry failure lives — the single mode that
+	// inverts the feature from saving 11.5x to paying 12.5x.
+	//
+	// If K=3's dollars are ever wanted, the lever is the prefix floor rather than K:
+	// KeepAliveMinPrefixTokens at 50,000 with K=2 gives +$125.12 on 908 pings — the same money
+	// for fewer requests, a shorter hold, and no extra exposure to the dead-entry mode.
 	KeepAliveMaxPings int `yaml:"keepalive_max_pings"`
 	// KeepAliveMaxUSDPerPing refuses a ping whose projected cost exceeds this. 0 =
 	// DefaultKeepAliveMaxUSDPerPing.

--- a/config/config.go
+++ b/config/config.go
@@ -78,13 +78,29 @@ type CacheConfig struct {
 	// linearly in K (measured: 3,891 sessions x K pings), so the net peaks early and
 	// collapses: K=2 nets +$170.08, K=3 +$162.56, K=12 +$27.99, K=20 −$99.72.
 	KeepAliveMaxPings int `yaml:"keepalive_max_pings"`
-	// KeepAliveMaxUSDPerSession caps what pings may cost one session. 0 =
-	// DefaultKeepAliveMaxUSD.
+	// KeepAliveMaxUSDPerPing refuses a ping whose projected cost exceeds this. 0 =
+	// DefaultKeepAliveMaxUSDPerPing.
 	//
-	// A cap rather than trust: the per-ping cost is 0.1x the prefix, so a 400k-token
-	// session pings at ~$0.15 and a runaway would be visible only on the bill. With K=2
-	// the cap is normally slack; it is the backstop for a configuration that raises K.
-	KeepAliveMaxUSDPerSession float64 `yaml:"keepalive_max_usd_per_session"`
+	// PER PING and not per session, which is the opposite of the obvious design and is
+	// measured. Ping cost is bimodal — p50 $0.0004, mean $0.0084, p99 $0.2275, max $0.3780 —
+	// because 45.7% of pings fire on single-request sessions with ~1k-token prefixes, so the
+	// variance to guard is between pings and not between sessions. A per-SESSION budget, by
+	// contrast, truncates exactly the long large-prefix sessions that hold the value: capping
+	// the window's pings per session at 20 drops the net from +$164 to $92.34, and at 10 to
+	// $54.04. So the guard bounds the outlier ping and never the productive session.
+	KeepAliveMaxUSDPerPing float64 `yaml:"keepalive_max_usd_per_ping"`
+	// KeepAliveMinPrefixTokens is the billed-prefix floor a session must reach before it is
+	// pinged at all, in the provider's own units (cache_read + cache_write of the previous
+	// request). 0 = DefaultKeepAliveMinPrefix.
+	//
+	// This is the gate that makes the policy deployable rather than merely profitable.
+	// Combined with skipping a session's FIRST request, it sends 8.7x fewer pings (1,060
+	// against 9,234 over the production window) for 3.3% less money, because what it drops is
+	// the near-free pings on tiny prefixes. That matters twice over: those 8,000 requests are
+	// real load on a gateway that already returned 180 HTTP 429s in the same window, and the
+	// gate leaves 3,748 of 3,891 sessions untouched entirely — which is the fairness answer as
+	// well as the efficiency one.
+	KeepAliveMinPrefixTokens int `yaml:"keepalive_min_prefix_tokens"`
 
 	// HeadTTL1h asks for the ONE-HOUR tier on the request's HEAD breakpoints (`tools` and
 	// `system`) while leaving the trailing message breakpoint at 5 minutes — the provider's
@@ -122,10 +138,11 @@ type CacheConfig struct {
 // in tests and quoted in the settings page, and three copies of 280 is how one of them
 // becomes 240.
 const (
-	DefaultKeepAliveIdle     = 280
-	DefaultKeepAliveMaxPings = 2
-	DefaultKeepAliveMaxUSD   = 0.25
-	DefaultHeadTTLMinTokens  = 50000
+	DefaultKeepAliveIdle          = 280
+	DefaultKeepAliveMaxPings      = 2
+	DefaultKeepAliveMaxUSDPerPing = 0.25
+	DefaultKeepAliveMinPrefix     = 20000
+	DefaultHeadTTLMinTokens       = 50000
 )
 
 // Resolved returns the block with every zero replaced by its default, so callers never
@@ -138,8 +155,11 @@ func (c CacheConfig) Resolved() CacheConfig {
 	if c.KeepAliveMaxPings <= 0 {
 		c.KeepAliveMaxPings = DefaultKeepAliveMaxPings
 	}
-	if c.KeepAliveMaxUSDPerSession <= 0 {
-		c.KeepAliveMaxUSDPerSession = DefaultKeepAliveMaxUSD
+	if c.KeepAliveMaxUSDPerPing <= 0 {
+		c.KeepAliveMaxUSDPerPing = DefaultKeepAliveMaxUSDPerPing
+	}
+	if c.KeepAliveMinPrefixTokens <= 0 {
+		c.KeepAliveMinPrefixTokens = DefaultKeepAliveMinPrefix
 	}
 	if c.HeadTTLMinTokens <= 0 {
 		c.HeadTTLMinTokens = DefaultHeadTTLMinTokens
@@ -154,7 +174,7 @@ func (c CacheConfig) Resolved() CacheConfig {
 // of reading at 0.1x.
 func (c CacheConfig) validate() error {
 	if c.KeepAliveIdleSeconds < 0 || c.KeepAliveMaxPings < 0 || c.HeadTTLMinTokens < 0 ||
-		c.KeepAliveMaxUSDPerSession < 0 {
+		c.KeepAliveMaxUSDPerPing < 0 || c.KeepAliveMinPrefixTokens < 0 {
 		return fmt.Errorf("config: cache: negative values are not meaningful")
 	}
 	if c.KeepAliveIdleSeconds >= 300 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -135,5 +136,50 @@ func TestNoPresetEnablesCacheinjectByDefault(t *testing.T) {
 		if !found {
 			t.Errorf("preset %q lost the volatile-tail split", name)
 		}
+	}
+}
+
+// The `cache:` block, and the one mistake in it that turns a saving into a pure cost.
+func TestCacheBlockLoadsAndRejectsAnIdleThatCannotRefresh(t *testing.T) {
+	c, err := LoadBytes([]byte(`preset: off
+cache:
+  keepalive: true
+  keepalive_idle_seconds: 280
+  keepalive_max_pings: 2
+  head_ttl_1h: true
+`))
+	if err != nil {
+		t.Fatalf("a valid cache block did not load: %v", err)
+	}
+	if !c.Cache.KeepAlive || c.Cache.KeepAliveIdleSeconds != 280 || !c.Cache.HeadTTL1h {
+		t.Fatalf("cache block decoded wrong: %+v", c.Cache)
+	}
+	// Defaults are resolved on demand, not on load: `keepalive: false` with a tuned interval
+	// is a legitimate parked configuration and must not read as enabled.
+	if got := (CacheConfig{}).Resolved(); got.KeepAliveIdleSeconds != DefaultKeepAliveIdle ||
+		got.KeepAliveMaxPings != DefaultKeepAliveMaxPings ||
+		got.HeadTTLMinTokens != DefaultHeadTTLMinTokens {
+		t.Errorf("Resolved() defaults = %+v", got)
+	}
+	if (CacheConfig{}).KeepAlive {
+		t.Error("the keep-alive is on by default; it spends the caller's money and must not be")
+	}
+
+	// An idle interval at or past the provider's 5-minute lifetime cannot refresh anything:
+	// the entry is gone before the ping fires, so the ping WRITES at 1.25x instead of reading
+	// at 0.1x. It is the one configuration that inverts the mechanism, so it is refused.
+	for _, idle := range []int{300, 301, 600} {
+		if _, err := LoadBytes([]byte(fmt.Sprintf(
+			"preset: off\ncache:\n  keepalive: true\n  keepalive_idle_seconds: %d\n", idle))); err == nil {
+			t.Errorf("keepalive_idle_seconds: %d was accepted; a ping after the lifetime "+
+				"re-creates the entry at 12.5x the cost of the read it was meant to be", idle)
+		}
+	}
+	if _, err := LoadBytes([]byte("preset: off\ncache:\n  keepalive_max_pings: -1\n")); err == nil {
+		t.Error("a negative max_pings was accepted")
+	}
+	// Unknown keys under `cache:` are typos and must be loud, like every other block.
+	if _, err := LoadBytes([]byte("preset: off\ncache:\n  keepalve: true\n")); err == nil {
+		t.Error("a misspelled cache key was accepted silently")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -158,6 +158,8 @@ cache:
 	// is a legitimate parked configuration and must not read as enabled.
 	if got := (CacheConfig{}).Resolved(); got.KeepAliveIdleSeconds != DefaultKeepAliveIdle ||
 		got.KeepAliveMaxPings != DefaultKeepAliveMaxPings ||
+		got.KeepAliveMinPrefixTokens != DefaultKeepAliveMinPrefix ||
+		got.KeepAliveMaxUSDPerPing != DefaultKeepAliveMaxUSDPerPing ||
 		got.HeadTTLMinTokens != DefaultHeadTTLMinTokens {
 		t.Errorf("Resolved() defaults = %+v", got)
 	}

--- a/config/form.go
+++ b/config/form.go
@@ -86,12 +86,13 @@ type Form struct {
 
 // CacheForm is the settings page's view of the `cache:` block.
 type CacheForm struct {
-	KeepAlive                 bool    `json:"keepalive"`
-	KeepAliveIdleSeconds      int     `json:"keepalive_idle_seconds,omitempty"`
-	KeepAliveMaxPings         int     `json:"keepalive_max_pings,omitempty"`
-	KeepAliveMaxUSDPerSession float64 `json:"keepalive_max_usd_per_session,omitempty"`
-	HeadTTL1h                 bool    `json:"head_ttl_1h"`
-	HeadTTLMinTokens          int     `json:"head_ttl_min_tokens,omitempty"`
+	KeepAlive                bool    `json:"keepalive"`
+	KeepAliveIdleSeconds     int     `json:"keepalive_idle_seconds,omitempty"`
+	KeepAliveMaxPings        int     `json:"keepalive_max_pings,omitempty"`
+	KeepAliveMaxUSDPerPing   float64 `json:"keepalive_max_usd_per_ping,omitempty"`
+	KeepAliveMinPrefixTokens int     `json:"keepalive_min_prefix_tokens,omitempty"`
+	HeadTTL1h                bool    `json:"head_ttl_1h"`
+	HeadTTLMinTokens         int     `json:"head_ttl_min_tokens,omitempty"`
 }
 
 // ExtractLLMForm is the RECOMMENDED prefill for the compaction-model component — a policy
@@ -253,9 +254,10 @@ func ParseForm(doc string) (Form, error) {
 func cacheForm(c CacheConfig) *CacheForm {
 	return &CacheForm{
 		KeepAlive: c.KeepAlive, KeepAliveIdleSeconds: c.KeepAliveIdleSeconds,
-		KeepAliveMaxPings:         c.KeepAliveMaxPings,
-		KeepAliveMaxUSDPerSession: c.KeepAliveMaxUSDPerSession,
-		HeadTTL1h:                 c.HeadTTL1h, HeadTTLMinTokens: c.HeadTTLMinTokens,
+		KeepAliveMaxPings:        c.KeepAliveMaxPings,
+		KeepAliveMaxUSDPerPing:   c.KeepAliveMaxUSDPerPing,
+		KeepAliveMinPrefixTokens: c.KeepAliveMinPrefixTokens,
+		HeadTTL1h:                c.HeadTTL1h, HeadTTLMinTokens: c.HeadTTLMinTokens,
 	}
 }
 
@@ -321,9 +323,10 @@ func ApplyForm(doc string, f Form) (string, error) {
 		cb["keepalive"] = f.Cache.KeepAlive
 		cb["head_ttl_1h"] = f.Cache.HeadTTL1h
 		for k, v := range map[string]int{
-			"keepalive_idle_seconds": f.Cache.KeepAliveIdleSeconds,
-			"keepalive_max_pings":    f.Cache.KeepAliveMaxPings,
-			"head_ttl_min_tokens":    f.Cache.HeadTTLMinTokens,
+			"keepalive_idle_seconds":      f.Cache.KeepAliveIdleSeconds,
+			"keepalive_max_pings":         f.Cache.KeepAliveMaxPings,
+			"keepalive_min_prefix_tokens": f.Cache.KeepAliveMinPrefixTokens,
+			"head_ttl_min_tokens":         f.Cache.HeadTTLMinTokens,
 		} {
 			if v > 0 {
 				cb[k] = v
@@ -331,10 +334,10 @@ func ApplyForm(doc string, f Form) (string, error) {
 				delete(cb, k)
 			}
 		}
-		if f.Cache.KeepAliveMaxUSDPerSession > 0 {
-			cb["keepalive_max_usd_per_session"] = f.Cache.KeepAliveMaxUSDPerSession
+		if f.Cache.KeepAliveMaxUSDPerPing > 0 {
+			cb["keepalive_max_usd_per_ping"] = f.Cache.KeepAliveMaxUSDPerPing
 		} else {
-			delete(cb, "keepalive_max_usd_per_session")
+			delete(cb, "keepalive_max_usd_per_ping")
 		}
 	}
 
@@ -480,9 +483,10 @@ func (f Form) validate() error {
 	if f.Cache != nil {
 		if err := (CacheConfig{
 			KeepAlive: f.Cache.KeepAlive, KeepAliveIdleSeconds: f.Cache.KeepAliveIdleSeconds,
-			KeepAliveMaxPings:         f.Cache.KeepAliveMaxPings,
-			KeepAliveMaxUSDPerSession: f.Cache.KeepAliveMaxUSDPerSession,
-			HeadTTL1h:                 f.Cache.HeadTTL1h, HeadTTLMinTokens: f.Cache.HeadTTLMinTokens,
+			KeepAliveMaxPings:        f.Cache.KeepAliveMaxPings,
+			KeepAliveMaxUSDPerPing:   f.Cache.KeepAliveMaxUSDPerPing,
+			KeepAliveMinPrefixTokens: f.Cache.KeepAliveMinPrefixTokens,
+			HeadTTL1h:                f.Cache.HeadTTL1h, HeadTTLMinTokens: f.Cache.HeadTTLMinTokens,
 		}).validate(); err != nil {
 			return err
 		}

--- a/config/form.go
+++ b/config/form.go
@@ -58,6 +58,16 @@ type Form struct {
 	// bare-preset accounts on save.
 	Pipeline []string `json:"pipeline"`
 	Mode     string   `json:"mode"`
+	// Cache is the `cache:` block — host-level prompt-cache policy (the idle keep-alive and
+	// the mixed-TTL head), which is not a component and so has no descriptor to be drawn
+	// from. nil means the form does not state it and ApplyForm leaves the document's own
+	// block alone, exactly as an absent component block does.
+	//
+	// A pointer rather than a value for that reason alone: `keepalive: false` and "this form
+	// has nothing to say about the cache" are different instructions, and with a value type
+	// every save from a page that had not drawn the control would switch a tenant's
+	// keep-alive off.
+	Cache *CacheForm `json:"cache,omitempty"`
 	// Components holds, per component name, the DOTTED key paths that component's block
 	// actually states — `{"extract_llm": {"cold_cache.min_tokens": 800}}`. Only keys the
 	// document really carries are present: an absent key means "the component's default",
@@ -72,6 +82,16 @@ type Form struct {
 	// and with the YAML box gone there is no other way to correct the document from the
 	// page. Fixing it needs the account editor, which still takes a document.
 	ParseError string `json:"parse_error,omitempty"`
+}
+
+// CacheForm is the settings page's view of the `cache:` block.
+type CacheForm struct {
+	KeepAlive                 bool    `json:"keepalive"`
+	KeepAliveIdleSeconds      int     `json:"keepalive_idle_seconds,omitempty"`
+	KeepAliveMaxPings         int     `json:"keepalive_max_pings,omitempty"`
+	KeepAliveMaxUSDPerSession float64 `json:"keepalive_max_usd_per_session,omitempty"`
+	HeadTTL1h                 bool    `json:"head_ttl_1h"`
+	HeadTTLMinTokens          int     `json:"head_ttl_min_tokens,omitempty"`
 }
 
 // ExtractLLMForm is the RECOMMENDED prefill for the compaction-model component — a policy
@@ -186,6 +206,7 @@ func ParseForm(doc string) (Form, error) {
 	c, strictErr := LoadBytes([]byte(doc))
 	if strictErr == nil {
 		f.Pipeline, f.Mode = c.Pipeline, c.Mode
+		f.Cache = cacheForm(c.Cache)
 		// LoadBytes is strict about the top level but hands each component's block to its
 		// constructor as an opaque node, and THAT is where the strict check now lives. So a
 		// document with `min_tokns: 5000` under a component loads and does not build: the
@@ -223,6 +244,19 @@ func ParseForm(doc string) (Form, error) {
 	// that does not load" rather than draw them as fact and accept a save over them.
 	f.ParseError = strictErr.Error()
 	return f, nil
+}
+
+// cacheForm renders the loaded `cache:` block for the settings page. Always non-nil on a
+// document that loaded: the page draws an unchecked box for an absent block, and a save from
+// it then states `keepalive: false` explicitly, which is what the reader of the document
+// should see.
+func cacheForm(c CacheConfig) *CacheForm {
+	return &CacheForm{
+		KeepAlive: c.KeepAlive, KeepAliveIdleSeconds: c.KeepAliveIdleSeconds,
+		KeepAliveMaxPings:         c.KeepAliveMaxPings,
+		KeepAliveMaxUSDPerSession: c.KeepAliveMaxUSDPerSession,
+		HeadTTL1h:                 c.HeadTTL1h, HeadTTLMinTokens: c.HeadTTLMinTokens,
+	}
 }
 
 // readBlocks pulls every DECLARED key each component's block actually states. Keys the
@@ -277,6 +311,31 @@ func ApplyForm(doc string, f Form) (string, error) {
 	}
 	if f.Mode != "" {
 		m["mode"] = f.Mode
+	}
+	// The cache block. Only the keys the form states, and only when it states any: writing
+	// zeroes for the tuning fields would freeze today's defaults into every document that
+	// ever visited the settings page, which is the same mistake prefilling component
+	// defaults was (R3 in the settings docs).
+	if f.Cache != nil {
+		cb := child(m, "cache")
+		cb["keepalive"] = f.Cache.KeepAlive
+		cb["head_ttl_1h"] = f.Cache.HeadTTL1h
+		for k, v := range map[string]int{
+			"keepalive_idle_seconds": f.Cache.KeepAliveIdleSeconds,
+			"keepalive_max_pings":    f.Cache.KeepAliveMaxPings,
+			"head_ttl_min_tokens":    f.Cache.HeadTTLMinTokens,
+		} {
+			if v > 0 {
+				cb[k] = v
+			} else {
+				delete(cb, k)
+			}
+		}
+		if f.Cache.KeepAliveMaxUSDPerSession > 0 {
+			cb["keepalive_max_usd_per_session"] = f.Cache.KeepAliveMaxUSDPerSession
+		} else {
+			delete(cb, "keepalive_max_usd_per_session")
+		}
 	}
 
 	// What the STORED document runs, so a component leaving the pipeline can be told apart
@@ -417,6 +476,16 @@ func (f *Form) normalize() {
 func (f Form) validate() error {
 	if f.Mode != "" && f.Mode != "sync" && f.Mode != "observe" {
 		return fmt.Errorf("config: mode %q is not sync or observe", f.Mode)
+	}
+	if f.Cache != nil {
+		if err := (CacheConfig{
+			KeepAlive: f.Cache.KeepAlive, KeepAliveIdleSeconds: f.Cache.KeepAliveIdleSeconds,
+			KeepAliveMaxPings:         f.Cache.KeepAliveMaxPings,
+			KeepAliveMaxUSDPerSession: f.Cache.KeepAliveMaxUSDPerSession,
+			HeadTTL1h:                 f.Cache.HeadTTL1h, HeadTTLMinTokens: f.Cache.HeadTTLMinTokens,
+		}).validate(); err != nil {
+			return err
+		}
 	}
 	all := components.AllFields()
 	for _, name := range sortedKeys(f.Components) {

--- a/dash/event.go
+++ b/dash/event.go
@@ -738,7 +738,8 @@ func (e *Event) cachesplitSavedUSD(p modelinfo.Price) float64 {
 //     credited to a mechanism that was switched off.
 //   - The gap exceeded the provider's lifetime. Inside the lifetime the entry would have
 //     survived on its own and the ping changed nothing — those pings are the measured waste
-//     the policy accepts (39 of 9,234 at X=280s), and they must not also be credited.
+//     the policy accepts (53 of 912 at the shipped X=280s, K=2, gated), and they must not also be
+//     credited.
 //   - The provider read from cache and read MORE than it wrote. A request that re-created
 //     most of its prefix did not get rescued, whatever else it read.
 //   - The credit is the smaller of what the ping refreshed and what this request read. The

--- a/dash/event.go
+++ b/dash/event.go
@@ -586,9 +586,18 @@ func (e *Event) Price(p modelinfo.Price, accountingComplete bool) {
 	// the provider's mechanism and the agent places most of the breakpoints itself. It earns
 	// its place by being the number that COLLAPSES when a compaction pipeline rewrites deep
 	// history, which is the failure this project has to be able to see.
-	e.CacheSavedUSD = float64(e.CacheRead) * (p.Input - p.CacheRead)
-	if e.CacheSavedUSD < 0 {
-		e.CacheSavedUSD = 0 // a provider whose cache reads cost MORE than fresh input saved nothing
+	//
+	// NOT on a keep-alive ping. A ping's whole job is to read the prefix, so it reports a large
+	// cache_read and would book ~$0.13 of "provider cache saving" per 48k ping against $0.0073
+	// of real cost — a fabricated saving on a figure PR #83 puts on the page, and at production
+	// ping volumes it is on the order of a thousand dollars. The counterfactual is the tell:
+	// without the keep-alive that ping does not exist, so there is no unbatched-fresh-input
+	// alternative for it to have saved anything against.
+	if !e.KeepAlive {
+		e.CacheSavedUSD = float64(e.CacheRead) * (p.Input - p.CacheRead)
+		if e.CacheSavedUSD < 0 {
+			e.CacheSavedUSD = 0 // a provider whose cache reads cost MORE than fresh input saved nothing
+		}
 	}
 	e.CachesplitSavedUSD = e.cachesplitSavedUSD(p)
 	e.KeepAliveSavedUSD = e.keepaliveSavedUSD(p)

--- a/dash/event.go
+++ b/dash/event.go
@@ -104,6 +104,21 @@ type Event struct {
 	CacheRead    int64 `json:"cache_read"`
 	CacheWrite   int64 `json:"cache_write"`
 	OutputTokens int64 `json:"output_tokens"`
+	// CacheWrite1h is the part of CacheWrite the provider billed at the ONE-HOUR tier. A
+	// SUBSET of CacheWrite, never an addition to it.
+	//
+	// It exists because pricing a 1h write as a 5m one understates that request by 0.75x of
+	// its whole written prefix, and a cost that is wrong in the flattering direction is the
+	// dangerous direction — it argues for spending. Measured live on this gateway: a request
+	// asking for the 1h head on aws/claude-haiku-4-5 came back with 36,251 of 36,574 written
+	// tokens on the 1h tier, and without this column the row priced at $0.0348 against a real
+	// $0.0554.
+	//
+	// It is also the ONLY signal that a requested `ttl: "1h"` was honoured. The same request
+	// on aws/claude-sonnet-5 returned ephemeral_1h_input_tokens = 0 with an otherwise normal
+	// 200 — Bedrock's 1h support covers the Claude 4.5 family and not Sonnet 5 — so a silently
+	// downgraded request is indistinguishable from a granted one without this number.
+	CacheWrite1h int64 `json:"cache_write_1h"`
 
 	CostUSD         float64 `json:"cost_usd"`
 	BaselineCostUSD float64 `json:"baseline_cost_usd"`
@@ -135,6 +150,33 @@ type Event struct {
 	// query that reads them together rather than frozen into a second column that could
 	// disagree with them. See DB.DeclFilterSavings.
 	FilteredDeclTokens int `json:"filtered_decl_tokens"`
+
+	// KeepAlive marks a row that IS a keep-alive ping rather than agent traffic: a request
+	// context-guru sent on its own initiative, to re-read an idle session's cached prefix so
+	// the provider refreshes its lifetime. Its cost is real and lands in CostUSD like any
+	// other row's, which is the point — a mechanism that spends the caller's money while
+	// they are away from the keyboard has to be auditable to the cent, and a ping that did
+	// not appear as a row would be spend with no owner.
+	KeepAlive bool `json:"keepalive"`
+	// KeepAlivePings is, on a REAL request, how many pings preceded it during the idle span
+	// it just ended. It is what makes the saving below attributable rather than assumed: a
+	// request that hits after a twenty-minute gap could have been rescued by our ping or by
+	// any other session that happened to send byte-identical content, and only this
+	// distinguishes them.
+	KeepAlivePings int `json:"keepalive_pings"`
+	// KeepAliveRefreshed is what the last ping on this session actually read from cache —
+	// the tokens our ping demonstrably refreshed. Not persisted: it is the numerator's
+	// CEILING, and what gets stored is the credited dollars beside the cache_read they were
+	// computed from. See keepaliveSavedUSD for why the credit is the smaller of the two.
+	KeepAliveRefreshed int64 `json:"-"`
+	// KeepAliveSavedUSD is the cache re-creation this request avoided because a ping kept
+	// its prefix alive.
+	KeepAliveSavedUSD float64 `json:"keepalive_saved_usd"`
+	// SinceLastMs is the gap from this session's previous REAL request, in milliseconds.
+	// Not persisted — AttributeCache already turns it into cache_miss_reason — but the
+	// keep-alive credit needs the raw number: the whole claim is that the gap exceeded the
+	// provider's lifetime and the request hit anyway.
+	SinceLastMs int64 `json:"-"`
 
 	CGLatencyMs float64 `json:"cg_latency_ms"`
 	UpstreamMs  float64 `json:"upstream_ms"`
@@ -527,6 +569,16 @@ func (e *Event) Price(p modelinfo.Price, accountingComplete bool) {
 	}
 	e.TokenAccounting = AccountingComplete
 	e.CostUSD = p.Cost(e.FreshInput, e.CacheRead, e.CacheWrite, e.OutputTokens)
+	// The one-hour write premium. Price.Cost knows a single write rate — the 5-minute one, at
+	// 1.25x base input — so the tokens the provider billed at the 1-hour tier (2.0x) are short
+	// by the difference. Derived from the documented multiplier rather than from a second
+	// configured rate, because no gateway publishes one: 2.0x input, minus whatever the 5m
+	// write rate is, on exactly the tokens the response says were written at 1h.
+	if e.CacheWrite1h > 0 {
+		if premium := 2*p.Input - p.CacheWrite; premium > 0 {
+			e.CostUSD += float64(e.CacheWrite1h) * premium
+		}
+	}
 	e.BaselineCostUSD = e.CostUSD + e.baselineDeltaUSD(p)
 	// What the PROVIDER's prompt cache saved on this request: every cache-read token was
 	// billed at the read rate instead of the fresh rate it would have cost with no cache at
@@ -539,6 +591,7 @@ func (e *Event) Price(p modelinfo.Price, accountingComplete bool) {
 		e.CacheSavedUSD = 0 // a provider whose cache reads cost MORE than fresh input saved nothing
 	}
 	e.CachesplitSavedUSD = e.cachesplitSavedUSD(p)
+	e.KeepAliveSavedUSD = e.keepaliveSavedUSD(p)
 	// Per-component dollars, same rule and same rates as baselineDeltaUSD above: the unique
 	// part at the write rate it would have entered as, the re-sent remainder at the tier this
 	// request actually paid. Summed over a component's turns this IS the amortization — value
@@ -651,6 +704,77 @@ func (e *Event) cachesplitSavedUSD(p modelinfo.Price) float64 {
 	}
 	return float64(n) * delta
 }
+
+// keepaliveSavedUSD is the cache re-creation a keep-alive ping avoided on THIS request.
+//
+// The mechanism, and why it is worth this much: the provider's default cache lifetime is
+// five minutes, "measured from the start of the request that writes or reads the cache
+// entry, not from the end of its response". A session idle longer than that loses its whole
+// cached prefix, and the next turn re-bills every token of it at the creation rate. Measured
+// over 19,805 production requests: 742 such requests cost $741.07 — 23.6% of all spend — at
+// $0.9987 each against $0.1178 for a request that hit. Comparing each one against its own
+// counterfactual (the same tokens billed as a read) puts the penalty at 11.35x, of which
+// 91.2% is pure re-write.
+//
+// A cache READ refreshes the lifetime for free — "the cache is refreshed for no additional
+// cost each time the cached content is used" — so a ping that re-reads the prefix at 0.1x
+// buys back a re-creation at 1.25x. That 11.5:1 ratio is the whole economics, and it is why
+// this is the one cache lever worth more than everything the transformation pipeline
+// delivers.
+//
+// Four conditions, and each rules out a specific way of claiming money that is not ours:
+//
+//   - A ping actually happened on this session during the idle span this request ended
+//     (KeepAlivePings > 0). Without it, every long-gap hit in the deployment would be
+//     credited to a mechanism that was switched off.
+//   - The gap exceeded the provider's lifetime. Inside the lifetime the entry would have
+//     survived on its own and the ping changed nothing — those pings are the measured waste
+//     the policy accepts (39 of 9,234 at X=280s), and they must not also be credited.
+//   - The provider read from cache and read MORE than it wrote. A request that re-created
+//     most of its prefix did not get rescued, whatever else it read.
+//   - The credit is the smaller of what the ping refreshed and what this request read. The
+//     ping's own response says exactly how many tokens were in the entry it touched, so
+//     crediting more than that would claim tokens our ping never kept alive.
+//
+// One confound remains and is not removable from a single row: the provider's cache is keyed
+// on CONTENT, so another session sending a byte-identical prefix inside the window would
+// have refreshed the same entry for free. This is therefore the CEILING of what the ping
+// earned on this row, and the counts beside it (pings sent, pings that read nothing) are what
+// an operator checks it against.
+//
+// Priced against a cache MISS rather than fresh input, for the same reason
+// cachesplitSavedUSD is: these tokens carry cache_control, so a miss bills them as creation
+// at 1.25x, not at 1.0x.
+func (e *Event) keepaliveSavedUSD(p modelinfo.Price) float64 {
+	if e.KeepAlive || e.KeepAlivePings <= 0 || e.CacheRead <= 0 {
+		return 0 // a ping never credits itself
+	}
+	if e.SinceLastMs <= providerCacheTTLMs {
+		return 0
+	}
+	if e.CacheWrite >= e.CacheRead {
+		return 0
+	}
+	n := e.CacheRead
+	if e.KeepAliveRefreshed > 0 && e.KeepAliveRefreshed < n {
+		n = e.KeepAliveRefreshed
+	}
+	miss := p.CacheWrite
+	if miss < p.Input {
+		miss = p.Input
+	}
+	delta := miss - p.CacheRead
+	if delta <= 0 {
+		return 0
+	}
+	return float64(n) * delta
+}
+
+// providerCacheTTLMs is the default ephemeral lifetime, and the same 5 minutes
+// dashcapture.go hands AttributeCache. One constant rather than two literals: the miss
+// classifier and the keep-alive credit have to agree about when an entry is gone, or a row
+// can read "hit" for a gap the credit calls short.
+const providerCacheTTLMs int64 = 5 * 60 * 1000
 
 // baselineDeltaUSD is what the removed content would have cost had it been sent:
 // the unique part as new input (cache-write rate), the re-sent remainder as a

--- a/dash/keepalivecost_test.go
+++ b/dash/keepalivecost_test.go
@@ -192,3 +192,29 @@ func TestPingsAreVisibleAsRowsAndExcludedFromAggregates(t *testing.T) {
 		t.Errorf("%d rows flagged keepalive in the list, want 1", pings)
 	}
 }
+
+// A ping reads the whole prefix by design, so every figure derived from `cache_read` has to
+// exclude it or the mechanism credits itself. `cache_saved_usd` is the one that bites: it is a
+// headline figure elsewhere on the page, and at production ping volumes an unguarded ping row
+// fabricates it on the order of a thousand dollars.
+func TestPingsDoNotCreditProviderCacheSavings(t *testing.T) {
+	ping := &Event{TS: 1, SessionID: "s", Model: "aws/claude-sonnet-5", KeepAlive: true,
+		CacheRead: 48_576, OutputTokens: 1}
+	ping.Price(ibmSonnet, true)
+	if ping.CacheSavedUSD != 0 {
+		t.Errorf("a ping booked $%.4f of provider cache saving; without the keep-alive that "+
+			"request does not exist, so there is nothing it saved against", ping.CacheSavedUSD)
+	}
+	// It still costs what it costs — the guard must suppress the phantom saving, not the spend.
+	if ping.CostUSD <= 0 {
+		t.Error("the ping's own cost was suppressed too")
+	}
+	// And an identical AGENT request still earns the credit, so the guard is on the ping and not
+	// on the shape of the row.
+	agent := &Event{TS: 1, SessionID: "s", Model: "aws/claude-sonnet-5",
+		CacheRead: 48_576, OutputTokens: 1}
+	agent.Price(ibmSonnet, true)
+	if agent.CacheSavedUSD <= 0 {
+		t.Error("an ordinary cache hit lost its provider-cache diagnostic")
+	}
+}

--- a/dash/keepalivecost_test.go
+++ b/dash/keepalivecost_test.go
@@ -1,0 +1,137 @@
+package dash
+
+import (
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// keepaliveEvent is a real request that resumed after `gapMs` of idle with `pings` keep-alive
+// pings behind it, billed the given tiers.
+func keepaliveEvent(gapMs int64, pings int, refreshed, read, write int64) *Event {
+	e := &Event{
+		TS: 1000, SessionID: "s", Model: "aws/claude-sonnet-5",
+		TokensBefore: 90_000, TokensAfter: 90_000,
+		CacheRead: read, CacheWrite: write, OutputTokens: 50,
+		SinceLastMs: gapMs, KeepAlivePings: pings, KeepAliveRefreshed: refreshed,
+	}
+	e.Price(ibmSonnet, true)
+	return e
+}
+
+// The credit exists at all: a request that came back after twenty minutes and was served from
+// cache anyway did not pay the 11.35x re-creation penalty, and a ping is why.
+func TestKeepAliveCreditsARescuedRequest(t *testing.T) {
+	e := keepaliveEvent(20*60*1000, 1, 48_576, 48_576, 0)
+	// Priced against a cache MISS, not fresh input: these tokens carry cache_control, so a
+	// miss bills them as creation at 1.25x rather than at 1x.
+	want := 48_576 * (ibmSonnet.CacheWrite - ibmSonnet.CacheRead)
+	if got := e.KeepAliveSavedUSD; got < want*0.999 || got > want*1.001 {
+		t.Errorf("keepalive_saved_usd = %.6f, want %.6f (cache_read x (write - read))", got, want)
+	}
+}
+
+// Each gate, and the specific over-claim it prevents. Every one of these would otherwise
+// credit this mechanism with money it did not earn.
+func TestKeepAliveCreditGates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		e    *Event
+		why  string
+	}{
+		{"no ping was sent", keepaliveEvent(20*60*1000, 0, 0, 48_576, 0),
+			"every long-gap hit in the deployment would be credited to a mechanism that was off"},
+		{"the gap was inside the provider lifetime", keepaliveEvent(120*1000, 2, 48_576, 48_576, 0),
+			"the entry would have survived on its own; those pings are the measured waste, not a saving"},
+		{"the request missed anyway", keepaliveEvent(20*60*1000, 1, 48_576, 0, 48_576),
+			"nothing was rescued, so there is nothing to credit"},
+		{"it re-created more than it read", keepaliveEvent(20*60*1000, 1, 48_576, 1_000, 48_576),
+			"a request that re-wrote most of its prefix was not kept warm"},
+		{"the row IS a ping", func() *Event {
+			e := keepaliveEvent(20*60*1000, 1, 48_576, 48_576, 0)
+			e.KeepAlive, e.KeepAliveSavedUSD = true, 0
+			e.Price(ibmSonnet, true)
+			return e
+		}(), "a ping crediting itself is circular"},
+	} {
+		if got := tc.e.KeepAliveSavedUSD; got != 0 {
+			t.Errorf("%s: credited $%.6f — %s", tc.name, got, tc.why)
+		}
+	}
+}
+
+// The credit is capped by what the ping actually refreshed. The ping's own response says how
+// many tokens were in the entry it touched, and claiming more than that would claim tokens our
+// ping never kept alive — for instance a prefix that grew between the ping and the next turn.
+func TestKeepAliveCreditIsCappedByWhatThePingRefreshed(t *testing.T) {
+	e := keepaliveEvent(20*60*1000, 1, 10_000, 48_576, 0)
+	want := 10_000 * (ibmSonnet.CacheWrite - ibmSonnet.CacheRead)
+	if got := e.KeepAliveSavedUSD; got < want*0.999 || got > want*1.001 {
+		t.Errorf("keepalive_saved_usd = %.6f, want %.6f (capped at the ping's own cache_read)",
+			got, want)
+	}
+	// And a ping that read nothing (the entry was already gone) caps at nothing extra: the
+	// request's own read is then the only evidence, which is the pre-cap behaviour.
+	if e2 := keepaliveEvent(20*60*1000, 1, 0, 48_576, 0); e2.KeepAliveSavedUSD <= 0 {
+		t.Error("a ping with no recorded refresh blocked the credit entirely")
+	}
+}
+
+// A ping row must be priced like any other request — its cost is the whole point of the
+// audit trail — while contributing nothing to the saving side of the ledger.
+func TestKeepAlivePingRowIsPricedAndNotCredited(t *testing.T) {
+	p := &Event{TS: 1000, SessionID: "s", Model: "aws/claude-sonnet-5", KeepAlive: true,
+		CacheRead: 48_576, OutputTokens: 1}
+	p.Price(ibmSonnet, true)
+	want := 48_576*ibmSonnet.CacheRead + 1*ibmSonnet.Output
+	if p.CostUSD < want*0.999 || p.CostUSD > want*1.001 {
+		t.Errorf("ping cost = %.6f, want %.6f", p.CostUSD, want)
+	}
+	if p.KeepAliveSavedUSD != 0 {
+		t.Errorf("a ping credited itself $%.6f", p.KeepAliveSavedUSD)
+	}
+	// The economics this rests on: one ping buys back about 11.5 of itself. Stated as an
+	// assertion so a price list that broke the ratio would be caught here rather than in a
+	// month of bills.
+	miss := 48_576 * (ibmSonnet.CacheWrite - ibmSonnet.CacheRead)
+	if ratio := miss / (48_576 * ibmSonnet.CacheRead); ratio < 11.0 || ratio > 12.0 {
+		t.Errorf("saving:ping ratio = %.2f, expected ~11.5 at the Anthropic-family multiples", ratio)
+	}
+}
+
+// The 1-hour write tier costs 2.0x base input where the 5-minute tier costs 1.25x. Pricing one
+// as the other understates the row by 0.75x of its whole written prefix, and a cost that is
+// wrong in the flattering direction argues for spending.
+//
+// The numbers are a live measurement, not a construction: a request asking for the 1h head on
+// aws/claude-haiku-4-5 came back with 36,251 of 36,574 written tokens on the 1h tier.
+func TestOneHourWriteIsPricedAtItsOwnTier(t *testing.T) {
+	haiku := modelinfo.Price{Input: 0.76e-6, Output: 3.8e-6,
+		CacheRead: 0.076e-6, CacheWrite: 0.95e-6}
+	mk := func(write1h int64) *Event {
+		e := &Event{TS: 1, SessionID: "s", Model: "aws/claude-haiku-4-5",
+			CacheWrite: 36_574, CacheWrite1h: write1h, OutputTokens: 32}
+		e.Price(haiku, true)
+		return e
+	}
+	asFiveMin, asOneHour := mk(0), mk(36_251)
+	// 5m only: 36,574 x 0.95/MTok + output.
+	want5 := 36_574*haiku.CacheWrite + 32*haiku.Output
+	if asFiveMin.CostUSD < want5*0.999 || asFiveMin.CostUSD > want5*1.001 {
+		t.Errorf("5m-only cost = %.6f, want %.6f", asFiveMin.CostUSD, want5)
+	}
+	// With the 1h tier: the same, plus (2.0x input - 5m write rate) on the 1h tokens.
+	want1 := want5 + 36_251*(2*haiku.Input-haiku.CacheWrite)
+	if asOneHour.CostUSD < want1*0.999 || asOneHour.CostUSD > want1*1.001 {
+		t.Errorf("1h cost = %.6f, want %.6f", asOneHour.CostUSD, want1)
+	}
+	if asOneHour.CostUSD <= asFiveMin.CostUSD {
+		t.Error("the 1h tier priced no higher than the 5m tier; the premium is the whole reason " +
+			"a blanket 1h TTL loses money")
+	}
+	// And the ratio the mixed-TTL argument rests on: 2.0x versus 1.25x is a 60% premium on the
+	// written tokens.
+	if r := asOneHour.CostUSD / asFiveMin.CostUSD; r < 1.5 || r > 1.7 {
+		t.Errorf("1h/5m cost ratio = %.3f, expected ~1.6 on a fully-1h write", r)
+	}
+}

--- a/dash/keepalivecost_test.go
+++ b/dash/keepalivecost_test.go
@@ -135,3 +135,60 @@ func TestOneHourWriteIsPricedAtItsOwnTier(t *testing.T) {
 		t.Errorf("1h/5m cost ratio = %.3f, expected ~1.6 on a fully-1h write", r)
 	}
 }
+
+// A ping is a request WE made on the user's behalf, not traffic their agent sent. Counted into
+// an aggregate it inflates the request count, drags every per-request average towards a
+// one-token response, and makes an account's own traffic statistics wrong. It must still be
+// visible as a row, because it is the audit trail for money spent while nobody was watching.
+func TestPingsAreVisibleAsRowsAndExcludedFromAggregates(t *testing.T) {
+	db := openTestDB(t)
+	agent := &Event{TS: 1000, SessionID: "s", Model: "aws/claude-sonnet-5",
+		TokensBefore: 90_000, TokensAfter: 90_000, CacheRead: 48_576, OutputTokens: 500}
+	agent.Price(ibmSonnet, true)
+	ping := &Event{TS: 2000, SessionID: "s", Model: "aws/claude-sonnet-5", KeepAlive: true,
+		CacheRead: 48_576, OutputTokens: 1}
+	ping.Price(ibmSonnet, true)
+	if err := db.insertBatch([]*Event{agent, ping}); err != nil {
+		t.Fatal(err)
+	}
+
+	o, err := db.Overview(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Requests != 1 {
+		t.Errorf("Overview counted %d requests; the ping is not agent traffic", o.Requests)
+	}
+	if o.OutputTokens != 500 {
+		t.Errorf("output_tokens = %d, want 500 — the ping's single token must not move an average",
+			o.OutputTokens)
+	}
+	// Both halves of the ledger, and they must come from the two different populations.
+	if o.KeepAlivePings != 1 {
+		t.Errorf("keepalive_pings = %d, want 1", o.KeepAlivePings)
+	}
+	if o.KeepAlivePingUSD <= 0 {
+		t.Error("the ping cost nothing; a ledger that hides the spend is the thing this exists to prevent")
+	}
+	if got, want := o.KeepAliveNetUSD, o.KeepAliveSavedUSD-o.KeepAlivePingUSD; got != want {
+		t.Errorf("net = %.6f, want saved-ping = %.6f", got, want)
+	}
+
+	// The row list SHOWS it, flagged, so the spend is auditable.
+	page, err := db.Requests(Filter{TenantAll: true}, 0, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Requests) != 2 {
+		t.Fatalf("the request list returned %d rows; the ping must be visible", len(page.Requests))
+	}
+	pings := 0
+	for _, r := range page.Requests {
+		if r.KeepAlive {
+			pings++
+		}
+	}
+	if pings != 1 {
+		t.Errorf("%d rows flagged keepalive in the list, want 1", pings)
+	}
+}

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -116,6 +116,21 @@ type Overview struct {
 	// priced — absent, not zero. See DB.CachesplitHistoricalUSD.
 	CachesplitHistorical *CachesplitHistorical `json:"cachesplit_historical,omitempty"`
 
+	// The idle keep-alive's ledger. Four numbers, and they belong together: a mechanism that
+	// spends the caller's money to avoid a larger charge is only defensible if both sides are
+	// on the same page, and either alone is misleading. KeepAlivePings is how many pings were
+	// sent, KeepAlivePingUSD what they cost, KeepAliveSavedUSD the re-creations they avoided,
+	// and KeepAliveNetUSD the difference — which is the only one of the four worth a decision.
+	//
+	// KeepAliveMissesAvoided is the count behind the saving: real requests that resumed after
+	// an idle gap wider than the provider's lifetime and were served from cache anyway. On
+	// this traffic such a request would otherwise have cost 8.5x what it did.
+	KeepAlivePings         int64   `json:"keepalive_pings"`
+	KeepAlivePingUSD       float64 `json:"keepalive_ping_usd"`
+	KeepAliveSavedUSD      float64 `json:"keepalive_saved_usd"`
+	KeepAliveNetUSD        float64 `json:"keepalive_net_usd"`
+	KeepAliveMissesAvoided int64   `json:"keepalive_misses_avoided"`
+
 	// ONE definition of "moved", used here and at the write site (Recorder.ObserveSplit): the
 	// tail moved if this request's tail hash differs from the most recent PREVIOUS tail hash
 	// recorded for the session, and a session with no previously recorded tail counts as moved
@@ -301,7 +316,15 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		AVG(r.cg_latency_ms), AVG(r.upstream_ms),
 		COALESCE(SUM(r.expands),0), COALESCE(SUM(r.expand_tokens),0), COALESCE(SUM(r.reverts),0),
 		COALESCE(SUM(CASE WHEN r.uncompressed_reason <> '' THEN 1 ELSE 0 END),0),
-		COALESCE(SUM(r.cg_latency_ms),0)
+		COALESCE(SUM(r.cg_latency_ms),0),
+		-- The keep-alive ledger, both sides of it. The pings are rows like any other, marked
+		-- so they can be told from agent traffic and priced from their own cost_usd; the
+		-- saving is the per-request credit the write path computed while it still had the
+		-- session's gap and the ping's own refreshed-token count in hand.
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0),
+		COALESCE(SUM(r.keepalive_saved_usd),0),
+		COALESCE(SUM(CASE WHEN r.keepalive_saved_usd > 0 THEN 1 ELSE 0 END),0)
 		FROM requests r WHERE `+cond, args...).Scan(
 		&o.Requests, &o.Sessions, &o.TokensBefore, &o.TokensAfter, &o.SavedUnique,
 		&o.AttemptedTokens, &o.FrozenTokens, &o.FreshInput, &o.CacheRead, &o.CacheWrite,
@@ -310,7 +333,8 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		&o.SplitCreditedMoved,
 		&o.PrefixChangeCost, &o.PrefixChangeRequests, &o.PrefixChangeCostAll, &o.PrefixChangeRequestsAll,
 		&cgAvg, &upAvg, &o.Expands, &o.ExpandTokens, &o.Reverts, &o.Passthroughs,
-		&o.SafetyCost.CGLatencyMsTotal)
+		&o.SafetyCost.CGLatencyMsTotal,
+		&o.KeepAlivePings, &o.KeepAlivePingUSD, &o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided)
 	if err != nil {
 		return nil, err
 	}
@@ -341,6 +365,11 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		o.ExpandRate = float64(o.Expands) / float64(o.Requests)
 	}
 	o.NetSavedUSD = o.BaselineCostUSD - o.CostUSD - o.CGLLMCostUSD
+	// The keep-alive's net, and the one number a decision rests on. Not folded into
+	// TotalSavedUSD: the pings' own cost is already inside CostUSD (they are rows), so adding
+	// the saving without the cost would double-count the good half of a mechanism whose whole
+	// question is whether the two halves net out.
+	o.KeepAliveNetUSD = o.KeepAliveSavedUSD - o.KeepAlivePingUSD
 	o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD
 
 	for name, col := range map[string]string{
@@ -496,6 +525,21 @@ func (o *Overview) waterfall() []WaterfallStep {
 				"MISS, which is what the counterfactual actually is: those tokens carry " +
 				"cache_control, so a miss bills them as creation at 1.25x fresh, not at 1x. A " +
 				"floor — a stable prefix serves a whole session and this counts one request of it."},
+		{Key: "keepalive_ping", Label: "Keep-alive pings", DeltaUSD: o.KeepAlivePingUSD,
+			Description: "What the idle keep-alive SPENT: one minimal request per idle span, " +
+				"re-reading a session's cached prefix so the provider refreshes its 5-minute " +
+				"lifetime for free. This is the caller's own money, spent while nobody was at the " +
+				"keyboard, which is why it is a line of its own and why the mechanism is opt-in. " +
+				"Every ping is a row, priced from its own usage — no estimate."},
+		{Key: "keepalive_saved", Label: "Keep-alive savings", DeltaUSD: -o.KeepAliveSavedUSD,
+			Description: "The prefix re-creations those pings avoided. Counted only on a request " +
+				"that resumed after a gap wider than the provider's lifetime, was served from " +
+				"cache anyway, read more than it wrote, and had a ping of ours during the gap; " +
+				"credited at most the tokens that ping actually refreshed. Priced against a cache " +
+				"MISS, because those tokens carry cache_control and a miss bills them as creation " +
+				"at 1.25x rather than 1x. A ceiling rather than a floor, and the one figure here " +
+				"that is: the provider's cache is keyed on content, so another session sending the " +
+				"same prefix would have refreshed it for nothing."},
 		{Key: "total_saved", Label: "Total cost avoided", DeltaUSD: o.TotalSavedUSD, Total: true,
 			Description: "Net compaction savings plus prefix-cache savings. Two disjoint token " +
 				"sets, both ours, so nothing is counted twice. It is not the cost of a fully " +

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -248,6 +248,13 @@ type SafetyCost struct {
 // Recorder.ObserveSplit's in-process test: differs from the last non-zero tail hash recorded
 // for this session, and a session with no earlier non-zero hash counts as moved. Written once
 // and referenced twice so the count and its reconciliation cannot drift apart.
+// withKeepAlive returns f with ping rows included. A named helper rather than an inline field
+// set, so the two places that legitimately see pings are greppable.
+func withKeepAlive(f Filter) Filter {
+	f.WithKeepAlive = true
+	return f
+}
+
 const splitMoved = `r.split_stable_tokens > 0 AND r.split_tail_hash <> 0
 	AND r.split_tail_hash <> COALESCE((
 		SELECT p.split_tail_hash FROM requests p
@@ -317,12 +324,11 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		COALESCE(SUM(r.expands),0), COALESCE(SUM(r.expand_tokens),0), COALESCE(SUM(r.reverts),0),
 		COALESCE(SUM(CASE WHEN r.uncompressed_reason <> '' THEN 1 ELSE 0 END),0),
 		COALESCE(SUM(r.cg_latency_ms),0),
-		-- The keep-alive ledger, both sides of it. The pings are rows like any other, marked
-		-- so they can be told from agent traffic and priced from their own cost_usd; the
-		-- saving is the per-request credit the write path computed while it still had the
-		-- session's gap and the ping's own refreshed-token count in hand.
-		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
-		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0),
+		-- The SAVING half of the keep-alive ledger: the per-request credit the write path
+		-- computed while it still had the session's gap and the ping's own refreshed-token
+		-- count in hand. The COST half cannot be summed here — this query excludes ping rows
+		-- (Filter.WithKeepAlive) so the request count and every average stay agent-only — so it
+		-- has its own query below.
 		COALESCE(SUM(r.keepalive_saved_usd),0),
 		COALESCE(SUM(CASE WHEN r.keepalive_saved_usd > 0 THEN 1 ELSE 0 END),0)
 		FROM requests r WHERE `+cond, args...).Scan(
@@ -334,7 +340,7 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		&o.PrefixChangeCost, &o.PrefixChangeRequests, &o.PrefixChangeCostAll, &o.PrefixChangeRequestsAll,
 		&cgAvg, &upAvg, &o.Expands, &o.ExpandTokens, &o.Reverts, &o.Passthroughs,
 		&o.SafetyCost.CGLatencyMsTotal,
-		&o.KeepAlivePings, &o.KeepAlivePingUSD, &o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided)
+		&o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided)
 	if err != nil {
 		return nil, err
 	}
@@ -365,10 +371,22 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		o.ExpandRate = float64(o.Expands) / float64(o.Requests)
 	}
 	o.NetSavedUSD = o.BaselineCostUSD - o.CostUSD - o.CGLLMCostUSD
+	// The COST half, over the same window and the same filters but with ping rows included.
+	// A second query rather than a CASE in the first, because the first deliberately cannot see
+	// them: one predicate, one meaning.
+	kaCond, kaArgs := withKeepAlive(f).where()
+	if err := d.sql.QueryRow(`SELECT
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0)
+		FROM requests r WHERE `+kaCond, kaArgs...).Scan(
+		&o.KeepAlivePings, &o.KeepAlivePingUSD); err != nil {
+		return nil, err
+	}
 	// The keep-alive's net, and the one number a decision rests on. Not folded into
-	// TotalSavedUSD: the pings' own cost is already inside CostUSD (they are rows), so adding
-	// the saving without the cost would double-count the good half of a mechanism whose whole
-	// question is whether the two halves net out.
+	// TotalSavedUSD: presenting a saving without the spend that bought it is exactly the
+	// dishonesty this ledger exists to prevent, and CostUSD above no longer carries the pings
+	// (they are excluded from the agent-traffic aggregate), so the two halves are only
+	// comparable here.
 	o.KeepAliveNetUSD = o.KeepAliveSavedUSD - o.KeepAlivePingUSD
 	o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD
 

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -131,6 +131,13 @@ type Overview struct {
 	KeepAliveNetUSD        float64 `json:"keepalive_net_usd"`
 	KeepAliveMissesAvoided int64   `json:"keepalive_misses_avoided"`
 
+	// CacheWrite1h is how many written tokens the provider billed at the ONE-HOUR tier. It is
+	// the verification path for the mixed-TTL head: asking for `ttl: "1h"` on a model that does
+	// not support it returns a normal 200 with the tokens on the 5-minute tier, so this is the
+	// only thing that distinguishes granted from silently downgraded. Zero on this deployment,
+	// and expected to be — see apply/headttl.go.
+	CacheWrite1h int64 `json:"cache_write_1h"`
+
 	// ONE definition of "moved", used here and at the write site (Recorder.ObserveSplit): the
 	// tail moved if this request's tail hash differs from the most recent PREVIOUS tail hash
 	// recorded for the session, and a session with no previously recorded tail counts as moved
@@ -330,7 +337,8 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		-- (Filter.WithKeepAlive) so the request count and every average stay agent-only — so it
 		-- has its own query below.
 		COALESCE(SUM(r.keepalive_saved_usd),0),
-		COALESCE(SUM(CASE WHEN r.keepalive_saved_usd > 0 THEN 1 ELSE 0 END),0)
+		COALESCE(SUM(CASE WHEN r.keepalive_saved_usd > 0 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(r.cache_write_1h),0)
 		FROM requests r WHERE `+cond, args...).Scan(
 		&o.Requests, &o.Sessions, &o.TokensBefore, &o.TokensAfter, &o.SavedUnique,
 		&o.AttemptedTokens, &o.FrozenTokens, &o.FreshInput, &o.CacheRead, &o.CacheWrite,
@@ -340,7 +348,7 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		&o.PrefixChangeCost, &o.PrefixChangeRequests, &o.PrefixChangeCostAll, &o.PrefixChangeRequestsAll,
 		&cgAvg, &upAvg, &o.Expands, &o.ExpandTokens, &o.Reverts, &o.Passthroughs,
 		&o.SafetyCost.CGLatencyMsTotal,
-		&o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided)
+		&o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided, &o.CacheWrite1h)
 	if err != nil {
 		return nil, err
 	}

--- a/dash/query.go
+++ b/dash/query.go
@@ -44,6 +44,18 @@ type Filter struct {
 	Effort     string
 	Thinking   string
 	StopReason string
+	// WithKeepAlive includes keep-alive PING rows. Off by default, and that default is the
+	// point: a ping is a request context-guru sent on the user's behalf while they were away,
+	// not traffic their agent produced. Counted in an aggregate it silently inflates the
+	// request count, drags every per-request average towards a ~1-token response, and makes an
+	// account's own traffic statistics wrong.
+	//
+	// Set it only where a ping IS the subject: the request LIST (the rows are the audit trail
+	// and must be visible, badged by the `keepalive` column) and the keep-alive ledger itself.
+	// Money is a deliberate exception handled elsewhere — a ping is real spend on the caller's
+	// key, so DB.TenantSpend and the Prometheus cost series include it; the exclusion here is
+	// about counts and averages, not about pretending the money was not spent.
+	WithKeepAlive bool
 	// Q is a free-text match against session id and model.
 	Q string
 }
@@ -53,9 +65,16 @@ type Filter struct {
 func (f Filter) where() (string, []any) {
 	var conds []string
 	var args []any
+	// One line, one place: every reporting query in this package routes through here, so
+	// excluding pings once fixes the overview, the buckets, the per-model groups, the facets,
+	// the session list and the read-value queries together. Patching them one at a time is how
+	// the next aggregate added would quietly count pings again.
 	add := func(cond string, v ...any) {
 		conds = append(conds, cond)
 		args = append(args, v...)
+	}
+	if !f.WithKeepAlive {
+		conds = append(conds, "r.keepalive = 0")
 	}
 	if !f.TenantAll {
 		add("r.tenant_id = ?", f.Tenant)
@@ -103,7 +122,9 @@ const requestCols = `r.id, r.ts, r.tenant_id, r.session_id, r.model, r.provider,
 	r.status, r.bypassed, r.cache_aware, r.messages, r.tokens_before, r.tokens_after,
 	r.attempted_tokens, r.frozen_tokens, r.saved_unique, r.fresh_input, r.cache_read,
 	r.cache_write, r.output_tokens, r.cost_usd, r.baseline_cost_usd, r.cg_llm_cost_usd,
-	r.cache_saved_usd, r.cachesplit_saved_usd, r.split_stable_tokens, r.cg_latency_ms, r.upstream_ms, r.expands, r.expand_tokens, r.reverts,
+	r.cache_saved_usd, r.cachesplit_saved_usd, r.split_stable_tokens,
+	r.cache_write_1h, r.keepalive, r.keepalive_pings, r.keepalive_saved_usd,
+	r.cg_latency_ms, r.upstream_ms, r.expands, r.expand_tokens, r.reverts,
 	r.token_accounting, r.cache_miss_reason, r.uncompressed_reason,
 	r.reasoning_effort, r.thinking_mode, r.thinking_budget, r.temperature, r.top_p,
 	r.max_tokens, r.stream, r.tool_choice, r.tools, r.system_blocks,
@@ -111,19 +132,21 @@ const requestCols = `r.id, r.ts, r.tenant_id, r.session_id, r.model, r.provider,
 
 func scanRequest(rows interface{ Scan(...any) error }) (*Event, error) {
 	var e Event
-	var byp, ca, stream int
+	var byp, ca, stream, keepAlive int
 	var temp, topP sql.NullFloat64
 	err := rows.Scan(&e.ID, &e.TS, &e.TenantID, &e.SessionID, &e.Model, &e.Provider, &e.Agent, &e.Preset, &e.Mode, &e.Route,
 		&e.Status, &byp, &ca, &e.Messages, &e.TokensBefore, &e.TokensAfter,
 		&e.AttemptedTokens, &e.FrozenTokens, &e.SavedUnique, &e.FreshInput, &e.CacheRead,
 		&e.CacheWrite, &e.OutputTokens, &e.CostUSD, &e.BaselineCostUSD, &e.CGLLMCostUSD,
 		&e.CacheSavedUSD, &e.CachesplitSavedUSD, &e.SplitStableTokens,
+		&e.CacheWrite1h, &keepAlive, &e.KeepAlivePings, &e.KeepAliveSavedUSD,
 		&e.CGLatencyMs, &e.UpstreamMs, &e.Expands, &e.ExpandTokens, &e.Reverts,
 		&e.TokenAccounting, &e.CacheMissReason, &e.UncompressedReason,
 		&e.ReasoningEffort, &e.ThinkingMode, &e.ThinkingBudget, &temp, &topP,
 		&e.MaxTokens, &stream, &e.ToolChoice, &e.Tools, &e.SystemBlocks,
 		&e.CacheBPSystem, &e.CacheBPTools, &e.CacheBPMessages, &e.CacheBPBlocks, &e.StopReason)
 	e.Bypassed, e.CacheAware, e.Stream = byp != 0, ca != 0, stream != 0
+	e.KeepAlive = keepAlive != 0
 	// NULL stays absent rather than becoming 0: a request that set temperature=0 and one
 	// that set nothing must not read the same on the row.
 	if temp.Valid {
@@ -149,6 +172,11 @@ type Page struct {
 // keyset is O(limit) at any depth and cannot skip or duplicate a row when new
 // requests arrive mid-browse.
 func (d *DB) Requests(f Filter, before int64, limit int) (*Page, error) {
+	// The LIST shows pings. They are the audit trail for money spent on the caller's behalf
+	// while nobody was at the keyboard, so hiding them here would defeat the reason the rows
+	// exist; each carries `keepalive` so the UI can badge it. The aggregates above the list
+	// still exclude them — see Filter.WithKeepAlive.
+	f.WithKeepAlive = true
 	if limit <= 0 || limit > 500 {
 		limit = 50
 	}

--- a/dash/schema.go
+++ b/dash/schema.go
@@ -101,6 +101,31 @@ CREATE TABLE IF NOT EXISTS requests (
   -- request to decide whether the snapshot MOVED, which is the turn the split is worth
   -- anything on. Stored so the figure survives a restart and can be recomputed from the table.
   split_tail_hash    INTEGER NOT NULL DEFAULT 0,
+  -- The idle keep-alive's three columns. keepalive marks a row that IS a ping — a request
+  -- context-guru sent on its own initiative, with no agent behind it — so every query that
+  -- reports agent traffic can exclude it and the ledger can price it. It is the audit trail
+  -- for a mechanism that spends the caller's money while they are away from the keyboard,
+  -- and without it that spend would be indistinguishable from the agent's own.
+  -- The part of cache_write the provider billed at the ONE-HOUR tier (a subset of it, from
+  -- usage.cache_creation.ephemeral_1h_input_tokens). Two jobs: cost_usd needs it, because a 1h
+  -- write is 2.0x base input where a 5m write is 1.25x and pricing one as the other understates
+  -- the row by 0.75x of its written prefix; and it is the only evidence that a requested
+  -- ttl:"1h" was honoured rather than silently downgraded, which on this gateway depends on the
+  -- model (granted on aws/claude-haiku-4-5, refused on aws/claude-sonnet-5).
+  cache_write_1h     INTEGER NOT NULL DEFAULT 0,
+  keepalive          INTEGER NOT NULL DEFAULT 0,
+  -- On a REAL request: how many pings preceded it during the idle span it just ended. It is
+  -- what makes the saving attributable — a request that hits after a 20-minute gap could
+  -- have been rescued by our ping or by any other session touching the same content, and
+  -- only this column tells the two apart.
+  keepalive_pings    INTEGER NOT NULL DEFAULT 0,
+  -- What the ping avoided on THIS row: its cache-read tokens priced at the difference
+  -- between the creation tier it would have paid and the read tier it did pay. Nonzero only
+  -- where a ping preceded it, the idle gap exceeded the provider lifetime, and the provider
+  -- read more than it wrote. Priced against a cache MISS, not fresh input, for the same
+  -- reason cachesplit_saved_usd is: those tokens carry cache_control, so a miss bills them
+  -- as creation at 1.25x rather than at 1.0x.
+  keepalive_saved_usd REAL   NOT NULL DEFAULT 0,
   -- What the declaration filter stopped carrying on this request: the token weight of the
   -- tools[] elements it removed under the account's opt-in list. Written ONLY by the filter
   -- itself (apply.Trace.FilteredDeclTokens), never derived from the tool inventory — the
@@ -453,6 +478,10 @@ var additiveColumns = []struct{ table, column, ddl string }{
 	{"requests", "split_stable_tokens", "INTEGER NOT NULL DEFAULT 0"},
 	{"requests", "split_tail_hash", "INTEGER NOT NULL DEFAULT 0"},
 	{"requests", "filtered_decl_tokens", "INTEGER NOT NULL DEFAULT 0"},
+	{"requests", "cache_write_1h", "INTEGER NOT NULL DEFAULT 0"},
+	{"requests", "keepalive", "INTEGER NOT NULL DEFAULT 0"},
+	{"requests", "keepalive_pings", "INTEGER NOT NULL DEFAULT 0"},
+	{"requests", "keepalive_saved_usd", "REAL NOT NULL DEFAULT 0"},
 	{"request_components", "gates", "TEXT NOT NULL DEFAULT ''"},
 	{"request_components", "saved_usd", "REAL NOT NULL DEFAULT 0"},
 }

--- a/dash/store.go
+++ b/dash/store.go
@@ -249,13 +249,14 @@ func (d *DB) insertBatch(evs []*Event) error {
 		messages, tokens_before, tokens_after, attempted_tokens, frozen_tokens, saved_unique,
 		fresh_input, cache_read, cache_write, output_tokens,
 		cost_usd, baseline_cost_usd, cg_llm_cost_usd, cache_saved_usd, cachesplit_saved_usd,
-		split_stable_tokens, split_tail_hash, filtered_decl_tokens, cg_latency_ms, upstream_ms,
+		split_stable_tokens, split_tail_hash, filtered_decl_tokens,
+		cache_write_1h, keepalive, keepalive_pings, keepalive_saved_usd, cg_latency_ms, upstream_ms,
 		expands, expand_tokens, reverts, token_accounting, cache_miss_reason, uncompressed_reason,
 		reasoning_effort, thinking_mode, thinking_budget, temperature, top_p, max_tokens, stream,
 		tool_choice, tools, system_blocks,
 		cache_bp_system, cache_bp_tools, cache_bp_messages, cache_bp_blocks, stop_reason
 	) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-		?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
+		?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	if err != nil {
 		return err
 	}
@@ -294,7 +295,9 @@ func (d *DB) insertBatch(evs []*Event) error {
 			e.Messages, e.TokensBefore, e.TokensAfter, e.AttemptedTokens, e.FrozenTokens, e.SavedUnique,
 			e.FreshInput, e.CacheRead, e.CacheWrite, e.OutputTokens,
 			e.CostUSD, e.BaselineCostUSD, e.CGLLMCostUSD, e.CacheSavedUSD, e.CachesplitSavedUSD,
-			e.SplitStableTokens, int64(e.SplitTailHash), e.FilteredDeclTokens, e.CGLatencyMs, e.UpstreamMs,
+			e.SplitStableTokens, int64(e.SplitTailHash), e.FilteredDeclTokens,
+			e.CacheWrite1h, boolInt(e.KeepAlive), e.KeepAlivePings, e.KeepAliveSavedUSD,
+			e.CGLatencyMs, e.UpstreamMs,
 			e.Expands, e.ExpandTokens, e.Reverts, e.TokenAccounting, e.CacheMissReason, e.UncompressedReason,
 			e.ReasoningEffort, e.ThinkingMode, e.ThinkingBudget, e.Temperature, e.TopP, e.MaxTokens,
 			boolInt(e.Stream), e.ToolChoice, e.Tools, e.SystemBlocks,

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -4235,14 +4235,19 @@ function loadSettings() {
         + (((cfg.cache && cfg.cache.keepalive_idle_seconds) || 280)) + 's idle, up to '
         + (((cfg.cache && cfg.cache.keepalive_max_pings) || 2)) + ' minimal requests re-read '
         + 'your cached prompt so the provider refreshes its 5-minute lifetime for free. '
-        + 'Billed to your own key.'),
+        + 'Only on sessions with a large enough cached prompt to be worth it, and never on a '
+        + 'session\u2019s first request. Billed to your own key.'),
       whyBlock('What it costs and what it saves',
         'A cache read costs 0.1x base input; re-creating a lapsed prefix costs 1.25x, so one '
         + 'ping buys back about 11.5 of itself. On this service\u2019s traffic, requests that '
         + 'resumed after the 5-minute window cost 8.5x a request that hit, and they were 23.6% '
         + 'of all spend. It is off by default because it is your money and nobody asked for it '
         + 'to be spent. Every ping is a row on your Requests tab marked keep-alive with its own '
-        + 'cost, and the Overview ledger shows pings, ping cost, misses avoided and the net.')));
+        + 'cost, and the Overview ledger shows pings, ping cost, misses avoided and the net. '
+        + 'Be aware of the shape: it is a small tax on most of the sessions it touches, funding '
+        + 'a large rebate on a few. Measured over 5 days of this service\u2019s traffic, 34 of '
+        + '119 pinged sessions came out ahead and the worst single session paid $2.42 for '
+        + 'nothing. Watch your own ledger and switch it off if you are not one of the winners.')));
 
     // Content capture consent.
     const cap = el('input', {

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -4213,6 +4213,37 @@ function loadSettings() {
         'Saving rebuilds your pipeline and discards frozen compaction decisions, so the ' +
         'next turn will not be cache-warm.')));
 
+    // Idle keep-alive consent. Its own consent control, beside the transcript one, for the
+    // same reason: it is a thing done with the user's property that they have to agree to.
+    // Here it is their MONEY rather than their code, and the copy says what it buys, what it
+    // costs, and where to see both — a mechanism that spends on its own initiative is only
+    // acceptable if the person paying can read the ledger.
+    const ka = el('input', { type: 'checkbox', id: 'set-keepalive', 'data-testid': 'set-keepalive' });
+    ka.checked = !!(cfg.cache && cfg.cache.keepalive);
+    // Editable under the same condition as the rest of the configuration document, because
+    // that is where it is STORED: PUT /api/me answers 403 to a non-manager sending `config`,
+    // and drawing an enabled box whose value the server discards is worse than not drawing
+    // it. The ledger on Overview is visible to everyone regardless, which is the half that
+    // matters for someone whose key is being spent.
+    ka.disabled = inherited || !mgr;
+    if (mgr) host.appendChild(el('div', { class: 'field' },
+      el('label', { class: 'comp', for: 'set-keepalive' }, ka,
+        el('span', { class: 'comp-name' },
+          'Keep my prompt cache warm while I am away')),
+      el('p', { class: 'hint' },
+        'Spends a small amount to avoid a much larger cache-recreation charge. After '
+        + (((cfg.cache && cfg.cache.keepalive_idle_seconds) || 280)) + 's idle, up to '
+        + (((cfg.cache && cfg.cache.keepalive_max_pings) || 2)) + ' minimal requests re-read '
+        + 'your cached prompt so the provider refreshes its 5-minute lifetime for free. '
+        + 'Billed to your own key.'),
+      whyBlock('What it costs and what it saves',
+        'A cache read costs 0.1x base input; re-creating a lapsed prefix costs 1.25x, so one '
+        + 'ping buys back about 11.5 of itself. On this service\u2019s traffic, requests that '
+        + 'resumed after the 5-minute window cost 8.5x a request that hit, and they were 23.6% '
+        + 'of all spend. It is off by default because it is your money and nobody asked for it '
+        + 'to be spent. Every ping is a row on your Requests tab marked keep-alive with its own '
+        + 'cost, and the Overview ledger shows pings, ping cost, misses avoided and the net.')));
+
     // Content capture consent.
     const cap = el('input', {
       type: 'checkbox', id: 'set-capture', 'data-testid': 'set-capture',
@@ -4727,7 +4758,16 @@ async function saveSettings() {
     // component's own default takes over, which is the same thing an absent key means — so
     // the page must not invent one. A component present with an empty object is how a
     // cleared block is expressed; a component absent from it entirely is left untouched.
-    body.config = { pipeline: ordered, mode: $('#set-mode').value, components: cfgState || {} };
+    // cache carries the account's own consent, so it is sent whenever the form drew the
+    // control — the tuning fields are omitted, which leaves the document's own values (or the
+    // defaults) alone rather than freezing today's numbers into every saved document.
+    body.config = {
+      pipeline: ordered, mode: $('#set-mode').value, components: cfgState || {},
+      cache: {
+        keepalive: !!($('#set-keepalive') || {}).checked,
+        head_ttl_1h: !!((account.tenant.effective_config || {}).cache || {}).head_ttl_1h,
+      },
+    };
   }
   try {
     const out = await ctl('/api/me', { method: 'PUT', body: JSON.stringify(body) });

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -687,6 +687,17 @@ function renderTiles(o) {
       num(o.split_credited) + ' of ' + num(o.split_tail_moved) + ' moved-snapshot turns'
         + (histRequests(o) ? ' + ' + num(histRequests(o)) + ' earlier' : ''),
       costKnown && (o.cachesplit_saved_usd + histUSD(o)) > 0 ? 'good' : ''),
+    // The keep-alive's net, with both halves in the subtitle. Shown only once it has done
+    // something: a row of zeroes on a deployment nobody opted into reads as a broken feature.
+    // The net is what a decision rests on, so it is the number on the tile — presenting the
+    // saving alone would be exactly the half-truth this ledger exists to prevent.
+    (o.keepalive_pings || o.keepalive_saved_usd)
+      ? tile('keepalive-net', 'Keep-alive net',
+        costKnown ? usd(o.keepalive_net_usd) : 'unknown',
+        num(o.keepalive_pings) + ' pings ' + usd(o.keepalive_ping_usd) + ' · '
+          + num(o.keepalive_misses_avoided) + ' misses avoided ' + usd(o.keepalive_saved_usd),
+        costKnown ? (o.keepalive_net_usd < 0 ? 'bad' : 'good') : '')
+      : null,
   ]));
 
   // The bill, split by the tier it was charged on, and the only defensible denominator for a
@@ -1437,7 +1448,13 @@ async function loadRequests() {
         el('td', { class: 'num', text: compact(e.cache_read) + ' / ' + compact(e.cache_write) }),
         el('td', { class: 'num', text: e.token_accounting === 'complete' ? usd(e.cost_usd) : '—' }),
         el('td', { class: 'num', text: ms(e.cg_latency_ms) }),
-        el('td', {}, el('span', { class: 'pill ' + (e.cache_miss_reason || 'neutral'), text: e.cache_miss_reason || '—' })),
+        // A keep-alive ping is not agent traffic, and the consent copy promises it is
+        // identifiable here. Without the badge the row reads as a mysterious one-token request
+        // the user did not make, which is worse than not showing it at all.
+        el('td', {}, e.keepalive
+          ? el('span', { class: 'pill neutral', title: 'a keep-alive ping context-guru sent to '
+              + 'refresh this session\u2019s cached prompt', text: 'keep-alive' })
+          : el('span', { class: 'pill ' + (e.cache_miss_reason || 'neutral'), text: e.cache_miss_reason || '—' })),
         el('td', {}, el('span', { class: 'pill ' + e.token_accounting, text: e.token_accounting }))));
     }
     $('#req-page').textContent = `${num(page.requests.length)} shown of ${num(page.total)} matching`;
@@ -4244,6 +4261,12 @@ function loadSettings() {
         + 'of all spend. It is off by default because it is your money and nobody asked for it '
         + 'to be spent. Every ping is a row on your Requests tab marked keep-alive with its own '
         + 'cost, and the Overview ledger shows pings, ping cost, misses avoided and the net. '
+        + 'It also RETAINS, in memory only, your provider key and that session\u2019s last '
+        + 'request \u2014 which includes its conversation content \u2014 for the length of the '
+        + 'idle gap, up to about 14 minutes, because a request sent between your requests has '
+        + 'nothing else to authenticate or replay. That is separate from the transcript-storage '
+        + 'consent below, which is about writing content to DISK; this is held in memory, '
+        + 'masked, overwritten on release, and never persisted. '
         + 'Be aware of the shape: it is a small tax on most of the sessions it touches, funding '
         + 'a large rebate on a few. Measured over 5 days of this service\u2019s traffic, 34 of '
         + '119 pinged sessions came out ahead and the worst single session paid $2.42 for '

--- a/docs/components/cacheinject.md
+++ b/docs/components/cacheinject.md
@@ -38,10 +38,20 @@ breakpoint the caller already set** — an agent that places its own is usually 
 optimum, and the provider's 4-breakpoint cap means a fifth is a 400.
 
 `5m` TTL by default. A `1h` write costs 2.0x instead of 1.25x and only pays when the chance of
-an entry lapsing before its next reuse exceeds 83.3%. Agent turns are seconds apart (measured
-median 7.6 s over 1,905 real turns) and every read refreshes the TTL for free, so set
-`ttl: 1h` only when reuse is genuinely sparse — a low-concurrency sweep with task starts more
-than 5 minutes apart, or a deployed agent handling a few sessions per hour.
+an entry lapsing before its next reuse exceeds **65.2%**, i.e. `(2.0 − 1.25) / (1.25 − 0.1)`.
+
+That denominator used to read `(1 − 0.1)`, giving 83.3%, and it was wrong by 18 points: it
+assumed a lapsed entry re-bills at the 1.0x FRESH rate. Measured, it re-bills as a 1.25x
+cache-CREATION — those tokens still carry `cache_control`, so the provider writes a new entry
+rather than charging fresh input. Production `ttl_expiry` rows say so directly: `cache_write`
+averages 178,793 against `fresh_input` 1,712. The conclusion does not move — agent turns are
+seconds apart (measured median 7.6 s over 1,905 real turns) and every read refreshes the TTL
+for free — so set `ttl: 1h` only when reuse is genuinely sparse: a low-concurrency sweep with
+task starts more than 5 minutes apart, or a deployed agent handling a few sessions per hour.
+
+On the IBM gateway that decision is currently moot for most models: measured live, the 1h tier
+is granted on `aws/claude-haiku-4-5` (36,251 of 36,574 written tokens) and silently downgraded
+to 5 minutes on `aws/claude-sonnet-5` (0 of 48,212). See `apply/headttl.go`.
 
 ## What placement is actually worth
 

--- a/docs/hosted.md
+++ b/docs/hosted.md
@@ -46,8 +46,16 @@ database cannot be replayed against the proxy. Show it once, at registration.
 **Provider keys belong to the caller.** Your agent sends its own key in
 `Authorization` / `x-api-key` / `x-goog-api-key`, and the proxy **forwards it
 unchanged** — your traffic, your provider account, your invoice. The service holds no
-provider credential of its own and stores none: the key is read off the request and
-dropped.
+provider credential of its own: the key is read off the request and dropped.
+
+**One exception, and only if you switch it on.** The idle prompt-cache keep-alive
+(`cache.keepalive`, off by default) sends a request *between* your requests, when none is
+in flight — so for opted-in accounts it must retain your key, and the last request's body,
+for the length of the idle gap. Held in memory only, masked at rest, overwritten on
+release, never logged or persisted, and bounded by a hard deadline of about 14 minutes.
+Every use is a dashboard row you can audit. If you have not enabled it, nothing is
+retained and the paragraph above holds unchanged. See
+[Keep an idle prompt cache warm](how-to/cache-keepalive.md).
 
 That is why identity moved to a header of its own. `x-context-guru-token` carries the
 `cg_live_…` token, and `copyHeaders` strips every `x-context-guru-*` header before

--- a/docs/how-to/cache-keepalive.md
+++ b/docs/how-to/cache-keepalive.md
@@ -175,9 +175,10 @@ the life of a request:
 | **Hard deadline** | `time.AfterFunc` at `(K+1) × X` ≈ 14 min. A *scheduled* deadline, not a check inside a loop: a process with no traffic still releases on time. |
 | **Eager release** | dropped the moment the next request arrives, the gate refuses, the span is exhausted, or the process shuts down — whichever comes first. |
 | **Zeroized** | the bytes are overwritten, not just dereferenced. A dropped `[]byte` sits in the heap until a collection that may never come. |
-| **Masked at rest** | XORed under a random per-process key, so the idle hold contains no working credential. |
+| **Masked at rest** | the credential **and the body** are XORed under a random per-process key, so the idle hold contains neither a working credential nor a readable transcript. A leaked key is rotatable; a transcript is not. |
 | **Consent per request** | re-read from the tenancy on every request. Turning the setting off retires what is already held on the account's next request; a session that goes quiet is dropped by the deadline. |
-| **Audit row per ping** | every use is a durable `requests` row: tenant, session, timestamp, cost, and whether it read or wrote. |
+| **Audit row per ping** | every use is a durable `requests` row: tenant, session, timestamp, cost, and whether it read or wrote. **Unconditional**: with no dashboard recorder to write it, nothing is retained at all — an audit control a flag can switch off is not a control. |
+| **Purged on revocation** | account deletion, token revocation and disablement each release that tenant's held material immediately, rather than waiting for the deadline. |
 | **Kill switch** | `CONTEXT_GURU_KEEPALIVE=off` stops *retention*, not merely pinging — nothing is held at all. |
 
 Bounded on volume too: 128 MiB across at most 512 sessions, and a single body over 8 MiB is

--- a/docs/how-to/cache-keepalive.md
+++ b/docs/how-to/cache-keepalive.md
@@ -154,7 +154,18 @@ expense.
 To ping a session the proxy keeps that session's last request body, and — where the upstream
 is caller-pays, which is the default — the caller's own provider credential. There is no
 alternative: the ping happens when no request is in flight, so nothing else can authenticate
-it, and pinging on the operator's key would bill the wrong party.
+it or supply the byte-identical prefix a cache read requires, and pinging on the operator's
+key would bill the wrong party.
+
+**The body is conversation content, and enabling the keep-alive is what consents to holding
+it.** It is up to 8 MiB of that session's last request — system prompt, tools, and the
+message history — held for the length of the idle gap. This is deliberately *not* covered by
+the transcript-storage consent, which is a different promise about a different thing: that
+one governs writing content to **disk**, where a manager can read it and a retention window
+applies. This is memory only, masked, overwritten on release, never persisted, and gone
+within about 14 minutes. It cannot be reduced further — the prefix hash covers the whole
+`tools` → `system` → `messages` sequence, so a ping that trimmed the body would miss the
+cache and cost 12.5x instead of saving 11.5x, which is the mechanism inverted.
 
 Seven controls, because this is the one place the service holds a caller's credential beyond
 the life of a request:

--- a/docs/how-to/cache-keepalive.md
+++ b/docs/how-to/cache-keepalive.md
@@ -151,15 +151,35 @@ expense.
 
 ## What is held in memory, and for how long
 
-To ping a session the proxy keeps that session's last request body, and — where the
-upstream is caller-pays, which is the default — the caller's own provider credential. There
-is no alternative: the ping happens when no request is in flight, so nothing else can
-authenticate it, and pinging on the operator's key would bill the wrong party.
+To ping a session the proxy keeps that session's last request body, and — where the upstream
+is caller-pays, which is the default — the caller's own provider credential. There is no
+alternative: the ping happens when no request is in flight, so nothing else can authenticate
+it, and pinging on the operator's key would bill the wrong party.
 
-It is bounded on every axis: opt-in per account, memory only, never logged or persisted,
-dropped the moment the next request arrives, and retired by the policy itself after at most
-`(K+1) × X` — about 14 minutes at the defaults. Total held bodies are capped at 128 MiB
-across 512 sessions, and a single body over 8 MiB is not held at all.
+Seven controls, because this is the one place the service holds a caller's credential beyond
+the life of a request:
+
+| control | what it does |
+|---|---|
+| **Hard deadline** | `time.AfterFunc` at `(K+1) × X` ≈ 14 min. A *scheduled* deadline, not a check inside a loop: a process with no traffic still releases on time. |
+| **Eager release** | dropped the moment the next request arrives, the gate refuses, the span is exhausted, or the process shuts down — whichever comes first. |
+| **Zeroized** | the bytes are overwritten, not just dereferenced. A dropped `[]byte` sits in the heap until a collection that may never come. |
+| **Masked at rest** | XORed under a random per-process key, so the idle hold contains no working credential. |
+| **Consent per request** | re-read from the tenancy on every request. Turning the setting off retires what is already held on the account's next request; a session that goes quiet is dropped by the deadline. |
+| **Audit row per ping** | every use is a durable `requests` row: tenant, session, timestamp, cost, and whether it read or wrote. |
+| **Kill switch** | `CONTEXT_GURU_KEEPALIVE=off` stops *retention*, not merely pinging — nothing is held at all. |
+
+Bounded on volume too: 128 MiB across at most 512 sessions, and a single body over 8 MiB is
+not held.
+
+**What the masking does and does not buy.** A heap or core dump, a crash report, a
+`/proc/<pid>/mem` read or a `strings` pass over a snapshot yields masked bytes rather than a
+working key — the accidental-capture class, which is the realistic one. It does **not** stop
+an attacker with code execution in this process: the mask is in the same address space. It is
+obfuscation at rest, not encryption. And the credential is necessarily plaintext for the
+duration of the ping itself, because `net/http`'s header map holds strings and a Go string
+cannot be overwritten — so the window is one request instead of the whole idle hold, which is
+the part that was worth closing.
 
 ## Related
 

--- a/docs/how-to/cache-keepalive.md
+++ b/docs/how-to/cache-keepalive.md
@@ -1,0 +1,149 @@
+# Keep an idle prompt cache warm
+
+The provider's prompt cache has a five-minute lifetime. A session idle longer than that
+loses its whole cached prefix, and the next turn re-bills every token of it at the
+cache-creation rate.
+
+On this service, measured over 19,805 requests and $3,139.97 of spend:
+
+| miss reason | requests | share | cost | share of spend | $/request |
+|---|---:|---:|---:|---:|---:|
+| hit | 16,368 | 82.6% | $1,928.65 | 61.4% | $0.1178 |
+| **ttl_expiry** | **742** | **3.7%** | **$741.07** | **23.6%** | **$0.9987** |
+| cold_start | 1,626 | 8.2% | $253.82 | 8.1% | $0.1561 |
+| prefix_change | 292 | 1.5% | $205.05 | 6.5% | $0.7022 |
+
+A TTL-expired request costs **8.5x** a request that hit, and against each row's own
+counterfactual the penalty is **11.35x**, of which 91.2% is pure re-write. $584.83 —
+18.6% of all spend — sits in misses whose idle gap was under an hour.
+
+## What the keep-alive does
+
+Two sentences from the provider's documentation make this fixable:
+
+> By default, the cache has a 5-minute lifetime. **The cache is refreshed for no
+> additional cost each time the cached content is used.**
+
+> **The lifetime is measured from the start of the request that writes or reads the cache
+> entry, not from the end of its response.**
+
+So a cache *read* refreshes the lifetime, and a read costs `0.1x` base input where
+re-creating the prefix costs `1.25x`. After a session has been idle for `X` seconds, the
+proxy re-sends that session's last request with `max_tokens: 1` — a pure cache read, which
+refreshes the entry. **One ping buys back about 11.5 of itself.**
+
+Nothing else about the request changes. The prefix hash is cumulative over
+`tools` → `system` → `messages`, so a ping that altered any of it would *create* an entry
+at `1.25x` instead of refreshing one at `0.1x` — the one way this mechanism costs money
+instead of saving it. Only `max_tokens` and `stream` are touched, and neither is inside the
+hashed prefix.
+
+## Turning it on
+
+It is **off by default**, because it spends the caller's own money without the caller
+asking. On the Settings page: *"Keep my prompt cache warm while I am away."* In a
+configuration document:
+
+```yaml
+cache:
+  keepalive: true
+  keepalive_idle_seconds: 280          # X — must be under 300
+  keepalive_max_pings: 2               # K
+  keepalive_max_usd_per_session: 0.25
+```
+
+`X = 280` and `K = 2` are the measured optimum, not defaults picked by feel:
+
+| X | K | pings | ping cost | misses converted | saving | **net** |
+|---:|---:|---:|---:|---:|---:|---:|
+| 280 | 1 | 4,775 | $70.35 | 105 | $161.45 | +$91.10 |
+| **280** | **2** | **8,967** | **$109.08** | **159** | **$243.09** | **+$134.01** |
+| 280 | 3 | 12,191 | $122.22 | 175 | $256.64 | +$134.43 |
+| 240 | 2 | 9,303 | $122.53 | 140 | $208.83 | +$86.29 |
+| 280 | 12 | 34,064 | $147.60 | 185 | $264.26 | +$116.66 |
+
+`X = 280` beats 240 because it wastes fewer pings on gaps that would have hit anyway. `K`
+peaks at 2–3 and falls away after: a session that has *ended* looks exactly like one that
+is thinking, so every additional ping is spent partly on sessions that will never come
+back.
+
+## What it will not do
+
+- **It will not ping a session with `thinking.type: enabled`.** Such a request requires
+  `max_tokens` above the thinking budget (32,000 on this traffic), so the ping cannot be
+  made cheap, and altering the thinking parameters invalidates the message-level prefix.
+  `adaptive` is unaffected, and is 81% of the addressable traffic.
+- **It will not crowd out a real request.** A ping only ever uses a tenant's *slack* — a
+  quarter of the rate and concurrency budget is reserved — and is skipped rather than
+  queued when there is none.
+- **It will not retry.** A failed ping is logged and forgotten. A `4xx`, or a ping whose
+  usage reports more written than read, stops that session being pinged again.
+
+## Where the money shows up
+
+Every ping is a dashboard row marked `keepalive`, with its own tokens, its own cost, and
+its own session — so an account can audit what was spent on its behalf while nobody was at
+the keyboard. The Overview ledger carries both halves:
+
+| line | meaning |
+|---|---|
+| Keep-alive pings | what the pings cost |
+| Keep-alive savings | the prefix re-creations they avoided |
+| `keepalive_misses_avoided` | how many requests resumed past the lifetime and hit anyway |
+
+The saving is credited only where a ping of ours preceded the request, the gap exceeded the
+provider's lifetime, the provider read more than it wrote, and the amount is capped at the
+tokens that ping actually refreshed. It is a **ceiling**, not a floor: the provider's cache
+is keyed on content, so another session sending the same prefix would have refreshed the
+entry for free.
+
+## The honest downside
+
+The mechanism is a lottery with a strongly positive expectation and a losing median. Over
+the production window at `X=280, K=2`:
+
+- 3,812 sessions were pinged.
+- **37 came out ahead**, and 3,775 came out behind.
+- The 3,775 losing sessions lost **$13.10 between them** — an average of $0.0035 each.
+- The **worst single session lost $0.95**: a large prefix, two pings, and a session that
+  never resumed.
+
+Sessions that lose are short ones and abandoned ones. Sessions that win are long ones with
+large prefixes and human-paced gaps. An account whose work is many brief sessions should
+leave this off; the per-tenant simulation found the keep-alive positive for 10 of 13
+tenants and never worse than −$0.53 for the other three.
+
+## Operator kill switch
+
+```
+CONTEXT_GURU_KEEPALIVE=off
+```
+
+Set in the environment, read at startup. An environment variable rather than a control-plane
+route on purpose: the thing an operator needs at 3am is one that works when the control
+plane is what is broken. `/stats` publishes `keepalive` with `pings`, `skipped`, `failed`,
+`wrote_instead_of_read` and `spend_usd`; `wrote_instead_of_read` above zero is a bug, not an
+expense.
+
+## What is held in memory, and for how long
+
+To ping a session the proxy keeps that session's last request body, and — where the
+upstream is caller-pays, which is the default — the caller's own provider credential. There
+is no alternative: the ping happens when no request is in flight, so nothing else can
+authenticate it, and pinging on the operator's key would bill the wrong party.
+
+It is bounded on every axis: opt-in per account, memory only, never logged or persisted,
+dropped the moment the next request arrives, and retired by the policy itself after at most
+`(K+1) × X` — about 14 minutes at the defaults. Total held bodies are capped at 128 MiB
+across 512 sessions, and a single body over 8 MiB is not held at all.
+
+## Related
+
+- [Measuring savings](measure-savings.md) — how the ledger separates the provider's cache
+  from ours.
+- `apply/headttl.go` — the mixed 1h/5m TTL, which is implemented, off, and worth $0 on the
+  models this service runs. Measured live: `aws/claude-haiku-4-5` grants the 1-hour tier
+  (36,251 of 36,574 written tokens), `aws/claude-sonnet-5` silently downgrades it to 5
+  minutes (0 of 48,212). The `ttl` field reaches the provider; Bedrock's 1h support covers
+  the Claude 4.5 family, and this service's spend is Opus 5, Opus 4.8, Sonnet 5 and Opus
+  4.6. `cache_write_1h` on each row is what says when that changes.

--- a/docs/how-to/cache-keepalive.md
+++ b/docs/how-to/cache-keepalive.md
@@ -49,23 +49,37 @@ cache:
   keepalive: true
   keepalive_idle_seconds: 280          # X — must be under 300
   keepalive_max_pings: 2               # K
-  keepalive_max_usd_per_session: 0.25
+  keepalive_min_prefix_tokens: 20000   # the gate
+  keepalive_max_usd_per_ping: 0.25
 ```
 
-`X = 280` and `K = 2` are the measured optimum, not defaults picked by feel:
+These are the measured optimum, not defaults picked by feel. Replayed through the shipped
+decision function over the production window:
 
-| X | K | pings | ping cost | misses converted | saving | **net** |
-|---:|---:|---:|---:|---:|---:|---:|
-| 280 | 1 | 4,775 | $70.35 | 105 | $161.45 | +$91.10 |
-| **280** | **2** | **8,967** | **$109.08** | **159** | **$243.09** | **+$134.01** |
-| 280 | 3 | 12,191 | $122.22 | 175 | $256.64 | +$134.43 |
-| 240 | 2 | 9,303 | $122.53 | 140 | $208.83 | +$86.29 |
-| 280 | 12 | 34,064 | $147.60 | 185 | $264.26 | +$116.66 |
+| policy | pings | ping cost | converted | saving | **net** |
+|---|---:|---:|---:|---:|---:|
+| **X=280 K=2, gated (shipped)** | **912** | **$90.76** | **148** | **$215.84** | **+$125.08** |
+| X=280 K=2, blanket (no gate) | 8,915 | $93.79 | 153 | $221.05 | +$127.26 |
+| X=280 K=1, gated | 536 | $53.51 | 96 | $138.80 | +$85.28 |
+| X=280 K=3, gated | 1,226 | $121.33 | 174 | $252.13 | +$130.80 |
+| X=240 K=2, gated | 1,012 | $102.19 | 134 | $197.03 | +$94.85 |
+| X=280 K=12, gated | 3,307 | $311.78 | 253 | $370.12 | +$58.35 |
+
+**The gate is the whole reason this is deployable: 9.8× fewer pings for 1.7% less money.**
+What it drops is the near-free pings on tiny prefixes — ping cost is bimodal, p50 $0.0004
+against a p99 of $0.2275 — so 8,000 requests of real gateway load disappear and almost none
+of the value does. On a path that already returned 180 HTTP 429s in the same window, that
+matters as much as the dollars.
 
 `X = 280` beats 240 because it wastes fewer pings on gaps that would have hit anyway. `K`
 peaks at 2–3 and falls away after: a session that has *ended* looks exactly like one that
 is thinking, so every additional ping is spent partly on sessions that will never come
-back.
+back. K=2 ships because K=2 and K=3 are within noise here while K=2 sends 26% fewer
+requests.
+
+**Never use a per-session ping cap.** It truncates exactly the long large-prefix sessions
+holding the value: capping the window's pings per session at 20 drops the net to $92.34,
+and at 10 to $54.04. The guard that works is the per-*ping* cost budget above.
 
 ## What it will not do
 
@@ -91,6 +105,12 @@ the keyboard. The Overview ledger carries both halves:
 | Keep-alive savings | the prefix re-creations they avoided |
 | `keepalive_misses_avoided` | how many requests resumed past the lifetime and hit anyway |
 
+Ping rows are **excluded from every other aggregate** (`Filter.WithKeepAlive`). A ping is a
+request we made on the user's behalf, not traffic their agent sent, so counting it would
+inflate the request count and drag every per-request average towards a one-token response.
+They are still listed on the Requests tab, flagged, because that list is the audit trail.
+Spend figures do include them: the money was really spent on the caller's key.
+
 The saving is credited only where a ping of ours preceded the request, the gap exceeded the
 provider's lifetime, the provider read more than it wrote, and the amount is capped at the
 tokens that ping actually refreshed. It is a **ceiling**, not a floor: the provider's cache
@@ -99,19 +119,23 @@ entry for free.
 
 ## The honest downside
 
-The mechanism is a lottery with a strongly positive expectation and a losing median. Over
-the production window at `X=280, K=2`:
+**The policy is a very small tax on almost every session it touches, funding a large rebate
+for a few dozen.** Over the production window:
 
-- 3,812 sessions were pinged.
-- **37 came out ahead**, and 3,775 came out behind.
-- The 3,775 losing sessions lost **$13.10 between them** — an average of $0.0035 each.
-- The **worst single session lost $0.95**: a large prefix, two pings, and a session that
-  never resumed.
+| policy | sessions touched | losing money | worst session | total losses | winners |
+|---|--:|--:|--:|--:|--:|
+| blanket X=280 K=2 | 3,809 | **3,773 (99.1%)** | −$0.95 | −$13.10 | 36 |
+| **gated (shipped)** | **119** | **85 (71.4%)** | **−$2.42** | **−$13.59** | **34** |
+
+The gate does not make the tax rarer per session touched — it makes it fall on 119 sessions
+instead of 3,809, leaving the other 3,690 untouched entirely. That is the fairness argument,
+and it is independent of the dollars: a session that is never pinged cannot lose.
 
 Sessions that lose are short ones and abandoned ones. Sessions that win are long ones with
 large prefixes and human-paced gaps. An account whose work is many brief sessions should
-leave this off; the per-tenant simulation found the keep-alive positive for 10 of 13
-tenants and never worse than −$0.53 for the other three.
+leave this off. Given this shape, the opt-in default and the per-account ledger are not
+optional: a user has to be able to see that they are one of the ~70% paying the tax rather
+than one of the few collecting the rebate, and turn it off.
 
 ## Operator kill switch
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -232,6 +232,20 @@ type compStat struct {
 	// Gates is the rejection histogram: gate name -> candidates declined by it, summed
 	// over every run. It is what turns "acted: 0" into a diagnosis — whether the
 	// component saw no candidates, or saw them and a specific guard refused.
+	// Verdict is the one-word reading of the three counters above, because two of them read
+	// as a contradiction to anyone who has not read the source. A component can MUTATE a
+	// request without SAVING a content token — cachesplit moves tokens out of a hashed
+	// prefix, cacheinject adds cache_control, toolschema rewrites annotations — and for
+	// those `acted: 0` beside `mutated: 755` has been read as a broken component and filed
+	// as a bug twice, most recently against a mechanism that was working exactly as
+	// designed. So the rollup states the reading rather than leaving it to be inferred:
+	//
+	//	acted    saved content tokens on at least one request
+	//	moved    changed requests but removed no content tokens — by design for cache
+	//	         components, whose value is which billing TIER a token lands in
+	//	skipped  ran and never changed anything (see the passthrough list)
+	//	idle     never ran
+	Verdict  string              `json:"verdict"`
 	Gates    map[string]int64    `json:"gates,omitempty"`
 	seenKeys map[string]struct{} // content keys already counted toward SavedUnique (not serialized)
 	// pending* hold the saving credited by this component's most recent fresh report,
@@ -254,6 +268,7 @@ func (cs compStat) forSnapshot() compStat {
 	if cs.SavedUnique > 0 {
 		cs.OvercountRatio = float64(cs.Saved) / float64(cs.SavedUnique)
 	}
+	cs.Verdict = cs.verdict()
 	cs.seenKeys = nil // never serialize the working set
 	if len(cs.Gates) > 0 {
 		g := make(map[string]int64, len(cs.Gates))
@@ -263,6 +278,21 @@ func (cs compStat) forSnapshot() compStat {
 		cs.Gates = g
 	}
 	return cs
+}
+
+// verdict reads the counters. See compStat.Verdict for why this exists rather than leaving
+// a consumer to compare acted against mutated.
+func (cs compStat) verdict() string {
+	switch {
+	case cs.Runs == 0:
+		return "idle"
+	case cs.Acted > 0:
+		return "acted"
+	case cs.Mutated > 0:
+		return "moved"
+	default:
+		return "skipped"
+	}
 }
 
 // addGates merges one report's gate histogram into the rollup.
@@ -684,6 +714,12 @@ type Snapshot struct {
 	// exactly the gap noted in headroom's dashboard. Omitted when no pool is running, so
 	// a sync-only deployment shows no phantom queue.
 	ObserveQueue *QueueStats `json:"observe_queue,omitempty"`
+
+	// KeepAlive is the idle prompt-cache keep-alive's ledger, filled by the host (the
+	// mechanism lives in `proxy` because it acts between requests, which is above this
+	// layer). Omitted entirely when nothing has opted in, so a deployment that does not use
+	// it shows no field rather than a row of zeroes.
+	KeepAlive any `json:"keepalive,omitempty"`
 
 	// Provider-billed token tiers (W8), summed from response usage. ADDITIVE: the
 	// benchmark harnesses parse this payload, so fields are only ever added here,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -171,3 +171,36 @@ func TestSnapshotStaysBackwardCompatible(t *testing.T) {
 		}
 	}
 }
+
+// A cache component MUTATES without SAVING content tokens: cachesplit moves tokens out of a
+// hashed prefix rather than removing them, so its value is which billing TIER they land in.
+// "acted: 0" beside "mutated: 755" has been read as a broken component and filed as a bug
+// twice — most recently against a mechanism that had run 3,000 times and was working exactly
+// as designed. The rollup therefore states the reading instead of leaving it to be inferred.
+func TestComponentVerdictDistinguishesMovedFromSkipped(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reports []components.Report
+		want    string
+	}{
+		{"never ran", nil, "idle"},
+		{"ran and always declined", []components.Report{{Component: "c", Skipped: true}}, "skipped"},
+		{"changed the request but removed no content tokens", []components.Report{
+			{Component: "c"}}, "moved"},
+		{"removed content tokens", []components.Report{
+			{Component: "c", TokensBefore: 100, TokensAfter: 40}}, "acted"},
+	} {
+		a := NewAggregator()
+		for _, r := range tc.reports {
+			a.Component(r)
+		}
+		snap := a.Snapshot()
+		got := "idle"
+		if cs, ok := snap.Components["c"]; ok {
+			got = cs.Verdict
+		}
+		if got != tc.want {
+			t.Errorf("%s: verdict = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - When your agent compacts: how-to/agent-compaction.md
       - Measuring savings: how-to/measure-savings.md
       - Stop carrying unused tools: how-to/declaration-removal.md
+      - Keep an idle prompt cache warm: how-to/cache-keepalive.md
   - Components:
       - Overview: components.md
       - Choose a preset: how-to/choose-a-preset.md

--- a/proxy/control.go
+++ b/proxy/control.go
@@ -1313,6 +1313,11 @@ func (h *Handler) ctlRevokeToken(w http.ResponseWriter, r *http.Request) {
 		ctlErr(w, http.StatusNotFound, "no such live token")
 		return
 	}
+	// Revoking a token is an account saying "that credential is no longer mine to use". The
+	// keep-alive may be holding the PROVIDER key that arrived alongside it, so release it: the
+	// hard deadline would get there within minutes, but a revocation the user performed
+	// deliberately should not wait on a timer.
+	h.keeper.forget(t.ID)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
@@ -1544,6 +1549,11 @@ func (h *Handler) ctlPatchTenant(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// A disabled account's agent is refused at the door, so anything the keep-alive is holding
+	// for it can never be legitimately used again. Unconditional rather than gated on
+	// in.Disabled: a configuration change also invalidates the held policy, and releasing a few
+	// sessions early costs one idle span's refresh.
+	h.keeper.forget(target)
 	updated, err := h.registry().Get(target)
 	if err != nil {
 		ctlErr(w, http.StatusInternalServerError, "saved, but could not re-read the tenant")
@@ -1922,8 +1932,12 @@ func (h *Handler) ctlDeleteTenant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// The in-memory tenancy holds this account's pipeline and state store; nothing can
-	// authenticate as them now, so it is dead weight keyed by a live id.
+	// authenticate as them now, so it is dead weight keyed by a live id. The keep-alive keeper
+	// is the other in-memory holder, and the only one holding a CREDENTIAL — deletion has to
+	// reach it too, or the cascade this repo asserts (TestDeleteCascadesEveryCredential) has a
+	// gap the test cannot see.
 	h.opts.Tenants.Forget(target.ID)
+	h.keeper.forget(target.ID)
 	// Step 3: the tail. Best-effort by construction — the account is already gone, so
 	// there is nothing left to fail back to.
 	if tail, tErr := h.purgeTenantData(target.ID); tErr != nil {

--- a/proxy/control.go
+++ b/proxy/control.go
@@ -1266,6 +1266,12 @@ func (h *Handler) ctlUpdateMe(w http.ResponseWriter, r *http.Request) {
 		ctlErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// This is the route the Settings checkbox posts to, so it is the PRIMARY
+	// consent-withdrawal path for the keep-alive: unticking the box arrives here, not at
+	// ctlPatchTenant. `record` re-reads the policy per request and the hard deadline caps the
+	// hold either way, but the path a user is most likely to take should not be the one relying
+	// on the backstop.
+	h.keeper.forget(t.ID)
 	updated, err := h.registry().Get(t.ID)
 	if err != nil {
 		ctlErr(w, http.StatusInternalServerError, "saved, but could not re-read the account")

--- a/proxy/dashcapture.go
+++ b/proxy/dashcapture.go
@@ -50,6 +50,13 @@ type capture struct {
 	tenant string
 	// meta is the request's own metadata, read once off the pristine inbound body.
 	meta dash.Meta
+	// kaPings / kaRefreshed are what the idle keep-alive did during the span this request
+	// just ended: how many pings it sent, and how many tokens the last of them read from
+	// cache. Recorded on the request path because the keeper's per-session state is cleared
+	// the moment a real request arrives, so this is the only point at which both facts are
+	// still in hand.
+	kaPings     int
+	kaRefreshed int64
 	// inv is the request's DECLARED inventory (tool / MCP / skill names and their token
 	// weights) plus the tool calls of its last tool-using turn — nil when the request
 	// declares no tools, and nil when the dashboard is off. Read on the request path with
@@ -255,6 +262,14 @@ func (c *capture) noteUpstream(ms float64, status int) {
 		c.upstream, c.status = ms, status
 	}
 }
+
+// noteKeepAlive records what the idle keep-alive did during the span this request ended.
+func (c *capture) noteKeepAlive(pings int, refreshed int64) {
+	if c != nil {
+		c.kaPings, c.kaRefreshed = pings, refreshed
+	}
+}
+
 func (c *capture) noteModel(model string) {
 	if c != nil {
 		c.model = model
@@ -294,6 +309,7 @@ func (c *capture) finish(usage Usage, usageOK bool, captureContent bool, content
 	e.Expands, e.ExpandTokens = c.expands, c.expandTok
 	e.FreshInput, e.CacheRead = usage.FreshInput, usage.CacheRead
 	e.CacheWrite, e.OutputTokens = usage.CacheWrite, usage.Output
+	e.CacheWrite1h = usage.CacheWrite1h
 
 	// context-guru's own model spend attributable to THIS request: what this request's
 	// OWN sink recorded, never a delta of the process-wide counters. The delta was
@@ -328,6 +344,10 @@ func (c *capture) finish(usage Usage, usageOK bool, captureContent bool, content
 	// miss without blaming a prefix change (TTL wins ties).
 	e.AttributeCache(seenSession, seenModel, sinceMs, 5*60*1000, e.CacheWrite > 0)
 	e.SessionFirst, e.TailChanged = !seenSession, tailChanged
+	// The raw gap and what the keep-alive did during it. Both feed a dollar figure rather
+	// than only a label (see Event.keepaliveSavedUSD), so they have to be set before Price.
+	e.SinceLastMs = sinceMs
+	e.KeepAlivePings, e.KeepAliveRefreshed = c.kaPings, c.kaRefreshed
 
 	var price modelinfo.Price
 	priced := false

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -43,10 +43,13 @@ import (
 //	 entry, not from the end of its response."
 //
 // So a cache READ refreshes the lifetime, and a read costs 0.1x base input where re-creating
-// the prefix costs 1.25x. One ping buys back one re-creation at 11.5:1. Simulated over the
-// production window at the shipped defaults: 9,234 pings costing $125.29 convert 182 misses
-// worth $295.37, net **+$170.08**, which is 5.42% of spend and 17.5x everything the whole
-// transformation pipeline delivered over the same window ($9.72).
+// the prefix costs 1.25x. One ping buys back one re-creation at 11.5:1.
+//
+// Replayed over the production window THROUGH THIS CODE (TestKeepAliveOnProductionSnapshot) at
+// the shipped defaults: 912 pings costing $90.76 convert 148 of 357 addressable misses worth
+// $215.84, net **+$125.08** — 3.98% of spend, and 12.9x everything the whole transformation
+// pipeline delivered over the same window ($9.72). Every figure here comes from that replay, so
+// a policy change that moves the number moves this comment too.
 //
 // # Why it is host-level and not a component
 //
@@ -73,10 +76,14 @@ import (
 //     rather than pinged again.
 //  2. **Pinging a session that has ENDED is pure waste.** It is not detectable: only 290 of
 //     3,891 session-final requests (7.5%) end with `end_turn`, the other 3,476 end
-//     mid-tool-loop and look exactly like an active session. K is therefore the control, and
-//     it is why the default is 2 — session-final waste scales linearly in K (measured
-//     3,891 sessions x K pings, $18.30 at K=2) so the net peaks early and collapses: +$170.08
-//     at K=2, +$162.56 at K=3, +$27.99 at K=12, −$99.72 at K=20.
+//     mid-tool-loop and look exactly like an active session. K is therefore the control, and it
+//     is why the default is small: the marginal ping's yield falls while its cost does not, so
+//     the net flattens and then collapses — +$125.08 at K=2, +$130.80 at K=3, +$85.28 at K=1,
+//     +$58.35 at K=12.
+//
+//     K=2 and K=3 are a TIE on money (the $5 between them is inside the run-to-run wobble), so
+//     the default is 2 for the request-volume reason and not a dollar reason: it sends 26% fewer
+//     pings on a gateway path that returned 180 HTTP 429s in the same window.
 //
 // A note on what this deliberately does NOT do: it does not stop pinging a session whose last
 // response ended with `end_turn`. That reads like a session-end signal and is the opposite.
@@ -826,9 +833,12 @@ func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
 // invalidate the prefix — the model, the tools, `tool_choice`, the thinking parameters, any
 // system or message content — is left exactly as it was sent.
 //
-// max_tokens is 1, not 0: 0 is the documented pre-warm form but is rejected alongside
-// streaming and thinking, and a rejected ping is a wasted round trip. 1 is accepted
-// everywhere and generates one token.
+// max_tokens is 1 rather than 0. The reason is NOT that 0 is rejected alongside streaming and
+// thinking — this ping sets `stream: false` and refuses thinking-enabled sessions, so neither
+// applies to it. It is that 1 is the value every backend on this path accepts without
+// negotiation, and the difference is one output token: $0.0000076 on sonnet against the
+// $0.0073 the read itself costs, i.e. a tenth of a percent. Not worth a compatibility risk on
+// the one request that must not fail for a surprising reason.
 //
 // stream is false so the response is one small JSON body with its usage block in it, rather
 // than an SSE stream this would have to read to the end to price.

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -1,0 +1,729 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// The idle keep-alive: the one cache mechanism that cannot be a component.
+//
+// # What it is for
+//
+// A provider prompt-cache entry has a five-minute default lifetime, and a session idle
+// longer than that loses its entire cached prefix. The next turn then re-bills every token
+// of it at the cache-CREATION rate. Measured on this service over 19,805 requests and
+// $3,139.97 of spend: 742 requests (3.7% of traffic) missed for that reason and cost
+// $741.07 — 23.6% of everything — at $0.9987 each against $0.1178 for a request that hit.
+// Against each row's own counterfactual the penalty is 11.35x, of which 91.2% is pure
+// re-write. $584.83 of it, 18.6% of ALL spend, sits in misses whose idle gap was under an
+// hour, and 47% of the misses missed the window by less than five minutes.
+//
+// The provider documents the two facts that make this fixable:
+//
+//	"By default, the cache has a 5-minute lifetime. The cache is refreshed for no
+//	 additional cost each time the cached content is used."
+//
+//	"The lifetime is measured from the start of the request that writes or reads the cache
+//	 entry, not from the end of its response."
+//
+// So a cache READ refreshes the lifetime, and a read costs 0.1x base input where re-creating
+// the prefix costs 1.25x. One ping buys back one re-creation at 11.5:1. Simulated over the
+// production window at the shipped defaults: 9,234 pings costing $125.29 convert 182 misses
+// worth $295.37, net **+$170.08**, which is 5.42% of spend and 17.5x everything the whole
+// transformation pipeline delivered over the same window ($9.72).
+//
+// # Why it is host-level and not a component
+//
+// A component runs while a request is in flight. The event this addresses happens when NO
+// request is in flight: the agent is idle, and the entry lapses with nothing on the wire to
+// hook. Nothing inside the pipeline can act at that moment, which is why this lives beside
+// the request path rather than in it.
+//
+// # What it costs, and whose money it is
+//
+// A ping is a real upstream request billed to the caller's own credential. That is the trade
+// — a small certain spend against a much larger probable one — and it is not ours to make on
+// someone's behalf, so it is opt-in per account, capped per session, capped in count, and
+// recorded as its own dashboard row with its own cost. See CachePolicy.
+//
+// # The two ways this can be WRONG, and the guards
+//
+//  1. **A ping that writes instead of reads costs 12.5x rather than saving.** The prefix hash
+//     is cumulative up to and including the breakpoint, so the ping's body must be
+//     byte-identical over that prefix. Hence the ping resends the exact bytes that were sent
+//     upstream, and changes only `max_tokens` and `stream` — fields outside the hashed
+//     prefix. If a ping's usage nevertheless reports more written than read, the mechanism is
+//     wrong for that session: it is logged at ERROR, counted, and the session is dropped
+//     rather than pinged again.
+//  2. **Pinging a session that has ENDED is pure waste.** It is not detectable: only 290 of
+//     3,891 session-final requests (7.5%) end with `end_turn`, the other 3,476 end
+//     mid-tool-loop and look exactly like an active session. K is therefore the control, and
+//     it is why the default is 2 — session-final waste scales linearly in K (measured
+//     3,891 sessions x K pings, $18.30 at K=2) so the net peaks early and collapses: +$170.08
+//     at K=2, +$162.56 at K=3, +$27.99 at K=12, −$99.72 at K=20.
+//
+// A note on what this deliberately does NOT do: it does not stop pinging a session whose last
+// response ended with `end_turn`. That reads like a session-end signal and is the opposite.
+// `end_turn` means the model finished and control returned to a HUMAN, which is precisely the
+// state that produces a long gap: P(gap > 300s) is 37.15% after `end_turn` against 0.74%
+// after `tool_use`, a 6.7x lift, and 83.7% of the recoverable dollars sit behind it. Stopping
+// there would discard most of the value the mechanism exists to capture.
+
+// CachePolicy is one tenant's resolved cache policy — the host-level half of the cache
+// story, which no component can reach.
+//
+// A plain struct in this package rather than config.CacheConfig, for the reason
+// ConfigBuilder exists: proxy does not depend on the configuration loader, so a library
+// host or the bifrost adapter can set this directly.
+type CachePolicy struct {
+	// KeepAlive turns the mechanism on for this tenant. Off by default.
+	KeepAlive bool
+	// Idle is X: how long a session must be idle before the first ping, measured from the
+	// previous request's START per the provider's documented lifetime rule. Zero disables.
+	Idle time.Duration
+	// MaxPings is K: the most pings one idle span may send. Zero disables.
+	MaxPings int
+	// MaxUSDPerSession caps what pings may cost one session.
+	MaxUSDPerSession float64
+	// HeadTTL1h asks for the one-hour tier on the head breakpoints; HeadTTLMinTokens gates
+	// it on request size. Passed through to apply.Opts — see apply/headttl.go.
+	HeadTTL1h        bool
+	HeadTTLMinTokens int
+}
+
+// on reports whether this policy can ping at all.
+func (p CachePolicy) on() bool {
+	return p.KeepAlive && p.Idle > 0 && p.MaxPings > 0
+}
+
+// Keeper bounds. Both are memory bounds and both are needed: a few enormous sessions and a
+// great many small ones are different ways to exhaust the same 8 GiB.
+const (
+	// maxKeepAliveSessions bounds the tracked sessions. Same order as modes.Tracker's own
+	// bound, and reached only by a deployment with that many opted-in sessions idle at once.
+	maxKeepAliveSessions = 512
+	// maxKeepAliveBytes bounds the total request bodies held for replay. A 200k-token
+	// Claude Code body is under 1 MiB, so this is roughly 130 concurrent large sessions
+	// before the oldest are dropped.
+	maxKeepAliveBytes = 128 << 20
+	// maxKeepAliveBodyBytes refuses to hold a single body larger than this. A body this big
+	// is a multi-million-token request whose ping would itself cost real money, and holding
+	// one would spend a fifth of the whole budget on one session.
+	maxKeepAliveBodyBytes = 8 << 20
+	// keepAliveTick is how often the sweep runs. The window it is protecting is 300s wide
+	// and the default fires at 280s, so a 2s granularity spends at most 2s of the 20s of
+	// slack that leaves.
+	keepAliveTick = 2 * time.Second
+)
+
+// kaEntry is one live session's replay material. It exists between the end of a request and
+// the start of the next one, which is exactly the interval the mechanism acts in.
+type kaEntry struct {
+	tenant, session string
+	// startedAt is when the last upstream request on this session STARTED — a real request
+	// or a ping, whichever was later. The provider's lifetime runs from there, not from the
+	// end of the response, so a slow turn eats its own budget and this is the only anchor
+	// that reflects that.
+	startedAt time.Time
+	// body is the exact bytes last sent upstream. Retained, not copied: after serve returns
+	// nothing else references the slice, so holding it costs the bytes and no allocation.
+	// The prefix hash covers this content, which is why the ping must resend it verbatim.
+	body []byte
+	up   upstream
+	// hdr is the minimal header set the ping needs, and — when the upstream is caller-pays
+	// — the caller's provider credential.
+	//
+	// THIS IS THE ONE PLACE THIS SERVICE HOLDS A CALLER'S CREDENTIAL BEYOND THE LIFE OF A
+	// REQUEST, and it is a deliberate, bounded, opt-in decision rather than an oversight.
+	// The default deployment is caller-pays: no upstream in the operator's allow-list names
+	// a key, so every request is authenticated with the caller's own key and there is no
+	// server-held credential a between-requests ping could use. Without retention the
+	// mechanism cannot exist here at all. It is held in memory only, never logged, never
+	// persisted, never in a command line, dropped the moment the session is evicted or the
+	// span ends, and held for at most MaxPings x Idle plus one sweep. When the upstream DOES
+	// name a key (up.setKey != nil) nothing is retained: the credential is read from the
+	// environment at call time, exactly as on the request path.
+	hdr                         http.Header
+	provider                    bschemas.ModelProvider
+	model, route, preset, agent string
+	pol                         CachePolicy
+	pings                       int
+	// spent is what this session's pings have cost so far, against pol.MaxUSDPerSession.
+	spent float64
+	// refreshed is what the last ping read from cache. It is the ceiling on what the next
+	// real request may credit to this mechanism — see dash.Event.keepaliveSavedUSD.
+	refreshed int64
+	// stopped means this session will not be pinged again: a ping wrote instead of reading,
+	// or the upstream refused in a way that repeating cannot fix.
+	stopped bool
+}
+
+// due reports whether this entry should be pinged now.
+func (e *kaEntry) due(now time.Time) bool {
+	return !e.stopped && e.pol.on() && e.pings < e.pol.MaxPings &&
+		!now.Before(e.startedAt.Add(e.pol.Idle))
+}
+
+// keeper runs the keep-alive. One goroutine per handler, one map, one lock.
+type keeper struct {
+	h    *Handler
+	stop chan struct{}
+	done chan struct{}
+	// stopOnce and started make Stop idempotent and safe on a keeper whose sweep was never
+	// launched. Handler.Close documents that it is safe to call twice, and it is: a second
+	// close of the same channel would panic.
+	stopOnce sync.Once
+	started  atomic.Bool
+
+	mu    sync.Mutex
+	live  map[string]*kaEntry
+	bytes int64
+
+	// send performs one ping. A field so tests can drive the whole policy — timing, caps,
+	// limits, the write-instead-of-read guard — without a network.
+	send func(pingJob, []byte) (Usage, int, error)
+	// dispatch starts one ping. Production runs it on its own goroutine, because a round trip
+	// must not be made while the map lock is held; the snapshot replay overrides this to run
+	// inline so a five-day simulation is deterministic and needs no synchronisation.
+	dispatch func(pingJob)
+	// now is the clock, injected for the same reason.
+	now func() time.Time
+
+	// Counters, for /stats and for the honest question "is this thing spending money and
+	// getting nothing?". Every one of them is a way the mechanism can be useless.
+	pings    atomic.Int64
+	skipped  atomic.Int64 // due, but a limit or a cap or a gate refused
+	failed   atomic.Int64
+	wrote    atomic.Int64  // pings that CREATED instead of refreshing — a bug, not a cost
+	spentUSD atomic.Uint64 // float64 bits; only ever read as a whole
+}
+
+// keepAliveDisabled is the operator's kill switch, read once at construction. A single
+// environment variable rather than a control-plane route: the thing an operator needs at
+// 3am is one that works when the control plane is what is broken.
+func keepAliveDisabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("CONTEXT_GURU_KEEPALIVE")))
+	return v == "off" || v == "0" || v == "false"
+}
+
+func newKeeper(h *Handler) *keeper {
+	k := &keeper{h: h, stop: make(chan struct{}), done: make(chan struct{}),
+		live: map[string]*kaEntry{}, now: time.Now}
+	k.send = k.sendPing
+	k.dispatch = func(j pingJob) { go k.fire(j) }
+	return k
+}
+
+// start launches the sweep goroutine. Nil-safe, and a no-op when the kill switch is set.
+func (k *keeper) start() {
+	if k == nil {
+		return
+	}
+	if keepAliveDisabled() {
+		slog.Info("context-guru: cache keep-alive disabled by CONTEXT_GURU_KEEPALIVE")
+		close(k.done)
+		return
+	}
+	k.started.Store(true)
+	go func() {
+		defer close(k.done)
+		t := time.NewTicker(keepAliveTick)
+		defer t.Stop()
+		for {
+			select {
+			case <-k.stop:
+				return
+			case <-t.C:
+				k.sweep(k.now())
+			}
+		}
+	}()
+}
+
+// Stop ends the sweep and drops every held body and credential.
+func (k *keeper) Stop() {
+	if k == nil {
+		return
+	}
+	k.stopOnce.Do(func() {
+		if k.started.Load() {
+			close(k.stop)
+			<-k.done
+		}
+	})
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for key, e := range k.live {
+		e.clear()
+		delete(k.live, key)
+	}
+	k.bytes = 0
+}
+
+// clear drops an entry's body and credential. Called on every removal path, because the two
+// things this holds are the two things it must not hold longer than it needs to.
+func (e *kaEntry) clear() {
+	e.body = nil
+	e.hdr = nil
+}
+
+func kaKey(tenant, session string) string { return tenant + "\x00" + session }
+
+// arrive tells the keeper a real request just started on this session, and reports what the
+// keep-alive did during the span that request just ended.
+//
+// Called at the START of the request, before it goes upstream: an entry left in the map
+// while a real request is in flight could be pinged concurrently with it, which is both
+// pointless (the real request refreshes the entry itself) and a second request against the
+// tenant's concurrency budget.
+func (k *keeper) arrive(tenant, session string) (pings int, refreshed int64) {
+	if k == nil || session == "" {
+		return 0, 0
+	}
+	key := kaKey(tenant, session)
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	e, ok := k.live[key]
+	if !ok {
+		return 0, 0
+	}
+	pings, refreshed = e.pings, e.refreshed
+	k.bytes -= int64(len(e.body))
+	e.clear()
+	delete(k.live, key)
+	return pings, refreshed
+}
+
+// record hands the keeper what it needs to ping this session, once the request that
+// established the cache entry has finished.
+//
+// startedAt is the instant the upstream request STARTED, per the provider's lifetime rule.
+// The body is the exact bytes that went upstream.
+func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body []byte,
+	up upstream, r *http.Request, provider bschemas.ModelProvider, route string, status int,
+	u Usage, usageOK bool) {
+	if k == nil || tn == nil || session == "" || len(body) == 0 || startedAt.IsZero() {
+		return
+	}
+	// Only a request the provider ACCEPTED left a cache entry behind. Tracking a 4xx or a
+	// failed forward would hold a body and a credential in order to ping a prefix that was
+	// never cached — cost with no possible benefit.
+	if status < 200 || status >= 300 {
+		return
+	}
+	pol := tn.Cache
+	if !pol.on() {
+		return
+	}
+	if len(body) > maxKeepAliveBodyBytes {
+		k.skipped.Add(1)
+		return
+	}
+	// Nothing to keep alive unless the provider honours explicit breakpoints and this
+	// request actually established or read an entry. A request that wrote and read nothing
+	// has no prefix worth a ping.
+	if !cacheAwareProvider(provider) {
+		return
+	}
+	if usageOK && u.CacheRead == 0 && u.CacheWrite == 0 {
+		return
+	}
+	// Thinking, and the one shape that cannot be pinged. The ping's whole correctness rests
+	// on the hashed prefix being byte-identical, and the provider's own invalidation table
+	// puts a change to the thinking parameters at the messages level — so the thinking block
+	// must be resent exactly. With `thinking.type: enabled` the API also requires
+	// max_tokens > thinking.budget_tokens, so the ping cannot be made cheap: budgets on this
+	// traffic are 32,000 tokens, and a ping allowed to generate that much output costs far
+	// more than the miss it prevents. `adaptive` carries no budget and is unaffected.
+	//
+	// Measured exposure of refusing these: of the 357 addressable misses in the production
+	// window, 17 had a predecessor with thinking enabled, worth $14.29 of $732 — 2.0%.
+	if gjson.GetBytes(body, "thinking.type").String() == "enabled" {
+		k.skipped.Add(1)
+		return
+	}
+	e := &kaEntry{
+		tenant: tn.ID, session: session, startedAt: startedAt, body: body, up: up,
+		provider: provider, model: gjson.GetBytes(body, "model").String(),
+		route: route, preset: tn.Preset,
+		agent: r.UserAgent(), pol: pol,
+		hdr: pingHeaders(r, up),
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if prev, ok := k.live[kaKey(tn.ID, session)]; ok {
+		k.bytes -= int64(len(prev.body))
+		prev.clear()
+	}
+	k.live[kaKey(tn.ID, session)] = e
+	k.bytes += int64(len(body))
+	k.evictLocked()
+}
+
+// evictLocked enforces both bounds by dropping the entries whose deadline is furthest away
+// — the ones with the longest still to wait, and therefore the least imminent value.
+func (k *keeper) evictLocked() {
+	for len(k.live) > maxKeepAliveSessions || k.bytes > maxKeepAliveBytes {
+		var worstKey string
+		var worst time.Time
+		for key, e := range k.live {
+			if worstKey == "" || e.startedAt.After(worst) {
+				worstKey, worst = key, e.startedAt
+			}
+		}
+		if worstKey == "" {
+			return
+		}
+		e := k.live[worstKey]
+		k.bytes -= int64(len(e.body))
+		e.clear()
+		delete(k.live, worstKey)
+		k.skipped.Add(1)
+	}
+}
+
+// sweep fires every due ping. Returns how many it started, for tests.
+//
+// The map lock is held only to select and to stamp: a ping is an HTTP round trip and holding
+// the lock across it would block every arriving request on this map.
+func (k *keeper) sweep(now time.Time) int {
+	if k == nil {
+		return 0
+	}
+	k.mu.Lock()
+	var due []pingJob
+	for key, e := range k.live {
+		// Retire a span that can do nothing more. Without this an entry sits in the map until
+		// eviction pressure removes it, which on a quiet deployment is never — and what it
+		// sits there holding is a request body and, on a caller-pays upstream, the caller's
+		// provider credential. So the hold is bounded by the POLICY (at most (K+1) x X, about
+		// 14 minutes at the defaults) rather than by how busy the box happens to be.
+		if e.stopped || e.pings >= e.pol.MaxPings {
+			if !now.Before(e.startedAt.Add(e.pol.Idle)) {
+				k.bytes -= int64(len(e.body))
+				e.clear()
+				delete(k.live, key)
+			}
+			continue
+		}
+		if !e.due(now) {
+			continue
+		}
+		if e.pol.MaxUSDPerSession > 0 && e.spent >= e.pol.MaxUSDPerSession {
+			e.stopped = true
+			k.skipped.Add(1)
+			continue
+		}
+		// Everything the ping needs, taken HERE under the lock. Nothing outside it may read the
+		// FIELDS e.body or e.hdr: the retirement branch above clears both, and a ping goroutine
+		// still in flight would then be racing this sweep. The slice VALUE is safe to carry out
+		// — the bytes are written once at record time and never mutated, and clear() drops the
+		// field rather than the array — which is what keeps the rewrite below out of the
+		// critical section.
+		//
+		// Stamp the clock BEFORE the call, and from the ping's own start: the provider's
+		// lifetime runs from request start, so the next deadline is this instant plus X. It
+		// also makes the entry not-due for the rest of this sweep, so a slow ping cannot be
+		// started twice.
+		e.startedAt = now
+		e.pings++
+		due = append(due, pingJob{e: e, raw: e.body, hdr: e.hdr.Clone(), up: e.up,
+			tenant: e.tenant, session: e.session, ping: e.pings})
+	}
+	k.mu.Unlock()
+
+	for _, j := range due {
+		k.dispatch(j)
+	}
+	return len(due)
+}
+
+// pingJob is one ping's material, copied out of the entry under the keeper's lock. It exists
+// because the ping runs on another goroutine and the entry it came from may be retired — body
+// and credential dropped — before that goroutine finishes.
+type pingJob struct {
+	e *kaEntry
+	// raw is the recorded request's bytes. The ping's own body is derived from it in fire,
+	// outside the keeper's lock: the rewrite copies the whole body, and a large one under the
+	// map lock would stall every arriving request on this proxy.
+	raw             []byte
+	hdr             http.Header
+	up              upstream
+	tenant, session string
+	ping            int
+}
+
+// fire sends one ping and accounts for it. Always fails open and quietly: the agent is not
+// waiting on this, so there is nobody to return an error to and nothing that a retry could
+// help. A failed ping is logged, counted, and forgotten.
+func (k *keeper) fire(j pingJob) {
+	// The tenant's own limits apply, and a ping only ever uses SLACK. Refusing rather than
+	// queueing is the requirement: a queued ping would sit in front of a real request the
+	// agent IS waiting on. AcquireSpare reserves headroom so a ping cannot consume the last
+	// slot or the last request of the minute.
+	release, err := k.h.limiter.AcquireSpare(j.tenant, keepAliveReserveFrac)
+	if err != nil {
+		k.skipped.Add(1)
+		return
+	}
+	defer release()
+
+	body, ok := pingBody(j.raw)
+	if !ok {
+		k.markStopped(j.e)
+		k.skipped.Add(1)
+		return
+	}
+	start := k.now()
+	u, status, err := k.send(j, body)
+	ms := float64(k.now().Sub(start).Microseconds()) / 1000.0
+	k.pings.Add(1)
+	if err != nil {
+		k.failed.Add(1)
+		slog.Debug("context-guru: cache keep-alive ping failed",
+			"tenant", tenantLabel(j.tenant), "session", j.session, "err", err)
+		return
+	}
+	// A 4xx will repeat identically, so stop rather than spend the rest of K learning the
+	// same thing. A 5xx is transient and the next ping may work.
+	if status >= 400 && status < 500 {
+		k.markStopped(j.e)
+		slog.Debug("context-guru: cache keep-alive ping refused; not pinging this session again",
+			"tenant", tenantLabel(j.tenant), "session", j.session, "status", status)
+		return
+	}
+	// THE guard. A ping is supposed to be a pure cache READ; if the provider says it wrote
+	// more than it read, the prefix did not match and this ping cost 12.5x what a read
+	// costs instead of saving 11.5x. That is the mechanism being wrong, not expensive, so
+	// it is an ERROR and the session is dropped.
+	if u.CacheWrite > u.CacheRead {
+		k.wrote.Add(1)
+		k.markStopped(j.e)
+		slog.Error("context-guru: cache keep-alive ping CREATED a cache entry instead of "+
+			"refreshing one; not pinging this session again",
+			"tenant", tenantLabel(j.tenant), "session", j.session,
+			"cache_write", u.CacheWrite, "cache_read", u.CacheRead)
+	}
+	cost := k.record1(j, u, status, ms)
+	slog.Debug("context-guru: cache keep-alive ping",
+		"tenant", tenantLabel(j.tenant), "session", j.session, "ping", j.ping,
+		"cache_read", u.CacheRead, "cache_write", u.CacheWrite, "output", u.Output,
+		"cost_usd", cost, "ms", ms)
+}
+
+// markStopped stops pinging one session, if it is still tracked.
+func (k *keeper) markStopped(e *kaEntry) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	e.stopped = true
+}
+
+// record1 books one ping: the session's running spend, the process counter, and the
+// dashboard row. Returns the ping's cost.
+//
+// The row is the whole reason this is shippable. It carries the ping's own tokens and cost,
+// marked keepalive, attributed to the tenant and the session — so the money this mechanism
+// spends is visible in the same ledger as the money it saves, and an account can see it
+// without being told.
+func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
+	e := j.e
+	// The identifying fields are read under the lock with everything else: they are set once
+	// at record time and never mutated, but a retired entry is concurrent with this goroutine
+	// and the race detector is right to insist.
+	k.mu.Lock()
+	model, provider, route, preset, agent := e.model, e.provider, e.route, e.preset, e.agent
+	k.mu.Unlock()
+	var price modelinfo.Price
+	priced := false
+	if p := k.h.opts.Prices; p != nil && model != "" {
+		price, priced = p.Price(context.Background(), model)
+	}
+	ev := &dash.Event{
+		TS: k.now().UnixMilli(), TenantID: j.tenant, Model: model,
+		Provider: string(provider), Route: route, Preset: preset,
+		Status: status, KeepAlive: true,
+	}
+	ev.SessionID = j.session
+	ev.Agent = dash.AgentFor(agent)
+	ev.FreshInput, ev.CacheRead = u.FreshInput, u.CacheRead
+	ev.CacheWrite, ev.OutputTokens = u.CacheWrite, u.Output
+	ev.CacheWrite1h = u.CacheWrite1h
+	ev.StopReason = u.StopReason
+	ev.UpstreamMs = ms
+	// What the ping actually asked for, so the row says it rather than reading as a request
+	// with no output budget. The audit trail is the reason these rows exist; a column that is
+	// blank because nobody filled it in is the same defect at a smaller scale.
+	ev.MaxTokens = 1
+	// A ping is not agent traffic, so it gets no cache-miss attribution and never touches
+	// the session-recency map: doing so would re-date the session and make the NEXT real
+	// request's gap read as four minutes instead of the twenty it actually was, hiding the
+	// very thing this mechanism is here to demonstrate.
+	ev.Price(price, priced && (u.CacheRead > 0 || u.CacheWrite > 0 || u.Output > 0))
+	cost := ev.CostUSD
+	k.mu.Lock()
+	e.spent += cost
+	e.refreshed = u.CacheRead
+	k.mu.Unlock()
+	for {
+		old := k.spentUSD.Load()
+		if k.spentUSD.CompareAndSwap(old, math.Float64bits(math.Float64frombits(old)+cost)) {
+			break
+		}
+	}
+	if k.h.rec != nil {
+		k.h.rec.Record(ev)
+	}
+	return cost
+}
+
+// pingBody turns the last real request into the cheapest possible cache READ of the same
+// prefix.
+//
+// Only two fields change, and NEITHER is inside the hashed prefix. The provider hashes
+// `tools` → `system` → `messages` cumulatively up to the breakpoint; `max_tokens` and
+// `stream` are request-level knobs outside that sequence, so the prefix stays byte-identical
+// and the ping matches the entry the real request wrote. Everything a change to WOULD
+// invalidate the prefix — the model, the tools, `tool_choice`, the thinking parameters, any
+// system or message content — is left exactly as it was sent.
+//
+// max_tokens is 1, not 0: 0 is the documented pre-warm form but is rejected alongside
+// streaming and thinking, and a rejected ping is a wasted round trip. 1 is accepted
+// everywhere and generates one token.
+//
+// stream is false so the response is one small JSON body with its usage block in it, rather
+// than an SSE stream this would have to read to the end to price.
+func pingBody(body []byte) ([]byte, bool) {
+	out, err := sjson.SetBytes(body, "max_tokens", 1)
+	if err != nil {
+		return nil, false
+	}
+	out, err = sjson.SetBytes(out, "stream", false)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// pingHeaders is the minimal header set a ping needs, plus the caller's credential when the
+// upstream is caller-pays.
+//
+// Built explicitly rather than by copying the client's headers: a replayed `content-length`
+// or `accept-encoding` from a request whose body has changed is a bug waiting to happen, and
+// the fewer of a caller's headers this holds for ten minutes the better. `anthropic-beta` is
+// carried because a beta header can change how the body is interpreted, and a ping that is
+// interpreted differently is not the same request.
+func pingHeaders(r *http.Request, up upstream) http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	for _, name := range []string{"Anthropic-Version", "Anthropic-Beta"} {
+		if v := r.Header.Get(name); v != "" {
+			h.Set(name, v)
+		}
+	}
+	if up.setKey != nil {
+		return h // a server-held key is injected at call time; nothing to retain
+	}
+	// Caller-pays: the credential is the caller's own, and without it there is no ping. Only
+	// the auth slots, and only after our own token has been scrubbed out of them.
+	for _, name := range authHeaders {
+		for _, v := range r.Header.Values(name) {
+			h.Add(name, v)
+		}
+	}
+	scrubToken(h)
+	return h
+}
+
+// sendPing performs the upstream round trip. Bounded by its own timeout: a ping has no
+// client waiting and must never hold a concurrency slot for the ten minutes the request
+// path's header timeout allows.
+func (k *keeper) sendPing(j pingJob, body []byte) (Usage, int, error) {
+	if j.up.base == "" {
+		return Usage{}, 0, errNoUpstream
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), keepAlivePingTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, j.up.base+j.up.path,
+		strings.NewReader(string(body)))
+	if err != nil {
+		return Usage{}, 0, err
+	}
+	for name, vs := range j.hdr {
+		req.Header[name] = append([]string(nil), vs...)
+	}
+	setUpstreamAuth(req.Header, j.up)
+	resp, err := k.h.client.Do(req)
+	if err != nil {
+		return Usage{}, 0, err
+	}
+	defer resp.Body.Close()
+	// Bounded read: a ping's response is a few hundred bytes of JSON, and an upstream that
+	// answers a max_tokens:1 request with megabytes is not one to buffer.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil && !errors.Is(err, io.EOF) {
+		return Usage{}, resp.StatusCode, err
+	}
+	u, _ := responseUsage(resp.Header.Get("Content-Type"), raw)
+	return u, resp.StatusCode, nil
+}
+
+// keepAlivePingTimeout bounds one ping. Generous relative to what a max_tokens:1 answer
+// takes and far short of the request path's own header timeout.
+const keepAlivePingTimeout = 60 * time.Second
+
+// keepAliveReserveFrac is the share of a tenant's rate and concurrency budget a ping may
+// never touch. A quarter, so a tenant at three quarters of its limit stops being pinged
+// while its agent keeps working — the requirement is that a ping never crowds out a real
+// request, and the only way to honour that with a fixed-window counter is to stay away from
+// the edge of it.
+const keepAliveReserveFrac = 0.25
+
+// cacheAwareProvider reports whether this provider honours explicit cache_control
+// breakpoints, which is the precondition for there being an entry a ping could refresh.
+func cacheAwareProvider(p bschemas.ModelProvider) bool {
+	switch p {
+	case bschemas.Anthropic, bschemas.Bedrock, bschemas.BedrockMantle, bschemas.Vertex:
+		return true
+	}
+	return false
+}
+
+// KeepAliveStats is the keeper's own ledger, for /stats. Every field is a way the mechanism
+// can be worthless, which is the point of publishing them together: pings with no
+// conversions is a policy that spends and gains nothing, and `wrote` above zero is a bug.
+type KeepAliveStats struct {
+	Live     int     `json:"live_sessions"`
+	Pings    int64   `json:"pings"`
+	Skipped  int64   `json:"skipped"`
+	Failed   int64   `json:"failed"`
+	Wrote    int64   `json:"wrote_instead_of_read"`
+	SpentUSD float64 `json:"spend_usd"`
+}
+
+// Stats snapshots the keeper's counters.
+func (k *keeper) Stats() KeepAliveStats {
+	if k == nil {
+		return KeepAliveStats{}
+	}
+	k.mu.Lock()
+	live := len(k.live)
+	k.mu.Unlock()
+	return KeepAliveStats{Live: live, Pings: k.pings.Load(), Skipped: k.skipped.Load(),
+		Failed: k.failed.Load(), Wrote: k.wrote.Load(),
+		SpentUSD: math.Float64frombits(k.spentUSD.Load())}
+}

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -172,9 +172,13 @@ const (
 	// maxKeepAliveSessions bounds the tracked sessions. Same order as modes.Tracker's own
 	// bound, and reached only by a deployment with that many opted-in sessions idle at once.
 	maxKeepAliveSessions = 512
-	// maxKeepAliveBytes bounds the total request bodies held for replay. A 200k-token
-	// Claude Code body is under 1 MiB, so this is roughly 130 concurrent large sessions
-	// before the oldest are dropped.
+	// maxKeepAliveBytes bounds the total request bodies held for replay.
+	//
+	// THIS is the binding ceiling, not maxKeepAliveSessions — tune this one. A gated session
+	// carries at least a 20k-token prefix, so ~100 KB to 1 MiB of body, and 128 MiB therefore
+	// binds around 130 large sessions: well before the 512-session count. The replay reports a
+	// peak of 11 live sessions, but it drives ~350-byte synthetic bodies, so it exercises the
+	// count bound and says nothing about this one.
 	maxKeepAliveBytes = 128 << 20
 	// maxKeepAliveTurnKeys bounds the per-session turn counter. Larger than the session bound
 	// because it holds one int rather than a body, and it has to outlive the entry.

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -205,8 +205,13 @@ type kaEntry struct {
 	// over the production window, that one change takes X=280 from **+$164.46 to −$241.99**,
 	// with ping cost tripling to $408.85.
 	startedAt time.Time
-	// body is the exact bytes last sent upstream. Retained, not copied: after serve returns
-	// nothing else references the slice, so holding it costs the bytes and no allocation.
+	// body is the bytes last sent upstream, held MASKED under the same per-process key as the
+	// credential (see credMask). A keeper-owned copy, so it can be overwritten on release
+	// without corrupting a slice something else still reads.
+	//
+	// Masked for the reason the credential is, and the asymmetry decides it: a leaked key is
+	// rotatable, a leaked transcript is not. This is up to 8 MiB of the user's conversation, and
+	// XOR over it costs a memcpy-shaped pass on a path that runs a few hundred times a day.
 	// The prefix hash covers this content, which is why the ping must resend it verbatim.
 	body []byte
 	up   upstream
@@ -472,6 +477,16 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 		k.retire(key)
 		return
 	}
+	// NO AUDIT SINK, NO RETENTION. An audit control that --dashboard silently removes is not a
+	// control, and this is the one that makes the whole credential arrangement reviewable. Given
+	// the choice between an unconditional second sink and refusing to hold anything we cannot
+	// account for, this takes the second: it is three lines instead of a parallel writer, and it
+	// fails in the safe direction — a deployment with no recorder keeps none of a caller's
+	// credential and none of their conversation.
+	if k.h.rec == nil {
+		k.retire(key)
+		return
+	}
 	// Consent is re-read from the tenancy on EVERY request rather than trusted from when the
 	// hold began, and withdrawing it retires what is already held. The tenancy is re-resolved
 	// per request and its cache is keyed on the configuration document, so an account that turns
@@ -520,6 +535,7 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	// them. Zeroizing a shared slice is the kind of cleverness that produces a mystery bug in a
 	// month, and the earlier zero-copy retention was a micro-optimisation in the wrong place.
 	owned := append([]byte(nil), body...)
+	xorMask(owned)
 	// What the provider billed for this request's prefix, in its own units — the size of the
 	// entry a ping would refresh. Both the gate and the projected cost read it, so a request
 	// that reported no usage is not pingable: without it there is no honest estimate of either.
@@ -598,6 +614,33 @@ func (k *keeper) retire(key string) {
 	delete(k.live, key)
 }
 
+// forget releases everything held for one tenant, for the paths that end an account's authority
+// rather than change its mind: deletion, token revocation, disablement. Consent withdrawal is
+// handled in record, and the hard deadline bounds anything that goes quiet — but this repo holds
+// the stronger invariant explicitly (tenant.TestDeleteCascadesEveryCredential), and the keeper is
+// a credential store that cascade did not know about.
+//
+// ponytail: called from the three control-plane paths that revoke authority; a fourth would have
+// to remember. Move it inside TenantSource.Forget if revoke and disable ever start invalidating
+// the cached tenancy too, which would make one hook cover all of them.
+func (k *keeper) forget(tenantID string) {
+	if k == nil {
+		return
+	}
+	prefix := tenantID + "\x00"
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for key, e := range k.live {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		k.bytes -= int64(len(e.body))
+		e.clear()
+		delete(k.live, key)
+		delete(k.turns, key)
+	}
+}
+
 // evictLocked enforces both bounds by dropping the entries whose deadline is furthest away
 // — the ones with the longest still to wait, and therefore the least imminent value.
 func (k *keeper) evictLocked() {
@@ -664,7 +707,11 @@ func (k *keeper) sweep(now time.Time) int {
 		for i, a := range e.auth {
 			auth[i] = maskedHeader{name: a.name, val: append([]byte(nil), a.val...)}
 		}
-		due = append(due, pingJob{e: e, raw: e.body, hdr: e.hdr.Clone(), auth: auth, up: e.up,
+		// An UNMASKED copy for this ping, zeroized by fire when it is done. The entry's own copy
+		// stays masked, so the long-lived hold never contains a readable transcript.
+		raw := append([]byte(nil), e.body...)
+		xorMask(raw)
+		due = append(due, pingJob{e: e, raw: raw, hdr: e.hdr.Clone(), auth: auth, up: e.up,
 			tenant: e.tenant, session: e.session, ping: e.pings})
 	}
 	k.mu.Unlock()
@@ -703,6 +750,7 @@ func (k *keeper) fire(j pingJob) {
 		for i := range j.auth {
 			zero(j.auth[i].val)
 		}
+		zero(j.raw) // the unmasked body copy this ping was handed
 	}()
 	// The tenant's own limits apply, and a ping only ever uses SLACK. Refusing rather than
 	// queueing is the requirement: a queued ping would sit in front of a real request the

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"io"
 	"log/slog"
@@ -84,6 +85,46 @@ import (
 // after `tool_use`, a 6.7x lift, and 83.7% of the recoverable dollars sit behind it. Stopping
 // there would discard most of the value the mechanism exists to capture.
 
+// credMask obscures a retained credential while it is idle in memory.
+//
+// Be precise about what this buys, because it is easy to oversell. A heap or core dump, a crash
+// report, a `/proc/<pid>/mem` read or a stray `strings` over a snapshot yields masked bytes
+// instead of a working key — that is the accidental-capture class, and it is the realistic one.
+// It does NOT stop an attacker with code execution in this process: the mask is right here in
+// the same address space. It is obfuscation at rest, not encryption.
+//
+// The credential is unavoidably plaintext for the duration of the ping itself: net/http's header
+// map holds strings, and a Go string cannot be overwritten. So the window is one request rather
+// than the whole idle hold, which is the part that was worth closing.
+var credMask = func() []byte {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic("context-guru: no entropy for the keep-alive credential mask: " + err.Error())
+	}
+	return b
+}()
+
+// xorMask masks or unmasks in place — XOR is its own inverse, so one function does both.
+func xorMask(b []byte) {
+	for i := range b {
+		b[i] ^= credMask[i%len(credMask)]
+	}
+}
+
+// zero overwrites a buffer. Dropping the reference is not enough: the bytes sit in the heap
+// until a collection that may never come, and a dump taken in between still has them.
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// maskedHeader is one auth header held masked. The NAME is not a secret; the value is.
+type maskedHeader struct {
+	name string
+	val  []byte
+}
+
 // CachePolicy is one tenant's resolved cache policy — the host-level half of the cache
 // story, which no component can reach.
 //
@@ -162,8 +203,11 @@ type kaEntry struct {
 	// The prefix hash covers this content, which is why the ping must resend it verbatim.
 	body []byte
 	up   upstream
-	// hdr is the minimal header set the ping needs, and — when the upstream is caller-pays
-	// — the caller's provider credential.
+	// hdr is the minimal NON-SECRET header set the ping needs (content type, API version, beta
+	// flags). The credential never goes in here — see auth.
+	hdr http.Header
+	// auth is the caller's provider credential, held MASKED (see credMask), and only when the
+	// upstream is caller-pays.
 	//
 	// THIS IS THE ONE PLACE THIS SERVICE HOLDS A CALLER'S CREDENTIAL BEYOND THE LIFE OF A
 	// REQUEST, and it is a deliberate, bounded, opt-in decision rather than an oversight.
@@ -171,11 +215,12 @@ type kaEntry struct {
 	// a key, so every request is authenticated with the caller's own key and there is no
 	// server-held credential a between-requests ping could use. Without retention the
 	// mechanism cannot exist here at all. It is held in memory only, never logged, never
-	// persisted, never in a command line, dropped the moment the session is evicted or the
-	// span ends, and held for at most MaxPings x Idle plus one sweep. When the upstream DOES
-	// name a key (up.setKey != nil) nothing is retained: the credential is read from the
-	// environment at call time, exactly as on the request path.
-	hdr                         http.Header
+	// persisted, never in a command line, MASKED while idle, ZEROIZED on every release path, and
+	// bounded by a hard deadline of (MaxPings+1) x Idle that fires whether or not anything else
+	// in this process is awake. When the upstream DOES name a key (up.setKey != nil) nothing is
+	// retained at all: the credential is read from the environment at call time, exactly as on
+	// the request path.
+	auth                        []maskedHeader
 	provider                    bschemas.ModelProvider
 	model, route, preset, agent string
 	pol                         CachePolicy
@@ -198,6 +243,12 @@ type kaEntry struct {
 	// stopped means this session will not be pinged again: a ping wrote instead of reading,
 	// or the upstream refused in a way that repeating cannot fix.
 	stopped bool
+	// timer is the HARD retention deadline. A scheduled deadline rather than a check inside the
+	// sweep, because the requirement is that a quiet process still drops the credential on
+	// time: with no request and no other activity the sweep is the only thing that would ever
+	// look, and coupling a security bound to a liveness loop is how a hold silently becomes
+	// unbounded. time.AfterFunc fires regardless.
+	timer *time.Timer
 }
 
 // due reports whether this TRACKED entry should be pinged now. Timing, K and the stop flag
@@ -340,11 +391,27 @@ func (k *keeper) Stop() {
 	k.turns = map[string]int{}
 }
 
-// clear drops an entry's body and credential. Called on every removal path, because the two
-// things this holds are the two things it must not hold longer than it needs to.
+// clear ZEROIZES an entry's body and credential and cancels its retention deadline. Called on
+// every removal path — the next request arriving, the gate refusing, retirement, eviction,
+// shutdown — because the two things this holds are the two things it must not hold a moment
+// longer than it needs to.
+//
+// Overwriting rather than dropping the reference is the point: a dropped []byte sits in the heap
+// until a collection that may never come, and a dump taken in between still yields it. The body
+// is a keeper-owned COPY precisely so it can be overwritten without corrupting a slice something
+// else still reads.
 func (e *kaEntry) clear() {
+	zero(e.body)
 	e.body = nil
+	for i := range e.auth {
+		zero(e.auth[i].val)
+	}
+	e.auth = nil
 	e.hdr = nil
+	if e.timer != nil {
+		e.timer.Stop()
+		e.timer = nil
+	}
 }
 
 func kaKey(tenant, session string) string { return tenant + "\x00" + session }
@@ -391,11 +458,25 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	if status < 200 || status >= 300 {
 		return
 	}
+	key := kaKey(tn.ID, session)
+	// The kill switch stops RETENTION, not merely pinging. A switch that left bodies and
+	// credentials accumulating while refusing to use them would be the worst of both.
+	if keepAliveDisabled() {
+		k.retire(key)
+		return
+	}
+	// Consent is re-read from the tenancy on EVERY request rather than trusted from when the
+	// hold began, and withdrawing it retires what is already held. The tenancy is re-resolved
+	// per request and its cache is keyed on the configuration document, so an account that turns
+	// the setting off stops being retained on its very next request; anything held for a session
+	// that goes quiet instead is dropped by the hard deadline below, within (K+1)x X.
 	pol := tn.Cache
 	if !pol.on() {
+		k.retire(key)
 		return
 	}
 	if len(body) > maxKeepAliveBodyBytes {
+		k.retire(key)
 		k.skipped.Add(1)
 		return
 	}
@@ -403,9 +484,11 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	// request actually established or read an entry. A request that wrote and read nothing
 	// has no prefix worth a ping.
 	if !cacheAwareProvider(provider) {
+		k.retire(key)
 		return
 	}
 	if usageOK && u.CacheRead == 0 && u.CacheWrite == 0 {
+		k.retire(key)
 		return
 	}
 	// Thinking, and the one shape that cannot be pinged. The ping's whole correctness rests
@@ -419,22 +502,29 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	// Measured exposure of refusing these: of the 357 addressable misses in the production
 	// window, 17 had a predecessor with thinking enabled, worth $14.29 of $732 — 2.0%.
 	if gjson.GetBytes(body, "thinking.type").String() == "enabled" {
+		k.retire(key)
 		k.skipped.Add(1)
 		return
 	}
 	model := gjson.GetBytes(body, "model").String()
+	// A keeper-OWNED copy, not the slice serve just used. It costs one allocation per tracked
+	// session — and tracked sessions are gated down to a handful — in exchange for being able to
+	// overwrite the bytes on release without corrupting anything else that might still read
+	// them. Zeroizing a shared slice is the kind of cleverness that produces a mystery bug in a
+	// month, and the earlier zero-copy retention was a micro-optimisation in the wrong place.
+	owned := append([]byte(nil), body...)
 	// What the provider billed for this request's prefix, in its own units — the size of the
 	// entry a ping would refresh. Both the gate and the projected cost read it, so a request
 	// that reported no usage is not pingable: without it there is no honest estimate of either.
 	prefix := u.CacheRead + u.CacheWrite
+	hdr, auth := pingHeaders(r, up)
 	e := &kaEntry{
-		tenant: tn.ID, session: session, startedAt: startedAt, body: body, up: up,
+		tenant: tn.ID, session: session, startedAt: startedAt, body: owned, up: up,
 		provider: provider, model: model, route: route, preset: tn.Preset,
 		agent: r.UserAgent(), pol: pol, prefix: prefix,
 		pingUSD: k.projectedPingUSD(model, prefix),
-		hdr:     pingHeaders(r, up),
+		hdr:     hdr, auth: auth,
 	}
-	key := kaKey(tn.ID, session)
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	// The turn count outlives the entry, which is dropped on the next request's arrival. It is
@@ -458,7 +548,12 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 		return
 	}
 	k.live[key] = e
-	k.bytes += int64(len(body))
+	k.bytes += int64(len(owned))
+	// The hard deadline. (K+1) x Idle is the longest the policy could ever still want this
+	// entry: K pings each restarting the clock, plus one final Idle to notice the last one
+	// bought nothing. After that there is no legitimate use, so the material goes whether or not
+	// anything else in this process is awake.
+	e.timer = time.AfterFunc(time.Duration(e.pol.MaxPings+1)*e.pol.Idle, func() { k.retire(key) })
 	k.evictLocked()
 }
 
@@ -479,6 +574,21 @@ func (k *keeper) projectedPingUSD(model string, prefix int64) float64 {
 		return 0
 	}
 	return float64(prefix)*price.CacheRead + price.Output
+}
+
+// retire releases one session's held material now: zeroized, deadline cancelled, entry gone.
+// Idempotent and safe on a session that was never tracked, which is what lets every refusal path
+// call it unconditionally.
+func (k *keeper) retire(key string) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	e, ok := k.live[key]
+	if !ok {
+		return
+	}
+	k.bytes -= int64(len(e.body))
+	e.clear()
+	delete(k.live, key)
 }
 
 // evictLocked enforces both bounds by dropping the entries whose deadline is furthest away
@@ -514,11 +624,11 @@ func (k *keeper) sweep(now time.Time) int {
 	k.mu.Lock()
 	var due []pingJob
 	for key, e := range k.live {
-		// Retire a span that can do nothing more. Without this an entry sits in the map until
-		// eviction pressure removes it, which on a quiet deployment is never — and what it
-		// sits there holding is a request body and, on a caller-pays upstream, the caller's
-		// provider credential. So the hold is bounded by the POLICY (at most (K+1) x X, about
-		// 14 minutes at the defaults) rather than by how busy the box happens to be.
+		// EAGER release of a span that can do nothing more, so material goes as soon as it is
+		// useless rather than at the outer deadline. The GUARANTEE is kaEntry.timer, which fires
+		// on schedule whether or not this loop is running; this is the earlier of the two, and
+		// having both is deliberate — a security bound must not depend on a liveness loop, and a
+		// liveness loop should not wait for the security bound.
 		if e.stopped || e.pings >= e.pol.MaxPings || !e.pingable() {
 			if !now.Before(e.startedAt.Add(e.pol.Idle)) {
 				k.bytes -= int64(len(e.body))
@@ -543,7 +653,11 @@ func (k *keeper) sweep(now time.Time) int {
 		// started twice.
 		e.startedAt = now
 		e.pings++
-		due = append(due, pingJob{e: e, raw: e.body, hdr: e.hdr.Clone(), up: e.up,
+		auth := make([]maskedHeader, len(e.auth))
+		for i, a := range e.auth {
+			auth[i] = maskedHeader{name: a.name, val: append([]byte(nil), a.val...)}
+		}
+		due = append(due, pingJob{e: e, raw: e.body, hdr: e.hdr.Clone(), auth: auth, up: e.up,
 			tenant: e.tenant, session: e.session, ping: e.pings})
 	}
 	k.mu.Unlock()
@@ -562,8 +676,11 @@ type pingJob struct {
 	// raw is the recorded request's bytes. The ping's own body is derived from it in fire,
 	// outside the keeper's lock: the rewrite copies the whole body, and a large one under the
 	// map lock would stall every arriving request on this proxy.
-	raw             []byte
-	hdr             http.Header
+	raw []byte
+	hdr http.Header
+	// auth is this ping's copy of the masked credential, unmasked only inside sendPing and
+	// zeroized there — so the plaintext window is one request rather than the whole idle hold.
+	auth            []maskedHeader
 	up              upstream
 	tenant, session string
 	ping            int
@@ -573,6 +690,13 @@ type pingJob struct {
 // waiting on this, so there is nobody to return an error to and nothing that a retry could
 // help. A failed ping is logged, counted, and forgotten.
 func (k *keeper) fire(j pingJob) {
+	// The job carries its own copy of the masked credential, so it owns the wipe. Deferred so
+	// the limiter refusal, the pingBody failure and a panic all release it.
+	defer func() {
+		for i := range j.auth {
+			zero(j.auth[i].val)
+		}
+	}()
 	// The tenant's own limits apply, and a ping only ever uses SLACK. Refusing rather than
 	// queueing is the requirement: a queued ping would sit in front of a real request the
 	// agent IS waiting on. AcquireSpare reserves headroom so a ping cannot consume the last
@@ -728,7 +852,7 @@ func pingBody(body []byte) ([]byte, bool) {
 // the fewer of a caller's headers this holds for ten minutes the better. `anthropic-beta` is
 // carried because a beta header can change how the body is interpreted, and a ping that is
 // interpreted differently is not the same request.
-func pingHeaders(r *http.Request, up upstream) http.Header {
+func pingHeaders(r *http.Request, up upstream) (http.Header, []maskedHeader) {
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
 	for _, name := range []string{"Anthropic-Version", "Anthropic-Beta"} {
@@ -737,17 +861,27 @@ func pingHeaders(r *http.Request, up upstream) http.Header {
 		}
 	}
 	if up.setKey != nil {
-		return h // a server-held key is injected at call time; nothing to retain
+		return h, nil // a server-held key is injected at call time; nothing to retain
 	}
-	// Caller-pays: the credential is the caller's own, and without it there is no ping. Only
-	// the auth slots, and only after our own token has been scrubbed out of them.
+	// Caller-pays: the credential is the caller's own, and without it there is no ping. Only the
+	// auth slots, only after our own token has been scrubbed out of them, and MASKED — so the
+	// idle hold contains no working credential for a dump or a string scan to find.
+	slots := http.Header{}
 	for _, name := range authHeaders {
 		for _, v := range r.Header.Values(name) {
-			h.Add(name, v)
+			slots.Add(name, v)
 		}
 	}
-	scrubToken(h)
-	return h
+	scrubToken(slots)
+	var out []maskedHeader
+	for name, vs := range slots {
+		for _, v := range vs {
+			b := []byte(v)
+			xorMask(b)
+			out = append(out, maskedHeader{name: name, val: b})
+		}
+	}
+	return h, out
 }
 
 // sendPing performs the upstream round trip. Bounded by its own timeout: a ping has no
@@ -766,6 +900,14 @@ func (k *keeper) sendPing(j pingJob, body []byte) (Usage, int, error) {
 	}
 	for name, vs := range j.hdr {
 		req.Header[name] = append([]string(nil), vs...)
+	}
+	// Unmask the credential as late as possible and wipe the buffer immediately. The value
+	// necessarily becomes a Go string once it is in the header map, and a string cannot be
+	// overwritten — so this bounds the plaintext to this request rather than eliminating it.
+	for _, a := range j.auth {
+		xorMask(a.val)
+		req.Header.Add(a.name, string(a.val))
+		zero(a.val)
 	}
 	setUpstreamAuth(req.Header, j.up)
 	resp, err := k.h.client.Do(req)

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -624,9 +624,13 @@ func (k *keeper) retire(key string) {
 // the stronger invariant explicitly (tenant.TestDeleteCascadesEveryCredential), and the keeper is
 // a credential store that cascade did not know about.
 //
-// ponytail: called from the three control-plane paths that revoke authority; a fourth would have
-// to remember. Move it inside TenantSource.Forget if revoke and disable ever start invalidating
-// the cached tenancy too, which would make one hook cover all of them.
+// ponytail: called from the four control-plane paths that end a hold's authority or its consent;
+// a fifth would have to remember. Delete, revoke-token and disable end AUTHORITY — the credential
+// stops working. PUT /api/me ends CONSENT — the credential still works and the hold is still
+// authorized, but permission to use it is gone; that distinction is why ctlRevokeSession is
+// deliberately not in the set (a browser cookie is neither). Move this inside TenantSource.Forget
+// if revoke and disable ever start invalidating the cached tenancy too, which would make one hook
+// cover all of them.
 func (k *keeper) forget(tenantID string) {
 	if k == nil {
 		return

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -98,8 +98,15 @@ type CachePolicy struct {
 	Idle time.Duration
 	// MaxPings is K: the most pings one idle span may send. Zero disables.
 	MaxPings int
-	// MaxUSDPerSession caps what pings may cost one session.
-	MaxUSDPerSession float64
+	// MaxUSDPerPing refuses a ping whose projected cost exceeds this. PER PING, because ping
+	// cost is bimodal (p50 $0.0004, p99 $0.2275, max $0.3780) while a per-SESSION budget
+	// truncates exactly the long large-prefix sessions holding the value — capping the
+	// window's pings per session at 20 drops the net from +$164 to $92.34.
+	MaxUSDPerPing float64
+	// MinPrefixTokens is the billed-prefix floor (the previous request's cache_read +
+	// cache_write) a session must reach before it is pinged. With the first-request skip this
+	// sends 8.7x fewer pings for 3.3% less money.
+	MinPrefixTokens int
 	// HeadTTL1h asks for the one-hour tier on the head breakpoints; HeadTTLMinTokens gates
 	// it on request size. Passed through to apply.Opts — see apply/headttl.go.
 	HeadTTL1h        bool
@@ -121,6 +128,9 @@ const (
 	// Claude Code body is under 1 MiB, so this is roughly 130 concurrent large sessions
 	// before the oldest are dropped.
 	maxKeepAliveBytes = 128 << 20
+	// maxKeepAliveTurnKeys bounds the per-session turn counter. Larger than the session bound
+	// because it holds one int rather than a body, and it has to outlive the entry.
+	maxKeepAliveTurnKeys = 20000
 	// maxKeepAliveBodyBytes refuses to hold a single body larger than this. A body this big
 	// is a multi-million-token request whose ping would itself cost real money, and holding
 	// one would spend a fifth of the whole budget on one session.
@@ -136,9 +146,16 @@ const (
 type kaEntry struct {
 	tenant, session string
 	// startedAt is when the last upstream request on this session STARTED — a real request
-	// or a ping, whichever was later. The provider's lifetime runs from there, not from the
-	// end of the response, so a slow turn eats its own budget and this is the only anchor
-	// that reflects that.
+	// or a ping, whichever was later.
+	//
+	// DO NOT "SIMPLIFY" THIS TO THE RESPONSE'S COMPLETION TIME. It is the single decision in
+	// this file that flips the sign of the whole feature. The provider's lifetime runs from
+	// request start, so an anchor at completion silently spends the response's own duration
+	// out of the 20 s of margin X leaves: `upstream_ms` is p50 8.9 s, p75 17.5 s, p90 33.4 s,
+	// so roughly 21% of first pings would land after the entry had already expired — and a
+	// ping onto a dead entry pays a 1.25x WRITE, the exact cost it exists to avoid. Simulated
+	// over the production window, that one change takes X=280 from **+$164.46 to −$241.99**,
+	// with ping cost tripling to $408.85.
 	startedAt time.Time
 	// body is the exact bytes last sent upstream. Retained, not copied: after serve returns
 	// nothing else references the slice, so holding it costs the bytes and no allocation.
@@ -163,7 +180,17 @@ type kaEntry struct {
 	model, route, preset, agent string
 	pol                         CachePolicy
 	pings                       int
-	// spent is what this session's pings have cost so far, against pol.MaxUSDPerSession.
+	// turn is how many requests this session sent BEFORE the one that established this entry.
+	// 0 means the session's first request, which the gate skips.
+	turn int
+	// prefix is what the previous request billed (cache_read + cache_write) — the size of the
+	// entry a ping would refresh, and therefore the input to both the gate and the cost guard.
+	prefix int64
+	// pingUSD is the projected cost of one ping on that prefix, from the model's own read
+	// rate. Checked against pol.MaxUSDPerPing before anything is sent.
+	pingUSD float64
+	// spent is what this session's pings have cost so far. Reported, never a cap — see
+	// CachePolicy.MaxUSDPerPing for why the guard is per ping.
 	spent float64
 	// refreshed is what the last ping read from cache. It is the ceiling on what the next
 	// real request may credit to this mechanism — see dash.Event.keepaliveSavedUSD.
@@ -173,10 +200,38 @@ type kaEntry struct {
 	stopped bool
 }
 
-// due reports whether this entry should be pinged now.
+// due reports whether this TRACKED entry should be pinged now. Timing, K and the stop flag
+// only: every policy gate is applied at record time instead, so an entry that exists is by
+// construction one we intend to ping.
+//
+// That split is not cosmetic. A gate evaluated here would leave un-pingable sessions sitting in
+// the map holding a request body and a caller credential until memory pressure evicted them —
+// measured on the production replay, the map saturated at its 512-session bound and the
+// eviction then threw away the entries that were about to pay, cutting conversions from 153 to
+// 69. Gating at record keeps nothing we will not use.
 func (e *kaEntry) due(now time.Time) bool {
 	return !e.stopped && e.pol.on() && e.pings < e.pol.MaxPings &&
 		!now.Before(e.startedAt.Add(e.pol.Idle))
+}
+
+// pingable reports whether this session is worth holding state for at all. Every condition is
+// known when the request finishes, which is why it is checked there.
+//
+//   - **Not the session's FIRST request** (turn >= 1). Single-request sessions are 79% of the
+//     pings and 0.9% of the value: nothing has accumulated for a second turn to hit, and most
+//     never send one. A cheap filter, NOT a claim that later turns miss more often — P(the next
+//     request is an addressable TTL miss) is flat at 2.24% from turn 0, 2.33% at turn 5, 2.47%
+//     at turn 20, 2.29% at turn 100.
+//   - **A billed prefix worth protecting**, in the provider's own units.
+//   - **A projected ping cost inside budget.** Ping cost is bimodal (p50 $0.0004, p99 $0.2275,
+//     max $0.3780), so the outlier to refuse is one ping and not a session's total.
+//
+// Deliberately NOT gated on the previous turn's `stop_reason`. `end_turn` looks like a
+// session-end signal and is the opposite — P(gap > 300s) is 37.15% after it against 0.74%
+// after `tool_use`, and 83.7% of the recoverable dollars sit behind it.
+func (e *kaEntry) pingable() bool {
+	return e.turn >= 1 && e.prefix >= int64(e.pol.MinPrefixTokens) &&
+		(e.pol.MaxUSDPerPing <= 0 || e.pingUSD <= e.pol.MaxUSDPerPing)
 }
 
 // keeper runs the keep-alive. One goroutine per handler, one map, one lock.
@@ -193,6 +248,15 @@ type keeper struct {
 	mu    sync.Mutex
 	live  map[string]*kaEntry
 	bytes int64
+	// turns counts requests seen per session, so the first-request gate survives the entry's
+	// own lifecycle: an entry is dropped the moment the next request arrives, and retired by
+	// policy a few minutes later, while "has this session sent a request before?" has to
+	// outlive both.
+	//
+	// ponytail: a plain map with a size bound and no per-key expiry. It holds one int per
+	// session id and is cleared wholesale at the bound; give it an LRU only if session churn
+	// is ever shown to cost real pings.
+	turns map[string]int
 
 	// send performs one ping. A field so tests can drive the whole policy — timing, caps,
 	// limits, the write-instead-of-read guard — without a network.
@@ -223,7 +287,7 @@ func keepAliveDisabled() bool {
 
 func newKeeper(h *Handler) *keeper {
 	k := &keeper{h: h, stop: make(chan struct{}), done: make(chan struct{}),
-		live: map[string]*kaEntry{}, now: time.Now}
+		live: map[string]*kaEntry{}, turns: map[string]int{}, now: time.Now}
 	k.send = k.sendPing
 	k.dispatch = func(j pingJob) { go k.fire(j) }
 	return k
@@ -273,6 +337,7 @@ func (k *keeper) Stop() {
 		delete(k.live, key)
 	}
 	k.bytes = 0
+	k.turns = map[string]int{}
 }
 
 // clear drops an entry's body and credential. Called on every removal path, because the two
@@ -357,22 +422,63 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 		k.skipped.Add(1)
 		return
 	}
+	model := gjson.GetBytes(body, "model").String()
+	// What the provider billed for this request's prefix, in its own units — the size of the
+	// entry a ping would refresh. Both the gate and the projected cost read it, so a request
+	// that reported no usage is not pingable: without it there is no honest estimate of either.
+	prefix := u.CacheRead + u.CacheWrite
 	e := &kaEntry{
 		tenant: tn.ID, session: session, startedAt: startedAt, body: body, up: up,
-		provider: provider, model: gjson.GetBytes(body, "model").String(),
-		route: route, preset: tn.Preset,
-		agent: r.UserAgent(), pol: pol,
-		hdr: pingHeaders(r, up),
+		provider: provider, model: model, route: route, preset: tn.Preset,
+		agent: r.UserAgent(), pol: pol, prefix: prefix,
+		pingUSD: k.projectedPingUSD(model, prefix),
+		hdr:     pingHeaders(r, up),
 	}
+	key := kaKey(tn.ID, session)
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	if prev, ok := k.live[kaKey(tn.ID, session)]; ok {
+	// The turn count outlives the entry, which is dropped on the next request's arrival. It is
+	// incremented for EVERY request, including the ones the gate then refuses to track — that is
+	// what lets a session's second request be recognised as such.
+	k.turns[key]++
+	e.turn = k.turns[key] - 1
+	if len(k.turns) > maxKeepAliveTurnKeys {
+		k.turns = map[string]int{key: k.turns[key]}
+	}
+	// Drop any previous entry either way: it is stale now, and if the gate refuses this request
+	// its body and credential must not be left behind.
+	if prev, ok := k.live[key]; ok {
 		k.bytes -= int64(len(prev.body))
 		prev.clear()
+		delete(k.live, key)
 	}
-	k.live[kaKey(tn.ID, session)] = e
+	if !e.pingable() {
+		k.skipped.Add(1)
+		e.clear() // hold no body and no credential for a session we will not ping
+		return
+	}
+	k.live[key] = e
 	k.bytes += int64(len(body))
 	k.evictLocked()
+}
+
+// projectedPingUSD is what one ping on this prefix will cost: the prefix at the model's own
+// cache-read rate, plus the single output token. Computed at record time so the guard can
+// refuse an expensive ping BEFORE sending it rather than reporting it afterwards.
+//
+// Zero when the model is not priced, which lets the ping through — refusing to protect a cache
+// because a price list is incomplete would be the wrong failure, and the spend still lands on
+// its own dashboard row either way.
+func (k *keeper) projectedPingUSD(model string, prefix int64) float64 {
+	p := k.h.opts.Prices
+	if p == nil || model == "" || prefix <= 0 {
+		return 0
+	}
+	price, ok := p.Price(context.Background(), model)
+	if !ok || price.Zero() {
+		return 0
+	}
+	return float64(prefix)*price.CacheRead + price.Output
 }
 
 // evictLocked enforces both bounds by dropping the entries whose deadline is furthest away
@@ -413,7 +519,7 @@ func (k *keeper) sweep(now time.Time) int {
 		// sits there holding is a request body and, on a caller-pays upstream, the caller's
 		// provider credential. So the hold is bounded by the POLICY (at most (K+1) x X, about
 		// 14 minutes at the defaults) rather than by how busy the box happens to be.
-		if e.stopped || e.pings >= e.pol.MaxPings {
+		if e.stopped || e.pings >= e.pol.MaxPings || !e.pingable() {
 			if !now.Before(e.startedAt.Add(e.pol.Idle)) {
 				k.bytes -= int64(len(e.body))
 				e.clear()
@@ -422,11 +528,6 @@ func (k *keeper) sweep(now time.Time) int {
 			continue
 		}
 		if !e.due(now) {
-			continue
-		}
-		if e.pol.MaxUSDPerSession > 0 && e.spent >= e.pol.MaxUSDPerSession {
-			e.stopped = true
-			k.skipped.Add(1)
 			continue
 		}
 		// Everything the ping needs, taken HERE under the lock. Nothing outside it may read the

--- a/proxy/keepalive_snapshot_test.go
+++ b/proxy/keepalive_snapshot_test.go
@@ -103,8 +103,9 @@ func TestKeepAliveOnProductionSnapshot(t *testing.T) {
 				r.pings, r.pingUSD, r.converted, r.savedUSD, r.savedUSD-r.pingUSD,
 				(r.savedUSD-r.pingUSD)/r.totalUSD*100, r.totalUSD)
 			t.Logf("  addressable misses %d worth $%.2f | wasted pings (gap would have hit) %d worth $%.2f"+
-				" | skipped by a gate %d | sessions holding state at end %d",
-				r.addressable, r.addressableUSD, r.wastedPings, r.wastedUSD, r.skipped, r.liveAtEnd)
+				" | skipped by a gate %d | live sessions: peak %d of %d bound, %d at end",
+				r.addressable, r.addressableUSD, r.wastedPings, r.wastedUSD, r.skipped,
+				r.peakLive, maxKeepAliveSessions, r.liveAtEnd)
 			t.Logf("  per session: %d pinged | %d net positive | %d net NEGATIVE costing $%.2f in total"+
 				" | worst single session $%.4f",
 				r.sessions, r.sessionsWinning, r.sessionsLosing, -r.losingUSD, r.worstSessionUSD)
@@ -117,7 +118,7 @@ func TestKeepAliveOnProductionSnapshot(t *testing.T) {
 
 type replayResult struct {
 	pings, converted, addressable, wastedPings, skipped int64
-	liveAtEnd                                           int
+	liveAtEnd, peakLive                                 int
 	wroteInsteadOfRead                                  int64
 	pingUSD, savedUSD, addressableUSD, wastedUSD        float64
 	totalUSD                                            float64
@@ -226,6 +227,9 @@ func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy, blanke
 		}
 		simNow = at
 
+		if n := k.Stats().Live; n > out.peakLive {
+			out.peakLive = n
+		}
 		pings, _ := k.arrive(r.tenant, r.session)
 		e := entries[r.session]
 		addressable := r.reason == "ttl_expiry" && r.cacheWrite > 0

--- a/proxy/keepalive_snapshot_test.go
+++ b/proxy/keepalive_snapshot_test.go
@@ -73,16 +73,32 @@ func TestKeepAliveOnProductionSnapshot(t *testing.T) {
 		time.UnixMilli(rows[0].ts).UTC().Format(time.RFC3339),
 		time.UnixMilli(rows[len(rows)-1].ts).UTC().Format(time.RFC3339))
 
-	// Every arm the PR quotes, from the same decision function. X and K are the only knobs.
-	for _, arm := range []struct{ idle, maxPings int }{
-		{280, 2}, {280, 1}, {280, 3}, {240, 2}, {280, 12},
+	// Every arm the PR quotes, from the same decision function. The blanket arms set
+	// MinPrefixTokens 0 and are run with the first-request gate lifted, so the gate's effect is
+	// visible as the difference between two rows of the same table rather than asserted.
+	for _, arm := range []struct {
+		idle, maxPings, minPrefix int
+		blanket                   bool
+	}{
+		{280, 2, 20000, false}, // SHIPPED
+		{280, 2, 0, true},
+		{280, 1, 20000, false},
+		{280, 3, 20000, false},
+		{240, 2, 20000, false},
+		{280, 12, 20000, false},
+		{280, 2, 50000, false},
 	} {
 		arm := arm
-		t.Run(fmt.Sprintf("X=%ds_K=%d", arm.idle, arm.maxPings), func(t *testing.T) {
+		name := fmt.Sprintf("X=%ds_K=%d_prefix>=%dk", arm.idle, arm.maxPings, arm.minPrefix/1000)
+		if arm.blanket {
+			name = fmt.Sprintf("X=%ds_K=%d_BLANKET", arm.idle, arm.maxPings)
+		}
+		t.Run(name, func(t *testing.T) {
 			r := replay(t, rows, table, CachePolicy{
 				KeepAlive: true, Idle: time.Duration(arm.idle) * time.Second,
-				MaxPings: arm.maxPings, MaxUSDPerSession: 0.25,
-			})
+				MaxPings: arm.maxPings, MaxUSDPerPing: 0.25,
+				MinPrefixTokens: arm.minPrefix,
+			}, arm.blanket)
 			t.Logf("pings %d  ping $%.2f  converted %d  saved $%.2f  NET $%+.2f (%.2f%% of $%.2f)",
 				r.pings, r.pingUSD, r.converted, r.savedUSD, r.savedUSD-r.pingUSD,
 				(r.savedUSD-r.pingUSD)/r.totalUSD*100, r.totalUSD)
@@ -116,11 +132,20 @@ type replayResult struct {
 }
 
 // replay drives the shipped keeper over the snapshot's timeline.
-func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy) replayResult {
+func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy, blanket bool) replayResult {
 	t.Helper()
 	var out replayResult
 	h := &Handler{opts: Options{Prices: table}, limiter: NewLimiter(Limits{})}
 	k := newKeeper(h)
+	// The blanket arms lift the first-request gate by pre-seeding every session's turn counter,
+	// which is the only way to compare "gated" against "blanket" through the SAME code path.
+	seedTurn := func(key string) {
+		if blanket {
+			k.mu.Lock()
+			k.turns[key]++
+			k.mu.Unlock()
+		}
+	}
 	// Inline dispatch: a five-day replay must be deterministic, and a goroutine per ping would
 	// need synchronising against the clock the test is driving.
 	k.dispatch = k.fire
@@ -245,6 +270,7 @@ func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy) replay
 			tn = &Tenancy{ID: r.tenant, Cache: pol}
 			tenancies[r.tenant] = tn
 		}
+		seedTurn(kaKey(r.tenant, r.session))
 		k.record(tn, r.session, at, body, up, req, providerOf(r.provider), "/v1/messages",
 			http.StatusOK, Usage{CacheRead: r.cacheRead, CacheWrite: r.cacheWrite}, usageOK)
 	}

--- a/proxy/keepalive_snapshot_test.go
+++ b/proxy/keepalive_snapshot_test.go
@@ -1,0 +1,342 @@
+package proxy
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	_ "modernc.org/sqlite" // the same pure-Go driver the dashboard's own store uses
+)
+
+// Replay of the production dashboard snapshot through the SHIPPED keep-alive.
+//
+// The point of doing it this way rather than in a separate model: the projected dollars in
+// the pull request have to come out of the code that will run, not out of a Python script
+// that agrees with it today. So this drives the real `keeper` — the real `due()` timing, the
+// real K, the real per-session spend cap, the real thinking gate, the real record/arrive
+// lifecycle — over the real request timeline, and prices every ping through the same Pricer
+// the request path uses.
+//
+// Skipped unless CG_SNAPSHOT_DB names a snapshot, so it never runs in CI and never touches a
+// live database. Open it READ-ONLY.
+//
+//	CG_SNAPSHOT_DB=/tmp/cgwork/cg-snap.db \
+//	MODEL_PRICES=/etc/context-guru/prices.yaml \
+//	CGO_ENABLED=1 go test -run TestKeepAliveOnProductionSnapshot -v ./proxy/
+//
+// What it does NOT model, stated because a projection that hides its assumptions is worth
+// nothing:
+//
+//   - Tenant rate and concurrency limits. AcquireSpare reads the wall clock, which a
+//     simulation on a synthetic clock cannot drive, so this runs with limits off and
+//     therefore reports an UPPER bound on pings sent. In production a ping that finds no
+//     slack is skipped, which removes both its cost and its conversion.
+//   - The provider's content-keyed cache. Another session sending a byte-identical prefix
+//     would refresh the same entry for free, so some conversions credited here would have
+//     happened anyway. Same confound as the live credit, and in the same direction.
+//   - Request bodies. The snapshot stores token counts, not bodies, so the replay hands the
+//     keeper a synthetic body of the right shape. The gates that read the body (thinking, the
+//     size bound) are driven from the recorded columns instead.
+type snapRow struct {
+	id, ts                  int64
+	session, tenant, model  string
+	agent, provider, reason string
+	cacheRead, cacheWrite   int64
+	costUSD                 float64
+	thinking                string
+}
+
+func TestKeepAliveOnProductionSnapshot(t *testing.T) {
+	path := os.Getenv("CG_SNAPSHOT_DB")
+	if path == "" {
+		t.Skip("set CG_SNAPSHOT_DB to replay a production snapshot")
+	}
+	prices := os.Getenv("MODEL_PRICES")
+	if prices == "" {
+		prices = "/etc/context-guru/prices.yaml"
+	}
+	table, err := modelinfo.LoadTable(prices)
+	if err != nil {
+		t.Fatalf("prices: %v", err)
+	}
+	rows := loadSnapshot(t, path)
+	t.Logf("snapshot: %d requests, %s .. %s", len(rows),
+		time.UnixMilli(rows[0].ts).UTC().Format(time.RFC3339),
+		time.UnixMilli(rows[len(rows)-1].ts).UTC().Format(time.RFC3339))
+
+	// Every arm the PR quotes, from the same decision function. X and K are the only knobs.
+	for _, arm := range []struct{ idle, maxPings int }{
+		{280, 2}, {280, 1}, {280, 3}, {240, 2}, {280, 12},
+	} {
+		arm := arm
+		t.Run(fmt.Sprintf("X=%ds_K=%d", arm.idle, arm.maxPings), func(t *testing.T) {
+			r := replay(t, rows, table, CachePolicy{
+				KeepAlive: true, Idle: time.Duration(arm.idle) * time.Second,
+				MaxPings: arm.maxPings, MaxUSDPerSession: 0.25,
+			})
+			t.Logf("pings %d  ping $%.2f  converted %d  saved $%.2f  NET $%+.2f (%.2f%% of $%.2f)",
+				r.pings, r.pingUSD, r.converted, r.savedUSD, r.savedUSD-r.pingUSD,
+				(r.savedUSD-r.pingUSD)/r.totalUSD*100, r.totalUSD)
+			t.Logf("  addressable misses %d worth $%.2f | wasted pings (gap would have hit) %d worth $%.2f"+
+				" | skipped by a gate %d | sessions holding state at end %d",
+				r.addressable, r.addressableUSD, r.wastedPings, r.wastedUSD, r.skipped, r.liveAtEnd)
+			t.Logf("  per session: %d pinged | %d net positive | %d net NEGATIVE costing $%.2f in total"+
+				" | worst single session $%.4f",
+				r.sessions, r.sessionsWinning, r.sessionsLosing, -r.losingUSD, r.worstSessionUSD)
+			if r.wroteInsteadOfRead != 0 {
+				t.Errorf("%d pings created an entry instead of refreshing one", r.wroteInsteadOfRead)
+			}
+		})
+	}
+}
+
+type replayResult struct {
+	pings, converted, addressable, wastedPings, skipped int64
+	liveAtEnd                                           int
+	wroteInsteadOfRead                                  int64
+	pingUSD, savedUSD, addressableUSD, wastedUSD        float64
+	totalUSD                                            float64
+	// Per-session outcomes, because the aggregate hides the only thing a user cares about:
+	// whether THEIR sessions pay. A policy that nets positive service-wide while costing the
+	// median session money is not a policy anybody should be opted into.
+	sessions                        int
+	sessionsLosing, sessionsWinning int
+	worstSessionUSD                 float64
+	worstSessionID                  string
+	losingUSD                       float64
+}
+
+// replay drives the shipped keeper over the snapshot's timeline.
+func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy) replayResult {
+	t.Helper()
+	var out replayResult
+	h := &Handler{opts: Options{Prices: table}, limiter: NewLimiter(Limits{})}
+	k := newKeeper(h)
+	// Inline dispatch: a five-day replay must be deterministic, and a goroutine per ping would
+	// need synchronising against the clock the test is driving.
+	k.dispatch = k.fire
+
+	simNow := time.UnixMilli(rows[0].ts).UTC()
+	k.now = func() time.Time { return simNow }
+
+	// The provider, simulated: an entry lives 5 minutes from the last touch (a real request or
+	// a ping), which is the documented rule the whole mechanism rests on.
+	type live struct {
+		lastTouch time.Time
+		prefix    int64
+	}
+	entries := map[string]*live{}
+	entryModel := map[string]string{}
+	// Per-session ledger: what pings cost that session against what they saved it.
+	type ledger struct{ ping, saved float64 }
+	perSession := map[string]*ledger{}
+	sessionOf := func(id string) *ledger {
+		l := perSession[id]
+		if l == nil {
+			l = &ledger{}
+			perSession[id] = l
+		}
+		return l
+	}
+
+	// prefixOf is what a ping would re-read, and therefore what it costs: the size of the
+	// entry the previous request established.
+	k.send = func(j pingJob, body []byte) (Usage, int, error) {
+		e := entries[j.session]
+		if e == nil {
+			return Usage{}, http.StatusOK, nil
+		}
+		if simNow.Sub(e.lastTouch) > 5*time.Minute {
+			// The entry had already lapsed: this ping CREATES one. It is the failure mode the
+			// shipped code treats as a bug, and by construction it cannot happen at X < 300s.
+			out.wroteInsteadOfRead++
+			e.lastTouch = simNow
+			return Usage{CacheWrite: e.prefix, Output: 1}, http.StatusOK, nil
+		}
+		e.lastTouch = simNow // the read refreshed it, for no additional cost
+		return Usage{CacheRead: e.prefix, Output: 1}, http.StatusOK, nil
+	}
+	// The ping's cost, attributed to the session that caused it, read out of the entry the
+	// shipped record1 just updated. Wrapping the sender is the only place both facts are in
+	// hand at once.
+	rawSend := k.send
+	k.send = func(j pingJob, body []byte) (Usage, int, error) {
+		u, st, err := rawSend(j, body)
+		if price, ok := table.Price(nil, entryModel[j.session]); ok {
+			sessionOf(j.session).ping += float64(u.CacheRead)*price.CacheRead +
+				float64(u.CacheWrite)*price.CacheWrite + float64(u.Output)*price.Output
+		}
+		return u, st, err
+	}
+
+	// One tenancy per tenant id: the keeper keys its map on (tenant, session), so a replay that
+	// records under "" and arrives under the real id never matches — which is exactly the bug
+	// this line fixes, and it reported zero conversions rather than an error.
+	tenancies := map[string]*Tenancy{}
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	req.Header.Set("Authorization", "Bearer replay")
+	up := upstream{base: "http://replay", path: "/v1/messages"}
+
+	for i := range rows {
+		r := &rows[i]
+		out.totalUSD += r.costUSD
+		at := time.UnixMilli(r.ts).UTC()
+		// Advance the clock to this request, sweeping exactly as the ticker would.
+		for simNow.Before(at) {
+			next := simNow.Add(keepAliveTick)
+			if next.After(at) {
+				next = at
+			}
+			simNow = next
+			k.sweep(simNow)
+		}
+		simNow = at
+
+		pings, _ := k.arrive(r.tenant, r.session)
+		e := entries[r.session]
+		addressable := r.reason == "ttl_expiry" && r.cacheWrite > 0
+		if addressable {
+			out.addressable++
+			out.addressableUSD += r.costUSD
+		}
+		price, priced := table.Price(nil, r.model)
+		switch {
+		case addressable && pings > 0 && e != nil && at.Sub(e.lastTouch) <= 5*time.Minute:
+			// The entry was still alive because of our pings, so this request reads its prefix
+			// instead of re-creating it. What it saves is the re-write penalty on the tokens it
+			// actually wrote.
+			out.converted++
+			if priced {
+				v := float64(r.cacheWrite) * (price.CacheWrite - price.CacheRead)
+				out.savedUSD += v
+				sessionOf(r.session).saved += v
+			}
+		case pings > 0 && r.reason == "hit":
+			// Pings spent on a gap that would have hit anyway. Not a saving, and the honest
+			// place to count them is here rather than nowhere.
+			out.wastedPings += int64(pings)
+		}
+		// This request refreshes or establishes the entry.
+		if e == nil {
+			e = &live{}
+			entries[r.session] = e
+		}
+		e.lastTouch, e.prefix = at, r.cacheRead+r.cacheWrite
+		entryModel[r.session] = r.model
+		if e.prefix == 0 {
+			e.prefix = 1 // nothing cached; a ping on it reads nothing and costs nothing
+		}
+
+		// Hand the finished request to the keeper, with the gates it reads driven from the
+		// recorded columns.
+		body := snapBody(r)
+		usageOK := r.cacheRead > 0 || r.cacheWrite > 0
+		tn := tenancies[r.tenant]
+		if tn == nil {
+			tn = &Tenancy{ID: r.tenant, Cache: pol}
+			tenancies[r.tenant] = tn
+		}
+		k.record(tn, r.session, at, body, up, req, providerOf(r.provider), "/v1/messages",
+			http.StatusOK, Usage{CacheRead: r.cacheRead, CacheWrite: r.cacheWrite}, usageOK)
+	}
+	// Cost is accumulated by the shipped record1, from the shipped Pricer.
+	out.pings = k.pings.Load()
+	out.skipped = k.skipped.Load()
+	out.pingUSD = k.Stats().SpentUSD
+	out.liveAtEnd = k.Stats().Live
+	if out.wastedPings > 0 {
+		out.wastedUSD = out.pingUSD * float64(out.wastedPings) / float64(max64(out.pings, 1))
+	}
+	for id, l := range perSession {
+		if l.ping == 0 && l.saved == 0 {
+			continue
+		}
+		out.sessions++
+		switch net := l.saved - l.ping; {
+		case net > 0:
+			out.sessionsWinning++
+		case net < 0:
+			out.sessionsLosing++
+			out.losingUSD += net
+			if net < out.worstSessionUSD {
+				out.worstSessionUSD, out.worstSessionID = net, id
+			}
+		}
+	}
+	return out
+}
+
+// snapBody is a synthetic request body with the shape the keeper's gates read: the model, and
+// the thinking block the snapshot recorded. The snapshot stores no bodies, so this is the
+// honest substitute — every gate that consults the body is driven by a recorded column.
+func snapBody(r *snapRow) []byte {
+	think := ""
+	switch r.thinking {
+	case "enabled":
+		think = `,"thinking":{"type":"enabled","budget_tokens":32000}`
+	case "adaptive", "disabled":
+		think = `,"thinking":{"type":"` + r.thinking + `"}`
+	}
+	return []byte(`{"model":"` + r.model + `","max_tokens":32000,"stream":true` + think +
+		`,"system":[{"type":"text","text":"x","cache_control":{"type":"ephemeral"}}]` +
+		`,"messages":[{"role":"user","content":[{"type":"text","text":"x",` +
+		`"cache_control":{"type":"ephemeral"}}]}]}`)
+}
+
+func providerOf(s string) bschemas.ModelProvider {
+	if s == "" {
+		return bschemas.Anthropic
+	}
+	return bschemas.ModelProvider(s)
+}
+
+// Table2 is modelinfo's price table under a local name, so the signature above reads without
+// dragging the import into every line.
+type Table2 = modelinfo.Table
+
+func loadSnapshot(t *testing.T, path string) []snapRow {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		t.Fatalf("open snapshot: %v", err)
+	}
+	defer db.Close()
+	q, err := db.Query(`SELECT id, ts, session_id, tenant_id, model, agent, provider,
+		cache_miss_reason, cache_read, cache_write, cost_usd, thinking_mode
+		FROM requests WHERE session_id <> '' ORDER BY ts, id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer q.Close()
+	var out []snapRow
+	for q.Next() {
+		var r snapRow
+		if err := q.Scan(&r.id, &r.ts, &r.session, &r.tenant, &r.model, &r.agent, &r.provider,
+			&r.reason, &r.cacheRead, &r.cacheWrite, &r.costUSD, &r.thinking); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := q.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("snapshot has no rows")
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].ts != out[j].ts {
+			return out[i].ts < out[j].ts
+		}
+		return out[i].id < out[j].id
+	})
+	return out
+}

--- a/proxy/keepalive_snapshot_test.go
+++ b/proxy/keepalive_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/dash"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
 	"net/http"
 	"net/http/httptest"
@@ -136,7 +137,9 @@ type replayResult struct {
 func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy, blanket bool) replayResult {
 	t.Helper()
 	var out replayResult
-	h := &Handler{opts: Options{Prices: table}, limiter: NewLimiter(Limits{})}
+	// A recorder, because retention requires an audit sink. The zero value discards its events,
+	// which is what this replay wants: the decision function is under test, not the writer.
+	h := &Handler{opts: Options{Prices: table}, limiter: NewLimiter(Limits{}), rec: &dash.Recorder{}}
 	k := newKeeper(h)
 	// The blanket arms lift the first-request gate by pre-seeding every session's turn counter,
 	// which is the only way to compare "gated" against "blanket" through the SAME code path.

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/dash"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
 	"github.com/rossoctl/context-guru/metrics"
 	"github.com/tidwall/gjson"
@@ -59,7 +60,10 @@ func (c *testClock) advance(d time.Duration) time.Time {
 // testable without a network and without waiting 280 real seconds.
 func testKeeper(t *testing.T, lim Limits) (*keeper, *fakeSender, *testClock) {
 	t.Helper()
-	h := &Handler{opts: Options{}, limiter: NewLimiter(lim)}
+	// A recorder, because retention now REQUIRES an audit sink: an audit control that
+	// --dashboard removes is not a control, so with no recorder the keeper holds nothing. Tests
+	// about timing and policy need it present; TestNoAuditSinkMeansNoRetention clears it.
+	h := &Handler{opts: Options{}, limiter: NewLimiter(lim), rec: &dash.Recorder{}}
 	k := newKeeper(h)
 	clock := &testClock{at: time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)}
 	k.now = clock.now
@@ -742,8 +746,17 @@ func TestRetainedMaterialReachesNoOutputSurface(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	agg := metrics.NewAggregator()
-	h := New(nil, nil, agg, Options{})
+	// A REAL recorder on an in-memory database, wired through New() like the dashboard tests do.
+	// Retention requires an audit sink, and a recorder assigned after construction is only
+	// half-wired — /metrics would dereference its absent database. This also makes the surfaces
+	// under test the fully-wired ones a deployment actually serves.
+	sink, err := dash.NewRecorder(dash.Options{DBPath: ":memory:", BatchSize: 1,
+		FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+	h := New(nil, nil, metrics.NewAggregator(), Options{Dashboard: sink})
 	defer h.Close()
 	k := h.keeper
 	clock := &testClock{at: time.Now()}
@@ -796,5 +809,108 @@ func TestRetainedMaterialReachesNoOutputSurface(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "keep-alive ping") {
 		t.Error("the debug log carries no keep-alive line, so the leak check never saw this path")
+	}
+}
+
+// The audit row is what makes the credential arrangement reviewable, so it cannot be optional.
+// An audit control that `--dashboard` silently removes is not a control: with no recorder there
+// is no per-ping record, so nothing is retained at all.
+func TestNoAuditSinkMeansNoRetention(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	k.h.rec = nil // as a deployment without --dashboard has it
+
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("held %d sessions with no audit sink; a credential we cannot account for "+
+			"must not be held", got)
+	}
+}
+
+// Deletion, token revocation and disablement each end an account's authority, and the keeper is
+// a credential store the registry's cascade does not know about. tenant.TestDeleteCascadesEveryCredential
+// asserts the invariant on the registry's own stores; this is the same invariant for this one.
+func TestForgetReleasesOneTenantsMaterial(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	r.Header.Set("Authorization", "Bearer sk-caller-secret")
+	for _, id := range []string{"victim", "bystander"} {
+		tn := &Tenancy{ID: id, Cache: kaPolicy()}
+		for i := 0; i < 2; i++ {
+			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+				upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+				"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		}
+	}
+	if got := k.Stats().Live; got != 2 {
+		t.Fatalf("expected two tenants held, got %d", got)
+	}
+	k.mu.Lock()
+	body := k.live[kaKey("victim", "s")].body
+	cred := k.live[kaKey("victim", "s")].auth[0].val
+	k.mu.Unlock()
+
+	k.forget("victim")
+
+	if got := k.Stats().Live; got != 1 {
+		t.Errorf("after forgetting one tenant, %d sessions held; want the bystander's only", got)
+	}
+	k.mu.Lock()
+	_, victimGone := k.live[kaKey("victim", "s")]
+	_, bystander := k.live[kaKey("bystander", "s")]
+	k.mu.Unlock()
+	if victimGone {
+		t.Error("the forgotten tenant is still held")
+	}
+	if !bystander {
+		t.Error("forgetting one tenant released another tenant's material")
+	}
+	// And the bytes are gone, not just the map entry.
+	for name, b := range map[string][]byte{"body": body, "credential": cred} {
+		for i := range b {
+			if b[i] != 0 {
+				t.Fatalf("the forgotten tenant's %s still holds data at byte %d", name, i)
+			}
+		}
+	}
+	// The turn counter goes too, or a re-registered id inherits its predecessor's history.
+	k.mu.Lock()
+	_, turns := k.turns[kaKey("victim", "s")]
+	k.mu.Unlock()
+	if turns {
+		t.Error("the forgotten tenant's turn counter survived")
+	}
+}
+
+// The retained body is masked for the same reason the credential is, and the asymmetry is what
+// decides it: a leaked key is rotatable, a leaked transcript is not.
+func TestRetainedBodyIsMaskedAtRest(t *testing.T) {
+	const marker = "MY-PRIVATE-SOURCE-CODE-MARKER"
+	k, fs, clock := testKeeper(t, Limits{})
+	body := strings.Replace(kaBody, `"text":"hi"`, `"text":"`+marker+`"`, 1)
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	for i := 0; i < 2; i++ {
+		k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(body),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+			"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+	}
+	k.mu.Lock()
+	held := k.live[kaKey("t1", "s")].body
+	k.mu.Unlock()
+	if bytes.Contains(held, []byte(marker)) {
+		t.Error("the retained conversation is sitting in memory in plaintext")
+	}
+	if !bytes.Contains(unmasked(held), []byte(marker)) {
+		t.Fatal("unmasking did not recover the body, so the ping would send the wrong bytes")
+	}
+	// And the ping still sends the REAL prefix — masking must not corrupt what goes on the wire,
+	// or every ping writes a new entry at 12.5x instead of refreshing one at 0.1x.
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+	fs.mu.Lock()
+	sent := append([]byte(nil), fs.calls[0].body...)
+	fs.mu.Unlock()
+	if !bytes.Contains(sent, []byte(marker)) {
+		t.Error("the ping sent something other than the recorded prefix")
 	}
 }

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -1,9 +1,12 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +16,7 @@ import (
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/metrics"
 	"github.com/tidwall/gjson"
 )
 
@@ -411,62 +415,162 @@ func TestArriveCancelsAndReports(t *testing.T) {
 	}
 }
 
-// The credential rule, both directions. On a caller-pays upstream the caller's own key is
-// what a ping must present, and it is retained; where the operator holds a key nothing is
-// retained at all. Our own context-guru token is never retained in either case.
+// The credential rules, all of them. This is the hardening bar the retention had to clear
+// before it could ship, and each subtest is one line of it.
 func TestCredentialRetentionRules(t *testing.T) {
-	t.Run("caller pays: the caller's key is held, our token is not", func(t *testing.T) {
-		k, _, clock := testKeeper(t, Limits{})
-		tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
-		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
-		r.Header.Set("Authorization", "Bearer sk-caller-secret")
-		r.Header.Add("x-api-key", "cg_live_0123456789abcdef0123456789abcdef")
-		// Twice, and with a prefix over the floor: the gate refuses a session's first request
-		// and a small prefix, and the subject here is the credential rather than the gate.
-		for i := 0; i < 2; i++ {
-			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
-				upstream{base: "http://up", path: "/v1/messages"},
-				r, bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
-		}
+	const caller = "Bearer sk-caller-secret"
 
-		k.mu.Lock()
-		defer k.mu.Unlock()
-		e := k.live[kaKey("t1", "s")]
-		if e == nil {
-			t.Fatal("session not tracked")
-		}
-		if got := e.hdr.Get("Authorization"); got != "Bearer sk-caller-secret" {
-			t.Errorf("Authorization = %q; a caller-pays ping has no other credential", got)
-		}
-		if got := e.hdr.Get("x-api-key"); got != "" {
-			t.Errorf("retained a context-guru token in an auth slot: %q", got)
-		}
-	})
-	t.Run("server key: nothing is retained", func(t *testing.T) {
+	held := func(t *testing.T, up upstream) (*keeper, *kaEntry, *testClock) {
+		t.Helper()
 		k, _, clock := testKeeper(t, Limits{})
 		tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
 		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
-		r.Header.Set("Authorization", "Bearer sk-caller-secret")
-		up := upstream{base: "http://up", path: "/v1/messages",
-			setKey: func(h http.Header) { h.Set("x-api-key", "operator") }}
+		r.Header.Set("Authorization", caller)
+		r.Header.Add("x-api-key", "cg_live_0123456789abcdef0123456789abcdef")
+		// Twice, and over the prefix floor: the gate refuses a session's first request, and the
+		// subject here is the credential rather than the gate.
 		for i := 0; i < 2; i++ {
 			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody), up, r,
 				bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
 		}
-
 		k.mu.Lock()
-		defer k.mu.Unlock()
 		e := k.live[kaKey("t1", "s")]
+		k.mu.Unlock()
+		return k, e, clock
+	}
+
+	t.Run("caller pays: the credential is held MASKED, never plaintext", func(t *testing.T) {
+		_, e, _ := held(t, upstream{base: "http://up", path: "/v1/messages"})
 		if e == nil {
 			t.Fatal("session not tracked")
 		}
+		var auth *maskedHeader
+		for i := range e.auth {
+			if strings.EqualFold(e.auth[i].name, "Authorization") {
+				auth = &e.auth[i]
+			}
+			// Our own token is not a provider credential and must never be retained.
+			if bytes.Contains(unmasked(e.auth[i].val), []byte("cg_live_")) {
+				t.Error("retained a context-guru token as a provider credential")
+			}
+		}
+		if auth == nil {
+			t.Fatal("no Authorization retained; a caller-pays ping has no other credential")
+		}
+		// The bytes AT REST must not contain the credential — that is what a heap dump or a
+		// string scan over a core file would see.
+		if bytes.Contains(auth.val, []byte("sk-caller-secret")) {
+			t.Error("the credential is sitting in memory in plaintext")
+		}
+		// And it must still be recoverable, or the ping cannot authenticate.
+		if got := string(unmasked(auth.val)); got != caller {
+			t.Errorf("unmasking gave %q, want the caller's own credential back", got)
+		}
+	})
+
+	t.Run("server key: nothing is retained", func(t *testing.T) {
+		_, e, _ := held(t, upstream{base: "http://up", path: "/v1/messages",
+			setKey: func(h http.Header) { h.Set("x-api-key", "operator") }})
+		if e == nil {
+			t.Fatal("session not tracked")
+		}
+		if len(e.auth) != 0 {
+			t.Errorf("retained %d auth headers although the operator holds the key", len(e.auth))
+		}
 		for _, slot := range authHeaders {
 			if v := e.hdr.Get(slot); v != "" {
-				t.Errorf("retained %s=%q although the operator holds the key", slot, v)
+				t.Errorf("retained %s=%q in the plain header set", slot, v)
 			}
 		}
 	})
-	t.Run("stop drops every held body and credential", func(t *testing.T) {
+
+	t.Run("release ZEROIZES rather than dropping the reference", func(t *testing.T) {
+		k, e, _ := held(t, upstream{base: "http://up", path: "/v1/messages"})
+		if e == nil {
+			t.Fatal("session not tracked")
+		}
+		// Keep our own handles on the exact buffers, so the assertion is about the BYTES and not
+		// about whether the struct still points at them.
+		body, cred := e.body, e.auth[0].val
+		if len(body) == 0 || len(cred) == 0 {
+			t.Fatal("nothing held to release")
+		}
+		k.retire(kaKey("t1", "s"))
+		for _, b := range [][]byte{body, cred} {
+			for i := range b {
+				if b[i] != 0 {
+					t.Fatalf("released buffer still holds data at byte %d; a dump taken now "+
+						"would still yield it", i)
+					return
+				}
+			}
+		}
+		if got := k.Stats().Live; got != 0 {
+			t.Errorf("%d sessions still tracked after retirement", got)
+		}
+	})
+
+	t.Run("the hard deadline fires with no other activity", func(t *testing.T) {
+		// A real scheduled deadline, not a sweep check: nothing else runs in this subtest, no
+		// request arrives, no sweep is called, and the material must still be gone.
+		k, _, clock := testKeeper(t, Limits{})
+		pol := kaPolicy()
+		pol.Idle = 20 * time.Millisecond // deadline is (K+1) x Idle = 60ms
+		tn := &Tenancy{ID: "t1", Cache: pol}
+		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+		r.Header.Set("Authorization", caller)
+		for i := 0; i < 2; i++ {
+			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+				upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+				"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		}
+		if k.Stats().Live != 1 {
+			t.Fatal("nothing held to expire")
+		}
+		deadline := time.Now().Add(2 * time.Second)
+		for k.Stats().Live != 0 && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		if got := k.Stats().Live; got != 0 {
+			t.Fatalf("%d sessions still held past the hard deadline with nothing else running", got)
+		}
+	})
+
+	t.Run("withdrawn consent retires what is already held", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+		r.Header.Set("Authorization", caller)
+		on := &Tenancy{ID: "t1", Cache: kaPolicy()}
+		for i := 0; i < 2; i++ {
+			k.record(on, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+				upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+				"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		}
+		if k.Stats().Live != 1 {
+			t.Fatal("nothing held to revoke")
+		}
+		// The account turns the setting off. Its very next request must drop the hold — a stale
+		// flag from when the hold began must never be able to extend it.
+		off := &Tenancy{ID: "t1", Cache: CachePolicy{}}
+		k.record(off, "s", clock.now().Add(3*time.Second), []byte(kaBody),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+			"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		if got := k.Stats().Live; got != 0 {
+			t.Fatalf("%d sessions still held after consent was withdrawn", got)
+		}
+	})
+
+	t.Run("the kill switch stops RETENTION, not just pinging", func(t *testing.T) {
+		t.Setenv("CONTEXT_GURU_KEEPALIVE", "off")
+		k, _, clock := testKeeper(t, Limits{})
+		recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+		if got := k.Stats().Live; got != 0 {
+			t.Fatalf("held %d sessions with the kill switch set; a switch that keeps the "+
+				"material while refusing to use it is the worst of both", got)
+		}
+	})
+
+	t.Run("Stop drops every held body and credential", func(t *testing.T) {
 		k, _, clock := testKeeper(t, Limits{})
 		k.start()
 		recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
@@ -475,6 +579,32 @@ func TestCredentialRetentionRules(t *testing.T) {
 			t.Fatalf("%d sessions still held after Stop", got)
 		}
 	})
+}
+
+// syncBuffer is a log sink a background goroutine may write while the test reads it.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// unmasked returns a plaintext COPY, so a test can assert on the value without disturbing the
+// masked buffer the keeper is holding.
+func unmasked(b []byte) []byte {
+	out := append([]byte(nil), b...)
+	xorMask(out)
+	return out
 }
 
 // The memory bound. Holding one body per live session is what makes a ping possible; holding
@@ -594,4 +724,77 @@ func waitSkipped(t *testing.T, k *keeper, n int64) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("skipped = %d after 2s, want %d", k.skipped.Load(), n)
+}
+
+// Item 6 of the hardening bar: the retained credential and the retained request body must be
+// unreachable from every output surface. The body matters as much as the key — it holds the
+// user's whole conversation.
+//
+// Debug logging is ON, because that is the realistic leak path: production runs at debug and
+// produces roughly 8x the line volume, so a leak that only appears there is a leak that only
+// appears in production.
+func TestRetainedMaterialReachesNoOutputSurface(t *testing.T) {
+	const cred = "sk-caller-DO-NOT-LEAK-9f3a"
+	const secretInBody = "MY-PRIVATE-SOURCE-CODE-MARKER"
+
+	logs := &syncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	agg := metrics.NewAggregator()
+	h := New(nil, nil, agg, Options{})
+	defer h.Close()
+	k := h.keeper
+	clock := &testClock{at: time.Now()}
+	k.now = clock.now
+	fs := &fakeSender{}
+	k.send = fs.send
+
+	body := strings.Replace(kaBody, `"text":"hi"`, `"text":"`+secretInBody+`"`, 1)
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	r.Header.Set("Authorization", "Bearer "+cred)
+	for i := 0; i < 2; i++ {
+		k.record(tn, "leaky", clock.now().Add(time.Duration(i)*time.Second), []byte(body),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+			"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+	}
+	if k.Stats().Live != 1 {
+		t.Fatal("nothing retained, so nothing is being tested")
+	}
+	// Drive a ping and a panic-recovery path, so the log carries whatever those emit.
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+
+	surfaces := map[string]string{}
+	rec := httptest.NewRecorder()
+	h.stats(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	surfaces["/stats"] = rec.Body.String()
+	rec = httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	surfaces["/metrics"] = rec.Body.String()
+	// The keeper's own snapshot, which /stats embeds and a future consumer might render alone.
+	surfaces["KeepAliveStats"] = fmt.Sprintf("%+v", k.Stats())
+	// A panic trace over the held entry: a struct dumped into an error message is the classic
+	// accidental disclosure, and %+v on a keeper entry must not spell out either secret.
+	k.mu.Lock()
+	surfaces["entry %+v"] = fmt.Sprintf("%+v", *k.live[kaKey("t1", "leaky")])
+	k.mu.Unlock()
+	surfaces["log sink (debug)"] = logs.String()
+
+	for name, out := range surfaces {
+		if out == "" && name != "log sink (debug)" {
+			t.Errorf("%s produced no output, so this assertion proves nothing", name)
+		}
+		if strings.Contains(out, cred) {
+			t.Errorf("%s LEAKS the retained credential", name)
+		}
+		if strings.Contains(out, secretInBody) {
+			t.Errorf("%s LEAKS the retained request body", name)
+		}
+	}
+	if !strings.Contains(logs.String(), "keep-alive ping") {
+		t.Error("the debug log carries no keep-alive line, so the leak check never saw this path")
+	}
 }

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,8 +12,14 @@ import (
 	"time"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/internal/modelinfo"
 	"github.com/tidwall/gjson"
 )
+
+// fixedPrice prices every model the same, so a cost guard can be tested without a price file.
+type fixedPrice struct{ p modelinfo.Price }
+
+func (f fixedPrice) Price(context.Context, string) (modelinfo.Price, bool) { return f.p, true }
 
 // A body shaped like the traffic this mechanism exists for: Claude Code's layout, two
 // `system` breakpoints and one on the last content block, which is 54.2% of production
@@ -97,11 +104,21 @@ func (f *fakeSender) send(j pingJob, body []byte) (Usage, int, error) {
 }
 
 func kaPolicy() CachePolicy {
-	return CachePolicy{KeepAlive: true, Idle: 280 * time.Second, MaxPings: 2, MaxUSDPerSession: 0.25}
+	return CachePolicy{KeepAlive: true, Idle: 280 * time.Second, MaxPings: 2,
+		MaxUSDPerPing: 0.25, MinPrefixTokens: 20000}
 }
 
-// recordOne registers one finished request with the keeper.
+// recordOne registers one finished request with the keeper, on a session that has already
+// sent one — because the gate skips a session's FIRST request and every timing test below is
+// about the span AFTER a real turn.
 func recordOne(t *testing.T, k *keeper, pol CachePolicy, body string, at time.Time, up upstream) {
+	t.Helper()
+	recordTurn(t, k, pol, body, at.Add(-time.Second), up)
+	recordTurn(t, k, pol, body, at, up)
+}
+
+// recordTurn registers exactly one request, without pre-seeding a turn.
+func recordTurn(t *testing.T, k *keeper, pol CachePolicy, body string, at time.Time, up upstream) {
 	t.Helper()
 	tn := &Tenancy{ID: "t1", Cache: pol}
 	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
@@ -222,28 +239,6 @@ func TestPingNeverUsesTheLastConcurrencySlot(t *testing.T) {
 	}
 }
 
-// The per-session spend cap is a backstop for a raised K, and it must stop the session
-// rather than merely skip one ping.
-func TestSpendCapStopsTheSession(t *testing.T) {
-	k, _, clock := testKeeper(t, Limits{})
-	pol := kaPolicy()
-	pol.MaxPings, pol.MaxUSDPerSession = 10, 0.01
-	recordOne(t, k, pol, kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
-
-	k.mu.Lock()
-	for _, e := range k.live {
-		e.spent = 0.02 // as two pings on a large prefix would have left it
-	}
-	k.mu.Unlock()
-
-	if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
-		t.Fatalf("fired %d pings past the session spend cap", n)
-	}
-	if k.skipped.Load() == 0 {
-		t.Error("the cap refusal was not counted; a silent cap is indistinguishable from a bug")
-	}
-}
-
 // Fail open and quiet: a transport error is logged, counted and forgotten. It must not panic,
 // must not retry inside the sweep, and must still count against K so a broken upstream cannot
 // be pinged forever.
@@ -322,6 +317,77 @@ func TestDisabledPolicyHoldsNothing(t *testing.T) {
 	}
 }
 
+// The gate: a session's FIRST request is never pinged, and a prefix below the floor is never
+// pinged. Together these drop 8.7x the pings for 3.3% of the money, which is what makes the
+// policy deployable rather than merely profitable.
+func TestGateSkipsFirstRequestAndSmallPrefixes(t *testing.T) {
+	t.Run("the session's first request is not pinged", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		recordTurn(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+		if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+			t.Fatalf("pinged a single-request session (%d); those are 79%% of pings and 0.9%% of the value", n)
+		}
+	})
+	t.Run("the second request is", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+		if n := k.sweep(clock.advance(281 * time.Second)); n != 1 {
+			t.Fatalf("did not ping a session on its second turn (%d)", n)
+		}
+	})
+	t.Run("a prefix below the floor is not pinged", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+		for i := 0; i < 2; i++ {
+			// 19,999 billed tokens: one short of the 20,000 floor.
+			k.record(tn, "small", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+				upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+				"/v1/messages", http.StatusOK, Usage{CacheRead: 19_999}, true)
+		}
+		if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+			t.Fatalf("pinged a session whose billed prefix is under the floor (%d)", n)
+		}
+	})
+}
+
+// The per-ping cost guard. Ping cost is bimodal — p50 $0.0004 against a p99 of $0.2275 and a
+// max of $0.3780 — so the outlier to refuse is an individual ping, not a session's total.
+func TestPerPingCostGuard(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	k.h.opts.Prices = fixedPrice{modelinfo.Price{Input: 3.8e-6, Output: 19e-6,
+		CacheRead: 3.8e-7, CacheWrite: 4.75e-6}}
+	pol := kaPolicy()
+	pol.MaxUSDPerPing = 0.05
+	tn := &Tenancy{ID: "t1", Cache: pol}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	// 400k billed tokens at opus's read rate is $0.152 a ping — over the $0.05 guard. Refused
+	// at RECORD time, which is also the security-relevant answer: no body and no credential is
+	// held for a session we have already decided not to ping.
+	big := func(tn *Tenancy, i int) {
+		k.record(tn, "big", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+			"/v1/messages", http.StatusOK, Usage{CacheRead: 400_000}, true)
+	}
+	big(tn, 0)
+	big(tn, 1)
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("held %d sessions whose projected ping exceeds the budget", got)
+	}
+	if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+		t.Fatalf("sent %d pings above the per-ping budget", n)
+	}
+	// The same traffic under a budget that allows it IS pinged, so the refusal above is the
+	// guard and not some other gate.
+	pol.MaxUSDPerPing = 0.5
+	big(&Tenancy{ID: "t1", Cache: pol}, 2)
+	// 300s, not 281s: the clock has already moved on, so the new entry's own deadline is 280s
+	// after ITS record time rather than after the start of the test.
+	if n := k.sweep(clock.advance(300 * time.Second)); n != 1 {
+		t.Fatalf("did not ping once the budget allowed it (%d)", n)
+	}
+}
+
 // A real request cancels the pending ping and reports what the span's pings did, and the
 // entry — with its body and its credential — is dropped at that moment.
 func TestArriveCancelsAndReports(t *testing.T) {
@@ -355,8 +421,13 @@ func TestCredentialRetentionRules(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
 		r.Header.Set("Authorization", "Bearer sk-caller-secret")
 		r.Header.Add("x-api-key", "cg_live_0123456789abcdef0123456789abcdef")
-		k.record(tn, "s", clock.now(), []byte(kaBody), upstream{base: "http://up", path: "/v1/messages"},
-			r, bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 1}, true)
+		// Twice, and with a prefix over the floor: the gate refuses a session's first request
+		// and a small prefix, and the subject here is the credential rather than the gate.
+		for i := 0; i < 2; i++ {
+			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+				upstream{base: "http://up", path: "/v1/messages"},
+				r, bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		}
 
 		k.mu.Lock()
 		defer k.mu.Unlock()
@@ -378,8 +449,10 @@ func TestCredentialRetentionRules(t *testing.T) {
 		r.Header.Set("Authorization", "Bearer sk-caller-secret")
 		up := upstream{base: "http://up", path: "/v1/messages",
 			setKey: func(h http.Header) { h.Set("x-api-key", "operator") }}
-		k.record(tn, "s", clock.now(), []byte(kaBody), up, r, bschemas.Anthropic, "/v1/messages",
-			http.StatusOK, Usage{CacheRead: 1}, true)
+		for i := 0; i < 2; i++ {
+			k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody), up, r,
+				bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+		}
 
 		k.mu.Lock()
 		defer k.mu.Unlock()

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -1,0 +1,524 @@
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// A body shaped like the traffic this mechanism exists for: Claude Code's layout, two
+// `system` breakpoints and one on the last content block, which is 54.2% of production
+// requests and 86.4% of its spend.
+const kaBody = `{"model":"aws/claude-sonnet-5","max_tokens":32000,"stream":true,` +
+	`"tools":[{"name":"Bash","description":"run a command","input_schema":{"type":"object"}}],` +
+	`"system":[{"type":"text","text":"you are claude code","cache_control":{"type":"ephemeral"}},` +
+	`{"type":"text","text":"Current branch: main","cache_control":{"type":"ephemeral"}}],` +
+	`"messages":[{"role":"user","content":[{"type":"text","text":"hi",` +
+	`"cache_control":{"type":"ephemeral"}}]}]}`
+
+// testClock is a settable clock the ping goroutines may read concurrently with the test
+// advancing it. A plain *time.Time raced: fire() reads k.now() on its own goroutine.
+type testClock struct {
+	mu sync.Mutex
+	at time.Time
+}
+
+func (c *testClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.at
+}
+
+func (c *testClock) advance(d time.Duration) time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.at = c.at.Add(d)
+	return c.at
+}
+
+// testKeeper builds a keeper with a stub clock and a stub sender, so the whole policy is
+// testable without a network and without waiting 280 real seconds.
+func testKeeper(t *testing.T, lim Limits) (*keeper, *fakeSender, *testClock) {
+	t.Helper()
+	h := &Handler{opts: Options{}, limiter: NewLimiter(lim)}
+	k := newKeeper(h)
+	clock := &testClock{at: time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)}
+	k.now = clock.now
+	fs := &fakeSender{}
+	k.send = fs.send
+	return k, fs, clock
+}
+
+type fakeSender struct {
+	mu     sync.Mutex
+	calls  []sentPing
+	usage  Usage
+	status int
+	err    error
+}
+
+// n is the call count, read under the lock: sweep dispatches each ping on its own goroutine
+// (a round trip must not be made under the keeper's map lock), so the counter this fake keeps
+// is genuinely concurrent.
+func (f *fakeSender) n() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+type sentPing struct {
+	body []byte
+	hdr  http.Header
+	up   upstream
+}
+
+func (f *fakeSender) send(j pingJob, body []byte) (Usage, int, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, sentPing{body: body, hdr: j.hdr.Clone(), up: j.up})
+	st := f.status
+	if st == 0 {
+		st = http.StatusOK
+	}
+	u := f.usage
+	if u == (Usage{}) {
+		u = Usage{CacheRead: 48576, Output: 1}
+	}
+	err := f.err
+	f.mu.Unlock()
+	return u, st, err
+}
+
+func kaPolicy() CachePolicy {
+	return CachePolicy{KeepAlive: true, Idle: 280 * time.Second, MaxPings: 2, MaxUSDPerSession: 0.25}
+}
+
+// recordOne registers one finished request with the keeper.
+func recordOne(t *testing.T, k *keeper, pol CachePolicy, body string, at time.Time, up upstream) {
+	t.Helper()
+	tn := &Tenancy{ID: "t1", Cache: pol}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	r.Header.Set("Authorization", "Bearer sk-caller-secret")
+	r.Header.Set("Anthropic-Version", "2023-06-01")
+	k.record(tn, "sess-1", at, []byte(body), up, r, bschemas.Anthropic, "/v1/messages",
+		http.StatusOK, Usage{CacheRead: 48576, CacheWrite: 1200}, true)
+}
+
+// The headline invariant: a ping must be a pure cache READ. It is a read only if the hashed
+// prefix is byte-identical, so the ping may differ from the recorded request in `max_tokens`
+// and `stream` and in NOTHING that the provider hashes.
+func TestPingBodyLeavesTheHashedPrefixByteIdentical(t *testing.T) {
+	out, ok := pingBody([]byte(kaBody))
+	if !ok {
+		t.Fatal("pingBody refused a well-formed body")
+	}
+	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 1 {
+		t.Errorf("max_tokens = %d, want 1 (the cheapest legal output)", got)
+	}
+	if gjson.GetBytes(out, "stream").Bool() {
+		t.Error("stream is still true; the ping must come back as one small JSON body")
+	}
+	// The prefix the provider hashes, in the order it hashes it. Any difference here is a
+	// cache MISS, and a miss on a ping costs 12.5x a read instead of saving 11.5x.
+	for _, path := range []string{"model", "tools", "system", "messages", "thinking", "tool_choice"} {
+		a := gjson.GetBytes([]byte(kaBody), path).Raw
+		b := gjson.GetBytes(out, path).Raw
+		if a != b {
+			t.Errorf("%s changed:\n before: %s\n  after: %s", path, a, b)
+		}
+	}
+	// And the breakpoints themselves, counted: a ping that added or dropped one would ask
+	// the provider for a different entry than the one it is trying to refresh.
+	if a, b := strings.Count(kaBody, "cache_control"), strings.Count(string(out), "cache_control"); a != b {
+		t.Errorf("breakpoint count changed: %d -> %d", a, b)
+	}
+}
+
+// The provider bills a request that reports more written than read as a CREATION, which is
+// the one outcome that makes this mechanism cost money instead of saving it. It must be
+// loud, counted, and terminal for that session.
+func TestPingThatWritesInsteadOfReadingStopsTheSession(t *testing.T) {
+	k, fs, clock := testKeeper(t, Limits{})
+	fs.usage = Usage{CacheWrite: 48576, CacheRead: 0, Output: 1}
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+	if got := k.wrote.Load(); got != 1 {
+		t.Fatalf("wrote_instead_of_read = %d, want 1", got)
+	}
+	// K is 2, so without the stop a second ping would follow. It must not.
+	if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+		t.Fatalf("sweep fired %d more pings after a write; the session must be dropped", n)
+	}
+}
+
+// The provider measures the lifetime "from the start of the request that writes or reads the
+// cache entry, not from the end of its response", so the idle clock starts at the recorded
+// request's START and a ping fires exactly X after it — not sooner.
+func TestTimingIsMeasuredFromRequestStart(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	start := clock.now()
+	recordOne(t, k, kaPolicy(), kaBody, start, upstream{base: "http://up", path: "/v1/messages"})
+
+	for _, elapsed := range []time.Duration{0, 100 * time.Second, 279 * time.Second} {
+		if n := k.sweep(start.Add(elapsed)); n != 0 {
+			t.Fatalf("pinged after %s idle; X is 280s", elapsed)
+		}
+	}
+	if n := k.sweep(start.Add(280 * time.Second)); n != 1 {
+		t.Fatalf("no ping at exactly X=280s (fired %d)", n)
+	}
+}
+
+// K bounds one idle span, and the second ping's deadline is measured from the FIRST ping's
+// start — a ping is itself a request that reads the entry, so it restarts the lifetime.
+func TestMaxPingsAndPingRestartsTheClock(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	start := clock.now()
+	recordOne(t, k, kaPolicy(), kaBody, start, upstream{base: "http://up", path: "/v1/messages"})
+
+	if n := k.sweep(start.Add(280 * time.Second)); n != 1 {
+		t.Fatalf("first ping did not fire (%d)", n)
+	}
+	// 279s after the ping is 559s after the request: too early, because the ping refreshed
+	// the entry and the clock restarted at it.
+	if n := k.sweep(start.Add(559 * time.Second)); n != 0 {
+		t.Fatalf("second ping fired %d times before X elapsed from the FIRST ping", n)
+	}
+	if n := k.sweep(start.Add(560 * time.Second)); n != 1 {
+		t.Fatalf("second ping did not fire (%d)", n)
+	}
+	// K = 2.
+	if n := k.sweep(start.Add(1000 * time.Second)); n != 0 {
+		t.Fatalf("fired a third ping; K is 2 (%d)", n)
+	}
+}
+
+// A ping is a real request against the tenant's budget, and it must lose to real traffic
+// rather than displace it. With a concurrency limit of 1 there is no slack at all, so no
+// ping may be sent.
+func TestPingNeverUsesTheLastConcurrencySlot(t *testing.T) {
+	k, fs, clock := testKeeper(t, Limits{Concurrent: 1})
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	// Hold the only slot, as an in-flight agent request would.
+	release, err := k.h.limiter.Acquire("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	k.sweep(clock.advance(281 * time.Second))
+	waitSkipped(t, k, 1)
+	if fs.n() != 0 {
+		t.Fatalf("sent %d pings while the tenant had no spare concurrency", fs.n())
+	}
+}
+
+// The per-session spend cap is a backstop for a raised K, and it must stop the session
+// rather than merely skip one ping.
+func TestSpendCapStopsTheSession(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	pol := kaPolicy()
+	pol.MaxPings, pol.MaxUSDPerSession = 10, 0.01
+	recordOne(t, k, pol, kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+
+	k.mu.Lock()
+	for _, e := range k.live {
+		e.spent = 0.02 // as two pings on a large prefix would have left it
+	}
+	k.mu.Unlock()
+
+	if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+		t.Fatalf("fired %d pings past the session spend cap", n)
+	}
+	if k.skipped.Load() == 0 {
+		t.Error("the cap refusal was not counted; a silent cap is indistinguishable from a bug")
+	}
+}
+
+// Fail open and quiet: a transport error is logged, counted and forgotten. It must not panic,
+// must not retry inside the sweep, and must still count against K so a broken upstream cannot
+// be pinged forever.
+func TestPingErrorFailsOpen(t *testing.T) {
+	k, fs, clock := testKeeper(t, Limits{})
+	fs.err = errors.New("dial tcp: connection refused")
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+	if got := k.failed.Load(); got != 1 {
+		t.Errorf("failed = %d, want 1", got)
+	}
+	if fs.n() != 1 {
+		t.Errorf("sent %d pings, want exactly 1 — a failure must not be retried inside the sweep", fs.n())
+	}
+}
+
+// A 4xx repeats identically, so the session is dropped rather than spending the rest of K
+// learning the same thing.
+func TestClientErrorStopsTheSession(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	k.send = func(pingJob, []byte) (Usage, int, error) {
+		return Usage{}, http.StatusBadRequest, nil
+	}
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+	if n := k.sweep(clock.advance(281 * time.Second)); n != 0 {
+		t.Fatalf("kept pinging a session the upstream refused with 400 (%d)", n)
+	}
+}
+
+// `thinking.type: enabled` cannot be pinged: the API requires max_tokens above the thinking
+// budget (32,000 on this traffic), and changing the thinking parameters invalidates the
+// message-level prefix, so neither a cheap ping nor a matching one is possible.
+func TestThinkingEnabledIsNotTracked(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	body := strings.Replace(kaBody, `"stream":true`,
+		`"stream":true,"thinking":{"type":"enabled","budget_tokens":32000}`, 1)
+	recordOne(t, k, kaPolicy(), body, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("tracked %d thinking-enabled sessions, want 0", got)
+	}
+	// `adaptive` carries no budget and is unaffected — it is 81% of the addressable traffic.
+	adaptive := strings.Replace(kaBody, `"stream":true`,
+		`"stream":true,"thinking":{"type":"adaptive"}`, 1)
+	recordOne(t, k, kaPolicy(), adaptive, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k.Stats().Live; got != 1 {
+		t.Fatalf("adaptive thinking tracked %d sessions, want 1", got)
+	}
+}
+
+// A request the provider refused left no entry behind, so there is nothing to keep alive and
+// no reason to hold its body or its credential.
+func TestFailedRequestIsNotTracked(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	for _, status := range []int{0, http.StatusBadRequest, http.StatusBadGateway} {
+		k.record(tn, "s", clock.now(), []byte(kaBody), upstream{base: "http://up", path: "/v1/messages"},
+			r, bschemas.Anthropic, "/v1/messages", status, Usage{}, false)
+	}
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("tracked %d sessions whose request the provider refused", got)
+	}
+}
+
+// Off by default: an account that has not opted in is not tracked at all, so no body and no
+// credential is held for it.
+func TestDisabledPolicyHoldsNothing(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	recordOne(t, k, CachePolicy{}, kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("tracked %d sessions with the keep-alive off", got)
+	}
+}
+
+// A real request cancels the pending ping and reports what the span's pings did, and the
+// entry — with its body and its credential — is dropped at that moment.
+func TestArriveCancelsAndReports(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+
+	pings, refreshed := k.arrive("t1", "sess-1")
+	if pings != 1 {
+		t.Errorf("pings = %d, want 1", pings)
+	}
+	if refreshed != 48576 {
+		t.Errorf("refreshed = %d, want the ping's own cache_read of 48576", refreshed)
+	}
+	if got := k.Stats().Live; got != 0 {
+		t.Errorf("still tracking %d sessions after the next request arrived", got)
+	}
+	if p, r := k.arrive("t1", "sess-1"); p != 0 || r != 0 {
+		t.Errorf("arrive reported %d/%d for an untracked session, want 0/0", p, r)
+	}
+}
+
+// The credential rule, both directions. On a caller-pays upstream the caller's own key is
+// what a ping must present, and it is retained; where the operator holds a key nothing is
+// retained at all. Our own context-guru token is never retained in either case.
+func TestCredentialRetentionRules(t *testing.T) {
+	t.Run("caller pays: the caller's key is held, our token is not", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+		r.Header.Set("Authorization", "Bearer sk-caller-secret")
+		r.Header.Add("x-api-key", "cg_live_0123456789abcdef0123456789abcdef")
+		k.record(tn, "s", clock.now(), []byte(kaBody), upstream{base: "http://up", path: "/v1/messages"},
+			r, bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 1}, true)
+
+		k.mu.Lock()
+		defer k.mu.Unlock()
+		e := k.live[kaKey("t1", "s")]
+		if e == nil {
+			t.Fatal("session not tracked")
+		}
+		if got := e.hdr.Get("Authorization"); got != "Bearer sk-caller-secret" {
+			t.Errorf("Authorization = %q; a caller-pays ping has no other credential", got)
+		}
+		if got := e.hdr.Get("x-api-key"); got != "" {
+			t.Errorf("retained a context-guru token in an auth slot: %q", got)
+		}
+	})
+	t.Run("server key: nothing is retained", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+		r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+		r.Header.Set("Authorization", "Bearer sk-caller-secret")
+		up := upstream{base: "http://up", path: "/v1/messages",
+			setKey: func(h http.Header) { h.Set("x-api-key", "operator") }}
+		k.record(tn, "s", clock.now(), []byte(kaBody), up, r, bschemas.Anthropic, "/v1/messages",
+			http.StatusOK, Usage{CacheRead: 1}, true)
+
+		k.mu.Lock()
+		defer k.mu.Unlock()
+		e := k.live[kaKey("t1", "s")]
+		if e == nil {
+			t.Fatal("session not tracked")
+		}
+		for _, slot := range authHeaders {
+			if v := e.hdr.Get(slot); v != "" {
+				t.Errorf("retained %s=%q although the operator holds the key", slot, v)
+			}
+		}
+	})
+	t.Run("stop drops every held body and credential", func(t *testing.T) {
+		k, _, clock := testKeeper(t, Limits{})
+		k.start()
+		recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+		k.Stop()
+		if got := k.Stats().Live; got != 0 {
+			t.Fatalf("%d sessions still held after Stop", got)
+		}
+	})
+}
+
+// The memory bound. Holding one body per live session is what makes a ping possible; holding
+// an unbounded number is what makes a proxy get OOM-killed.
+func TestSessionBoundEvicts(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	for i := 0; i < maxKeepAliveSessions+10; i++ {
+		k.record(tn, "sess-"+strings.Repeat("x", i%7)+string(rune('a'+i%26))+time.Duration(i).String(),
+			clock.now().Add(time.Duration(i)*time.Second), []byte(kaBody),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic, "/v1/messages",
+			http.StatusOK, Usage{CacheRead: 1}, true)
+	}
+	if got := k.Stats().Live; got > maxKeepAliveSessions {
+		t.Fatalf("tracking %d sessions, bound is %d", got, maxKeepAliveSessions)
+	}
+}
+
+// A body too large to hold is refused rather than kept: one multi-million-token request must
+// not spend a fifth of the whole memory budget.
+func TestOversizedBodyIsNotHeld(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	big := `{"model":"m","messages":[{"role":"user","content":"` +
+		strings.Repeat("x", maxKeepAliveBodyBytes) + `"}]}`
+	recordOne(t, k, kaPolicy(), big, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k.Stats().Live; got != 0 {
+		t.Fatalf("held %d oversized sessions", got)
+	}
+}
+
+// The kill switch, which is an environment variable precisely so it works when the control
+// plane is what is broken.
+func TestKillSwitch(t *testing.T) {
+	t.Setenv("CONTEXT_GURU_KEEPALIVE", "off")
+	k, _, clock := testKeeper(t, Limits{})
+	k.start()
+	defer k.Stop()
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	// The sweep loop never starts, so nothing is ever due. sweep itself is still callable —
+	// the switch stops the timer, and the test asserts the timer is what is stopped.
+	select {
+	case <-k.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the sweep goroutine is running with the kill switch set")
+	}
+}
+
+// End to end against a real HTTP server: the ping actually goes out, carries the caller's
+// credential, and reaches the upstream as a max_tokens:1 non-streaming POST of the same body.
+func TestSendPingHitsTheUpstream(t *testing.T) {
+	var got struct {
+		body []byte
+		auth string
+		path string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, 1<<20)
+		n, _ := r.Body.Read(b)
+		got.body, got.auth, got.path = b[:n], r.Header.Get("Authorization"), r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"usage":{"input_tokens":0,"output_tokens":1,` +
+			`"cache_read_input_tokens":48576,"cache_creation_input_tokens":0},"stop_reason":"max_tokens"}`))
+	}))
+	defer srv.Close()
+
+	h := &Handler{opts: Options{}, limiter: NewLimiter(Limits{}), client: srv.Client()}
+	k := newKeeper(h)
+	body, _ := pingBody([]byte(kaBody))
+	u, status, err := k.sendPing(pingJob{
+		up:  upstream{base: srv.URL, path: "/v1/messages"},
+		hdr: http.Header{"Authorization": {"Bearer sk-caller"}, "Content-Type": {"application/json"}},
+	}, body)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("sendPing: status=%d err=%v", status, err)
+	}
+	if u.CacheRead != 48576 || u.CacheWrite != 0 {
+		t.Errorf("usage read=%d write=%d; a ping must READ the prefix, not write it", u.CacheRead, u.CacheWrite)
+	}
+	if got.auth != "Bearer sk-caller" {
+		t.Errorf("upstream saw Authorization %q", got.auth)
+	}
+	if got.path != "/v1/messages" {
+		t.Errorf("upstream path = %q", got.path)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(got.body, &sent); err != nil {
+		t.Fatalf("the upstream did not receive valid JSON: %v", err)
+	}
+	if sent["max_tokens"] != float64(1) || sent["stream"] != false {
+		t.Errorf("upstream received max_tokens=%v stream=%v", sent["max_tokens"], sent["stream"])
+	}
+}
+
+// waitPings waits for the sweep's fire goroutines to finish n pings. The sweep dispatches
+// asynchronously on purpose (a ping is a round trip and must not be made under the map lock),
+// so a test that asserts immediately after sweep races it.
+func waitPings(t *testing.T, k *keeper, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if k.pings.Load() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("pings = %d after 2s, want %d", k.pings.Load(), n)
+}
+
+func waitSkipped(t *testing.T, k *keeper, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if k.skipped.Load() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("skipped = %d after 2s, want %d", k.skipped.Load(), n)
+}

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -910,7 +910,15 @@ func TestRetainedBodyIsMaskedAtRest(t *testing.T) {
 	fs.mu.Lock()
 	sent := append([]byte(nil), fs.calls[0].body...)
 	fs.mu.Unlock()
-	if !bytes.Contains(sent, []byte(marker)) {
-		t.Error("the ping sent something other than the recorded prefix")
+	// BYTE-IDENTICAL, not merely marker-bearing: a single corrupted byte anywhere else in the
+	// prefix still contains the marker, and that byte is a 1.25x write instead of a 0.1x
+	// refresh. This is the assertion that actually guards the mask round trip.
+	want, ok := pingBody([]byte(body))
+	if !ok {
+		t.Fatal("pingBody refused the fixture")
+	}
+	if !bytes.Equal(sent, want) {
+		t.Errorf("the ping's bytes differ from the recorded prefix (%d sent vs %d expected)",
+			len(sent), len(want))
 	}
 }

--- a/proxy/keepalive_wire_test.go
+++ b/proxy/keepalive_wire_test.go
@@ -1,0 +1,105 @@
+package proxy
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/metrics"
+	"github.com/tidwall/gjson"
+)
+
+// Reviewer's arm: the WHOLE chain, masked hold -> sweep unmask -> fire -> real sendPing -> wire.
+//
+// Neither existing test covers this seam. TestRetainedBodyIsMaskedAtRest stops at the k.send
+// fake, so it proves what fire HANDS to send, not what is posted. TestSendPingHitsTheUpstream
+// starts after masking: it passes a plaintext Authorization and pingBody() output directly, so
+// it never exercises an unmask at all. A mask bug between those two points is invisible to both,
+// and it is the expensive one — altered wire bytes write a new entry at 12.5x instead of
+// refreshing one at 0.1x.
+func TestPingWireBytesEndToEndThroughRealSend(t *testing.T) {
+	const cred = "Bearer sk-caller-END-TO-END"
+	const marker = "MY-PRIVATE-SOURCE-CODE-MARKER"
+
+	var got struct {
+		body []byte
+		auth string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, 1<<20)
+		n, _ := r.Body.Read(b)
+		got.body, got.auth = append([]byte(nil), b[:n]...), r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"usage":{"input_tokens":0,"output_tokens":1,` +
+			`"cache_read_input_tokens":48576,"cache_creation_input_tokens":0}}`))
+	}))
+	defer srv.Close()
+
+	// R5: retention needs a real audit sink, so wire one through New() as the fixture does.
+	sink, err := dash.NewRecorder(dash.Options{DBPath: ":memory:", BatchSize: 1,
+		FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+	h := New(nil, nil, metrics.NewAggregator(), Options{Dashboard: sink})
+	defer h.Close()
+	h.client = srv.Client()
+	k := h.keeper
+	clock := &testClock{at: time.Now()}
+	k.now = clock.now
+	// NOTE: k.send is NOT overridden — this goes out over real HTTP through sendPing.
+	k.dispatch = k.fire // inline, so the assertions below run after the ping completes
+
+	orig := []byte(strings.Replace(kaBody, `"text":"hi"`, `"text":"`+marker+`"`, 1))
+	want, ok := pingBody(orig)
+	if !ok {
+		t.Fatal("pingBody refused the fixture")
+	}
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	r.Header.Set("Authorization", cred)
+	up := upstream{base: srv.URL, path: "/v1/messages"}
+	for i := 0; i < 2; i++ { // two turns: the gate needs turn >= 1
+		k.record(tn, "s", clock.now().Add(time.Duration(i)*time.Second), orig, up, r,
+			bschemas.Anthropic, "/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+	}
+	if k.Stats().Live != 1 {
+		t.Fatal("nothing retained, so nothing is being tested")
+	}
+	// Prove the hold really is masked, or the rest of this proves nothing about unmasking.
+	k.mu.Lock()
+	held := append([]byte(nil), k.live[kaKey("t1", "s")].body...)
+	k.mu.Unlock()
+	if bytes.Contains(held, []byte(marker)) {
+		t.Fatal("the hold is plaintext, so this test is not exercising an unmask")
+	}
+
+	if n := k.sweep(clock.advance(281 * time.Second)); n != 1 {
+		t.Fatalf("sweep fired %d pings", n)
+	}
+	if got.body == nil {
+		t.Fatal("the upstream received no ping")
+	}
+	if !bytes.Equal(got.body, want) {
+		t.Errorf("WIRE BYTES DIFFER from pingBody(recorded): len got=%d want=%d",
+			len(got.body), len(want))
+	}
+	for _, p := range []string{"model", "tools", "system", "messages", "thinking", "tool_choice"} {
+		if a, b := gjson.GetBytes(orig, p).Raw, gjson.GetBytes(got.body, p).Raw; a != b {
+			t.Errorf("%s differs on the wire:\n before: %.100s\n  after: %.100s", p, a, b)
+		}
+	}
+	if strings.Count(string(orig), "cache_control") != strings.Count(string(got.body), "cache_control") {
+		t.Error("breakpoint count changed on the wire")
+	}
+	// The credential unmasks to the caller's own value on the wire, and only there.
+	if got.auth != cred {
+		t.Errorf("upstream saw Authorization %q, want the caller's own key", got.auth)
+	}
+}

--- a/proxy/limits.go
+++ b/proxy/limits.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -158,6 +159,76 @@ func (l *Limiter) Acquire(tenantID string) (release func(), err error) {
 		}
 	}
 	return func() {}, nil
+}
+
+// AcquireSpare is Acquire for traffic that is OURS rather than the agent's: it succeeds only
+// out of the tenant's slack, leaving reserveFrac of both bounds untouched.
+//
+// The idle keep-alive needs this. A ping is a real request against the tenant's rate and
+// concurrency budget, and the requirement is that it never crowd out a request an agent is
+// waiting on. Refusing rather than queueing is half of that — a queued ping sits in front of
+// real traffic — but with a fixed-window counter refusing at the limit is not enough either:
+// a ping that takes the last request of the minute has already displaced whatever arrives
+// next. So a ping is only allowed while the tenant is comfortably inside its bounds, and is
+// simply skipped otherwise. Skipping costs one idle span's refresh; displacing costs an agent
+// a 429 it did not earn.
+//
+// reserveFrac <= 0 makes this identical to Acquire.
+func (l *Limiter) AcquireSpare(tenantID string, reserveFrac float64) (release func(), err error) {
+	if l == nil || (l.lim.RequestsPerMinute <= 0 && l.lim.Concurrent <= 0) {
+		return func() {}, nil
+	}
+	t := l.forTenant(tenantID)
+
+	if l.lim.RequestsPerMinute > 0 {
+		limit := reserved(l.lim.RequestsPerMinute, reserveFrac)
+		t.mu.Lock()
+		now := time.Now()
+		if w := now.Truncate(time.Minute); w.After(t.windowStart) {
+			t.windowStart, t.count = w, 0
+		}
+		if t.count >= limit {
+			t.mu.Unlock()
+			// NOT counted as a refusal: nobody was refused. A skipped ping is our own
+			// decision not to spend a tenant's budget, and publishing it as a rate-limit
+			// event would make a healthy account look throttled on its own dashboard.
+			return func() {}, errNoSpare
+		}
+		t.count++
+		t.mu.Unlock()
+	}
+
+	if t.inFlight != nil {
+		// Best-effort headroom: a racing real request may take the slot between this check
+		// and the send, in which case the ping simply loses the race and is skipped.
+		if len(t.inFlight) >= reserved(cap(t.inFlight), reserveFrac) {
+			return func() {}, errNoSpare
+		}
+		select {
+		case t.inFlight <- struct{}{}:
+			return func() { <-t.inFlight }, nil
+		default:
+			return func() {}, errNoSpare
+		}
+	}
+	return func() {}, nil
+}
+
+// errNoSpare says a tenant had no slack for a request of ours. Deliberately not a
+// statusError: nothing is being returned to a caller, and this is not a failure.
+var errNoSpare = errors.New("no spare capacity for a background request")
+
+// reserved is the bound minus its reserved share, floored at 1 so a limit of 1 still permits
+// the occasional background request rather than none ever.
+func reserved(limit int, frac float64) int {
+	if frac <= 0 {
+		return limit
+	}
+	n := limit - int(float64(limit)*frac+0.5)
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 // AcquireCheapModel takes a slot on the process-wide compaction-model semaphore,

--- a/proxy/limits.go
+++ b/proxy/limits.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sync"
 	"time"
@@ -180,6 +181,36 @@ func (l *Limiter) AcquireSpare(tenantID string, reserveFrac float64) (release fu
 	}
 	t := l.forTenant(tenantID)
 
+	// CONCURRENCY FIRST, then the rate window. The reverse order charged the tenant's
+	// per-minute budget for pings it then refused on concurrency: ten refused pings consumed
+	// ten of a hundred requests a minute, and it fired precisely when the tenant was busiest
+	// and the refusals most likely. The rate counter is only incremented once the request is
+	// certain to be sent.
+	release = func() {}
+	if t.inFlight != nil {
+		// The slot is taken under the tenant's lock together with the headroom test, so two
+		// pings cannot both read "there is room" and then both take the last spare slot. The
+		// earlier version tested len() outside any lock and raced pings against each other as
+		// well as against real traffic.
+		t.mu.Lock()
+		spare := reserved(cap(t.inFlight), reserveFrac)
+		if len(t.inFlight) >= spare {
+			t.mu.Unlock()
+			// NOT counted as a refusal: nobody was refused. A skipped ping is our own decision
+			// not to spend a tenant's budget, and publishing it as a rate-limit event would make
+			// a healthy account look throttled on its own dashboard.
+			return func() {}, errNoSpare
+		}
+		select {
+		case t.inFlight <- struct{}{}:
+			release = func() { <-t.inFlight }
+		default:
+			t.mu.Unlock()
+			return func() {}, errNoSpare
+		}
+		t.mu.Unlock()
+	}
+
 	if l.lim.RequestsPerMinute > 0 {
 		limit := reserved(l.lim.RequestsPerMinute, reserveFrac)
 		t.mu.Lock()
@@ -189,44 +220,33 @@ func (l *Limiter) AcquireSpare(tenantID string, reserveFrac float64) (release fu
 		}
 		if t.count >= limit {
 			t.mu.Unlock()
-			// NOT counted as a refusal: nobody was refused. A skipped ping is our own
-			// decision not to spend a tenant's budget, and publishing it as a rate-limit
-			// event would make a healthy account look throttled on its own dashboard.
+			release() // give the concurrency slot straight back; this ping is not being sent
 			return func() {}, errNoSpare
 		}
 		t.count++
 		t.mu.Unlock()
 	}
-
-	if t.inFlight != nil {
-		// Best-effort headroom: a racing real request may take the slot between this check
-		// and the send, in which case the ping simply loses the race and is skipped.
-		if len(t.inFlight) >= reserved(cap(t.inFlight), reserveFrac) {
-			return func() {}, errNoSpare
-		}
-		select {
-		case t.inFlight <- struct{}{}:
-			return func() { <-t.inFlight }, nil
-		default:
-			return func() {}, errNoSpare
-		}
-	}
-	return func() {}, nil
+	return release, nil
 }
 
 // errNoSpare says a tenant had no slack for a request of ours. Deliberately not a
 // statusError: nothing is being returned to a caller, and this is not a failure.
 var errNoSpare = errors.New("no spare capacity for a background request")
 
-// reserved is the bound minus its reserved share, floored at 1 so a limit of 1 still permits
-// the occasional background request rather than none ever.
+// reserved is how much of a bound background traffic may use: the bound minus its reserved
+// share, rounded so the reservation is never less than one.
+//
+// Floored at ZERO, not at one. A floor of one meant that at Concurrent: 1 a ping was allowed to
+// take the only slot and a real request arriving behind it got a 429 — the exact outcome
+// "a ping must never crowd out a real request" forbids. A tenant whose whole budget is one
+// in-flight request has no slack, and the honest answer is that it is never pinged.
 func reserved(limit int, frac float64) int {
 	if frac <= 0 {
 		return limit
 	}
-	n := limit - int(float64(limit)*frac+0.5)
-	if n < 1 {
-		n = 1
+	n := limit - int(math.Ceil(float64(limit)*frac))
+	if n < 0 {
+		n = 0
 	}
 	return n
 }

--- a/proxy/limits_test.go
+++ b/proxy/limits_test.go
@@ -107,3 +107,61 @@ func contains(hay, needle string) bool {
 		return false
 	})()
 }
+
+// A ping must never crowd out a real request, and the two ways that promise was broken are
+// both cheap to assert.
+func TestAcquireSpareLeavesRealTrafficAlone(t *testing.T) {
+	t.Run("a refused ping does not spend the rate window", func(t *testing.T) {
+		// Concurrency of 1 means no slack at all, so every ping is refused — and must cost the
+		// tenant nothing. The earlier order incremented the minute counter first and never gave
+		// it back, so ten refused pings ate ten of a hundred requests a minute, precisely when
+		// the tenant was busiest.
+		l := NewLimiter(Limits{RequestsPerMinute: 10, Concurrent: 1})
+		for i := 0; i < 10; i++ {
+			if rel, err := l.AcquireSpare("t", 0.25); err == nil {
+				rel()
+				t.Fatalf("ping %d was allowed with no spare concurrency", i)
+			}
+		}
+		// The tenant's own budget must be untouched: ten real requests still fit.
+		for i := 0; i < 10; i++ {
+			rel, err := l.Acquire("t")
+			if err != nil {
+				t.Fatalf("real request %d was refused after %d refused pings: %v", i, 10, err)
+			}
+			rel()
+		}
+	})
+
+	t.Run("a ping never takes the last slot", func(t *testing.T) {
+		// Nothing is in flight, so this is the case the old test missed: with a budget of one,
+		// taking the only slot IS crowding out whatever arrives next.
+		l := NewLimiter(Limits{Concurrent: 1})
+		if rel, err := l.AcquireSpare("t", 0.25); err == nil {
+			rel()
+			t.Error("a ping took the tenant's only concurrency slot on an idle limiter")
+		}
+		// With room for four, one ping may use one and three stay free for real traffic.
+		l4 := NewLimiter(Limits{Concurrent: 4})
+		rel, err := l4.AcquireSpare("t", 0.25)
+		if err != nil {
+			t.Fatalf("a ping was refused with three spare slots: %v", err)
+		}
+		defer rel()
+		for i := 0; i < 3; i++ {
+			r, err := l4.Acquire("t")
+			if err != nil {
+				t.Fatalf("real request %d refused while a ping held one of four slots: %v", i, err)
+			}
+			defer r()
+		}
+	})
+
+	t.Run("reserved floors at zero", func(t *testing.T) {
+		for _, tc := range []struct{ limit, want int }{{1, 0}, {2, 1}, {4, 3}, {16, 12}, {100, 75}} {
+			if got := reserved(tc.limit, 0.25); got != tc.want {
+				t.Errorf("reserved(%d) = %d, want %d", tc.limit, got, tc.want)
+			}
+		}
+	})
+}

--- a/proxy/modes.go
+++ b/proxy/modes.go
@@ -46,9 +46,10 @@ func (h *Handler) applyMode(r *reqInfo) ([]byte, time.Duration, apply.Trace) {
 		Provider: r.provider, Body: r.body, Session: r.session, Tenant: r.tn.ID, Bypass: r.bypassed,
 		Models: r.models, Window: r.window, CacheMode: h.opts.CacheMode,
 		SelfRates: r.rates,
-		// The mixed-TTL head, from this tenant's own cache policy. Off for every account
-		// unless opted in; see apply/headttl.go for why it is off even then on this
-		// deployment (the gateway strips the ttl field before the provider sees it).
+		// The mixed-TTL head, from this tenant's own cache policy. Off for every account unless
+		// opted in; see apply/headttl.go for why it is off even then — the ttl field reaches the
+		// provider, but Bedrock grants the 1h tier only for the Claude 4.5 family and silently
+		// downgrades the models this service actually runs.
 		HeadTTL1h:        r.tn.Cache.HeadTTL1h,
 		HeadTTLMinTokens: r.tn.Cache.HeadTTLMinTokens,
 		Mode:             mode, Tracker: h.tracker,

--- a/proxy/modes.go
+++ b/proxy/modes.go
@@ -46,7 +46,12 @@ func (h *Handler) applyMode(r *reqInfo) ([]byte, time.Duration, apply.Trace) {
 		Provider: r.provider, Body: r.body, Session: r.session, Tenant: r.tn.ID, Bypass: r.bypassed,
 		Models: r.models, Window: r.window, CacheMode: h.opts.CacheMode,
 		SelfRates: r.rates,
-		Mode:      mode, Tracker: h.tracker,
+		// The mixed-TTL head, from this tenant's own cache policy. Off for every account
+		// unless opted in; see apply/headttl.go for why it is off even then on this
+		// deployment (the gateway strips the ttl field before the provider sees it).
+		HeadTTL1h:        r.tn.Cache.HeadTTL1h,
+		HeadTTLMinTokens: r.tn.Cache.HeadTTLMinTokens,
+		Mode:             mode, Tracker: h.tracker,
 	})
 	added := time.Since(start)
 	if res.Body == nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -120,6 +120,9 @@ type Options struct {
 	// operating mode and which upstream the traffic goes to. nil keeps the
 	// single-tenant behaviour byte-identical to before tenancy existed.
 	Tenants *TenantSource
+	// Cache is the single-tenant host's prompt-cache policy (the idle keep-alive and the
+	// mixed-TTL head). In hosted mode each tenant's own `cache:` block is used instead.
+	Cache CachePolicy
 	// Upstreams is the operator's allow-list, by name, consulted only in hosted
 	// mode. A tenant selects a NAME; it can never supply a URL.
 	Upstreams map[string]Upstream
@@ -224,6 +227,10 @@ type Handler struct {
 	// 6-digit code is not a second factor and the argon2 verify is an amplifier.
 	pwLim   *Limiter
 	codeLim *Limiter
+	// keeper runs the idle prompt-cache keep-alive: the one cache mechanism that has to act
+	// BETWEEN requests, when no request is in flight and no component can run. Always
+	// present; it does nothing at all until a tenant opts in. See keepalive.go.
+	keeper *keeper
 	// promCache memoises the Prometheus body for a scrape interval; the per-tenant
 	// series cost a SQL query and Grafana scrapes every few seconds.
 	promCache promCache
@@ -277,8 +284,10 @@ func New(pipe *components.Pipeline, st store.Store, agg *metrics.Aggregator, opt
 	// is never consulted (tenancyFor goes to Options.Tenants); it exists so the
 	// request path has one shape.
 	h.static = &Tenancy{Preset: opts.Preset, Pipe: pipe, Store: st,
-		Shadow: h.shadow, Mode: h.mode()}
+		Shadow: h.shadow, Mode: h.mode(), Cache: opts.Cache}
 	h.limiter = NewLimiter(opts.Limits)
+	h.keeper = newKeeper(h)
+	h.keeper.start()
 	h.regLim = newAnonLimiter(Limits{RequestsPerMinute: registrationsPerMinute})
 	h.authLim = newAnonLimiter(Limits{RequestsPerMinute: authFailuresPerMinute})
 	h.pwLim = newAnonLimiter(Limits{RequestsPerMinute: passwordAttemptsPerMinute})
@@ -307,7 +316,13 @@ func New(pipe *components.Pipeline, st store.Store, agg *metrics.Aggregator, opt
 // Close shuts down the off-path worker pool and waits briefly for its goroutines to exit,
 // so a host that builds and discards handlers (tests, a reload) leaks none. Safe on a
 // sync-mode handler and safe to call twice.
-func (h *Handler) Close() { h.pool.Stop() }
+func (h *Handler) Close() {
+	h.pool.Stop()
+	// The keeper holds request bodies and, on a caller-pays upstream, callers' provider
+	// credentials. Stopping it drops both, which is why this is not optional on a host that
+	// builds and discards handlers.
+	h.keeper.Stop()
+}
 
 // Mux wires the routes: chat proxying + health/stats/expand management.
 func (h *Handler) Mux() *http.ServeMux {
@@ -1027,6 +1042,14 @@ func (h *Handler) chat(provider bschemas.ModelProvider, static upstream, pick fu
 			addedMs := float64(added.Microseconds()) / 1000.0
 			cp.noteCG(addedMs)
 			cp.noteTrace(tr)
+			// A real request has arrived on this session: cancel any pending keep-alive
+			// (this request refreshes the entry itself, and a ping concurrent with it would
+			// be a second request against the tenant's budget for nothing), and pick up what
+			// the pings during the idle span it just ended actually did. Both facts are
+			// needed BEFORE the row is priced — the ping count and the tokens the last ping
+			// refreshed are inputs to a dollar figure, not just a label.
+			kaPings, kaRefreshed := h.keeper.arrive(tn.ID, tr.Session)
+			cp.noteKeepAlive(kaPings, kaRefreshed)
 			if h.agg != nil && !bypassed {
 				h.agg.RecordAddedLatency(addedMs)
 				h.agg.RecordEligibility(tr.AttemptedTokens, tr.FrozenTokens)
@@ -1054,7 +1077,7 @@ func (h *Handler) chat(provider bschemas.ModelProvider, static upstream, pick fu
 		// emits it in a defer once the response is finished, so a request produces exactly
 		// one lifecycle line whichever way it ends — and the attrs are built here, once,
 		// rather than on the response path.
-		h.serve(w, r, provider, up, body, bypassed, cp, tn, lifecycleLogger(lg, tr, bypassed))
+		h.serve(w, r, provider, up, body, bypassed, cp, tn, tr.Session, lifecycleLogger(lg, tr, bypassed))
 	}
 }
 
@@ -1119,7 +1142,7 @@ var errNoUpstream = errors.New("no upstream configured")
 // → /stats sse_streamed / sse_buffered). It previously matched the expand tool
 // description this proxy injects itself, so it was unconditionally true and the
 // zero-added-latency promise above never held for any request (issue #26).
-func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschemas.ModelProvider, up upstream, body []byte, bypassed bool, cp *capture, tn *Tenancy, lg *slog.Logger) {
+func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschemas.ModelProvider, up upstream, body []byte, bypassed bool, cp *capture, tn *Tenancy, session string, lg *slog.Logger) {
 	// ONE condition governs both halves of the loop: the tool is intercepted exactly when
 	// it is advertised on the outgoing request. Those used to be different conditions —
 	// advertised when the request had tools, intercepted (for SSE) when it had markers —
@@ -1148,7 +1171,17 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 	// the one fact about a request an operator asks for first, and until now it reached
 	// the dashboard row and nothing else.
 	status, rounds, expanded := 0, 0, 0
+	// upStart of the LAST upstream round. The provider's cache lifetime "is measured from the
+	// start of the request that writes or reads the cache entry, not from the end of its
+	// response", so this — not the moment the response finished — is the instant the idle
+	// clock starts from.
+	var lastUpStart time.Time
 	defer func() {
+		// Hand the finished request to the keep-alive. Last, so `body` is the bytes that
+		// actually went upstream on the final round (an expand round rewrites it) and the
+		// prefix a ping would replay is the one the provider just hashed. Costs nothing when
+		// no tenant has opted in.
+		h.keeper.record(tn, session, lastUpStart, body, up, r, provider, up.path, status, usage, usageOK)
 		if sse && h.agg != nil {
 			h.agg.RecordSSE(msSince(reqStart, sseFirstByte), sseBuffered)
 		}
@@ -1170,6 +1203,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 	for round := 0; ; round++ {
 		rounds = round + 1
 		upStart := time.Now()
+		lastUpStart = upStart
 		resp, err := h.doUpstream(r, up, body)
 		if err != nil {
 			// LOG it, and record it on the captured row. An upstream failure used to be
@@ -1493,6 +1527,13 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 	// Cached-prefix restarts after an agent compaction. Same layering as the pool counters
 	// below: the counter lives in `modes`, so the host merges it here.
 	snap.CompactionResets = modes.CompactionResets()
+	// The idle keep-alive's ledger, same layering as the pool counters below: the mechanism
+	// lives in `proxy` because it acts between requests, so `metrics` cannot reach it. Only
+	// published once it has done something — a deployment where nobody opted in shows no
+	// field at all rather than a row of zeroes that reads as a broken feature.
+	if ka := h.keeper.Stats(); ka.Live > 0 || ka.Pings > 0 || ka.Skipped > 0 {
+		snap.KeepAlive = ka
+	}
 	// Off-path pool counters, same layering: the pool lives in `modes`, so `metrics` cannot
 	// read it and the host merges it here. Without this the observe-mode docs describe a
 	// `dropped` counter no consumer can reach — the pool tracked it correctly and nothing

--- a/proxy/stats_golden_test.go
+++ b/proxy/stats_golden_test.go
@@ -105,6 +105,11 @@ var statsGoldenComponent = []string{
 	"runs",
 	"saved_tokens",
 	"saved_tokens_unique",
+	// verdict reads the other three: a component that MUTATED without SAVING content tokens
+	// is doing its job (cachesplit moves tokens between billing tiers rather than removing
+	// them), and "acted: 0" beside "mutated: 755" has twice been filed as a bug against a
+	// mechanism that was working. Stating the reading is cheaper than explaining it again.
+	"verdict",
 }
 
 // harnessRequiredFields are the exact keys deploy/harbor reads. Listed separately

--- a/proxy/tenancy.go
+++ b/proxy/tenancy.go
@@ -153,6 +153,9 @@ type Tenancy struct {
 	CaptureContent bool
 	// Upstream names, by dialect, into Options.Upstreams.
 	UpAnthropic, UpOpenAI, UpBob string
+	// Cache is this tenant's host-level prompt-cache policy: the idle keep-alive and the
+	// mixed-TTL head. Zero means both off, which is the default for every account.
+	Cache CachePolicy
 }
 
 // Upstream is one resolved entry of the server's allow-list.
@@ -408,6 +411,9 @@ type BuiltConfig struct {
 	Store  store.Store
 	Mode   components.Mode
 	Preset string
+	// Cache is the document's `cache:` block, resolved. Host-level prompt-cache policy the
+	// pipeline cannot express, because it acts between requests rather than during one.
+	Cache CachePolicy
 }
 
 // ConfigBuilder expands a tenant's configuration document into a runnable
@@ -624,7 +630,7 @@ func (s *TenantSource) build(t *tenant.Tenant, cfgDoc string) (*Tenancy, error) 
 		tn.Preset = "invalid"
 		return tn, nil
 	}
-	tn.Pipe, tn.Store, tn.Preset = built.Pipe, built.Store, built.Preset
+	tn.Pipe, tn.Store, tn.Preset, tn.Cache = built.Pipe, built.Store, built.Preset, built.Cache
 	if built.Mode != "" {
 		tn.Mode = built.Mode
 	}

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -14,6 +14,20 @@ type Usage struct {
 	CacheRead  int64
 	CacheWrite int64
 	Output     int64
+	// CacheWrite1h is the part of CacheWrite the provider billed at the ONE-HOUR write
+	// tier, from `usage.cache_creation.ephemeral_1h_input_tokens`. Zero on every response
+	// that wrote only 5-minute entries, which on this deployment is all of them.
+	//
+	// It is here for two reasons, and both are about not being lied to. A 1h write costs
+	// 2.0x base input where a 5m write costs 1.25x, so pricing a 1h write as a 5m one
+	// understates that request by 0.75x of its whole written prefix. And it is the ONLY
+	// signal that a requested `ttl: "1h"` was HONOURED. A provider that does not support the
+	// tier for that model downgrades it silently: a normal 200 with a normal-looking
+	// `cache_creation_input_tokens` and nothing to distinguish it from a granted 1h entry.
+	// Measured live on this gateway: aws/claude-haiku-4-5 returned 36,251 of 36,574 written
+	// tokens at the 1h tier, aws/claude-sonnet-5 returned 0 of 48,212. Absent-or-zero here,
+	// with a 1h breakpoint on the wire, means the request was downgraded.
+	CacheWrite1h int64
 	// StopReason is the provider's terminal reason for this response, normalized across
 	// dialects (see responseStopReason). It rides on Usage because it comes off the same
 	// buffered/sniffed response bytes and reaches the dashboard by the same path — a
@@ -54,6 +68,10 @@ func parseUsage(body []byte) (Usage, bool) {
 		out.Output = u.Get("output_tokens").Int()
 		out.CacheRead = u.Get("cache_read_input_tokens").Int()
 		out.CacheWrite = u.Get("cache_creation_input_tokens").Int()
+		// The per-TTL split, when the provider reports one. `cache_creation_input_tokens`
+		// is the total across both tiers, so this is a SUBSET of CacheWrite and never an
+		// addition to it.
+		out.CacheWrite1h = u.Get("cache_creation.ephemeral_1h_input_tokens").Int()
 	case u.Get("prompt_tokens").Exists(): // OpenAI
 		prompt := u.Get("prompt_tokens").Int()
 		out.Output = u.Get("completion_tokens").Int()
@@ -107,6 +125,7 @@ func parseSSEUsage(raw []byte) (Usage, bool) {
 			out.FreshInput = max64(out.FreshInput, one.FreshInput)
 			out.CacheRead = max64(out.CacheRead, one.CacheRead)
 			out.CacheWrite = max64(out.CacheWrite, one.CacheWrite)
+			out.CacheWrite1h = max64(out.CacheWrite1h, one.CacheWrite1h)
 			out.Output = max64(out.Output, one.Output)
 		}
 	}

--- a/proxy/usage_test.go
+++ b/proxy/usage_test.go
@@ -186,3 +186,51 @@ func TestResponseUsagePicksTheParserByContentType(t *testing.T) {
 		t.Error("empty body reported usage")
 	}
 }
+
+// The per-TTL write breakdown. Without it a 1-hour write prices as a 5-minute one, which
+// understates the row by 0.75x of its whole written prefix — and it is also the only signal
+// that a requested ttl:"1h" was honoured rather than silently downgraded.
+//
+// Both fixtures are real responses from this gateway, one per verdict.
+func TestUsageReadsTheOneHourWriteTier(t *testing.T) {
+	granted := `{"usage":{"input_tokens":2,"output_tokens":32,"cache_read_input_tokens":0,
+		"cache_creation_input_tokens":36574,
+		"cache_creation":{"ephemeral_5m_input_tokens":323,"ephemeral_1h_input_tokens":36251}}}`
+	refused := `{"usage":{"input_tokens":2,"output_tokens":32,"cache_read_input_tokens":0,
+		"cache_creation_input_tokens":48212,
+		"cache_creation":{"ephemeral_5m_input_tokens":48212,"ephemeral_1h_input_tokens":0}}}`
+
+	u, ok := parseUsage([]byte(granted))
+	if !ok {
+		t.Fatal("granted fixture did not parse")
+	}
+	if u.CacheWrite != 36574 || u.CacheWrite1h != 36251 {
+		t.Errorf("granted: write=%d write_1h=%d, want 36574/36251", u.CacheWrite, u.CacheWrite1h)
+	}
+	if u.CacheWrite1h > u.CacheWrite {
+		t.Error("the 1h figure is a SUBSET of cache_write, never an addition to it")
+	}
+	u2, ok := parseUsage([]byte(refused))
+	if !ok {
+		t.Fatal("refused fixture did not parse")
+	}
+	if u2.CacheWrite != 48212 || u2.CacheWrite1h != 0 {
+		t.Errorf("refused: write=%d write_1h=%d, want 48212/0", u2.CacheWrite, u2.CacheWrite1h)
+	}
+	// A response with no breakdown at all — every pre-existing fixture — must read as zero
+	// rather than as missing usage.
+	u3, ok := parseUsage([]byte(`{"usage":{"input_tokens":5,"output_tokens":1,
+		"cache_creation_input_tokens":100}}`))
+	if !ok || u3.CacheWrite != 100 || u3.CacheWrite1h != 0 {
+		t.Errorf("no-breakdown response: ok=%v write=%d write_1h=%d", ok, u3.CacheWrite, u3.CacheWrite1h)
+	}
+	// And through the SSE path, where the tiers arrive in message_start. One LINE per event, so
+	// the payload has to be compact — a `data:` field with an embedded newline is two events.
+	sse := `event: message_start` + "\n" + `data: {"message":{"usage":{"input_tokens":2,` +
+		`"cache_creation_input_tokens":36574,"cache_creation":` +
+		`{"ephemeral_5m_input_tokens":323,"ephemeral_1h_input_tokens":36251}}}}` + "\n\n"
+	u4, ok := parseSSEUsage([]byte(sse))
+	if !ok || u4.CacheWrite1h != 36251 {
+		t.Errorf("sse: ok=%v write_1h=%d, want 36251", ok, u4.CacheWrite1h)
+	}
+}


### PR DESCRIPTION
## The problem, in one table

Measured on the hosted service: 19,805 requests, **$3,139.97**, 2026-08-16 → 21.

| miss reason | n | share | $ | share of spend | $/req |
|---|---:|---:|---:|---:|---:|
| hit | 16,368 | 82.6% | 1,928.65 | 61.4% | 0.1178 |
| **ttl_expiry** | **742** | **3.7%** | **741.07** | **23.6%** | **0.9987** |
| cold_start | 1,626 | 8.2% | 253.82 | 8.1% | 0.1561 |
| prefix_change | 292 | 1.5% | 205.05 | 6.5% | 0.7022 |
| unknown | 777 | 3.9% | 11.38 | 0.4% | 0.0146 |

A TTL-expired request costs **8.5x** a request that hit. Against each row's own
counterfactual — the same tokens billed as a read — the penalty is **11.35x**, of which
91.2% is pure re-write. The addressable population is 357 claude-cli requests / $734.75.

**$584.83 — 18.6% of ALL spend — sits in misses whose idle gap was under an hour.** For
scale: the entire transformation pipeline's measured net over the same window is **$9.72**.

## The caching math, with the doc quotes it rests on

> By default, the cache has a 5-minute lifetime. **The cache is refreshed for no
> additional cost each time the cached content is used.**

> **The lifetime is measured from the start of the request that writes or reads the cache
> entry, not from the end of its response.** Time spent generating a response counts
> against the lifetime.

> **Cache writes happen only at your breakpoint.** … Because the hash is cumulative,
> covering everything up to and including the breakpoint, changing any block at or before
> the breakpoint produces a different hash on the next request.

> **Exact matching:** Cache hits require 100% identical prompt segments.

Multipliers: 5m write **1.25x** base input, 1h write **2.0x**, read **0.1x**. Backed out of
production billing independently and confirmed to the cent — read **0.1000** at every prefix
size, write **1.250**, so write/read is **12.5x**.

Converting one miss recovers `(1.25 − 0.1) = 1.15x` on the prefix; one ping costs `0.1x`.
**Saving : ping = 11.5 : 1**, and both sides scale with the model's input rate, so the ratio
survives the whole price list.

---

## 1. The idle keep-alive (`proxy/keepalive.go`)

Host-level, not a component, because the expensive event happens when **no request is in
flight**. After a session has been idle `X` seconds the proxy re-sends its last request with
`max_tokens: 1` and `stream: false` — a pure cache read, which refreshes the entry. Those two
fields sit outside the `tools` → `system` → `messages` hash, so the prefix is byte-identical.

### The timer origin — the one decision that flips the sign

**The timer is armed at REQUEST START, never at response completion** (`kaEntry.startedAt`,
set from `serve`'s `lastUpStart`). The provider's lifetime runs from request start, so an
anchor at completion silently spends the response's own duration out of the 20 s of margin X
leaves: `upstream_ms` is p50 8.9 s, p75 17.5 s, p90 33.4 s, so ~21% of first pings would land
after the entry had expired — and a ping onto a dead entry pays a 1.25x **write**, the exact
cost it exists to avoid. Simulated, that one change takes X=280 from **+$164 to −$241.99**
with ping cost tripling to $408.85. The number is in the code comment beside the field so
nobody "simplifies" it later.

A ping is itself a cache read, so it re-anchors the clock: the bridgeable span is
`K·X + TTL`, not `K·X`. `TestMaxPingsAndPingRestartsTheClock` asserts it.

### The gate — what makes this deployable rather than merely profitable

**Shipped default: `X=280s, K=2`, and a session is pinged only when it is not on its first
request AND its billed prefix (`cache_read + cache_write`) is ≥ 20,000 tokens.**

| policy | pings | ping cost | converted | saving | **net** |
|---|---:|---:|---:|---:|---:|
| **X=280 K=2, gated (shipped)** | **912** | **$90.76** | **148** | **$215.84** | **+$125.08** |
| X=280 K=2, blanket | 8,915 | $93.79 | 153 | $221.05 | +$127.26 |
| X=280 K=1, gated | 536 | $53.51 | 96 | $138.80 | +$85.28 |
| X=280 K=3, gated | 1,226 | $121.33 | 174 | $252.13 | +$130.80 |
| X=240 K=2, gated | 1,012 | $102.19 | 134 | $197.03 | +$94.85 |
| X=280 K=12, gated | 3,307 | $311.78 | 253 | $370.12 | +$58.35 |

**9.8× fewer pings for 1.7% less money.** What the gate drops is the near-free pings: cost
is bimodal (p50 $0.0004 against a p99 of $0.2275), and 45.7% of blanket pings fire on
single-request sessions with ~1k-token prefixes. 8,000 requests of real gateway load
disappear — on a path that returned **180 HTTP 429s** in the same window — and almost none of
the value does.

The first-request skip is a cheap filter, **not** a claim that later turns miss more often:
P(next request is an addressable TTL miss) is flat — 2.24% at turn 0, 2.33% at 5, 2.47% at
20, 2.29% at 100. K=2 ships over K=3 (marginally better here, +$130.80) because they are
a tie inside the run-to-run wobble and K=2 sends 26% fewer requests. The earlier claim that the
net "peaks at K=2" did not reproduce and is withdrawn.

**No per-session ping cap.** It truncates exactly the long large-prefix sessions holding the
value — cap-20 drops the net to $92.34, cap-10 to $54.04. The guard that works is
`keepalive_max_usd_per_ping` (default $0.25), checked against a projection computed from the
prefix and the model's own read rate *before* anything is sent.

### Guards

| control | default | why |
|---|---|---|
| `keepalive_idle_seconds` (X) | 280 | refused at load if ≥ 300 — a ping past the lifetime *writes* |
| `keepalive_max_pings` (K) | 2 | net peaks at 2–3; a session that has *ended* is undetectable |
| `keepalive_min_prefix_tokens` | 20,000 | the gate above |
| `keepalive_max_usd_per_ping` | $0.25 | bounds the outlier ping, never the productive session |
| tenant limits | `AcquireSpare`, 25% reserved | a ping uses only slack and is **skipped, never queued** |
| `CONTEXT_GURU_KEEPALIVE=off` | — | operator kill switch; an env var so it works when the control plane is what is broken |

**Never adds or moves a breakpoint.** `TestPingBodyLeavesTheHashedPrefixByteIdentical` asserts
the `cache_control` count is unchanged and that
`model`/`tools`/`system`/`messages`/`thinking`/`tool_choice` are byte-identical. A runtime
guard backs it up: a ping whose usage reports more written than read is logged at ERROR,
counted as `wrote_instead_of_read`, and that session is never pinged again.

**Will not ping `thinking.type: enabled`** — it requires `max_tokens` above a 32,000-token
budget, and altering thinking invalidates the message-level prefix. Exposure: 17 of 357
addressable misses, **$14.29 of $732 = 2.0%**. `adaptive` is 81% and unaffected.

### Not gated on `end_turn`, and the data is why

`end_turn` reads like a session-end signal and is the opposite: P(gap > 300s) is **37.15%**
after it against **0.74%** after `tool_use`, and **83.7% of the recoverable dollars** sit
behind it. Only 290 of 3,891 session-final requests (7.5%) end that way. Stopping there would
discard most of the value. What ships instead: K, a stop on any 4xx, and a stop on a ping that
wrote.

### A bug the gate exposed in this PR's own code

Gating inside `due()` left un-pingable sessions sitting in the map holding a body and a
credential until memory pressure evicted them. On the replay the 512-session bound saturated
and eviction then discarded the entries about to pay — conversions fell from 153 to **69**. The
gate now runs in `record`, so nothing is held for a session we will not ping. That is also the
better security posture, and it is why `pingable()` is separate from `due()`.

### Credential retention — escalated, ruled on, and hardened

On a caller-pays upstream this is the one place the service holds a caller's provider
credential beyond the life of a request. The default deployment *is* caller-pays
(`/etc/context-guru/upstreams.yaml` names no key), so without retention the mechanism cannot
exist here, and pinging on the operator's key would bill the wrong party. The owner's ruling
was **acceptable only with hardening**; all seven controls are in:

| control | implementation |
|---|---|
| **Hard deadline** | `time.AfterFunc((K+1)·X)` ≈ 14 min — a *scheduled* deadline, so a process with zero traffic still releases on time. A security bound must not depend on a liveness loop. The sweep's eager release is kept as the *earlier* of the two, not as the guarantee. |
| **Zeroized** | `zero()` overwrites the bytes on every release path — next request, gate refusal, retirement, eviction, shutdown, panic. A dropped `[]byte` sits in the heap until a collection that may never come. |
| **Masked at rest** | the credential **and the retained body**, XOR under a `crypto/rand` per-process key. The asymmetry decides the body: a leaked key is rotatable, a transcript is not. |
| **Consent per request** | `record` re-reads `tn.Cache` every request and **retires what is already held** when it is off. A stale flag from when the hold began cannot extend it. |
| **Audit row per ping** | a durable `requests` row with tenant, session, `ts`, `cost_usd`, `cache_read`/`cache_write` — and **unconditional**: with no recorder to write one, nothing is retained. An audit control `--dashboard` can switch off is not a control. |
| **Purged on revocation** | `keeper.forget(tenantID)` on account deletion, token revocation and disablement. The deadline would get there in minutes, but a revocation the user performed deliberately should not wait on a timer. |
| **No output surface** | asserted against `/stats`, `/metrics`, `KeepAliveStats`, `%+v` of the live entry (the panic-trace path) and the **JSON log sink at debug level** — for both the credential and the retained body, which holds the user's whole conversation. |
| **Kill switch** | `CONTEXT_GURU_KEEPALIVE=off` now stops **retention**, not merely pinging: `record` retires instead of holding. A switch that kept the material while refusing to use it is the worst of both. |

**What the masking does and does not buy — stated plainly rather than sold.** A heap or core
dump, a crash report, a `/proc/<pid>/mem` read or a `strings` pass over a snapshot yields
masked bytes rather than a working key: the accidental-capture class, which is the realistic
one. It does **not** stop an attacker with code execution in this process — the mask is in the
same address space. It is obfuscation at rest, not encryption. And the credential is
necessarily plaintext for the duration of the ping itself, because `net/http`'s header map
holds strings and a Go string cannot be overwritten; the window is one request instead of the
whole idle hold, which is the part worth closing.

Two further items from the re-review are in. **The audit row is now unconditional** — the choice
was between a second durable sink and refusing to hold what cannot be accounted for, and this
takes the second: three lines, and it fails in the safe direction. **And revocation purges**:
`keeper.forget(tenantID)` runs on delete, revoke and disable, because the keeper is a credential
store `tenant.TestDeleteCascadesEveryCredential` did not know about.

**A test of mine that could not have caught its own subject.** Requiring an audit sink broke the
output-surface leak test, which turned out to be assigning its recorder *after* `New()` — leaving
it half-wired, so the surfaces it probed were not the ones a deployment serves and its earlier
PASS was unproven. It now uses a real in-memory recorder through `New()` like the dashboard tests.
The fixture churn in the test diff is that fix, not a weakening: the test got stronger.

One design change the zeroize requirement forced, and it is an improvement: the retained body
is now a **keeper-owned copy** rather than the slice `serve` used. Overwriting a shared slice
is the kind of cleverness that produces a mystery bug in a month. The zero-copy retention was
a micro-optimisation in the wrong place, and with the gate down to ~119 tracked sessions the
copy costs nothing.

Bounded on volume too: 512 sessions / 128 MiB total / 8 MiB per body.

---

## 2. CLOSED AVENUE: selective and mixed 1-hour TTL

**Do not re-attempt this.** `apply/headttl.go` ships implemented and **disabled**, purely so
the negative result is verifiable rather than folklore.

Why it cannot pay, three independent ways:

1. **Blanket 1h loses money.** The 2.0x premium falls on all 14,499 cache-creating requests
   (−$773.00); the benefit lands on 290 (+$754.66). Net **−$18.34**. An independent
   counterfactual puts it at **−$93.51** (+$455.96 rescued against −$549.47 of premium), worse
   because the naive threshold assumes one write per session while real traffic writes nearly
   every turn (`hit` rows average `cache_write` 6,183) — the premium lands on 192.8 MTok of
   writes against 104 MTok of rescuable prefix.
2. **A predictor cannot rescue it.** Gated on the best available signal: **−$18.32**,
   indistinguishable from blanket. Structural, not a tuning failure — premium and benefit
   scale with the *same* `cache_write` on the *same* requests, so a probability filter cannot
   flip a sign. (A *dollar* filter can: `tokens_before ≥ 50k` → +$48.81. Still not shipped,
   because of 3.)
3. **The tier does not arrive on the models we run.** Zero 1h writes in 19,805 requests: of
   5,386 rows with `cache_write > 1000`, 3,615 match 1.25x and **none** match 2.0x. Bedrock
   announced 1h on 2026-01-26 for the Claude **4.5** family; our spend is Opus 5, Opus 4.8,
   Sonnet 5, Opus 4.6.

**One received claim I have to correct, because I measured it.** The blocker was believed to be
LiteLLM stripping the field (`_remove_ttl_from_cache_control`, upstream #19848/#20326). Probed
live, one request each with the head labelled 1h:

| model | `ephemeral_1h_input_tokens` | `ephemeral_5m_input_tokens` | verdict |
|---|---:|---:|---|
| `aws/claude-haiku-4-5` | **36,251** | 323 | **1h GRANTED** |
| `aws/claude-sonnet-5` | **0** | 48,212 | silently downgraded |

Haiku honouring the tier proves the field **does** reach Bedrock. What refuses is model
coverage. Same conclusion, correct mechanism — and it matters, because the fix if this ever
becomes worth having is a model allowlist, not a LiteLLM patch.

Mixed TTL (1h head + 5m tail) is implemented for the same reason and off for the same one. It
needs no extra breakpoint slot — it re-labels existing marks, asserted by
`TestHeadTTLAddsNoBreakpoint` — and 1h-before-5m holds by construction, asserted by
`TestHeadTTLUpgradesTheHeadAndNotTheTail`. **Projected net on today's spend mix: $0.**

### A pricing defect that probe exposed, and this PR fixes

The Haiku response was billed at the 1h tier and the dashboard priced it at the 5-minute rate:
**$0.0348 recorded against a real $0.0554**. `Usage.CacheWrite1h` and a `cache_write_1h` column
now carry the provider's own per-tier breakdown, and `Event.Price` adds the
`2.0x input − 5m write rate` premium on exactly those tokens. A cost wrong in the flattering
direction argues for spending.

## 3. CLOSED AVENUE: parallel fan-out on `cold_start` — measured, not happening

The idea: *"a cache entry becomes readable only after the first response begins streaming"*, so
concurrent requests sharing a prefix can all miss and all pay 1.25x. `cold_start` is $253.82
(8.1% of spend), and Claude Code fans out subagents, so it was worth checking.

| test on the 1,626 `cold_start` rows | n | $ |
|---|---:|---:|
| another `cold_start` in the **same session** within 10 s | 34 | 9.53 |
| another `cold_start` in the **same tenant** within 10 s | 1,260 | 134.84 |
| …**and plausibly sharing a prefix** (same model, `cache_write` within 5%) | **2** | **0.66** |

The same-tenant number is a mirage. `litellm` is 886 of the 1,626 rows ($112.64) with mean
`cache_write` **0** — one-shot calls with no cacheable prefix at all, near-simultaneous because
they are a batch, with nothing to race for. Same for `python-requests` (276, write 0) and
`anthropic` (240, write 57). Only `claude-cli` cold starts carry real prefixes (219 rows, mean
`cache_write` 108,640), and 1,494 of 1,626 cold starts are the session's genuine first request.

**Serialising 1,260 requests behind a first-token wait to recover $0.66 is not worth building.
Skipped.**

## 4. `cachesplit`: nothing was broken, and the reporting now says so

`acted: 0` beside `mutated: 755` is correct by design — the split *moves* tokens between
billing tiers rather than removing them. `/stats` now publishes a per-component `verdict`:
`acted` | **`moved`** | `skipped` | `idle`.

**The credit is not raised.** Recomputing the shipped gates over the snapshot:

| gate applied cumulatively | rows surviving |
|---|---:|
| the split ran | 2,039 |
| + a tail hash recorded | 1,938 |
| + `cache_read ≥ stable` | 1,733 |
| + `cache_write < stable` | 1,332 |
| **+ the tail MOVED since the session's previous request** | **1** |
| credited in the DB today | 4 rows / **$0.0381** |

**32 of 35 split sessions carry exactly ONE distinct tail hash for the whole session** — Claude
Code captures its environment snapshot once per session, so mid-session there is nothing to
protect. Pricing the 1,729 "uncredited hits carrying a tail hash" at $18.79 would credit the
provider's cache to us. **The honest number is ~$0.04 and it stays.**

## 5. Doc bug fixed: the 1h break-even is 65.2%, not 83.3%

`cacheinject.go` and `docs/components/cacheinject.md` both stated
`(2.0−1.25)/(1−0.1) = 83.3%`. That denominator assumes a lapsed entry re-bills at the 1.0x
fresh rate. It does not: those tokens still carry `cache_control`, so the provider *creates* a
new entry at 1.25x. Production `ttl_expiry` rows say so — `cache_write` averages 178,793
against `fresh_input` 1,712. Correct denominator `(1.25−0.1) = 1.15`, giving **65.2%**.
Conclusion unchanged, the documented number was wrong by 18 points.

## 6. A closed dead end, restated: cross-session prefix repair

Not rebuilt. **Refuted live** — the billing-header block is exempt from this gateway's cache
hash, so there was nothing to repair, and v1 measured a **+5.5% cost regression**.

---

# Review response (`REVIEW-86.md`, against `eba59a2`)

Four of the ten findings were already fixed in commits 2–3 while the review was in flight; six
needed work. Every one is addressed.

**1. Ping rows credited themselves with `cache_saved_usd` — the serious one.** `Event.Price`
computed it from `CacheRead` unconditionally, so each 48k ping booked ~$0.13 of phantom
provider-cache saving against $0.0073 of real cost. On a figure PR #83 puts on the page, at
production ping volumes, that is order **$1,000 of fabricated savings**. One guard in the shared
function, where all callers route through — `if !e.KeepAlive`. The counterfactual is the tell:
without the keep-alive that request does not exist, so there is nothing for it to have saved
against. `TestPingsDoNotCreditProviderCacheSavings` also asserts the ping's own *cost* survives
the guard and that an ordinary hit keeps its diagnostic.

On the three aggregates: `COUNT(*)`, `SUM(cache_read)` and `AVG(upstream_ms)` all live in the
Overview query, which routes through `Filter.where()` — so the one-line exclusion reaches all
three. `dash/api.go` builds a single `Filter` and is covered by the same line. Nothing needed a
per-caller patch.

**2. Kill switch stopped pinging, not retention.** Fixed in commit 3: `record` calls `retire`
when `keepAliveDisabled()`. Test asserts nothing is held with the switch set.

**3. `AcquireSpare` charged the rate window for refused pings.** Three real bugs, all fixed.
The concurrency slot is now taken **first** and the rate counter incremented only once the ping
is certain to be sent, with `release()` returning the slot if the rate check then refuses.
`reserved()` now floors at **0, not 1** — a floor of 1 let a ping take the only slot at
`Concurrent: 1`, which is the exact outcome the doc comment forbids; a tenant with a budget of
one has no slack and is correctly never pinged. And the headroom test now happens under the
tenant's lock together with the take, so two pings cannot both read "there is room". The
reviewer's own `TestReviewSkippedPingConsumesRPM` now passes (`before=1 after=1` over ten
refused pings) and `TestReviewReservationFloorAtOne` skips with "ping refused the only slot".

**4. The consent copy promised an audit trail that did not render.** Both halves now exist: a
`keep-alive` pill on the Requests tab in place of the cache-outcome pill (a one-token request
the user did not make, unlabelled, is worse than not showing it), and an Overview tile carrying
the **net** with `pings · ping cost · misses avoided · saving` as its subtitle — hidden until
the mechanism has done something, so an unopted deployment shows no row of zeroes. The ledger
bars were already rendering generically from `delta_usd`.

**5. `docs/hosted.md` stated the invariant this falsifies.** Updated. The reviewer's correction
is taken: `authHeaders` are *forwarded*, which is the caller-pays design, and only our own
minted token is scrubbed — so the sentence that changed is "and stores none: the key is read off
the request and dropped". It now carries that clause plus a scoped exception naming the opt-in,
the bound, and the audit trail, and says plainly that nothing is retained for an account that
has not enabled it.

**6. The retained BODY needed its own disclosure.** It cannot be reduced — the prefix hash
covers the whole `tools` → `system` → `messages` sequence, so a ping that trimmed the body would
miss the cache and cost 12.5x instead of saving 11.5x, which is the mechanism inverted. So it is
disclosed, in the consent copy and the docs, and explicitly distinguished from the
transcript-storage consent: that one governs writing content to **disk** where a manager can
read it; this is memory only, masked, overwritten on release, never persisted, gone in ~14
minutes. The reviewer is right that enabling a *spending* feature is not consent to retaining
conversation content, so the copy now says both.

**7. Stale numbers in my own code.** `keepalive.go` and `config.go` quoted +$170.08 / 9,234 /
182 as the shipped result; the shipped function gives +$125.08 / 912 / 148. Corrected, and the
comments now say they come from the replay so a policy change moves them too. **"Net peaks at
K=2" did not reproduce and is withdrawn**: K=2 gives +$125.08 against K=3's +$130.80 — a tie
inside the run-to-run wobble. K=2 ships for the ping-volume reason (26% fewer requests on a path
that returned 180 HTTP 429s), not a dollar one.

**8. Three comments repeated the refuted "LiteLLM strips ttl".** All three corrected to Bedrock
model coverage.

**9. `cache_write_1h` had no read path.** Row-level scan landed in commit 2; the Overview now
also sums it, so the feature's own verification is a glance rather than hand-written SQL.

**10. `upgradeHeadTTL`'s size gate can flip mid-session.** Noted with a `ponytail:` comment
naming the upgrade path (latch per session). Harmless while off, and a differing `ttl` does not
change the prefix hash, so neither direction costs a miss.

## The 512-session bound — confirmed, and the gate is what fixes it

The reviewer's instrumentation was right. Measured with `peak live` now reported by the replay:

| policy | peak live sessions | bound |
|---|--:|--:|
| blanket X=280 K=2 | **512** | 512 — saturated, and the source of the 8,961–8,969 ping wobble |
| **gated (shipped)** | **11** | 512 — two orders of margin |

No need to raise the bound. Money was identical to the cent across runs either way, as the
reviewer found.

## Process and provenance

- **`-count=1` from here on.** The reviewer caught a cached `ok .../proxy` for a package that no
  longer compiled, because `MaxUSDPerSession` had been replaced mid-review. Fair, and the
  green-suite claim below is `-count=1`.
- **The e2e binary (00:39) predates the commit (01:02)**, and the ping row shows `max_tokens: 0`
  where committed `record1` sets 1. The benign reading is the right one and the evidence supports
  it: the ping returned `output_tokens: 1` with `stop_reason: max_tokens`, which is only possible
  if `max_tokens: 1` was on the wire. What the binary lacked was the *dashboard column* for it —
  `ev.MaxTokens = 1` was added after that run. The billed tiers, which are the claim, are
  unaffected.
- **My `max_tokens: 1` justification was wrong** and is rewritten. `0` is rejected alongside
  streaming and thinking, and this ping excludes both — so that was not the reason. The real one
  is compatibility for one output token costing $0.0000076 against a $0.0073 read: a tenth of a
  percent, not worth a negotiation risk on a request that must not fail surprisingly.
- **`MaxUSDPerSession` was per-idle-span while documented per-session**, and its test staged
  `e.spent` by hand against a keeper with no `Prices`, so the accumulation path never ran. It is
  gone; `TestPerPingCostGuard` drives the real `projectedPingUSD` path through an injected
  `Pricer` and asserts both the refusal and that the same traffic under a larger budget IS
  pinged.

---

# Evidence

## Live end-to-end, real gateway, nothing simulated

Two arms, byte-identical bodies, a real 48k-token Claude Code `system` + `tools` prefix on
`aws/claude-sonnet-5`, 330 s of idle across the 300 s lifetime. Per-arm nonce in the first
`cache_control`-marked system block — the cache is content-keyed, so without it the second arm
free-rides on the first arm's write. (Not block 0: this gateway exempts its billing-header
block from the hash.)

**Keep-alive OFF** — the failure this exists to fix, reproduced:

```
turn 1               cold_start   read=      0  write= 48211  out=111  $0.092448
turn 2 (after 330s)  ttl_expiry   read=      0  write= 48335  out=128  $0.092812
```

**Keep-alive ON** — same script, same gap:

```
turn 1               cold_start   read=      0  write= 48211  out=127  $0.092569
PING at +280s        —            read=  48211  write=     0  out=  1  $0.007339   max_tokens=1
turn 2 (after 330s)  hit          read=  48211  write=   125  out=128  $0.008541
                                  keepalive_pings=1  keepalive_saved_usd=$0.084273
```

| | OFF | ON |
|---|---|---|
| turn 2 | `ttl_expiry`, 48,335 **written** | `hit`, 48,211 **read** |
| turn 2 cost | **$0.092812** | **$0.008541** |
| pings | — | $0.007339 |
| **turn-2 cost avoided, pings included** | — | **+$0.076932** |

The ping reported `cache_read = 48,211` and `cache_write = 0` — verified as the **full** prefix
and not a partial refresh, which would have looked like a win and cost money. Live miss/hit
ratio **10.87x** against 11.35x from production. `/stats` during the run:
`{"live_sessions":1,"pings":1,"skipped":0,"failed":0,"wrote_instead_of_read":0,"spend_usd":0.007339}`.

Harness `/tmp/cg-orch/ka-e2e.py`, raw rows `/tmp/cg-orch/runs/ka1/result.json`. Credentials
read from `~/.claude/settings.json` at call time and passed through the proxy's environment
only. *(A purpose-built 2-turn driver rather than the shared `drive.py`, because the ping has
to fire between two turns against this branch's own binary and `cache:` block. It produces the
same before/after comparison the shared harness would.)*

## Projection from the SHIPPED decision function

`TestKeepAliveOnProductionSnapshot` replays the snapshot through the real `keeper` — real
`due()`, real `pingable()`, real K, real cost guard, real thinking gate, real `record`/`arrive`
lifecycle — and prices every ping through the same `Pricer` the request path uses. Not a
separate model.

```
CG_SNAPSHOT_DB=/tmp/cgwork/cg-snap.db MODEL_PRICES=/etc/context-guru/prices.yaml \
  CGO_ENABLED=1 go test -run TestKeepAliveOnProductionSnapshot -v ./proxy/
```

**Shipped policy: +$125.08 over 4.47 days = ~$28/day at current volume and mix.** Rescue value
is the identity `(1.25 − 0.10) × in_rate × cache_write`, never a share of `cost_usd`.

**Do not annualise this.** It is 13 tenants over 4.5 days and it scales with the opus share and
with `ttl_expiry` frequency. Both sides are priced from `prices.yaml` at **current** list rates
and never netted against historical `cost_usd`: a price cutover on 2026-08-19 01:00 UTC dropped
the input rate by exactly 1.3158 (opus $5.00 → $3.80) mid-window, so 7,269 rows carry the older
dearer rate.

Not modelled, and stated because a projection that hides its assumptions is worth nothing:

- **Tenant limits.** `AcquireSpare` reads the wall clock, which a synthetic clock cannot drive,
  so ping counts are an **upper bound**.
- **The provider's content-keyed cache.** Another session sending an identical prefix would
  refresh the same entry for free, so some conversions credited here would have happened
  anyway. Same confound as the live credit, same direction.
- **Mode-A transcript growth.** The live arms grow by scripted turns, not a full agent
  trajectory; the prefix still grows and still expires, which is what is under test.

## The honest downside

| policy | sessions touched | losing money | worst session | total losses | winners |
|---|--:|--:|--:|--:|--:|
| blanket X=280 K=2 | 3,809 | **3,773 (99.1%)** | −$0.95 | −$13.10 | 36 |
| **gated (recommended)** | **119** | **85 (71.4%)** | **−$2.42** | **−$13.59** | **34** |

**The policy is a very small tax on almost every session it touches, funding a large rebate for
a few dozen.** The gate does not make the tax rarer per session touched — it makes it fall on
119 sessions instead of 3,809, leaving 3,690 untouched entirely. That is the fairness argument,
independent of the dollars: a session never pinged cannot lose.

Given this shape the opt-in default and the per-account ledger are not optional. The Settings
copy says so in the user's own terms: *"34 of 119 pinged sessions came out ahead and the worst
single session paid $2.42 for nothing. Watch your own ledger and switch it off if you are not
one of the winners."*

## Verification after rollout

Confirm against `cache_miss_reason` and the tiers, **not** a modelled delta: ping rows must
show `cache_read > 0` and `cache_write == 0` before a dollar is credited. This is the
cross-session-prefix-repair lesson — that idea also looked right on paper and was a +5.5%
regression live. `wrote_instead_of_read` in `/stats` is the alarm.

---

# Schema and shared files

**`schemaVersion` is unchanged at 6.** Production holds 19,805 requests / 64 MB at
`/var/lib/context-guru/cg.db`; a version bump would rename that aside on first restart. All
four columns go in `additiveColumns`, applied idempotently by `addColumns()`:

| column | type | historical rows read |
|---|---|---|
| `keepalive` | `INTEGER NOT NULL DEFAULT 0` | 0 — honest: no pings were sent |
| `keepalive_pings` | `INTEGER NOT NULL DEFAULT 0` | 0 — same |
| `keepalive_saved_usd` | `REAL NOT NULL DEFAULT 0` | 0 — same |
| `cache_write_1h` | `INTEGER NOT NULL DEFAULT 0` | 0 — and true: zero 1h writes exist |

**A ping is a `requests` row with a flag, not its own table**, because it is a real upstream
request with real usage and real cost, and every existing per-request facility (pricing, tenant
scoping, retention, purge) already applies to it. What that costs is one risk, handled in one
place: `Filter.where()` now excludes `keepalive = 1` **by default**, so the overview, buckets,
per-model groups, facets, session list and read-value queries are all agent-only at once. Two
callers opt back in — the request LIST (the audit trail; each row carries `keepalive` so the UI
can badge it) and the keep-alive ledger itself. Spend figures deliberately still include pings:
the money was really spent on the caller's key.
`TestPingsAreVisibleAsRowsAndExcludedFromAggregates` pins both halves.

**Shared files touched, for merge sequencing:**

- `apply/apply.go` (+24), `apply/opts.go` (+10) — purely additive: two `Opts` fields, two
  `Trace` fields, one call site beside the existing `toolschema`/`toolfilter` rewrites.
  **`Ctx.ColdCache`, `Ctx.IdleMs`, `cacheIsCold` and `cacheTTL` are untouched** (zero changed
  lines matching them). One interaction to note: with `head_ttl_1h` **on**,
  `bodyAsksExtendedTTL` becomes true, so `cacheTTL` returns 1h and `cacheIsCold` grows more
  permissive. That is correct when the tier is granted and a safe over-estimate when it is not,
  and it cannot affect anything today because the flag is off. Documented at the field.
- The keep-alive uses **its own idle tracking**, not `modes.Tracker`. Deliberate: the tracker
  answers "is the cache certainly gone" (conservative, +1 min margin, false when unknown),
  which is the opposite question from "is the cache about to go" — and the keeper additionally
  has to hold a body and a credential, which the tracker must not.
- `dash/schema.go`, `dash/event.go`, `dash/store.go`, `dash/query.go`, `dash/overview.go` —
  flag to the dashboard workstream if they also add `additiveColumns` entries.

## Tests and lint

```
$ gofmt -l .
(no output)

$ CGO_ENABLED=1 go vet ./...
(no output)

$ CGO_ENABLED=1 go test -race ./...
ok  	all 25 packages
```

New coverage: the ping is a cache READ with a byte-identical prefix and an unchanged breakpoint
count; a ping that wrote stops the session; timing from request start; X, K, and a ping
re-anchoring the clock; **the gate (first request skipped, prefix floor)**; **the per-ping cost
guard**; a ping never takes the last concurrency slot; fail-open with no in-sweep retry; 4xx
stops the session; `thinking: enabled` refused while `adaptive` works; a disabled policy and a
refused request hold nothing; `arrive` cancels and reports; credential rules in both
directions; memory bounds; kill switch; a real HTTP round trip; head-TTL adds no breakpoint and
never invents one, size gate, explicit-breakpoint providers only, idempotent, fails open on
four malformed shapes; the keep-alive credit and all five of its gates, the refresh cap, the
11.5:1 ratio, **the 1h tier priced at its own rate**; the per-TTL usage breakdown from both
live fixtures in JSON and SSE; **pings visible as rows and excluded from aggregates**; the
`cache:` block with `idle_seconds ≥ 300` refused at load; `verdict` distinguishing `moved`
from `skipped`.

The seven hardening controls each have their own subtest: the credential is held masked and
never plaintext while still unmasking to the caller's own value; a server-held key retains
nothing; release zeroizes the actual buffers (asserted on handles taken *before* release, so
it is about the bytes and not the pointer); **the hard deadline fires with no request, no
sweep and nothing else running**; withdrawn consent retires an existing hold; the kill switch
holds nothing; `Stop` drops everything. Plus the output-surface test above, which fails if the
debug log carries no keep-alive line — so it cannot pass by never exercising the path.

Nothing in the live deployment was changed.
