### PR TITLE
fix(deploy): make the nightly control-db backup work without the sqlite3 CLI

### DIFF
--- a/deploy/service/context-guru-backup.sh
+++ b/deploy/service/context-guru-backup.sh
@@ -6,9 +6,17 @@
 # pressure it archives itself to Box session by session, and anything it loses beyond
 # that is reconstructible from nothing that matters.
 #
-# Uses `sqlite3 .backup`, not `cp`. Copying a live SQLite file while the service is
-# writing yields a torn snapshot that may not open at all — and a backup you discover
+# Uses SQLite's ONLINE BACKUP api, not `cp`. Copying a live SQLite file while the service
+# is writing yields a torn snapshot that may not open at all — and a backup you discover
 # is unreadable at restore time is worse than no backup, because you stopped worrying.
+#
+# Driven through python3's sqlite3 module rather than the `sqlite3` CLI. The CLI is NOT
+# part of a minimal RHEL install and was absent on the first host this ran on, so the
+# timer failed every night with `sqlite3: command not found` (exit 127) and the control
+# database — tenants, token hashes, per-tenant config, the audit trail — went unbacked-up
+# with no symptom except a line in the journal nobody reads. python3 is already a hard
+# requirement of install.sh and of the proxy's own helper scripts, and
+# Connection.backup() is the same online-backup API the CLI's `.backup` calls.
 #
 # Restore:
 #   systemctl stop context-guru
@@ -34,11 +42,24 @@ TMP="$(mktemp -t cg-control-backup-XXXXXX.db)"
 chmod 600 "$TMP"
 trap 'rm -f "$TMP" "$TMP-wal" "$TMP-shm"' EXIT
 
-# .backup takes a consistent snapshot of a live database, WAL included.
-sqlite3 "$CONTROL_DB" ".backup '$TMP'"
+# A consistent snapshot of a live database, WAL included.
+if ! python3 -c '
+import sqlite3, sys
+src, dst = sqlite3.connect(sys.argv[1]), sqlite3.connect(sys.argv[2])
+src.backup(dst)
+dst.close(); src.close()
+' "$CONTROL_DB" "$TMP"; then
+  echo "backup: could not snapshot $CONTROL_DB — REFUSING to upload" >&2
+  exit 1
+fi
 # Prove it opens and the tenant table is intact before shipping it anywhere. A backup
-# that is verified only at restore time is a backup nobody has verified.
-COUNT="$(sqlite3 "$TMP" 'SELECT COUNT(*) FROM tenants' 2>/dev/null || echo FAIL)"
+# that is verified only at restore time is a backup nobody has verified. Read-only, and
+# through a second connection, so this checks the FILE rather than the handle that wrote it.
+COUNT="$(python3 -c '
+import sqlite3, sys
+c = sqlite3.connect("file:" + sys.argv[1] + "?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM tenants").fetchone()[0])
+' "$TMP" 2>/dev/null || echo FAIL)"
 if [ "$COUNT" = "FAIL" ]; then
   echo "backup: the snapshot does not open or has no tenants table — REFUSING to upload" >&2
   exit 1

--- a/deploy/service/install.sh
+++ b/deploy/service/install.sh
@@ -263,6 +263,25 @@ cmd_preflight() {
   [ -x "$BIN_DST" ] && ok "binary $BIN_DST" || { no "binary $BIN_DST missing"; bad=1; }
   [ -x /usr/local/bin/context-guru-start ] && ok "start wrapper" || { no "/usr/local/bin/context-guru-start missing"; bad=1; }
   [ -d "$STATE" ] && ok "state dir $STATE" || { no "state dir $STATE missing"; bad=1; }
+
+  # Runtime dependencies of the NIGHTLY BACKUP, checked here because its own failure mode
+  # is invisible: context-guru-backup.sh is a oneshot triggered by a timer, so a missing
+  # tool exits 127 at 03:17 every morning and the only evidence is a journal line. That is
+  # exactly what happened on the first deployment — the script wanted the `sqlite3` CLI,
+  # which is not in a minimal RHEL install, and the control database went unbacked-up.
+  # Only checked when the backup script is actually installed.
+  if [ -x /usr/local/bin/context-guru-backup.sh ] || [ -f /etc/systemd/system/context-guru-backup.timer ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      ok "python3 (nightly control-db backup)"
+    else
+      no "python3 missing — the nightly control-db backup cannot take a snapshot"; bad=1
+    fi
+    if command -v rclone >/dev/null 2>&1; then
+      ok "rclone (nightly control-db backup)"
+    else
+      no "rclone missing — the nightly control-db backup cannot upload; run box-setup.sh"; bad=1
+    fi
+  fi
   [ -f "$ETC/upstreams.yaml" ] && ok "allow-list $ETC/upstreams.yaml" || { no "$ETC/upstreams.yaml missing"; bad=1; }
 
   # The example ships placeholder hosts. Starting with those means every request 502s.


### PR DESCRIPTION
## The backup has never once succeeded

`context-guru-backup.timer` reports `enabled` and fires daily at 03:17. Every run has failed:

```
context-guru-backup.sh: line 38: sqlite3: command not found
context-guru-backup.service: Main process exited, code=exited, status=127/n/a
context-guru-backup.service: Failed with result 'exit-code'.
```

The script shells out to `sqlite3 .backup`, and the `sqlite3` CLI is not part of a minimal
RHEL install. Because the unit is a timer-triggered oneshot, the only symptom is a journal
line nobody reads — `systemctl list-timers` shows a healthy schedule, and `is-enabled`
returns `enabled`.

The consequence: the control database has no backup. That is the file this script's own
header calls irreplaceable — tenants, token hashes, per-tenant configuration, and the
config audit trail. The metrics database is explicitly out of scope because it is
derived and self-archives; the control database is not.

This is also why it matters now: three in-flight PRs touch `dash/schema.go`, and
`migrate()` renames the database aside on a `schema_version` mismatch. Restoring a
working backup before the next deploy is the point.

## The fix

Drive SQLite's online-backup API through `python3` rather than the CLI. `python3` is
already a hard requirement of `install.sh` and of the proxy's helper scripts, and
`Connection.backup()` is the same online-backup API `.backup` calls — so the WAL-safe
snapshot property the script was written around is unchanged. Installing the `sqlite`
package would also work, but it adds a host dependency to remove one that is already
satisfied.

Two smaller changes in the same spirit:

- **Verification now reads the snapshot back through a separate read-only connection**,
  so it checks the file rather than the handle that just wrote it.
- **`install.sh preflight` now checks the backup's runtime dependencies** (`python3`,
  `rclone`), and only when the backup script is actually installed. A oneshot that dies
  at 03:17 with exit 127 is invisible; preflight is where a missing tool should surface,
  and it was silent about this one.

## Evidence

Run end to end against the **live** control database, twice — once to a local target and
once to the real remote — as the `cg` service user with the unit's own environment.

```
backup: box:context-guru/backup/cg-control-20260822T041736Z.db.gz uploaded (15 tenants)
EXIT=0
```

Then downloaded and restored to confirm the artifact is usable, which is the property the
old script claimed and never demonstrated:

```
remote object: cg-control-20260822T041736Z.db.gz  14320 bytes  2026-08-21T21:17:42-07:00
RESTORE CHECK -> tenants: 15 | tokens: 15 | audit: 62 | integrity: ok | user_version: 7
```

`bash -n` clean on both scripts. No Go code is touched, so the Go suite is unaffected.

## Notes for the reviewer

- The restore procedure in the script's header comment is unchanged and still correct.
- `KEEP_DAYS` ageing-out is untouched.
- The `chmod 600` on the temp snapshot and the `trap` cleanup are untouched; the snapshot
  still contains token hashes and per-tenant config and is still not world-readable.
- This does not change what is backed up, only whether the backup runs at all.