### PR TITLE
fix: version the dashboard asset URLs, and stop preflight crying wolf

### DIFF
--- a/cmd/context-guru-proxy/preflight_test.go
+++ b/cmd/context-guru-proxy/preflight_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installSH runs script with deploy/service/install.sh sourced, so a test exercises the
+// real functions instead of a copy of them. The file's dispatcher is cut off first —
+// sourcing it whole would run a subcommand. args arrive as $1, $2, …
+func installSH(t *testing.T, script string, args ...string) string {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("no bash")
+	}
+	src, err := filepath.Abs("../../deploy/service/install.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const cut = `case "${1:-preflight}" in`
+	if !strings.Contains(string(b), cut) {
+		t.Fatalf("install.sh no longer dispatches on %q, so this test cannot source it", cut)
+	}
+	prelude := `set -euo pipefail
+source <(sed '/^` + cut + `/,$d' "$CG_INSTALL_SH")
+`
+	cmd := exec.Command("bash", append([]string{"-c", prelude + script, "install.sh"}, args...)...)
+	cmd.Env = append(os.Environ(), "CG_INSTALL_SH="+src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// Preflight reported `credential for SOME_VAR … missing or empty` on a healthy host.
+// SOME_VAR was never configured anywhere: it comes from the paragraph in upstreams.yaml
+// that DOCUMENTS key_env. That comment ships with the file, so preflight cried wolf on
+// every host — and a preflight that cries wolf is the one people learn to ignore.
+func TestPreflightReadsKeyEnvFromConfigNotComments(t *testing.T) {
+	// The shipped example carries the documenting comment verbatim. Two real entries and
+	// a trailing comment are appended, because the case that must STILL be checked is
+	// the configured one.
+	example, err := os.ReadFile("../../deploy/service/upstreams.example.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(example), "key_env: SOME_VAR") {
+		t.Fatal("upstreams.example.yaml no longer documents key_env in a comment; " +
+			"keep this fixture honest or drop the test")
+	}
+	yaml := filepath.Join(t.TempDir(), "upstreams.yaml")
+	if err := os.WriteFile(yaml, append(example, []byte(`
+  - name: gateway
+    dialect: anthropic
+    base_url: https://example.invalid
+    key_env: UPSTREAM_GATEWAY_KEY
+  - name: other
+    dialect: openai
+    base_url: https://example.invalid
+    key_env: UPSTREAM_OTHER_KEY  # one shared budget
+`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Fields(installSH(t, `configured_key_envs "$1"`, yaml))
+	want := "UPSTREAM_GATEWAY_KEY UPSTREAM_OTHER_KEY"
+	if strings.Join(got, " ") != want {
+		t.Errorf("configured_key_envs = %v; want [%s] — a commented key_env is prose, a real one is config", got, want)
+	}
+
+	// An allow-list that configures none is the normal case (caller-pays), and must be
+	// silent rather than a pipeline failure.
+	only := filepath.Join(t.TempDir(), "upstreams.yaml")
+	if err := os.WriteFile(only, example, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out := installSH(t, `configured_key_envs "$1"; echo "rc=$?"`, only); strings.TrimSpace(out) != "rc=0" {
+		t.Errorf("a comment-only allow-list produced %q; want no variables and a clean status", out)
+	}
+}
+
+// The rclone check used bare `command -v`, which resolves against sudo's secure_path —
+// /sbin:/bin:/usr/sbin:/usr/bin, no /usr/local/bin. rclone lives in /usr/local/bin, and
+// the nightly backup unit — which inherits systemd's PATH — had been uploading to Box
+// successfully for weeks while preflight declared it missing. The check has to resolve
+// the way the unit does.
+func TestPreflightResolvesToolsOnTheServicePATH(t *testing.T) {
+	dir := t.TempDir()
+	// A tool that exists ONLY on the service's PATH — rclone's situation on the host.
+	svcBin := filepath.Join(dir, "svcbin")
+	fake := filepath.Join(dir, "fake")
+	for _, d := range []string{svcBin, fake} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(svcBin, "cg-only-on-service-path"), []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A stand-in systemctl that answers show-environment the way this host's does.
+	if err := os.WriteFile(filepath.Join(fake, "systemctl"),
+		[]byte("#!/bin/sh\necho LANG=en_US.UTF-8\necho PATH="+svcBin+":/usr/bin:/bin\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// PATH here stands in for sudo's: the fake systemctl and the basics, NOT svcBin.
+	out := installSH(t, `export PATH="`+fake+`:/usr/bin:/bin"
+in_service_path cg-only-on-service-path && echo on-service-path=found || echo on-service-path=MISSED
+in_service_path cg-nowhere-at-all && echo nowhere=FOUND || echo nowhere=missing`,
+	)
+	for _, want := range []string{"on-service-path=found", "nowhere=missing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("want %q in:\n%s", want, out)
+		}
+	}
+}

--- a/dash/assetversion_test.go
+++ b/dash/assetversion_test.go
@@ -1,0 +1,129 @@
+package dash
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// localRef finds every same-origin asset URL the served markup or script asks the
+// browser to fetch: href="…" / src="…" in the HTML, and the href: '…' that tools.js
+// builds at runtime. Absolute, data: and fragment URLs are not our assets.
+var localRef = regexp.MustCompile(`(?:src|href)(?:=|:\s*)["']([^"']+)["']`)
+
+// The production bug this guards. index.html is no-cache, the assets were
+// max-age=3600, and the URLs carried no version — so a deploy that changed the HTML and
+// the JS together served NEW HTML against an HOUR-OLD app.js: new buttons that did
+// nothing, the old refresh interval still running, and a deploy that looked like it had
+// silently failed until the cache expired. If the served markup ever again names an
+// asset without a version token, this fails.
+func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
+	a, _ := newTestAPI(t, Options{})
+	m := http.NewServeMux()
+	a.Mount(m)
+
+	get := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s -> %d", path, w.Code)
+		}
+		return w
+	}
+
+	if assetVersion == "" {
+		t.Fatal("no asset version was computed from the embedded UI")
+	}
+
+	// Both entry points must work and must be versioned: the plain directory URL and
+	// the explicit filename.
+	for _, entry := range []string{"/dashboard/", "/dashboard/index.html"} {
+		w := get(entry)
+		if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("%s Cache-Control = %q; the HTML must not be cached, or it cannot hand out new asset URLs", entry, cc)
+		}
+		checked := 0
+		for _, mm := range localRef.FindAllStringSubmatch(w.Body.String(), -1) {
+			ref := mm[1]
+			if strings.HasPrefix(ref, "data:") || strings.HasPrefix(ref, "#") || strings.Contains(ref, "://") {
+				continue
+			}
+			checked++
+			if !strings.Contains(ref, "?v="+assetVersion) {
+				t.Errorf("%s references %q with no version token — a stale cached copy of it will be paired with this HTML", entry, ref)
+				continue
+			}
+			// The versioned URL must actually serve the asset, not 404.
+			if body := get("/dashboard/" + ref).Body; body.Len() == 0 {
+				t.Errorf("%s serves an empty body", ref)
+			}
+		}
+		// Fail loudly if the reference extraction stops finding anything: a reshaped
+		// index.html that no longer matches must break this test, not quietly ship
+		// unversioned URLs.
+		if checked < 3 {
+			t.Errorf("%s: found only %d local asset references; index.html references at least style.css, app.js and tools.js", entry, checked)
+		}
+	}
+
+	// tools.css is fetched by tools.js, not by the HTML, and it goes stale the same
+	// way. The rewrite covers any text asset, so the reference inside the served
+	// script is versioned too.
+	js := get("/dashboard/tools.js").Body.String()
+	if !strings.Contains(js, "'tools.css?v="+assetVersion+"'") {
+		t.Error("tools.js still asks for an unversioned tools.css")
+	}
+
+	// Versioned URLs are what make the hour of caching safe; keep it.
+	if cc := get("/dashboard/app.js?v=" + assetVersion).Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Errorf("app.js Cache-Control = %q; want public, max-age=3600", cc)
+	}
+}
+
+// The token has to follow the BYTES, or a dirty rebuild at the same commit serves new
+// assets on old URLs.
+func TestAssetVersionFollowsAssetBytes(t *testing.T) {
+	// Attribute order, quoting style and element are all different from the real
+	// index.html: the rewrite must not depend on the shape of the markup.
+	markup := `<link href='style.css' rel=stylesheet><script defer src="app.js"></script>`
+	build := func(js string) (string, string) {
+		v, out := versionFS(fstest.MapFS{
+			"index.html": {Data: []byte(markup)},
+			"style.css":  {Data: []byte("body{}")},
+			"app.js":     {Data: []byte(js)},
+		})
+		if v == "" {
+			t.Fatal("versionFS computed no version")
+		}
+		return v, string(out["index.html"])
+	}
+
+	v1, html1 := build("let a = 1")
+	for _, want := range []string{"'style.css?v=" + v1 + "'", `"app.js?v=` + v1 + `"`} {
+		if !strings.Contains(html1, want) {
+			t.Errorf("rewritten HTML is missing %s: %s", want, html1)
+		}
+	}
+
+	v2, html2 := build("let a = 2")
+	if v2 == v1 {
+		t.Fatalf("app.js changed but the version did not: %s", v1)
+	}
+	if strings.Contains(html2, v1) {
+		t.Errorf("rewritten HTML still carries the old version %s: %s", v1, html2)
+	}
+
+	// Rewriting is idempotent: an already-versioned reference is not versioned twice.
+	if _, again := versionFS(fstest.MapFS{
+		"index.html": {Data: []byte(html2)},
+		"style.css":  {Data: []byte("body{}")},
+		"app.js":     {Data: []byte("let a = 2")},
+	}); strings.Count(string(again["index.html"]), "?v=") != 2 {
+		t.Errorf("re-versioning doubled up the tokens: %s", again["index.html"])
+	}
+}

--- a/dash/ui.go
+++ b/dash/ui.go
@@ -1,9 +1,19 @@
 package dash
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
+	"fmt"
 	"io/fs"
+	"mime"
 	"net/http"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
 )
 
 // The UI is ONE embedded directory: an HTML file, a stylesheet, and a script.
@@ -20,8 +30,91 @@ import (
 //go:embed ui
 var uiFS embed.FS
 
-// uiHandler serves the embedded UI. Assets are immutable per build, so they are
-// cacheable; the HTML is not, so a redeploy is picked up on reload.
+// assetVersion is a content hash over every embedded UI asset. versionedUI holds each
+// text asset with its references to sibling assets rewritten to carry that hash, so a
+// new binary serves NEW asset URLs.
+//
+// Why: the HTML is no-cache and the assets were max-age=3600 with unversioned URLs, so
+// a deploy that changed index.html and app.js together served NEW HTML against an
+// HOUR-OLD app.js. New markup ran old code — buttons that rendered and did nothing, the
+// previous refresh interval still ticking — and it healed itself when the cache expired,
+// which makes it look like the deploy silently failed. Versioning the URLs makes that
+// skew impossible: new bytes, new URL, and max-age=3600 is now correct rather than
+// dangerous, because the old URL is never requested again.
+//
+// ONE token over all assets, not one per asset, because tools.css is referenced from
+// tools.js rather than from the HTML. A per-asset hash of tools.js would not change when
+// only tools.css did, so tools.js would stay cached at its old URL and keep pointing at
+// the stale stylesheet — the same bug, moved. The cost of busting all five assets on any
+// change is one extra ~550 KB fetch per deploy.
+//
+// Content, not buildinfo.Commit, so a dirty local rebuild at an unchanged commit also
+// gets new URLs.
+var assetVersion, versionedUI = versionAssets()
+
+// rewritable lists the asset types that can name a sibling asset.
+var rewritable = map[string]bool{".html": true, ".htm": true, ".js": true, ".css": true, ".svg": true}
+
+func versionAssets() (string, map[string][]byte) {
+	sub, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		return "", nil
+	}
+	return versionFS(sub)
+}
+
+// versionFS hashes every file in fsys and returns that hash plus the rewritten assets.
+// On any error it returns no assets, and the caller falls back to serving the embedded
+// files verbatim — unversioned is the old behaviour, a blank dashboard is not.
+func versionFS(fsys fs.FS) (string, map[string][]byte) {
+	names, err := fs.Glob(fsys, "*")
+	if err != nil || len(names) == 0 {
+		return "", nil
+	}
+	sort.Strings(names)
+
+	sum := sha256.New()
+	raw := make(map[string][]byte, len(names))
+	for _, n := range names {
+		b, err := fs.ReadFile(fsys, n)
+		if err != nil {
+			return "", nil
+		}
+		// Name and length go into the hash too, so renaming a file or moving bytes
+		// between two of them also changes the token.
+		fmt.Fprintf(sum, "%s\x00%d\x00", n, len(b))
+		sum.Write(b)
+		raw[n] = b
+	}
+	v := hex.EncodeToString(sum.Sum(nil))[:12]
+
+	// Rewrite QUOTED references — href="style.css", src='app.js', and the
+	// href: 'tools.css' that tools.js builds at runtime — rather than fixed lines of
+	// known markup. Deliberately not a string replace against the shape of today's
+	// index.html: this is blind to element, attribute, attribute order, whitespace and
+	// quoting style, so reshaping the HTML cannot silently stop the versioning. The
+	// alternation is built from the embedded directory itself, so an asset added later
+	// is covered the day it lands. A reference that already carries ?v= does not match
+	// (the closing quote no longer follows the name), so it is idempotent.
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, regexp.QuoteMeta(n))
+	}
+	re := regexp.MustCompile(`(["'])(` + strings.Join(quoted, "|") + `)(["'])`)
+
+	out := make(map[string][]byte, len(names))
+	for n, b := range raw {
+		if rewritable[strings.ToLower(path.Ext(n))] {
+			b = re.ReplaceAll(b, []byte("${1}${2}?v="+v+"${3}"))
+		}
+		out[n] = b
+	}
+	return v, out
+}
+
+// uiHandler serves the embedded UI. Asset URLs carry a build content hash, so they are
+// cacheable for an hour; the HTML is not cached, so a redeploy is picked up on reload
+// and hands the browser the new asset URLs.
 func uiHandler() http.Handler {
 	sub, err := fs.Sub(uiFS, "ui")
 	if err != nil {
@@ -29,8 +122,13 @@ func uiHandler() http.Handler {
 	}
 	files := http.FileServer(http.FS(sub))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "", "/", "index.html":
+		// StripPrefix leaves "" for /dashboard/ and "index.html" for the explicit URL.
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		if name == "" {
+			name = "index.html"
+		}
+		switch name {
+		case "index.html":
 			w.Header().Set("Cache-Control", "no-cache")
 		default:
 			w.Header().Set("Cache-Control", "public, max-age=3600")
@@ -53,6 +151,16 @@ func uiHandler() http.Handler {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; "+
 				"connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'")
+		if b, ok := versionedUI[name]; ok {
+			if ct := mime.TypeByExtension(path.Ext(name)); ct != "" {
+				w.Header().Set("Content-Type", ct)
+			}
+			// Every request of this build serves identical bytes. The ETag turns the
+			// no-cache HTML's revalidation into a 304 instead of a re-download.
+			w.Header().Set("ETag", `"`+assetVersion+`"`)
+			http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(b))
+			return
+		}
 		files.ServeHTTP(w, r)
 	})
 }

--- a/deploy/service/install.sh
+++ b/deploy/service/install.sh
@@ -54,6 +54,30 @@ need_root() {
   [ "$(id -u)" = 0 ] || { echo "run this with sudo" >&2; exit 1; }
 }
 
+# Does the SERVICE find this tool? Not "does preflight find it": install.sh runs under
+# sudo, whose secure_path on RHEL is /sbin:/bin:/usr/sbin:/usr/bin and excludes
+# /usr/local/bin — which is where rclone is installed. So `command -v rclone` here
+# reported it missing while the nightly backup unit, which inherits systemd's PATH
+# (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin), had been uploading to Box
+# successfully for weeks. A preflight that cries wolf gets ignored, so resolve the tool
+# against the PATH the unit will actually run with. Falling back to our own PATH keeps
+# the old behaviour if systemd cannot be asked.
+# The key_env variables the allow-list CONFIGURES. Comments are stripped first, and not
+# only whole-comment lines: the shipped upstreams.yaml DOCUMENTS the feature with
+# `key_env: SOME_VAR` in a paragraph of prose, and reading that as configuration made
+# preflight demand a credential for a variable nobody had configured — on every host,
+# since the comment ships with the file. sed rather than grep -o so an allow-list that
+# names none (the normal case, caller-pays) is not a pipeline failure.
+configured_key_envs() {
+  sed -nE 's/#.*//; s/.*key_env:[[:space:]]*([A-Z0-9_]+).*/\1/p' "$1" 2>/dev/null | sort -u
+}
+
+in_service_path() {
+  local p
+  p=$(systemctl show-environment 2>/dev/null | sed -n 's/^PATH=//p' | head -1)
+  PATH="${p:-$PATH}" command -v "$1" >/dev/null 2>&1
+}
+
 # ── install ─────────────────────────────────────────────────────────────────
 cmd_install() {
   need_root
@@ -271,12 +295,12 @@ cmd_preflight() {
   # which is not in a minimal RHEL install, and the control database went unbacked-up.
   # Only checked when the backup script is actually installed.
   if [ -x /usr/local/bin/context-guru-backup.sh ] || [ -f /etc/systemd/system/context-guru-backup.timer ]; then
-    if command -v python3 >/dev/null 2>&1; then
+    if in_service_path python3; then
       ok "python3 (nightly control-db backup)"
     else
       no "python3 missing — the nightly control-db backup cannot take a snapshot"; bad=1
     fi
-    if command -v rclone >/dev/null 2>&1; then
+    if in_service_path rclone; then
       ok "rclone (nightly control-db backup)"
     else
       no "rclone missing — the nightly control-db backup cannot upload; run box-setup.sh"; bad=1
@@ -312,7 +336,7 @@ cmd_preflight() {
       no "credential for $env expected at $CREDS/$dashed — missing or empty"
       missing=1
     fi
-  done < <(grep -oE 'key_env:[[:space:]]*[A-Z0-9_]+' "$ETC/upstreams.yaml" 2>/dev/null | awk '{print $2}' | sort -u)
+  done < <(configured_key_envs "$ETC/upstreams.yaml")
   [ "$missing" = 0 ] || bad=1
 
   if [ -f "$DROPIN/10-credentials.conf" ]; then


### PR DESCRIPTION
Two deploy-hygiene defects found during this morning's redeploy. The first shipped a
broken UI to production; the second makes the diagnostic that should have caught it
untrustworthy.

## 1. Dashboard assets had no cache-busting

`dash/ui.go` serves `index.html` as `no-cache` and its assets as
`public, max-age=3600`, while the markup named them unversioned — `src="app.js"`.

So a deploy that changed `index.html`, `app.js`, `tools.js` and `style.css` together
served **new HTML against an hour-old `app.js`** to every returning visitor. Observed
symptom, reported by the service owner: the new buttons rendered and did nothing, the
previous 8-second refresh interval kept running, and it healed itself an hour later —
which is indistinguishable from a deploy that silently failed.

Confirmed against the live service before the fix:

| asset | Cache-Control | URL in markup |
|---|---|---|
| `index.html` | `no-cache` | — |
| `app.js` | `public, max-age=3600` | `src="app.js"` |
| `tools.js` | `public, max-age=3600` | `src="tools.js"` |
| `style.css` | `public, max-age=3600` | `href="style.css"` |

**After** — the served page (the HTML is already `no-cache`, so it is the right place
to inject):

```
href="style.css?v=fd6f54029fdc"
src="app.js?v=fd6f54029fdc"
src="tools.js?v=fd6f54029fdc"
```

`max-age=3600` is now correct rather than dangerous, because the stale URL is never
requested again.

Three deliberate choices:

- **Content hash, not the build commit** — a dirty local rebuild also gets fresh URLs.
- **One token across all assets, not one per asset.** `tools.css` is loaded by
  `tools.js`, not by the HTML, so a per-asset hash of `tools.js` would not move when
  only `tools.css` changed — leaving the identical stale-pair bug one level down.
- **The rewrite is driven by the embedded directory listing**, not a string match, so
  it is blind to attribute order, quoting and element; it covers a new asset the day it
  lands; and it is idempotent.

## 2. `install.sh preflight` failed on a healthy host, twice

Both were false negatives, and both had to be disproved by hand before this morning's
deploy could proceed.

- **`rclone missing`** — resolved with a bare `command -v`, which under `sudo` uses
  `secure_path` (`/sbin:/bin:/usr/sbin:/usr/bin`) and therefore cannot see
  `/usr/local/bin`, where rclone is installed. The backup unit inherits systemd's PATH
  and had been uploading to Box successfully all along. Tools are now resolved against
  the PATH the unit will run with, `python3` included.
- **`credential for SOME_VAR`** — not configured anywhere. It is the placeholder inside
  the comment that *documents* `key_env` in `upstreams.yaml`, and it ships with the
  file, so this fired on every host. Comments are now stripped before extraction,
  trailing ones included, and a configured `key_env` is still checked.

Acceptance test is the real host. Before: `Preflight FAILED` with those two lines.
After, from this branch, against the live `/etc/context-guru/upstreams.yaml`:

```
  ✓ python3 (nightly control-db backup)
  ✓ rclone (nightly control-db backup)
  ✓ allow-list /etc/context-guru/upstreams.yaml
  ✓ credential drop-in present
  ✓ MANAGER_EMAIL is set
  ✓ rclone config for cold storage

Preflight PASSED
```

A preflight that cries wolf is the one people learn to ignore.

## Tests

Four, one per property:

- `TestServedUIVersionsEveryAssetItReferences` — every asset the served page references
  carries a token
- `TestAssetVersionFollowsAssetBytes` — the token changes when the bytes change
- `TestPreflightReadsKeyEnvFromConfigNotComments`
- `TestPreflightResolvesToolsOnTheServicePATH`

`CGO_ENABLED=1 go test -race -count=1 ./...` → **25 packages ok, exit 0**.
`go vet ./...` clean. `gofmt -l .` empty. No schema change; `schemaVersion` untouched.