### PR TITLE
fix(deploy): read a quoted key_env, and test the direction that can hurt you

### DIFF
--- a/cmd/context-guru-proxy/preflight_test.go
+++ b/cmd/context-guru-proxy/preflight_test.go
@@ -67,27 +67,50 @@ func TestPreflightReadsKeyEnvFromConfigNotComments(t *testing.T) {
     base_url: https://example.invalid
     key_env: UPSTREAM_OTHER_KEY  # one shared budget
   - name: quoted
-    dialect: anthropic  # key_env: UPSTREAM_NEVER_CONFIGURED
+    dialect: anthropic  # unset, key_env: UPSTREAM_NEVER_CONFIGURED
     key_env: "UPSTREAM_QUOTED_KEY"
   - name: single
     dialect: openai
     key_env: 'UPSTREAM_SINGLE_KEY'
+  - name: quotedkey
+    dialect: openai
+    "key_env": UPSTREAM_QUOTED_NAME_KEY
 `)...), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	// Every shape that the loader accepts has to be extracted. A quoted value that is
-	// NOT extracted is the dangerous direction: config/upstreams.go refuses to boot on an
+	// Every shape that the loader accepts has to be extracted. A name that is NOT
+	// extracted is the dangerous direction: config/upstreams.go refuses to boot on an
 	// unset variable, so preflight would print PASSED and the service would then fail to
-	// start on exactly the credential this checks.
+	// start on exactly the credential this checks. Quoting is the shape that shipped
+	// broken; a quoted mapping KEY (`"key_env": X`) is legal YAML for the same field and
+	// was missed for the same reason, so it is fixtured here too.
 	//
 	// UPSTREAM_NEVER_CONFIGURED is the other direction, on the same line as a real field:
 	// comments are stripped wherever they start, not only on whole-comment lines. The
 	// exact-match assertion below is what enforces it — an extra name fails the compare.
+	// Its comma is load-bearing: comments have to be stripped BEFORE the line is split on
+	// commas, or the split hands the tail of a comment back as configuration.
 	got := strings.Fields(installSH(t, `configured_key_envs "$1"`, yaml))
-	want := "UPSTREAM_GATEWAY_KEY UPSTREAM_OTHER_KEY UPSTREAM_QUOTED_KEY UPSTREAM_SINGLE_KEY"
+	want := "UPSTREAM_GATEWAY_KEY UPSTREAM_OTHER_KEY UPSTREAM_QUOTED_KEY UPSTREAM_QUOTED_NAME_KEY UPSTREAM_SINGLE_KEY"
 	if strings.Join(got, " ") != want {
 		t.Errorf("configured_key_envs = %v; want [%s] — a commented key_env is prose, a real one is config, quoted or not", got, want)
+	}
+
+	// Flow style on ONE physical line, which is where the extraction used to lose names
+	// wholesale. Two failures at once: only the LAST key_env on a line was taken, and the
+	// `#` inside the quoted base_url was treated as a comment and erased the key_env after
+	// it — so this line yielded NOTHING, and the loader demands both names.
+	flow := filepath.Join(t.TempDir(), "upstreams.yaml")
+	if err := os.WriteFile(flow, []byte(
+		`upstreams: [{name: a, dialect: openai, base_url: 'https://x.invalid/#frag', key_env: UPSTREAM_FLOW_A_KEY}, `+
+			`{name: b, dialect: openai, base_url: 'https://x.invalid', key_env: UPSTREAM_FLOW_B_KEY}]`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got = strings.Fields(installSH(t, `configured_key_envs "$1"`, flow))
+	want = "UPSTREAM_FLOW_A_KEY UPSTREAM_FLOW_B_KEY"
+	if strings.Join(got, " ") != want {
+		t.Errorf("configured_key_envs on flow style = %v; want [%s] — every entry on the line configures a credential, not just the last", got, want)
 	}
 
 	// An allow-list that configures none is the normal case (caller-pays), and must be
@@ -120,10 +143,13 @@ func TestPreflightResolvesToolsOnTheServicePATH(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(svcBin, "cg-only-on-service-path"), []byte("#!/bin/sh\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	// And a tool that exists only on the CALLER's PATH. This is the direction that
-	// produces a false PASS: sudo's secure_path carries /sbin and /bin, systemd's default
-	// PATH does not, so a tool found here that the unit cannot run must be reported
-	// MISSING. Asserting only that a present tool is found cannot catch that.
+	// And a tool that exists only on the CALLER's PATH. The two PATHs are genuinely
+	// different sets — install.sh's own header documents the direction that bit us,
+	// /usr/local/bin being in systemd's PATH and absent from sudo's secure_path — and a
+	// set difference has two directions. The reverse one produces a false PASS: a tool
+	// preflight can see but the unit cannot must be reported MISSING, or the check passes
+	// and the unit then fails on the tool it was supposed to vouch for. Asserting only
+	// that a present tool is found cannot catch that.
 	if err := os.WriteFile(filepath.Join(callerBin, "cg-only-on-caller-path"), []byte("#!/bin/sh\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/context-guru-proxy/preflight_test.go
+++ b/cmd/context-guru-proxy/preflight_test.go
@@ -66,14 +66,28 @@ func TestPreflightReadsKeyEnvFromConfigNotComments(t *testing.T) {
     dialect: openai
     base_url: https://example.invalid
     key_env: UPSTREAM_OTHER_KEY  # one shared budget
+  - name: quoted
+    dialect: anthropic  # key_env: UPSTREAM_NEVER_CONFIGURED
+    key_env: "UPSTREAM_QUOTED_KEY"
+  - name: single
+    dialect: openai
+    key_env: 'UPSTREAM_SINGLE_KEY'
 `)...), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
+	// Every shape that the loader accepts has to be extracted. A quoted value that is
+	// NOT extracted is the dangerous direction: config/upstreams.go refuses to boot on an
+	// unset variable, so preflight would print PASSED and the service would then fail to
+	// start on exactly the credential this checks.
+	//
+	// UPSTREAM_NEVER_CONFIGURED is the other direction, on the same line as a real field:
+	// comments are stripped wherever they start, not only on whole-comment lines. The
+	// exact-match assertion below is what enforces it — an extra name fails the compare.
 	got := strings.Fields(installSH(t, `configured_key_envs "$1"`, yaml))
-	want := "UPSTREAM_GATEWAY_KEY UPSTREAM_OTHER_KEY"
+	want := "UPSTREAM_GATEWAY_KEY UPSTREAM_OTHER_KEY UPSTREAM_QUOTED_KEY UPSTREAM_SINGLE_KEY"
 	if strings.Join(got, " ") != want {
-		t.Errorf("configured_key_envs = %v; want [%s] — a commented key_env is prose, a real one is config", got, want)
+		t.Errorf("configured_key_envs = %v; want [%s] — a commented key_env is prose, a real one is config, quoted or not", got, want)
 	}
 
 	// An allow-list that configures none is the normal case (caller-pays), and must be
@@ -97,12 +111,20 @@ func TestPreflightResolvesToolsOnTheServicePATH(t *testing.T) {
 	// A tool that exists ONLY on the service's PATH — rclone's situation on the host.
 	svcBin := filepath.Join(dir, "svcbin")
 	fake := filepath.Join(dir, "fake")
-	for _, d := range []string{svcBin, fake} {
+	callerBin := filepath.Join(dir, "callerbin")
+	for _, d := range []string{svcBin, fake, callerBin} {
 		if err := os.MkdirAll(d, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}
 	if err := os.WriteFile(filepath.Join(svcBin, "cg-only-on-service-path"), []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// And a tool that exists only on the CALLER's PATH. This is the direction that
+	// produces a false PASS: sudo's secure_path carries /sbin and /bin, systemd's default
+	// PATH does not, so a tool found here that the unit cannot run must be reported
+	// MISSING. Asserting only that a present tool is found cannot catch that.
+	if err := os.WriteFile(filepath.Join(callerBin, "cg-only-on-caller-path"), []byte("#!/bin/sh\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	// A stand-in systemctl that answers show-environment the way this host's does.
@@ -112,11 +134,15 @@ func TestPreflightResolvesToolsOnTheServicePATH(t *testing.T) {
 	}
 
 	// PATH here stands in for sudo's: the fake systemctl and the basics, NOT svcBin.
-	out := installSH(t, `export PATH="`+fake+`:/usr/bin:/bin"
+	out := installSH(t, `export PATH="`+fake+`:`+callerBin+`:/usr/bin:/bin"
+command -v cg-only-on-caller-path >/dev/null && echo caller-tool-is-runnable-here=yes || echo caller-tool-is-runnable-here=NO
 in_service_path cg-only-on-service-path && echo on-service-path=found || echo on-service-path=MISSED
+in_service_path cg-only-on-caller-path && echo caller-only=FOUND || echo caller-only=missing
 in_service_path cg-nowhere-at-all && echo nowhere=FOUND || echo nowhere=missing`,
 	)
-	for _, want := range []string{"on-service-path=found", "nowhere=missing"} {
+	// The first line keeps the third honest: without it, a typo in the tool name would
+	// also report caller-only=missing and the assertion would pass for the wrong reason.
+	for _, want := range []string{"caller-tool-is-runnable-here=yes", "on-service-path=found", "caller-only=missing", "nowhere=missing"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("want %q in:\n%s", want, out)
 		}

--- a/dash/assetversion_test.go
+++ b/dash/assetversion_test.go
@@ -80,8 +80,14 @@ func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
 	}
 
 	// Versioned URLs are what make the hour of caching safe; keep it.
-	if cc := get("/dashboard/app.js?v=" + assetVersion).Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+	js2 := get("/dashboard/app.js?v=" + assetVersion)
+	if cc := js2.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
 		t.Errorf("app.js Cache-Control = %q; want public, max-age=3600", cc)
+	}
+	// http.ServeContent types the response from the name it is given; a script served as
+	// text/plain is not executed.
+	if ct := js2.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
+		t.Errorf("app.js Content-Type = %q; want a javascript type", ct)
 	}
 }
 
@@ -125,5 +131,40 @@ func TestAssetVersionFollowsAssetBytes(t *testing.T) {
 		"app.js":     {Data: []byte("let a = 2")},
 	}); strings.Count(string(again["index.html"]), "?v=") != 2 {
 		t.Errorf("re-versioning doubled up the tokens: %s", again["index.html"])
+	}
+
+	// The name and the length of every file go into the hash, not only the bytes. Two
+	// builds whose concatenated bytes are IDENTICAL must still get different tokens:
+	// a rename, and the same bytes split differently across two adjacent names. Hashing
+	// the bytes alone cannot tell either pair apart.
+	ver := func(files fstest.MapFS) string {
+		v, _ := versionFS(files)
+		if v == "" {
+			t.Fatal("versionFS computed no version")
+		}
+		return v
+	}
+	if a, b := ver(fstest.MapFS{"a.js": {Data: []byte("xy")}}),
+		ver(fstest.MapFS{"b.js": {Data: []byte("xy")}}); a == b {
+		t.Errorf("renaming the only asset left the version at %s", a)
+	}
+	if a, b := ver(fstest.MapFS{"a.js": {Data: []byte("xy")}, "b.js": {Data: []byte("")}}),
+		ver(fstest.MapFS{"a.js": {Data: []byte("x")}, "b.js": {Data: []byte("y")}}); a == b {
+		t.Errorf("moving a byte between two assets left the version at %s", a)
+	}
+
+	// An asset in a SUBDIRECTORY used to switch versioning off for everything: the old
+	// fs.Glob(fsys, "*") returned the directory as a name, reading it failed, and
+	// versionFS returned no assets — so the whole dashboard fell back to unversioned
+	// URLs at max-age=3600, which is the bug this file exists to prevent.
+	v, out := versionFS(fstest.MapFS{
+		"index.html":   {Data: []byte(`<script src="sub/extra.js"></script>`)},
+		"sub/extra.js": {Data: []byte("let a = 1")},
+	})
+	if v == "" {
+		t.Fatal("a subdirectory turned versioning off entirely")
+	}
+	if want := `"sub/extra.js?v=` + v + `"`; !strings.Contains(string(out["index.html"]), want) {
+		t.Errorf("a subdirectory asset was left unversioned, want %s in: %s", want, out["index.html"])
 	}
 }

--- a/dash/assetversion_test.go
+++ b/dash/assetversion_test.go
@@ -41,13 +41,15 @@ func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
 	}
 
 	// Both entry points must work and must be versioned: the plain directory URL and
-	// the explicit filename.
+	// the explicit filename. Both serve the same markup, so `checked` — the number of
+	// local references found in it — is reused by the rewrite-count assertion below.
+	checked := 0
 	for _, entry := range []string{"/dashboard/", "/dashboard/index.html"} {
 		w := get(entry)
 		if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
 			t.Errorf("%s Cache-Control = %q; the HTML must not be cached, or it cannot hand out new asset URLs", entry, cc)
 		}
-		checked := 0
+		checked = 0
 		for _, mm := range localRef.FindAllStringSubmatch(w.Body.String(), -1) {
 			ref := mm[1]
 			if strings.HasPrefix(ref, "data:") || strings.HasPrefix(ref, "#") || strings.Contains(ref, "://") {
@@ -88,6 +90,20 @@ func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
 	// text/plain is not executed.
 	if ct := js2.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
 		t.Errorf("app.js Content-Type = %q; want a javascript type", ct)
+	}
+
+	// Every rewrite has to be one this test knows about. The match in ui.go is
+	// deliberately blind to context — it has to be, because references live in an HTML
+	// attribute AND in a JS object literal — so a quoted asset name that is NOT a
+	// reference gets versioned too, silently. Totalling the rewrites and comparing them
+	// with the references enumerated above turns that into a red test: index.html's
+	// references, plus the one tools.js builds.
+	rewrites := 0
+	for _, b := range versionedUI {
+		rewrites += strings.Count(string(b), "?v="+assetVersion)
+	}
+	if want := checked + 1; rewrites != want {
+		t.Errorf("versionedUI rewrote %d references but this test accounts for %d — either a quoted asset name that is not a reference is being versioned, or a reference is no longer found", rewrites, want)
 	}
 }
 
@@ -133,10 +149,16 @@ func TestAssetVersionFollowsAssetBytes(t *testing.T) {
 		t.Errorf("re-versioning doubled up the tokens: %s", again["index.html"])
 	}
 
-	// The name and the length of every file go into the hash, not only the bytes. Two
-	// builds whose concatenated bytes are IDENTICAL must still get different tokens:
-	// a rename, and the same bytes split differently across two adjacent names. Hashing
-	// the bytes alone cannot tell either pair apart.
+	// The name of every file goes into the hash, not only the bytes. Two builds whose
+	// concatenated bytes are IDENTICAL must still get different tokens: a rename, and the
+	// same bytes split differently across two adjacent names. Hashing the bytes alone
+	// cannot tell either pair apart.
+	//
+	// Both pairs below are decided by the NUL-delimited NAME alone; neither exercises the
+	// %d length that ui.go also writes. The length is there for injectivity, not for these
+	// cases — without it {"a": "b.js\x00xy"} and {"a": "", "b.js": "xy"} hash the same —
+	// and closing that would need a third pair differing only in a length. Keep the
+	// length; it is not this test that justifies it.
 	ver := func(files fstest.MapFS) string {
 		v, _ := versionFS(files)
 		if v == "" {

--- a/dash/ui.go
+++ b/dash/ui.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
-	"mime"
 	"net/http"
 	"path"
 	"regexp"
@@ -67,7 +66,21 @@ func versionAssets() (string, map[string][]byte) {
 // On any error it returns no assets, and the caller falls back to serving the embedded
 // files verbatim — unversioned is the old behaviour, a blank dashboard is not.
 func versionFS(fsys fs.FS) (string, map[string][]byte) {
-	names, err := fs.Glob(fsys, "*")
+	// WalkDir, not fs.Glob(fsys, "*"): Glob returns a SUBDIRECTORY as a name, fs.ReadFile
+	// on it errors, and the whole function then bails to "no assets" — one nested file
+	// would silently turn versioning off everywhere and bring the stale-asset bug back.
+	// Walking covers assets in subdirectories instead, at their slash-separated names,
+	// which is also what a reference to one looks like in the markup.
+	var names []string
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			names = append(names, p)
+		}
+		return nil
+	})
 	if err != nil || len(names) == 0 {
 		return "", nil
 	}
@@ -96,6 +109,12 @@ func versionFS(fsys fs.FS) (string, map[string][]byte) {
 	// alternation is built from the embedded directory itself, so an asset added later
 	// is covered the day it lands. A reference that already carries ?v= does not match
 	// (the closing quote no longer follows the name), so it is idempotent.
+	//
+	// ponytail: blind means blind — a quoted asset name that is NOT a URL is rewritten
+	// too (a JS string literal, a CSP nonce, the inside of a percent-encoded data URI),
+	// and that would fail silently. Today there is no collision: every quoted occurrence
+	// of an asset name across the five assets is a real reference. Match on the enclosing
+	// attribute if one ever appears.
 	quoted := make([]string, 0, len(names))
 	for _, n := range names {
 		quoted = append(quoted, regexp.QuoteMeta(n))
@@ -152,9 +171,6 @@ func uiHandler() http.Handler {
 			"default-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; "+
 				"connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'")
 		if b, ok := versionedUI[name]; ok {
-			if ct := mime.TypeByExtension(path.Ext(name)); ct != "" {
-				w.Header().Set("Content-Type", ct)
-			}
 			// Every request of this build serves identical bytes. The ETag turns the
 			// no-cache HTML's revalidation into a 304 instead of a re-download.
 			w.Header().Set("ETag", `"`+assetVersion+`"`)

--- a/dash/ui.go
+++ b/dash/ui.go
@@ -94,7 +94,9 @@ func versionFS(fsys fs.FS) (string, map[string][]byte) {
 			return "", nil
 		}
 		// Name and length go into the hash too, so renaming a file or moving bytes
-		// between two of them also changes the token.
+		// between two of them also changes the token. The length is what makes the
+		// concatenation injective — without it {"a": "b.js\x00xy"} and {"a": "",
+		// "b.js": "xy"} hash identically — so do not drop it as redundant.
 		fmt.Fprintf(sum, "%s\x00%d\x00", n, len(b))
 		sum.Write(b)
 		raw[n] = b
@@ -113,8 +115,16 @@ func versionFS(fsys fs.FS) (string, map[string][]byte) {
 	// ponytail: blind means blind — a quoted asset name that is NOT a URL is rewritten
 	// too (a JS string literal, a CSP nonce, the inside of a percent-encoded data URI),
 	// and that would fail silently. Today there is no collision: every quoted occurrence
-	// of an asset name across the five assets is a real reference. Match on the enclosing
-	// attribute if one ever appears.
+	// of an asset name across the five assets is a real reference, four in total.
+	//
+	// Do NOT narrow this to an enclosing HTML attribute. References do not all live in
+	// attributes: tools.js builds one in a JavaScript object literal, el('link', {href:
+	// 'tools.css'}), so an attribute match would silently stop versioning tools.css and
+	// hand it back its unversioned URL at max-age=3600 — the stale-stylesheet bug named
+	// at the top of this file, reintroduced. The blindness is load-bearing. If a
+	// collision ever does appear, make the failure LOUD rather than the match narrower:
+	// the rewrite count is knowable, and assetversion_test.go asserts it against the
+	// references it enumerates, so an unaccounted rewrite is a red test.
 	quoted := make([]string, 0, len(names))
 	for _, n := range names {
 		quoted = append(quoted, regexp.QuoteMeta(n))

--- a/deploy/service/install.sh
+++ b/deploy/service/install.sh
@@ -62,23 +62,41 @@ need_root() {
 # successfully for weeks. A preflight that cries wolf gets ignored, so resolve the tool
 # against the PATH the unit will actually run with. Falling back to our own PATH keeps
 # the old behaviour if systemd cannot be asked.
-# The key_env variables the allow-list CONFIGURES. Comments are stripped first, and not
-# only whole-comment lines: the shipped upstreams.yaml DOCUMENTS the feature with
-# `key_env: SOME_VAR` in a paragraph of prose, and reading that as configuration made
-# preflight demand a credential for a variable nobody had configured — on every host,
-# since the comment ships with the file. sed rather than grep -o so an allow-list that
-# names none (the normal case, caller-pays) is not a pipeline failure.
+# The key_env variables the allow-list CONFIGURES. A MISSED name is the dangerous
+# direction: the loader refuses to boot on a named variable that is unset, so preflight
+# would print PASSED and the service would then fail to start on the very credential this
+# checks — under Restart=always, as a crash loop. An invented name only costs a false ✗.
+# So every stage here exists to miss fewer names, and each was checked by diffing this
+# extraction against what config.LoadUpstreams actually demands.
 #
-# [^A-Z0-9_]* rather than [[:space:]]*, so a QUOTED value is read too. `key_env: "X"` and
-# `key_env: 'X'` are both legal YAML for a plain string field, and the loader refuses to
-# boot when a named variable is unset — so skipping the quoted form made preflight print
-# PASSED and the service then fail to start on the very credential this checks. A false
-# PASS in a credential check is worse than the false FAIL above it. The name is assumed
-# UPPERCASE, as every UPSTREAM_*_KEY is and as the credential-file mapping below already
-# assumes; a lowercase one extracts noise and FAILS rather than passing in silence, which
-# is the safe direction to be wrong in.
+# Comments go first, and not only whole-comment lines: the shipped upstreams.yaml
+# DOCUMENTS the feature with `key_env: SOME_VAR` in a paragraph of prose, and reading that
+# as configuration made preflight demand a credential nobody had configured — on every
+# host, since the comment ships with the file. `(^|[[:space:]])#` is what YAML calls a
+# comment, so a `#` inside a quoted scalar earlier on the line (a base_url with a
+# fragment) no longer erases the real key_env after it. Stripping before the tr matters:
+# a comma inside a comment would otherwise resurrect its tail.
+#
+# tr then puts each flow-mapped entry on its own line, because the substitution takes one
+# name per LINE: `upstreams: [{…, key_env: A}, {…, key_env: B}]` yielded only B without
+# it. The comma is what does the work, flow entries being comma-separated; the braces are
+# belt-and-braces and no input the loader accepts needs them.
+#
+# [^A-Z0-9_]* around the colon rather than [[:space:]]*, so a quoted VALUE and a quoted
+# KEY are both read — `key_env: "X"`, `key_env: 'X'` and `"key_env": X` are all legal YAML
+# for a plain string field. sed rather than grep -o so an allow-list that names none (the
+# normal case, caller-pays) is not a pipeline failure.
+#
+# Two shapes are knowingly unhandled, both of which miss rather than invent:
+#   - a block scalar, `key_env: >-` with the name on the next line. Silent. Closing it
+#     needs a real YAML parser, and nobody folds an environment variable name.
+#   - a lowercase or mixed-case name, since the credential mapping below assumes UPPERCASE
+#     as every UPSTREAM_*_KEY is. At least loud: it extracts noise (`_`), which matches no
+#     credential file and prints ✗.
+# If either ever has to be closed, use a parser. A fifth sed stage is not the answer.
 configured_key_envs() {
-  sed -nE 's/#.*//; s/.*key_env:[^A-Z0-9_]*([A-Z0-9_]+).*/\1/p' "$1" 2>/dev/null | sort -u
+  sed -E 's/(^|[[:space:]])#.*//' "$1" 2>/dev/null | tr ',{}' '\n\n\n' \
+    | sed -nE 's/.*key_env[^:A-Z0-9_]*:[^A-Z0-9_]*([A-Z0-9_]+).*/\1/p' | sort -u
 }
 
 in_service_path() {

--- a/deploy/service/install.sh
+++ b/deploy/service/install.sh
@@ -68,8 +68,17 @@ need_root() {
 # preflight demand a credential for a variable nobody had configured — on every host,
 # since the comment ships with the file. sed rather than grep -o so an allow-list that
 # names none (the normal case, caller-pays) is not a pipeline failure.
+#
+# [^A-Z0-9_]* rather than [[:space:]]*, so a QUOTED value is read too. `key_env: "X"` and
+# `key_env: 'X'` are both legal YAML for a plain string field, and the loader refuses to
+# boot when a named variable is unset — so skipping the quoted form made preflight print
+# PASSED and the service then fail to start on the very credential this checks. A false
+# PASS in a credential check is worse than the false FAIL above it. The name is assumed
+# UPPERCASE, as every UPSTREAM_*_KEY is and as the credential-file mapping below already
+# assumes; a lowercase one extracts noise and FAILS rather than passing in silence, which
+# is the safe direction to be wrong in.
 configured_key_envs() {
-  sed -nE 's/#.*//; s/.*key_env:[[:space:]]*([A-Z0-9_]+).*/\1/p' "$1" 2>/dev/null | sort -u
+  sed -nE 's/#.*//; s/.*key_env:[^A-Z0-9_]*([A-Z0-9_]+).*/\1/p' "$1" 2>/dev/null | sort -u
 }
 
 in_service_path() {


### PR DESCRIPTION
Follow-up to #92, which was merged before its review landed. The review found that one of
its two fixes introduced a **false PASS** — strictly worse than the false FAIL it replaced.
The review of *this* PR then found that the same false-PASS class was still open in three
more shapes, so the extraction below is the second iteration and this time it was checked
against the parser rather than against a fixture.

## The defect

#92 rewrote the credential extraction as:

```
sed -nE 's/#.*//; s/.*key_env:[[:space:]]*([A-Z0-9_]+).*/\1/p'
```

`[[:space:]]*` requires the variable name to begin immediately after the whitespace, so a
**quoted** value is not extracted at all:

```yaml
key_env: "UPSTREAM_QUOTED_KEY"
key_env: 'UPSTREAM_SINGLE_KEY'
```

Both forms are legal — `config/upstreams.go:30` is a plain `KeyEnv string` and the loader
parses them — and `config/upstreams.go:93` **refuses to boot** when a named variable is
unset. So the sequence was: preflight prints `Preflight PASSED`, the operator proceeds,
and the service then fails to start on precisely the credential preflight existed to check.
Under `Restart=always` that is a crash loop.

A false PASS in a credential check is worse than the false FAIL it replaced.

## The fix

A regex over config is only right or wrong relative to what the *parser* does, so the
check is a differential one: an oracle links `config.LoadUpstreams` and prints the
`key_env` names it would demand, and the extraction is diffed against it over **41 inputs**
covering every shape the loader accepts. A name in truth but not in the extraction is a
false PASS; the reverse is only an annoying false FAIL.

Three independent causes had to be closed, none of them the quoting the first attempt
addressed:

| shape | before | now |
|---|---|---|
| `key_env: "X"` / `key_env: 'X'` | missed | ✓ |
| two or more `key_env` on one physical line (flow style) | only the **last** | ✓ all of them |
| a `#` inside a quoted scalar earlier on the line | erased the real `key_env` | ✓ |
| `"key_env": X` — a quoted mapping key | missed | ✓ |
| `key_env: >-` with the name on the next line (block scalar) | missed | **still missed, knowingly** |

So: comments are stripped the way YAML defines them (`(^|[[:space:]])#`) rather than at any
`#`; the line is then split on the flow separator so "one name per line" stops mattering;
and the colon no longer has to touch `key_env`. The order is load-bearing in both
directions and a test pins it: strip after splitting and the tail of a comma-bearing
comment comes back as configuration.

A block scalar stays unhandled and the in-code comment now says so rather than claiming
generality. Nobody folds an environment variable name, and closing it needs a real YAML
parser — which is the recorded upgrade path, explicitly in preference to a fifth `sed`
stage. The two other unhandled shapes (a lowercase or mixed-case name) at least fail
**loud**: they extract noise that matches no credential file and print `✗`.

Every stage was mutated and the test re-run: reverting to the previous extraction, dropping
the split, un-YAML-ing the comment strip, requiring the colon to touch `key_env`, stripping
comments after the split, stripping none, and over-stripping (`/#/d`) each turn a test
**red**.

## The test gap that let it ship

`TestPreflightResolvesToolsOnTheServicePATH` asserted only that a **present** tool is
found — the direction that cannot hurt you. A test that never exercises the failing
direction cannot catch a false PASS, which is exactly how this shipped.

It now asserts all four states:

```
caller-tool-is-runnable-here=yes    the plant exists where the caller can see it
on-service-path=found
caller-only=missing                 on the caller's PATH, absent from the service PATH
nowhere=missing
```

What the first assertion guards is a **vacuous pass**, not a broken tool. Typo the planted
filename and the test goes red; remove the first assertion *and* typo the plant and it goes
green — so the line is load-bearing. It cannot detect a tool that is present but
unrunnable, because `command -v` — the primitive `in_service_path` uses — reports a
mode-`0600` file as **found** (measured unprivileged; the same file cannot be executed).
That case is outside what this assertion can see, and the in-code comment says so.

## Also closed, from the same review

**A `ui/` subdirectory silently disabled ALL asset versioning.** `fs.Glob(fsys, "*")`
returns a subdirectory as a name, `fs.ReadFile` on it errors, and the whole function then
bails to "no assets" — so one nested file would turn versioning off everywhere and bring
back the stale-asset bug #92 existed to remove, silently and one level down. Replaced with
`fs.WalkDir`, which covers assets in subdirectories at their slash-separated names — which
is also what a reference to one looks like in the markup.

The remaining ceiling on the rewrite is named in a `ponytail:` comment rather than papered
over: it matches quoted asset names blindly, so a quoted occurrence that is not a URL (a JS
string literal, a CSP nonce, inside a percent-encoded data URI) would be rewritten too.
There is no collision across the five assets today — four rewrites, all real references.

**The upgrade path is NOT to narrow the match, and the comment now says why.** Matching on
an enclosing HTML attribute would be a regression: one of the four references is a
JavaScript object literal, `el('link', {href: 'tools.css'})` in `dash/ui/tools.js`, not an
attribute. An attribute match would stop versioning `tools.css`, hand it back an
unversioned URL at `max-age=3600`, and reintroduce the stale-stylesheet bug the
one-token-for-all-assets design exists to prevent. The blindness is load-bearing precisely
because references live in both an attribute and an object literal.

What lands instead makes the failure **loud** rather than the match narrower: three lines
totalling the rewrites actually performed and comparing them against the references the
test already enumerates. Planting a quoted asset name that is not a reference now turns
that assertion — and only that assertion — red; remove the assertion and the same plant is
silent again.

Two comment corrections in the same area, both cases of a comment claiming more than the
code or the test delivers:

- The asset hash writes the file **name and length**. Both new sub-cases in the test are
  decided by the NUL-delimited name alone, so the comment no longer implies they cover the
  length. The length stays, with its real reason recorded where it is written: it is what
  makes the concatenation injective, and without it `{"a": "b.js\0xy"}` and
  `{"a": "", "b.js": "xy"}` hash identically.
- The PATH test's illustration cited `/sbin` and `/bin` being absent from systemd's default
  PATH. On a usrmerge distribution those are symlinks into `/usr`, which systemd's PATH
  does contain, so the example produced no discrepancy. Replaced with the real one already
  documented in `install.sh`: `/usr/local/bin` is in systemd's PATH and not in sudo's
  `secure_path`. The test's mechanism was right; only the prose was wrong.

## Verification — both directions, on the real host

`sudo ./deploy/service/install.sh preflight` → **`Preflight PASSED`** against the deployed
allow-list, unchanged from before this PR, and the extraction still yields nothing at rc 0
on the shipped `upstreams.example.yaml` — the no-regression case, since the shipped file's
documenting comment is the false FAIL #92 set out to fix.

The other direction, against a temporary config that configures a quoted `key_env` and a
flow-mapped one on a single line, with no credential files present: both names are demanded
and preflight prints **`Preflight FAILED`** with a `✗` for each. Nothing live was modified,
restarted or reconfigured.

`CGO_ENABLED=1 go test -race -count=1 ./...` → **25 packages ok, exit 0**. `go vet` clean.
`gofmt -l .` empty. No schema change; `schemaVersion` untouched at 6.
