### PR TITLE
feat(dash): the keep-alive control tab, and two config-save bugs

### DIFF
--- a/config/form.go
+++ b/config/form.go
@@ -57,7 +57,31 @@ type Form struct {
 	// not enablement, and reading "no block" as "off" silently removed components from
 	// bare-preset accounts on save.
 	Pipeline []string `json:"pipeline"`
-	Mode     string   `json:"mode"`
+	// PipelineKnown lists the component names the CLIENT rendered a control for. Any name in
+	// the STORED pipeline that is not in this list is preserved at its original index,
+	// whatever Pipeline says — so removing a component is an act a client has to CLAIM, and a
+	// client that cannot see one cannot take it out.
+	//
+	// It exists because a save silently reverted an operator's pipeline: `linecap` was
+	// dropped and `toon` re-added. The server never knew either name — the pipeline is a
+	// wholesale write of whatever the browser rebuilt out of its checkbox grid — so a stale
+	// render or a cached bundle whose /api/options predated a component produces exactly that
+	// diff, and the server had no way to tell it from a deliberate removal. Now it does.
+	//
+	// Empty or absent means "this client declared nothing", and then NOTHING may be removed.
+	// That is the safe direction for an old bundle and for a hand-rolled API client: both can
+	// still add and reorder.
+	PipelineKnown []string `json:"pipeline_known,omitempty"`
+	// PipelineBase is the pipeline the page RENDERED from. A mismatch against the stored
+	// document means the document moved under the page, and the save is refused with a 409 —
+	// which is what stops a stale page ADDING a component back. Preserving the unmodelled
+	// only defends against dropping.
+	//
+	// nil is accepted (an older bundle does not send it) and then PipelineKnown is the only
+	// defence, which is again the safe direction. Checked at the HTTP layer, where the stored
+	// document is: see proxy.Handler.ctlUpdateMe.
+	PipelineBase []string `json:"pipeline_base,omitempty"`
+	Mode         string   `json:"mode"`
 	// Cache is the `cache:` block — host-level prompt-cache policy (the idle keep-alive and
 	// the mixed-TTL head), which is not a component and so has no descriptor to be drawn
 	// from. nil means the form does not state it and ApplyForm leaves the document's own
@@ -67,6 +91,12 @@ type Form struct {
 	// has nothing to say about the cache" are different instructions, and with a value type
 	// every save from a page that had not drawn the control would switch a tenant's
 	// keep-alive off.
+	//
+	// Reachable only from a direct Go or API caller, in practice. ParseForm's strict path
+	// always fills it in (cacheForm is unconditional), and its loose path leaves it nil but
+	// also sets ParseError — which the save route answers with a 409 before ApplyForm is ever
+	// called. So the nil branch in ApplyForm is a contract for library callers, not a state
+	// the settings page can produce.
 	Cache *CacheForm `json:"cache,omitempty"`
 	// Components holds, per component name, the DOTTED key paths that component's block
 	// actually states — `{"extract_llm": {"cold_cache.min_tokens": 800}}`. Only keys the
@@ -352,6 +382,11 @@ func ApplyForm(doc string, f Form) (string, error) {
 
 	pipeline := append([]string(nil), f.Pipeline...)
 	pipeline = applyExtractLLMCoupling(pipeline, f.Components["extract_llm"])
+	// Before the component loop, not after: a preserved component is ON, and the loop below
+	// CLEARS the declared keys of anything it reads as switched off. Resolving the pipeline
+	// once, here, is what stops a save preserving a component in the run order while deleting
+	// the block that configures it.
+	pipeline = preserveUnmodelled(was, pipeline, f.Pipeline, f.PipelineKnown)
 
 	comps := child(m, "components")
 	for name, decls := range components.AllFields() {
@@ -438,6 +473,45 @@ func applyExtractLLMCoupling(pipeline []string, vals map[string]any) []string {
 		return insertBefore(pipeline, name, "extract")
 	}
 	return pipeline
+}
+
+// preserveUnmodelled re-inserts every component the STORED pipeline ran that the posted one
+// does not mention AND the client did not declare a control for.
+//
+// This is the rule that makes a save unable to drop what the client cannot see. The posted
+// pipeline is a wholesale replacement built from a checkbox grid, so a name missing from it is
+// ambiguous: the operator may have unticked it, or the page may never have drawn a box for it
+// (a cached bundle whose /api/options predates the component) or may have drawn it from a
+// document that has since changed. `known` disambiguates — it is what the client says it drew —
+// and absence from `known` resolves the ambiguity in favour of the stored document.
+//
+// Position is preserved, not appended: a pipeline is an ORDER, and `linecap` reappearing at the
+// end is a different configuration from `linecap` where the operator put it. Each survivor goes
+// back at the index it held in `was`, which for the common case of one unmodelled component in
+// the middle restores the document exactly.
+//
+// A DECLARED removal still removes: a name in `known` and absent from `sent` is gone.
+//
+// `sent` is what the CLIENT posted and `resolved` is that after applyExtractLLMCoupling, and
+// the two are deliberately different arguments. The membership test is on `sent`, because this
+// rule is about what the client said; the insertion is into `resolved`, because that is the
+// pipeline being written. Testing membership on the resolved list instead would undo the
+// coupling's own removal of extract_llm — a SERVER decision, not a client omission — and put
+// a component back that its own constructor refuses to build.
+func preserveUnmodelled(was, resolved, sent, known []string) []string {
+	out := append([]string(nil), resolved...)
+	for i, name := range was {
+		if contains(out, name) || contains(sent, name) || contains(known, name) {
+			continue
+		}
+		// Clamped, because `was` may be longer than what is being written.
+		at := i
+		if at > len(out) {
+			at = len(out)
+		}
+		out = append(out[:at:at], append([]string{name}, out[at:]...)...)
+	}
+	return out
 }
 
 // normalize fills enum fields a caller left EMPTY with the component's own default, and
@@ -687,14 +761,26 @@ func delPath(m map[string]any, path string) {
 	}
 }
 
-// child returns m[key] as a map, creating it when absent and replacing it when it is
-// something else (a `components:` that decoded as nil because the key was written with no
-// body is the common case).
+// child returns m[key] as a map, creating it when absent — INSERTED INTO m — and replacing
+// it when it is something else (a `components:` that decoded as nil because the key was
+// written with no body is the common case).
+//
+// The insertion is the whole contract and it used to be missing: the function returned a
+// fresh detached map and left m untouched, so a caller that did not assign the result back
+// wrote its whole block into a throwaway. `components:` and setPath both happened to assign
+// it back and were fine; the `cache:` block did not, and a tenant switching the keep-alive on
+// for the first time — the one case where the key is absent — had their consent silently
+// discarded. Fixed here rather than at that one call site: the next block someone adds to
+// ApplyForm cannot repeat it. The three callers that do assign are unaffected, and the two
+// that prune an empty block (`components:` and each component's own) still prune it, so an
+// empty map created here does not reach the document.
 func child(m map[string]any, key string) map[string]any {
 	if sub, ok := m[key].(map[string]any); ok && sub != nil {
 		return sub
 	}
-	return map[string]any{}
+	sub := map[string]any{}
+	m[key] = sub
+	return sub
 }
 
 func contains(xs []string, v string) bool {

--- a/config/form_test.go
+++ b/config/form_test.go
@@ -603,8 +603,14 @@ func TestSwitchingAComponentOffClearsItsDeclaredKeysAndNothingElse(t *testing.T)
 			if err != nil {
 				t.Fatalf("configuring every key at once failed: %v", err)
 			}
-			// Now switch it off: out of the pipeline, values still posted.
+			// Now switch it off: out of the pipeline, values still posted. The removal is
+			// DECLARED — PipelineKnown is what the client says it modelled, and a save may
+			// only remove what it claims to have drawn a control for (see
+			// preserveUnmodelled). This caller read the whole document, so it claims all of
+			// it; a client that claims nothing removes nothing, which is the case
+			// TestASaveFromAClientThatDeclaresNothingRemovesNothing covers.
 			off := mustParse(t, configured)
+			off.PipelineKnown = append([]string(nil), off.Pipeline...)
 			off.Pipeline = remove(off.Pipeline, name)
 			if name == "extract_llm" {
 				// The one component with a coupling: it is switched off by its two
@@ -672,8 +678,18 @@ func TestTheColdCacheKeysSurviveASaveThatDoesNotMentionThem(t *testing.T) {
 			t.Errorf("a plain re-save lost %q:\n%s", want, out)
 		}
 	}
-	if paths := changedPaths(t, osherDoc, out); len(paths) != 0 {
-		t.Errorf("re-saving an unchanged form moved %v", paths)
+	// The `cache:` block is the one thing a re-save MATERIALISES, and that is the point of
+	// Bug 1's fix: the two consent booleans are written explicitly, so an absent block stops
+	// being indistinguishable from a stored `false`. Before the fix they were written into a
+	// detached map and thrown away, which is how a first-time keep-alive opt-in was lost.
+	// Nothing else may move, and no tuning field may appear — writing zeroes for those would
+	// freeze today's defaults into the document (R3).
+	for _, path := range changedPaths(t, osherDoc, out) {
+		switch path {
+		case "cache.keepalive", "cache.head_ttl_1h":
+		default:
+			t.Errorf("re-saving an unchanged form moved %s", path)
+		}
 	}
 }
 

--- a/config/formbugs_test.go
+++ b/config/formbugs_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	_ "github.com/rossoctl/context-guru/components/all"
+	"gopkg.in/yaml.v3"
+)
+
+// Two data-loss bugs in the settings save path, and the tests that fail without their fixes.
+//
+// Both are the same shape: a save wrote something the operator did not ask for and there was
+// no test at the layer where the decision is made. The first threw away a consent the user
+// had just given; the second threw away a component the client could not see.
+
+// Bug 1: the keep-alive opt-in did not persist on a document with no `cache:` block.
+//
+// The one case that breaks, and the reason it went unnoticed for so long: on a document that
+// ALREADY has a cache block every field round-trips correctly, because child() then returns
+// the real map. Absent key, detached map, whole block discarded — and "switching keep-alive on
+// for the first time" is by definition the absent-key case.
+//
+// Asserted through a ParseForm round trip rather than a substring. A test for
+// `"keepalive: true"` in the output text would also pass on a document that persisted the
+// consent and dropped something else.
+func TestSavingKeepAliveOnADocumentWithNoCacheBlockKeepsIt(t *testing.T) {
+	const doc = "pipeline:\n  - format\n  - extract\n"
+	if strings.Contains(doc, "cache") {
+		t.Fatal("the fixture must have NO cache block; that is the only case that breaks")
+	}
+	// Every field of CacheForm, one case each, so a field added later is covered by the same
+	// table. reflect over the struct rather than a hand-listed set: a hand-listed set is how
+	// the form drifted from its own declarations in the first place.
+	full := CacheForm{
+		KeepAlive: true, KeepAliveIdleSeconds: 280, KeepAliveMaxPings: 2,
+		KeepAliveMaxUSDPerPing: 0.05, KeepAliveMinPrefixTokens: 20000,
+		HeadTTL1h: true, HeadTTLMinTokens: 50000,
+	}
+	rt := reflect.TypeOf(full)
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		t.Run(name, func(t *testing.T) {
+			// One field at a time, on an otherwise zero form: a field that only survives
+			// because a neighbour happened to create the block is not a field that works.
+			var one CacheForm
+			reflect.ValueOf(&one).Elem().Field(i).Set(reflect.ValueOf(full).Field(i))
+			out, err := ApplyForm(doc, Form{Pipeline: []string{"format", "extract"}, Cache: &one})
+			if err != nil {
+				t.Fatalf("ApplyForm: %v", err)
+			}
+			got, err := ParseForm(out)
+			if err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got.Cache == nil {
+				t.Fatalf("the whole cache block was discarded; the saved document is:\n%s", out)
+			}
+			if *got.Cache != one {
+				t.Errorf("%s did not round-trip: sent %+v, read back %+v\nsaved document:\n%s",
+					name, one, *got.Cache, out)
+			}
+		})
+	}
+}
+
+// Bug 1's CLASS, on the helper. Three lines, and it is the assertion that generalises: the
+// next block added to ApplyForm inherits it for free.
+func TestChildAttachesTheBlockItCreates(t *testing.T) {
+	m := map[string]any{}
+	child(m, "x")["k"] = 1
+	sub, ok := m["x"].(map[string]any)
+	if !ok {
+		t.Fatalf(`child(m,"x") did not insert a map into m; m = %#v`, m)
+	}
+	if sub["k"] != 1 {
+		t.Errorf("the returned map is not the one in m: m[x] = %#v", sub)
+	}
+	// And it still adopts what is already there rather than replacing it.
+	m2 := map[string]any{"y": map[string]any{"keep": true}}
+	child(m2, "y")["added"] = true
+	y := m2["y"].(map[string]any)
+	if y["keep"] != true || y["added"] != true {
+		t.Errorf("child replaced an existing block: %#v", y)
+	}
+}
+
+// Bug 2: a save must never drop a component the client did not render a control for.
+//
+// The reported incident: `linecap` vanished from an operator's pipeline and `toon` was
+// re-added at the end. The server writes the posted pipeline wholesale, so a stale render or
+// a cached bundle whose /api/options predates a component produces exactly that — and the
+// server could not tell it from a deliberate removal. PipelineKnown is the client CLAIMING
+// what it drew, so absence from it resolves the ambiguity in favour of the stored document.
+func TestASaveNeverDropsAComponentTheClientDidNotRender(t *testing.T) {
+	const doc = "pipeline:\n  - format\n  - linecap\n  - extract\n"
+	// The client draws format and extract, does not know linecap, and posts without it.
+	out, err := ApplyForm(doc, Form{
+		Pipeline:      []string{"format", "extract"},
+		PipelineKnown: []string{"format", "extract"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyForm: %v", err)
+	}
+	if got := pipelineOf(t, out); !reflect.DeepEqual(got, []string{"format", "linecap", "extract"}) {
+		t.Errorf("linecap was not preserved at its own index: got %v\n%s", got, out)
+	}
+	// And a DECLARED removal still removes. Without this the fix would be "the pipeline is
+	// append-only", which is a different bug.
+	out, err = ApplyForm(doc, Form{
+		Pipeline:      []string{"format", "extract"},
+		PipelineKnown: []string{"format", "linecap", "extract"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyForm (declared removal): %v", err)
+	}
+	if got := pipelineOf(t, out); !reflect.DeepEqual(got, []string{"format", "extract"}) {
+		t.Errorf("a declared removal did not remove: got %v\n%s", got, out)
+	}
+}
+
+// The old-bundle direction: a client that declares nothing removes nothing. A cached app.js
+// and a hand-rolled API client are the same case, and both can still add and reorder.
+func TestASaveFromAClientThatDeclaresNothingRemovesNothing(t *testing.T) {
+	const doc = "pipeline:\n  - format\n  - linecap\n  - extract\n  - toon\n"
+	out, err := ApplyForm(doc, Form{Pipeline: []string{"format"}})
+	if err != nil {
+		t.Fatalf("ApplyForm: %v", err)
+	}
+	got := pipelineOf(t, out)
+	for _, want := range []string{"format", "linecap", "extract", "toon"} {
+		if !contains(got, want) {
+			t.Errorf("%s was removed by a client that declared nothing: got %v", want, got)
+		}
+	}
+}
+
+// A preserved component keeps its CONFIGURATION too. The component loop reads the resolved
+// pipeline to decide what is switched off, and switched-off clears the declared keys — so
+// preserving a name while wiping its block would leave a run order the document cannot explain.
+func TestAPreservedComponentKeepsItsOwnBlock(t *testing.T) {
+	const doc = `pipeline:
+  - format
+  - linecap
+components:
+  linecap:
+    max_line_chars: 4000
+`
+	out, err := ApplyForm(doc, Form{
+		Pipeline:      []string{"format"},
+		PipelineKnown: []string{"format"},
+		Components:    map[string]map[string]any{"linecap": {"max_line_chars": 4000}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyForm: %v", err)
+	}
+	if !strings.Contains(out, "max_line_chars: 4000") {
+		t.Errorf("the preserved component's configuration was cleared:\n%s", out)
+	}
+}
+
+// pipelineOf reads the pipeline back out of a saved document.
+func pipelineOf(t *testing.T, doc string) []string {
+	t.Helper()
+	var d struct {
+		Pipeline []string `yaml:"pipeline"`
+	}
+	if err := yaml.Unmarshal([]byte(doc), &d); err != nil {
+		t.Fatalf("the saved document does not parse: %v\n%s", err, doc)
+	}
+	return d.Pipeline
+}

--- a/dash/api.go
+++ b/dash/api.go
@@ -236,7 +236,10 @@ func (a *API) routes() []route {
 	// The tool/MCP/skill inventory's route, declared beside its handler in toolapi.go and
 	// appended here rather than mounted separately: this table is what the scoping test walks,
 	// so a route mounted around it would be a route whose scope nothing checks.
-	return append(rs, a.toolRoutes()...)
+	rs = append(rs, a.toolRoutes()...)
+	// The keep-alive tab's reads, declared beside their handlers in keepaliveapi.go and
+	// appended here for the same reason: this table is what both scoping tests walk.
+	return append(rs, a.keepAliveRoutes()...)
 }
 
 // Mount registers every dashboard route on a mux under the given prefix

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -249,17 +249,19 @@ func (d *DB) windowDays(cond string, args []any) float64 {
 // Band is one bucket of an ORDERED histogram: idle-gap bands, prefix-size bands, hour bins.
 //
 // Label carries the meaning and the order is the data — a bar chart of these must preserve it
-// and must not sort by size, because the order IS what the reader is reading. Since/Until make
-// each bar a drill-down into the requests behind it.
+// and must not sort by size, because the order IS what the reader is reading.
+//
+// Deliberately NO since/until here. These bands bucket by GAP LENGTH, by PREFIX SIZE and by HOUR
+// OF DAY — none of which is a time range, so a bar's drill-down is `reason=ttl_expiry` plus the
+// window already on screen and nothing more. A pair of fields that no band could ever populate
+// would be two zeroes on the wire that something eventually renders as a date.
 type Band struct {
 	Label string  `json:"label"`
 	N     int64   `json:"n"`
 	USD   float64 `json:"usd"`
 	// Beyond marks the bands the CURRENT policy's coverage cannot reach, which the chart draws
 	// in the de-emphasis gray beyond the coverage rule.
-	Beyond bool  `json:"beyond,omitempty"`
-	Since  int64 `json:"since,omitempty"`
-	Until  int64 `json:"until,omitempty"`
+	Beyond bool `json:"beyond,omitempty"`
 }
 
 // DayPoint is one day of the "how often, and what did it cost" series.

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"math/rand"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
@@ -458,20 +460,23 @@ func (d *DB) KeepAliveBehaviour(f Filter, coverageSeconds float64) (*KeepAliveBe
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	// Axis labels are read by a person, so they are ROUNDED. %g on 580/60 renders
+	// "9.666666666666666m", which is what the first live render of this panel showed.
 	secs := func(v float64) string {
-		if v >= 3600 {
-			return fmt.Sprintf("%gh", v/3600)
+		switch {
+		case v >= 3600:
+			return trimZero(v/3600) + "h"
+		case v >= 60:
+			return trimZero(v/60) + "m"
+		default:
+			return trimZero(v) + "s"
 		}
-		if v >= 60 {
-			return fmt.Sprintf("%gm", v/60)
-		}
-		return fmt.Sprintf("%gs", v)
 	}
 	toks := func(v float64) string {
 		if v >= 1000 {
-			return fmt.Sprintf("%gk", v/1000)
+			return trimZero(v/1000) + "k"
 		}
-		return fmt.Sprintf("%g", v)
+		return trimZero(v)
 	}
 	for i, label := range bandLabels(gapEdges, secs) {
 		out.GapBands = append(out.GapBands, Band{Label: label, N: gapN[i], USD: gapUSD[i],
@@ -877,27 +882,55 @@ func (d *DB) KeepAliveCalc(f Filter, idleSeconds float64, prefix int64, model st
 	return out, nil
 }
 
-// AccountMedianPrefix is the account's own median billed prefix at a lapsed entry, which is what
-// the calculator prefills when no session is selected. 0 when it has no addressable expiry.
-func (d *DB) AccountMedianPrefix(f Filter) (int64, error) {
+// AccountMedianPrefix is the account's own median billed prefix at a lapsed entry, and the model
+// most of those lapses were on. What the calculator prefills when no session is selected.
+//
+// The MODEL matters as much as the size: a rate belongs to a model, and without one the panel
+// reported "not priced" on a deployment whose price list was perfectly good. The modal model of
+// this account's own expiries is an honest answer to "what would this cost me"; a blended
+// average across models is not, and is the defect class this project has hit five times.
+// Returns 0 and "" when the account has no addressable expiry.
+func (d *DB) AccountMedianPrefix(f Filter) (int64, string, error) {
 	aCond, aArgs := addressable(f)
-	rows, err := d.sql.Query(aCond+` SELECT COALESCE(prev_prefix,0) FROM addressable`, aArgs...)
+	rows, err := d.sql.Query(aCond+` SELECT COALESCE(prev_prefix,0), model FROM addressable`, aArgs...)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	defer rows.Close()
 	var xs []float64
+	byModel := map[string]int{}
 	for rows.Next() {
 		var v float64
-		if err := rows.Scan(&v); err != nil {
-			return 0, err
+		var m sql.NullString
+		if err := rows.Scan(&v, &m); err != nil {
+			return 0, "", err
 		}
 		xs = append(xs, v)
+		if m.String != "" {
+			byModel[m.String]++
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return 0, err
+		return 0, "", err
 	}
-	return int64(pctlF(xs, 0.50)), nil
+	// Ties broken by name, so the same window gives the same answer twice.
+	var best string
+	for _, m := range sortedStrings(byModel) {
+		if best == "" || byModel[m] > byModel[best] {
+			best = m
+		}
+	}
+	return int64(pctlF(xs, 0.50)), best, nil
+}
+
+// sortedStrings is the keys of a map in a stable order.
+func sortedStrings[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // LastBilledPrefix is one session's most recent billed prefix and model, from AGENT rows only.
@@ -1060,10 +1093,24 @@ func (d *DB) KeepAliveRecommend(f Filter) (*KeepAliveRecommendation, error) {
 		return v
 	}
 	lo, hi := bootstrapCI(keys, func(s string) float64 { return net(s, recMaxPings) })
-	if lo <= 0 && hi >= 0 {
-		out.Refused = fmt.Sprintf("your own history cannot tell this apart from zero: over %d "+
-			"cache expiries in %d sessions the 90%% interval is $%.2f to $%.2f, which includes "+
-			"no change at all", out.N, out.Sessions, lo, hi)
+	// Condition 3, and it is a ONE-SIDED test. An interval that spans zero cannot tell the
+	// effect from nothing; an interval entirely BELOW zero is worse than inconclusive — this
+	// account's own gaps say the mechanism would cost it money — and both are refusals. The
+	// two-sided reading of "excludes zero" would have recommended a policy whose own 90%
+	// interval was -$39 to -$5, which is what the first live look at this route produced: an
+	// account whose median idle gap is 57 minutes has almost nothing inside any coverage worth
+	// having, so it pays for pings and converts nothing.
+	if lo <= 0 {
+		if hi < 0 {
+			out.Refused = fmt.Sprintf("your own history says this would COST you money: over %d "+
+				"cache expiries in %d sessions the 90%% interval is $%.2f to $%.2f, entirely "+
+				"below zero. Your idle gaps are mostly too long for any setting worth having to "+
+				"reach", out.N, out.Sessions, lo, hi)
+		} else {
+			out.Refused = fmt.Sprintf("your own history cannot tell this apart from zero: over %d "+
+				"cache expiries in %d sessions the 90%% interval is $%.2f to $%.2f, which "+
+				"includes no change at all", out.N, out.Sessions, lo, hi)
+		}
 		return out, nil
 	}
 	out.IdleSeconds, out.MaxPings = recIdleSeconds, recMaxPings
@@ -1165,4 +1212,11 @@ func (d *DB) spansBySession(f Filter) (map[string][]float64, error) {
 		out[s] = append(out[s], g)
 	}
 	return out, rows.Err()
+}
+
+// trimZero renders a number to at most one decimal place and drops a trailing ".0", so a band
+// edge reads as "9.7m" rather than "9.666666666666666m" and as "5m" rather than "5.0m".
+func trimZero(v float64) string {
+	s := strconv.FormatFloat(v, 'f', 1, 64)
+	return strings.TrimSuffix(s, ".0")
 }

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -1,0 +1,1168 @@
+package dash
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"time"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// The keep-alive tab's read side: one ledger, one behavioural read, one session list, one
+// calculator and one recommendation — computed here, in Go and SQL, and never in the browser.
+//
+// # Why the arithmetic is on this side
+//
+// The browser has twice duplicated a table the server owns and drifted from it: the defaults
+// table (R8) and the regex pipeline writer. Money arithmetic is the worst case of that class,
+// so the UI on this tab posts inputs and renders answers. Nothing below is recomputed client
+// side.
+//
+// # The one rule none of this may break
+//
+// PR #86 excludes ping rows from every agent aggregate with a single predicate,
+// `r.keepalive = 0` in Filter.where(). A ping is a request context-guru sent while nobody was
+// at the keyboard, so counted in COUNT(*), SUM(cache_read) or AVG(upstream_ms) it makes an
+// account's own statistics wrong. That predicate does not change here. Where a ping IS the
+// subject, this file runs a SECOND query with withKeepAlive(f) and joins in Go — the same
+// pattern DB.Overview already uses for the cost half of the ledger. There is no CASE over
+// `keepalive` inside an agent-traffic aggregate anywhere in this file.
+//
+// # Addressability, and why it is not optional
+//
+// A `ttl_expiry` row with `cache_write = 0` is a PHANTOM: 385 of the 742 in the production
+// corpus are exactly that and every one of them is an HTTP 400. They wrote nothing, so there
+// was no prefix to protect and no charge a ping could have avoided. `cache_write > 0` is the
+// addressability test and it gates every count, every dollar and every percentile on this tab.
+
+// ttlTTL is the provider's default prompt-cache lifetime. The coverage arithmetic rests on it.
+const ttlTTL = 300 * time.Second
+
+// addressableCTE is the shared read used by the behaviour panels, the calculator's own history
+// and the recommendation. ONE definition, so the panels cannot disagree with each other about
+// how many expiries an account had — which is how two tiles on the same page come to report
+// different denominators.
+//
+// The gap is computed at READ time with LAG: there is no `since_last_ms` column, because
+// Event.SinceLastMs is transient and was never stored. Window functions are available
+// (modernc.org/sqlite v1.56.0) and `idx_requests_session(session_id, ts)` already covers the
+// partition.
+//
+// prev_prefix is the PREVIOUS request's billed prefix (`cache_read + cache_write`), which is
+// the size of the entry that lapsed. Not `tokens_before`, which is message text only and runs
+// a median 3.38x low.
+const addressableCTE = `WITH s AS (
+	SELECT r.tenant_id, r.session_id, r.ts, r.cost_usd, r.model, r.cache_miss_reason, r.cache_write,
+	       LAG(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts) AS prev_ts,
+	       LAG(r.cache_read + r.cache_write) OVER
+	         (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts) AS prev_prefix
+	FROM requests r WHERE %s
+), addressable AS (
+	SELECT *, (ts - prev_ts) / 1000.0 AS gap_s FROM s
+	WHERE cache_miss_reason = 'ttl_expiry' AND cache_write > 0 AND prev_ts IS NOT NULL
+)`
+
+// addressable renders the CTE for one filter.
+func addressable(f Filter) (string, []any) {
+	cond, args := f.where()
+	return fmt.Sprintf(addressableCTE, cond), args
+}
+
+// KeepAliveCoverage is the "is this figure a measurement or an absence?" statement that
+// accompanies every number on the tab.
+//
+// It exists because `keepalive_pings` and `keepalive_saved_usd` arrived as ADDITIVE columns with
+// DEFAULT 0. On a row written before PR #86 a zero means NOT RECORDED, and rendering that as
+// "no pings" would be a fabricated measurement — the failure this project has hit repeatedly.
+// Three distinct states, never conflated: never ran, partially recorded, or plain figures.
+type KeepAliveCoverage struct {
+	// RecordedFrom is MIN(ts) of any row carrying a ping or a ping-derived credit. 0 means the
+	// keep-alive has never run on this account, which is not the same as having saved nothing.
+	RecordedFrom int64 `json:"keepalive_recorded_from"`
+	// RecordedRows is the rows at or after that instant, and Requests the rows in the window.
+	// RecordedRows < Requests is the partial state.
+	RecordedRows int64 `json:"keepalive_recorded_rows"`
+	Requests     int64 `json:"requests"`
+}
+
+// KeepAliveLedger is panel 1 and panel 2: the verdict, and the losing majority beside it.
+type KeepAliveLedger struct {
+	Pings         int64   `json:"pings"`
+	PingUSD       float64 `json:"ping_usd"`
+	MissesAvoided int64   `json:"misses_avoided"`
+	// SavedUSD is a CEILING, and every tile that shows it says so. The credit itself is exact
+	// arithmetic — see Event.keepaliveSavedUSD — but the provider's cache is keyed on CONTENT,
+	// so another session sending a byte-identical prefix would have refreshed the same entry
+	// for nothing. That confound cannot be measured from our side; it can only be declared.
+	SavedUSD float64 `json:"saved_usd"`
+	NetUSD   float64 `json:"net_usd"`
+	// The winner/loser split over the sessions the mechanism TOUCHED. 85 of 119 lose about a
+	// third of a cent service-wide, funding a large rebate on 34 — the panel states that in
+	// words, unconditionally, above the fold.
+	Sessions       int64   `json:"sessions_touched"`
+	Winners        int64   `json:"winners"`
+	Losers         int64   `json:"losers"`
+	WorstSession   string  `json:"worst_session"`
+	WorstNetUSD    float64 `json:"worst_net_usd"`
+	Addressable    int64   `json:"addressable_misses"`
+	AddressableUSD float64 `json:"addressable_usd"`
+	// PingsThatReadNothing is the operator's check on SavedUSD: a ping that read nothing
+	// refreshed nothing. PingsThatWrote is worse — it CREATED an entry, which costs 12.5x a
+	// read, and the keeper stops pinging that session.
+	PingsThatReadNothing int64 `json:"pings_that_read_nothing"`
+	PingsThatWrote       int64 `json:"pings_that_wrote"`
+	// BytesPerDay is what this account's own ping rows cost on disk, measured rather than
+	// assumed: 294 B of row plus ~103 B of index per ping. Here because per-session overrides
+	// are the mechanism by which somebody could raise it.
+	PingsPerDay float64 `json:"pings_per_day"`
+	BytesPerDay float64 `json:"bytes_per_day"`
+	KeepAliveCoverage
+}
+
+// bytesPerPingRow is one ping row's measured footprint: 294 B in `requests` plus ~103 B of
+// index, from dbstat over the production snapshot. Rounded up to 400.
+const bytesPerPingRow = 400
+
+// KeepAliveLedger computes the ledger for one filtered window.
+func (d *DB) KeepAliveLedger(f Filter) (*KeepAliveLedger, error) {
+	var o KeepAliveLedger
+	// The SAVING half and the coverage, over agent traffic only — the credit lives on the real
+	// request that benefited, never on the ping.
+	cond, args := f.where()
+	var from sql.NullInt64
+	if err := d.sql.QueryRow(`SELECT
+		COALESCE(SUM(r.keepalive_saved_usd),0),
+		COALESCE(SUM(CASE WHEN r.keepalive_saved_usd > 0 THEN 1 ELSE 0 END),0),
+		COUNT(*)
+		FROM requests r WHERE `+cond, args...).Scan(
+		&o.SavedUSD, &o.MissesAvoided, &o.Requests); err != nil {
+		return nil, err
+	}
+	// The COST half, with ping rows included. A second query and not a CASE: one predicate,
+	// one meaning.
+	kaCond, kaArgs := withKeepAlive(f).where()
+	if err := d.sql.QueryRow(`SELECT
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 AND r.cache_read = 0 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.keepalive = 1 AND r.cache_write > r.cache_read THEN 1 ELSE 0 END),0),
+		MIN(CASE WHEN r.keepalive = 1 OR r.keepalive_pings > 0 OR r.keepalive_saved_usd > 0
+			THEN r.ts END)
+		FROM requests r WHERE `+kaCond, kaArgs...).Scan(
+		&o.Pings, &o.PingUSD, &o.PingsThatReadNothing, &o.PingsThatWrote, &from); err != nil {
+		return nil, err
+	}
+	o.NetUSD = o.SavedUSD - o.PingUSD
+	o.RecordedFrom = from.Int64
+	if o.RecordedFrom > 0 {
+		if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+` AND r.ts >= ?`,
+			append(append([]any(nil), args...), o.RecordedFrom)...).Scan(&o.RecordedRows); err != nil {
+			return nil, err
+		}
+	}
+	// The winner/loser split, per session, over the sessions the mechanism touched. Two
+	// grouped queries joined in Go for the same reason as above: the credit is on agent rows
+	// and the cost is on ping rows, and one aggregate cannot honestly see both.
+	saved, err := d.sumBySession(cond, args, "r.keepalive_saved_usd", "r.keepalive_saved_usd > 0")
+	if err != nil {
+		return nil, err
+	}
+	spent, err := d.sumBySession(kaCond, kaArgs, "r.cost_usd", "r.keepalive = 1")
+	if err != nil {
+		return nil, err
+	}
+	nets := map[string]float64{}
+	for s, v := range saved {
+		nets[s] += v
+	}
+	for s, v := range spent {
+		nets[s] -= v
+	}
+	for s, net := range nets {
+		o.Sessions++
+		switch {
+		case net > 0:
+			o.Winners++
+		case net < 0:
+			o.Losers++
+		}
+		if net < o.WorstNetUSD {
+			o.WorstNetUSD, o.WorstSession = net, s
+		}
+	}
+	// What is still on the table: the addressable expiries in this window, and their bill.
+	aCond, aArgs := addressable(f)
+	if err := d.sql.QueryRow(aCond+`
+		SELECT COUNT(*), COALESCE(SUM(cost_usd),0) FROM addressable`, aArgs...).Scan(
+		&o.Addressable, &o.AddressableUSD); err != nil {
+		return nil, err
+	}
+	// Ping rate and its footprint on disk, over the window's own span. Nothing here stores
+	// text: for contrast a sibling feature put 264.7 MB on disk in a day by duplicating it.
+	if days := d.windowDays(kaCond, kaArgs); days > 0 {
+		o.PingsPerDay = float64(o.Pings) / days
+		o.BytesPerDay = o.PingsPerDay * bytesPerPingRow
+	}
+	return &o, nil
+}
+
+// sumBySession groups one column by session under an extra predicate.
+func (d *DB) sumBySession(cond string, args []any, col, extra string) (map[string]float64, error) {
+	rows, err := d.sql.Query(`SELECT r.session_id, COALESCE(SUM(`+col+`),0) FROM requests r
+		WHERE `+cond+` AND `+extra+` AND r.session_id <> '' GROUP BY 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]float64{}
+	for rows.Next() {
+		var s string
+		var v float64
+		if err := rows.Scan(&s, &v); err != nil {
+			return nil, err
+		}
+		out[s] = v
+	}
+	return out, rows.Err()
+}
+
+// windowDays is the span the rows actually cover, in days. Derived from the data and not from
+// the filter: a filter may be unbounded, and dividing by a window nobody has any rows in would
+// report a rate per day of traffic that did not happen.
+func (d *DB) windowDays(cond string, args []any) float64 {
+	var lo, hi sql.NullInt64
+	if err := d.sql.QueryRow(`SELECT MIN(r.ts), MAX(r.ts) FROM requests r WHERE `+cond,
+		args...).Scan(&lo, &hi); err != nil {
+		return 0
+	}
+	if !lo.Valid || !hi.Valid || hi.Int64 <= lo.Int64 {
+		return 0
+	}
+	return float64(hi.Int64-lo.Int64) / 86400000.0
+}
+
+// Band is one bucket of an ORDERED histogram: idle-gap bands, prefix-size bands, hour bins.
+//
+// Label carries the meaning and the order is the data — a bar chart of these must preserve it
+// and must not sort by size, because the order IS what the reader is reading. Since/Until make
+// each bar a drill-down into the requests behind it.
+type Band struct {
+	Label string  `json:"label"`
+	N     int64   `json:"n"`
+	USD   float64 `json:"usd"`
+	// Beyond marks the bands the CURRENT policy's coverage cannot reach, which the chart draws
+	// in the de-emphasis gray beyond the coverage rule.
+	Beyond bool  `json:"beyond,omitempty"`
+	Since  int64 `json:"since,omitempty"`
+	Until  int64 `json:"until,omitempty"`
+}
+
+// DayPoint is one day of the "how often, and what did it cost" series.
+type DayPoint struct {
+	Day        string  `json:"day"`
+	TS         int64   `json:"ts"`
+	Misses     int64   `json:"misses"`
+	USD        float64 `json:"usd"`
+	Requests   int64   `json:"requests"`
+	AllUSD     float64 `json:"all_usd"`
+	SharePct   float64 `json:"share_pct"`
+	MissRatePc float64 `json:"miss_rate_pct"`
+}
+
+// AccountGaps is panel 3d: how long between one account's own TTL expiries.
+//
+// Reported PER ACCOUNT and never blended. There is no service-wide "usually": per-account means
+// run 0.64 h to 6.56 h with maxima to 30 h, so a single mean across a 10x spread would be a
+// number that describes nobody.
+type AccountGaps struct {
+	Tenant   string  `json:"tenant"`
+	N        int64   `json:"n"`
+	MeanHrs  float64 `json:"mean_hours"`
+	MedHrs   float64 `json:"median_hours"`
+	MaxHrs   float64 `json:"max_hours"`
+	Coverage bool    `json:"has_gaps"`
+}
+
+// KeepAliveBehaviour is panels 3a–3e.
+type KeepAliveBehaviour struct {
+	Daily []DayPoint `json:"daily"`
+	// GapBands is the idle-gap histogram with FIXED edges, so the shape is comparable between
+	// accounts and between windows. The edge at 580 s is not arbitrary: it is the shipped
+	// policy's own coverage at X=280, K=1.
+	GapBands    []Band        `json:"gap_bands"`
+	PrefixBands []Band        `json:"prefix_bands"`
+	HourBins    []Band        `json:"hour_bins"`
+	Gaps        []AccountGaps `json:"account_gaps"`
+	// PrefixP10/P50/P90 in tokens, over the lapsed entries. p50 is 292,527 on the corpus and
+	// 347 of 356 are past 20k — which is the measured reason the shipped `prefix >= 20k` gate
+	// costs almost nothing, and the panel says so.
+	PrefixP10 int64 `json:"prefix_p10"`
+	PrefixP50 int64 `json:"prefix_p50"`
+	PrefixP90 int64 `json:"prefix_p90"`
+	// GapP10/P50/P90 in seconds.
+	GapP10 float64 `json:"gap_p10"`
+	GapP50 float64 `json:"gap_p50"`
+	GapP90 float64 `json:"gap_p90"`
+	// CoverageSeconds is K*X + TTL under the policy the bands are drawn against, which is what
+	// the threshold rule on the chart marks.
+	CoverageSeconds float64 `json:"coverage_seconds"`
+	AboveTwentyK    int64   `json:"prefix_above_20k"`
+	Addressable     int64   `json:"addressable_misses"`
+	Phantom         int64   `json:"phantom_ttl_rows"`
+	KeepAliveCoverage
+}
+
+// gapEdges are the idle-gap bands' fixed edges in seconds. The last is unbounded.
+var gapEdges = []float64{0, 300, 580, 600, 1800, 3600, 14400}
+
+// prefixEdges are the billed-prefix bands' fixed edges in tokens. 20,000 is the shipped gate.
+var prefixEdges = []float64{0, 20000, 50000, 100000, 200000, 400000, 800000}
+
+// bandLabels renders the edge list as human labels, with a unit formatter.
+func bandLabels(edges []float64, unit func(float64) string) []string {
+	out := make([]string, 0, len(edges))
+	for i, lo := range edges {
+		if i == len(edges)-1 {
+			out = append(out, "> "+unit(lo))
+			continue
+		}
+		out = append(out, unit(lo)+"–"+unit(edges[i+1]))
+	}
+	return out
+}
+
+// bandOf places a value in the edge list.
+func bandOf(edges []float64, v float64) int {
+	for i := len(edges) - 1; i >= 0; i-- {
+		if v >= edges[i] {
+			return i
+		}
+	}
+	return 0
+}
+
+// KeepAliveBehaviour computes the behavioural panels for one window.
+//
+// coverageSeconds is the policy the gap bands are marked against (K*X + TTL); 0 falls back to
+// the shipped default's 860 s.
+func (d *DB) KeepAliveBehaviour(f Filter, coverageSeconds float64) (*KeepAliveBehaviour, error) {
+	if coverageSeconds <= 0 {
+		coverageSeconds = 2*280 + ttlTTL.Seconds()
+	}
+	out := &KeepAliveBehaviour{CoverageSeconds: coverageSeconds,
+		Daily: []DayPoint{}, Gaps: []AccountGaps{}}
+	aCond, aArgs := addressable(f)
+	cond, args := f.where()
+
+	// 3a: per day, and the SHARE of that day's whole bill, because a count with no
+	// denominator cannot be sized.
+	all := map[string]struct {
+		n   int64
+		usd float64
+	}{}
+	rows, err := d.sql.Query(`SELECT date(r.ts/1000,'unixepoch'), COUNT(*), COALESCE(SUM(r.cost_usd),0)
+		FROM requests r WHERE `+cond+` GROUP BY 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var day string
+		var n int64
+		var usd float64
+		if err := rows.Scan(&day, &n, &usd); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		all[day] = struct {
+			n   int64
+			usd float64
+		}{n, usd}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows, err = d.sql.Query(aCond+`
+		SELECT date(ts/1000,'unixepoch'), MIN(ts), COUNT(*), COALESCE(SUM(cost_usd),0)
+		FROM addressable GROUP BY 1 ORDER BY 1`, aArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var p DayPoint
+		if err := rows.Scan(&p.Day, &p.TS, &p.Misses, &p.USD); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if a, ok := all[p.Day]; ok {
+			p.Requests, p.AllUSD = a.n, a.usd
+			if a.usd > 0 {
+				p.SharePct = 100 * p.USD / a.usd
+			}
+			if a.n > 0 {
+				p.MissRatePc = 100 * float64(p.Misses) / float64(a.n)
+			}
+		}
+		out.Daily = append(out.Daily, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// 3b/3e: the two band histograms and the 24 hour bins, from one pass over `addressable`.
+	// Percentiles come from the same read, so the bands and the p50 beside them cannot
+	// disagree.
+	gapN := make([]int64, len(gapEdges))
+	gapUSD := make([]float64, len(gapEdges))
+	preN := make([]int64, len(prefixEdges))
+	preUSD := make([]float64, len(prefixEdges))
+	hourN := make([]int64, 24)
+	hourUSD := make([]float64, 24)
+	var gaps, prefixes []float64
+	rows, err = d.sql.Query(aCond+`
+		SELECT gap_s, COALESCE(prev_prefix,0), cost_usd,
+		       CAST(strftime('%H', ts/1000, 'unixepoch') AS INTEGER)
+		FROM addressable`, aArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var gap, prefix, usd float64
+		var hour int
+		if err := rows.Scan(&gap, &prefix, &usd, &hour); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		out.Addressable++
+		gi := bandOf(gapEdges, gap)
+		gapN[gi]++
+		gapUSD[gi] += usd
+		pi := bandOf(prefixEdges, prefix)
+		preN[pi]++
+		preUSD[pi] += usd
+		if hour >= 0 && hour < 24 {
+			hourN[hour]++
+			hourUSD[hour] += usd
+		}
+		gaps = append(gaps, gap)
+		prefixes = append(prefixes, prefix)
+		if prefix >= 20000 {
+			out.AboveTwentyK++
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	secs := func(v float64) string {
+		if v >= 3600 {
+			return fmt.Sprintf("%gh", v/3600)
+		}
+		if v >= 60 {
+			return fmt.Sprintf("%gm", v/60)
+		}
+		return fmt.Sprintf("%gs", v)
+	}
+	toks := func(v float64) string {
+		if v >= 1000 {
+			return fmt.Sprintf("%gk", v/1000)
+		}
+		return fmt.Sprintf("%g", v)
+	}
+	for i, label := range bandLabels(gapEdges, secs) {
+		out.GapBands = append(out.GapBands, Band{Label: label, N: gapN[i], USD: gapUSD[i],
+			Beyond: gapEdges[i] >= coverageSeconds})
+	}
+	for i, label := range bandLabels(prefixEdges, toks) {
+		out.PrefixBands = append(out.PrefixBands, Band{Label: label, N: preN[i], USD: preUSD[i]})
+	}
+	for h := 0; h < 24; h++ {
+		out.HourBins = append(out.HourBins, Band{
+			Label: fmt.Sprintf("%02d", h), N: hourN[h], USD: hourUSD[h]})
+	}
+	out.GapP10, out.GapP50, out.GapP90 = pctlF(gaps, 0.10), pctlF(gaps, 0.50), pctlF(gaps, 0.90)
+	out.PrefixP10 = int64(pctlF(prefixes, 0.10))
+	out.PrefixP50 = int64(pctlF(prefixes, 0.50))
+	out.PrefixP90 = int64(pctlF(prefixes, 0.90))
+
+	// The phantoms, named rather than silently dropped: a reader comparing this panel with the
+	// cache-miss breakdown on Usage will see two different `ttl_expiry` counts, and the
+	// difference has to be explicable.
+	if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+`
+		AND r.cache_miss_reason = 'ttl_expiry' AND r.cache_write = 0`, args...).Scan(
+		&out.Phantom); err != nil {
+		return nil, err
+	}
+
+	// 3d: gaps BETWEEN expiries, per account.
+	rows, err = d.sql.Query(aCond+`, e AS (
+		SELECT tenant_id, (ts - LAG(ts) OVER (PARTITION BY tenant_id ORDER BY ts)) / 3600000.0 AS h
+		FROM addressable)
+		SELECT tenant_id, COUNT(h), AVG(h), MAX(h) FROM e WHERE h IS NOT NULL GROUP BY 1
+		ORDER BY 2 DESC`, aArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var g AccountGaps
+		var n int64
+		var mean, max sql.NullFloat64
+		if err := rows.Scan(&g.Tenant, &n, &mean, &max); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		g.N, g.MeanHrs, g.MaxHrs, g.Coverage = n, mean.Float64, max.Float64, n > 0
+		out.Gaps = append(out.Gaps, g)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// The median per account, in a second pass. Exact rather than interpolated, for the reason
+	// DB.percentile is: sorting a few hundred floats is free and an estimate here would be a
+	// number nobody can reproduce.
+	for i := range out.Gaps {
+		g := &out.Gaps[i]
+		var hs []float64
+		r2, err := d.sql.Query(aCond+`, e AS (
+			SELECT tenant_id, (ts - LAG(ts) OVER (PARTITION BY tenant_id ORDER BY ts)) / 3600000.0 AS h
+			FROM addressable)
+			SELECT h FROM e WHERE h IS NOT NULL AND tenant_id = ?`,
+			append(append([]any(nil), aArgs...), g.Tenant)...)
+		if err != nil {
+			return nil, err
+		}
+		for r2.Next() {
+			var h float64
+			if err := r2.Scan(&h); err != nil {
+				r2.Close()
+				return nil, err
+			}
+			hs = append(hs, h)
+		}
+		r2.Close()
+		if err := r2.Err(); err != nil {
+			return nil, err
+		}
+		g.MedHrs = pctlF(hs, 0.50)
+	}
+
+	cov, err := d.keepAliveCoverage(f)
+	if err != nil {
+		return nil, err
+	}
+	out.KeepAliveCoverage = *cov
+	return out, nil
+}
+
+// keepAliveCoverage answers "is a zero here a measurement or an absence?" for one window.
+func (d *DB) keepAliveCoverage(f Filter) (*KeepAliveCoverage, error) {
+	var c KeepAliveCoverage
+	cond, args := f.where()
+	kaCond, kaArgs := withKeepAlive(f).where()
+	var from sql.NullInt64
+	if err := d.sql.QueryRow(`SELECT MIN(CASE WHEN r.keepalive = 1 OR r.keepalive_pings > 0
+		OR r.keepalive_saved_usd > 0 THEN r.ts END) FROM requests r WHERE `+kaCond,
+		kaArgs...).Scan(&from); err != nil {
+		return nil, err
+	}
+	c.RecordedFrom = from.Int64
+	if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond, args...).Scan(
+		&c.Requests); err != nil {
+		return nil, err
+	}
+	if c.RecordedFrom > 0 {
+		if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+` AND r.ts >= ?`,
+			append(append([]any(nil), args...), c.RecordedFrom)...).Scan(&c.RecordedRows); err != nil {
+			return nil, err
+		}
+	}
+	return &c, nil
+}
+
+// pctlF is an exact percentile over an in-memory slice, nearest-rank. Sorts a copy.
+func pctlF(xs []float64, p float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	i := int(float64(len(s)-1) * p)
+	return s[i]
+}
+
+// KeepAliveSessionRow is one row of panel 3f / panel 5: a session, what its expiries cost, and
+// whether an override is armed on it.
+type KeepAliveSessionRow struct {
+	SessionID string `json:"session_id"`
+	TenantID  string `json:"tenant_id"`
+	Turns     int64  `json:"turns"`
+	Last      int64  `json:"last"`
+	Model     string `json:"model"`
+	// LastPrefix is the last billed prefix (cache_read + cache_write) on this session — the
+	// number the calculator prefills from, because per-ping cost is bimodal and a service-wide
+	// average would answer a question nobody asked.
+	LastPrefix int64   `json:"last_prefix"`
+	Expiries   int64   `json:"expiries"`
+	ExpiryUSD  float64 `json:"expiry_usd"`
+	Pings      int64   `json:"pings"`
+	PingUSD    float64 `json:"ping_usd"`
+	SavedUSD   float64 `json:"saved_usd"`
+	NetUSD     float64 `json:"net_usd"`
+}
+
+// KeepAliveSessions lists the sessions this window's addressable expiries are concentrated in,
+// costliest first, with each one's own keep-alive ledger.
+//
+// The concentration is real and it does NOT transfer forward: the top 8 sessions hold $431 of
+// $734.75, and a list fitted on one half of the week earned $5.27 in the next half where the
+// plain account-wide rule earned $53.32. The panel says that above the table.
+func (d *DB) KeepAliveSessions(f Filter, limit int) ([]*KeepAliveSessionRow, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 20
+	}
+	aCond, aArgs := addressable(f)
+	rows, err := d.sql.Query(aCond+`
+		SELECT session_id, MIN(tenant_id), COUNT(*), COALESCE(SUM(cost_usd),0)
+		FROM addressable WHERE session_id <> ''
+		GROUP BY session_id ORDER BY 4 DESC LIMIT ?`,
+		append(append([]any(nil), aArgs...), limit)...)
+	if err != nil {
+		return nil, err
+	}
+	out := []*KeepAliveSessionRow{}
+	byID := map[string]*KeepAliveSessionRow{}
+	for rows.Next() {
+		var s KeepAliveSessionRow
+		if err := rows.Scan(&s.SessionID, &s.TenantID, &s.Expiries, &s.ExpiryUSD); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		out = append(out, &s)
+		byID[s.SessionID] = &s
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return out, nil
+	}
+	// Turns, the last request and the last billed prefix — from AGENT rows, so a ping does not
+	// count as a turn or re-date the session.
+	cond, args := f.where()
+	for _, s := range out {
+		if err := d.sql.QueryRow(`SELECT COUNT(*), MAX(r.ts) FROM requests r
+			WHERE `+cond+` AND r.session_id = ?`,
+			append(append([]any(nil), args...), s.SessionID)...).Scan(&s.Turns, &s.Last); err != nil {
+			return nil, err
+		}
+		var prefix sql.NullInt64
+		var model sql.NullString
+		if err := d.sql.QueryRow(`SELECT r.cache_read + r.cache_write, r.model FROM requests r
+			WHERE `+cond+` AND r.session_id = ? ORDER BY r.ts DESC, r.id DESC LIMIT 1`,
+			append(append([]any(nil), args...), s.SessionID)...).Scan(&prefix, &model); err != nil &&
+			err != sql.ErrNoRows {
+			return nil, err
+		}
+		s.LastPrefix, s.Model = prefix.Int64, model.String
+	}
+	// The keep-alive halves, each from its own query. Same two-query pattern as the overview.
+	saved, err := d.sumBySession(cond, args, "r.keepalive_saved_usd", "r.keepalive_saved_usd > 0")
+	if err != nil {
+		return nil, err
+	}
+	kaCond, kaArgs := withKeepAlive(f).where()
+	spent, err := d.sumBySession(kaCond, kaArgs, "r.cost_usd", "r.keepalive = 1")
+	if err != nil {
+		return nil, err
+	}
+	pings, err := d.countBySession(kaCond, kaArgs, "r.keepalive = 1")
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range out {
+		s.SavedUSD, s.PingUSD, s.Pings = saved[s.SessionID], spent[s.SessionID], pings[s.SessionID]
+		s.NetUSD = s.SavedUSD - s.PingUSD
+	}
+	return out, nil
+}
+
+// countBySession counts rows per session under an extra predicate.
+func (d *DB) countBySession(cond string, args []any, extra string) (map[string]int64, error) {
+	rows, err := d.sql.Query(`SELECT r.session_id, COUNT(*) FROM requests r
+		WHERE `+cond+` AND `+extra+` AND r.session_id <> '' GROUP BY 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]int64{}
+	for rows.Next() {
+		var s string
+		var n int64
+		if err := rows.Scan(&s, &n); err != nil {
+			return nil, err
+		}
+		out[s] = n
+	}
+	return out, rows.Err()
+}
+
+// CoverageSeconds is the window one idle span's pings keep a cache entry alive for.
+//
+// K*X + TTL, and the trailing TTL is LOAD-BEARING: the last ping is itself a cache READ, and a
+// read refreshes the entry for the provider's full lifetime. Writing K*X instead is the single
+// error that made an earlier analysis of this mechanism wrong by a factor of 4.4, so
+// TestCoverageIncludesTheFinalPingsTTL exists to fail if anyone reintroduces it.
+func CoverageSeconds(idleSeconds float64, maxPings int) float64 {
+	if idleSeconds <= 0 || maxPings <= 0 {
+		return 0
+	}
+	return float64(maxPings)*idleSeconds + ttlTTL.Seconds()
+}
+
+// PingsPerSpan is how many pings one idle span of `gap` seconds attracts under (X, K).
+//
+// The first ping fires at X, each subsequent one X after the last, and K caps the count. A gap
+// no wider than X attracts none.
+func PingsPerSpan(gap, idleSeconds float64, maxPings int) int {
+	if gap <= idleSeconds || idleSeconds <= 0 || maxPings <= 0 {
+		return 0
+	}
+	n := int(math.Floor((gap-idleSeconds)/idleSeconds)) + 1
+	if n > maxPings {
+		n = maxPings
+	}
+	return n
+}
+
+// CalcRow is one rung of the K ladder.
+type CalcRow struct {
+	MaxPings int     `json:"max_pings"`
+	Coverage float64 `json:"coverage_seconds"`
+	// Convertible is the account's OWN addressable expiries whose idle gap falls inside
+	// coverage — a replay of its history, not a forecast, which the panel states in words.
+	Convertible    int64   `json:"convertible_misses"`
+	ConvertibleUSD float64 `json:"convertible_usd"`
+	SharePct       float64 `json:"share_of_addressable_pct"`
+	Pings          int64   `json:"pings"`
+	PingUSD        float64 `json:"ping_usd"`
+	SavedUSD       float64 `json:"saved_usd"`
+	NetUSD         float64 `json:"net_usd"`
+	Current        bool    `json:"current,omitempty"`
+}
+
+// KeepAliveCalc is the calculator's whole answer.
+type KeepAliveCalc struct {
+	IdleSeconds float64 `json:"idle_seconds"`
+	Prefix      int64   `json:"prefix_tokens"`
+	Model       string  `json:"model"`
+	// Priced false means the model has no rate on the operator's list. Then EVERY dollar field
+	// is omitted and the panel says "not priced". It does NOT fall back to a blended average:
+	// that is the defect class this project has hit five times.
+	Priced bool `json:"priced"`
+	// PingUSDEach is the cost of one ping on this prefix: prefix at the cache-READ rate plus
+	// the single output token. AvoidedUSDEach is what one converted miss is worth: the
+	// avoidable WRITE PREMIUM, (cache_write - cache_read) x prefix — not the whole miss.
+	PingUSDEach    float64   `json:"ping_usd_each,omitempty"`
+	AvoidedUSDEach float64   `json:"avoided_usd_each,omitempty"`
+	Addressable    int64     `json:"addressable_misses"`
+	AddressableUSD float64   `json:"addressable_usd"`
+	Rows           []CalcRow `json:"rows"`
+	// PrefixSource says where the prefill came from, so nobody reads a number as measured when
+	// it was typed: "session", "account_median" or "given".
+	PrefixSource string `json:"prefix_source,omitempty"`
+	KeepAliveCoverage
+}
+
+// KeepAliveCalc replays the account's own gaps against the K ladder at one idle interval.
+//
+// Everything is priced from the ROW'S OWN MODEL rates, per the operator's price list. The one
+// number that is not the account's own is the prefix, which the caller supplies — because
+// per-ping cost is bimodal (p50 $0.0004, p99 $0.2275) and there is no honest average of it.
+func (d *DB) KeepAliveCalc(f Filter, idleSeconds float64, prefix int64, model string,
+	price func(string) (modelinfo.Price, bool), currentPings int) (*KeepAliveCalc, error) {
+	if idleSeconds <= 0 {
+		idleSeconds = 280
+	}
+	out := &KeepAliveCalc{IdleSeconds: idleSeconds, Prefix: prefix, Model: model, Rows: []CalcRow{}}
+	var p modelinfo.Price
+	if price != nil && model != "" {
+		if pr, ok := price(model); ok && !pr.Zero() {
+			p, out.Priced = pr, true
+		}
+	}
+	// The account's own spans and its own addressable gaps, one read each.
+	aCond, aArgs := addressable(f)
+	var gaps []float64
+	var usd []float64
+	rows, err := d.sql.Query(aCond+` SELECT gap_s, cost_usd FROM addressable`, aArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var g, u float64
+		if err := rows.Scan(&g, &u); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		gaps = append(gaps, g)
+		usd = append(usd, u)
+		out.Addressable++
+		out.AddressableUSD += u
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// EVERY idle span, not only the ones that expired: the ping cost is paid on all of them,
+	// and counting only the spans that paid off is how a calculator flatters its own feature.
+	var spans []float64
+	cond, args := f.where()
+	rows, err = d.sql.Query(`WITH s AS (
+		SELECT (r.ts - LAG(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts))
+		         / 1000.0 AS gap_s
+		FROM requests r WHERE `+cond+`)
+		SELECT gap_s FROM s WHERE gap_s IS NOT NULL AND gap_s > 0`, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var g float64
+		if err := rows.Scan(&g); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		spans = append(spans, g)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if out.Priced {
+		out.PingUSDEach = float64(prefix)*p.CacheRead + p.Output
+		out.AvoidedUSDEach = float64(prefix) * (p.CacheWrite - p.CacheRead)
+	}
+	for k := 1; k <= 4; k++ {
+		row := CalcRow{MaxPings: k, Coverage: CoverageSeconds(idleSeconds, k),
+			Current: k == currentPings}
+		for i, g := range gaps {
+			if g > idleSeconds && g <= row.Coverage {
+				row.Convertible++
+				row.ConvertibleUSD += usd[i]
+			}
+		}
+		if out.AddressableUSD > 0 {
+			row.SharePct = 100 * row.ConvertibleUSD / out.AddressableUSD
+		}
+		for _, g := range spans {
+			row.Pings += int64(PingsPerSpan(g, idleSeconds, k))
+		}
+		if out.Priced {
+			row.PingUSD = float64(row.Pings) * out.PingUSDEach
+			row.SavedUSD = float64(row.Convertible) * out.AvoidedUSDEach
+			row.NetUSD = row.SavedUSD - row.PingUSD
+		}
+		out.Rows = append(out.Rows, row)
+	}
+	cov, err := d.keepAliveCoverage(f)
+	if err != nil {
+		return nil, err
+	}
+	out.KeepAliveCoverage = *cov
+	return out, nil
+}
+
+// AccountMedianPrefix is the account's own median billed prefix at a lapsed entry, which is what
+// the calculator prefills when no session is selected. 0 when it has no addressable expiry.
+func (d *DB) AccountMedianPrefix(f Filter) (int64, error) {
+	aCond, aArgs := addressable(f)
+	rows, err := d.sql.Query(aCond+` SELECT COALESCE(prev_prefix,0) FROM addressable`, aArgs...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var xs []float64
+	for rows.Next() {
+		var v float64
+		if err := rows.Scan(&v); err != nil {
+			return 0, err
+		}
+		xs = append(xs, v)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return int64(pctlF(xs, 0.50)), nil
+}
+
+// LastBilledPrefix is one session's most recent billed prefix and model, from AGENT rows only.
+// The number a person is shown before authorizing an override on that session.
+func (d *DB) LastBilledPrefix(f Filter, session string) (int64, string, error) {
+	cond, args := f.where()
+	var prefix sql.NullInt64
+	var model sql.NullString
+	err := d.sql.QueryRow(`SELECT r.cache_read + r.cache_write, r.model FROM requests r
+		WHERE `+cond+` AND r.session_id = ? ORDER BY r.ts DESC, r.id DESC LIMIT 1`,
+		append(append([]any(nil), args...), session)...).Scan(&prefix, &model)
+	if err == sql.ErrNoRows {
+		return 0, "", nil
+	}
+	return prefix.Int64, model.String, err
+}
+
+// The recommendation's admission rule. All three must hold, and condition 3 does the work.
+const (
+	// recMinMisses is the addressable-expiry floor. Below it a bootstrap over sessions has
+	// nothing to resample and its interval is an artefact.
+	recMinMisses = 20
+	// recMinRequests is the traffic floor.
+	recMinRequests = 200
+	// recBootstrapDraws and recBootstrapAlpha are the interval: 2,000 resamples over SESSIONS
+	// (not over requests — the unit of correlation is the session), 90% two-sided.
+	recBootstrapDraws = 2000
+	recBootstrapAlpha = 0.05
+	// recRecoverableShare is the documented share of an addressable miss's billed cost that is
+	// the avoidable WRITE PREMIUM. Measured at 78.4% on the production corpus. Used only here,
+	// where a per-row model rate is not available for every row of a resample.
+	recRecoverableShare = 0.784
+)
+
+// KeepAliveRecommendation is either a recommendation with its interval and its n, or a refusal
+// with the count that caused it. Never both, and there is no point estimate on the wire AT ALL.
+//
+// The missing field is deliberate and it is the whole design of this payload. Every account in
+// the production corpus has a 90% interval whose relative half-width is at least 62%, and 5 of
+// 12 cross zero — the account with 89 addressable expiries cannot pin its own figure closer
+// than [+$9, +$48]. A `point_estimate` field would be rendered as a number by somebody, some
+// day, so it does not exist.
+type KeepAliveRecommendation struct {
+	// Refused is the reason, when there is one. Its presence is the branch.
+	Refused string `json:"refused,omitempty"`
+	// IdleSeconds and MaxPings are the recommendation. K = 1 is NEVER returned: one ping
+	// reaches about 4.7 minutes, inside the free TTL, and it is -$71 service-wide.
+	IdleSeconds int `json:"idle_seconds,omitempty"`
+	MaxPings    int `json:"max_pings,omitempty"`
+	// LoUSD/HiUSD is the 90% interval over a window like this one. A RANGE, always, and the UI
+	// renders it as "$lo – $hi" and never as a hero figure.
+	LoUSD float64 `json:"lo_usd,omitempty"`
+	HiUSD float64 `json:"hi_usd,omitempty"`
+	// N is the addressable expiries the interval rests on and Sessions how many sessions they
+	// came from. Shown beside the range, because a range without its n is not honest either.
+	N        int64 `json:"n"`
+	Sessions int64 `json:"sessions"`
+	Requests int64 `json:"requests"`
+	// AltMaxPings is offered only where the account's own convertible count rises by more than
+	// its bootstrap's own noise between K=2 and K=3. On the production corpus that is nobody,
+	// and the panel says K=2 and K=3 are a measured tie.
+	AltMaxPings int `json:"alt_max_pings,omitempty"`
+	// ServiceLoUSD/ServiceHiUSD is the service-wide interval, for scale in a refusal.
+	ServiceLoUSD float64 `json:"service_lo_usd,omitempty"`
+	ServiceHiUSD float64 `json:"service_hi_usd,omitempty"`
+	KeepAliveCoverage
+}
+
+// The shipped policy, which is also what is recommended when the rule admits an account.
+const (
+	recIdleSeconds = 280
+	recMaxPings    = 2
+)
+
+// The service-wide interval, for scale inside a refusal. Measured by the adjudicated bootstrap
+// over 357 addressable misses across the 4.47-day production window; quoted, not recomputed,
+// because it is a property of that measurement and not of the caller's filter.
+const (
+	serviceLoUSD = 95.0
+	serviceHiUSD = 237.0
+)
+
+// KeepAliveRecommend answers "what should I set?" — or refuses.
+func (d *DB) KeepAliveRecommend(f Filter) (*KeepAliveRecommendation, error) {
+	out := &KeepAliveRecommendation{ServiceLoUSD: serviceLoUSD, ServiceHiUSD: serviceHiUSD}
+	cov, err := d.keepAliveCoverage(f)
+	if err != nil {
+		return nil, err
+	}
+	out.KeepAliveCoverage = *cov
+	out.Requests = cov.Requests
+
+	// The account's own addressable expiries, grouped by session — the resampling unit.
+	aCond, aArgs := addressable(f)
+	rows, err := d.sql.Query(aCond+`
+		SELECT session_id, gap_s, cost_usd FROM addressable`, aArgs...)
+	if err != nil {
+		return nil, err
+	}
+	type miss struct {
+		gap, usd float64
+	}
+	bySession := map[string][]miss{}
+	for rows.Next() {
+		var s string
+		var m miss
+		if err := rows.Scan(&s, &m.gap, &m.usd); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		bySession[s] = append(bySession[s], m)
+		out.N++
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out.Sessions = int64(len(bySession))
+
+	if out.N < recMinMisses {
+		out.Refused = fmt.Sprintf("you have %d cache expiries large enough to act on in this "+
+			"window; below %d we cannot tell a real saving from noise", out.N, recMinMisses)
+		return out, nil
+	}
+	if out.Requests < recMinRequests {
+		out.Refused = fmt.Sprintf("this window holds %d of your requests; below %d there is not "+
+			"enough history for an interval to mean anything", out.Requests, recMinRequests)
+		return out, nil
+	}
+
+	// The per-session ping cost of the SAME policy, so the resample scores a net and not a
+	// saving. Ping cost is derived from the account's own median back-derived input rate,
+	// applied to the prefix that lapsed — the same simplification the adjudicated per-account
+	// bootstrap used, and it measures the SPREAD rather than competing with the shipped
+	// replay's own figure.
+	pingUSD, err := d.medianPingUSD(f)
+	if err != nil {
+		return nil, err
+	}
+	spans, err := d.spansBySession(f)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(bySession))
+	for s := range bySession {
+		keys = append(keys, s)
+	}
+	sort.Strings(keys) // deterministic draw order for a given seed
+	net := func(s string, k int) float64 {
+		cover := CoverageSeconds(recIdleSeconds, k)
+		var v float64
+		for _, m := range bySession[s] {
+			if m.gap > recIdleSeconds && m.gap <= cover {
+				v += m.usd * recRecoverableShare
+			}
+		}
+		for _, g := range spans[s] {
+			v -= float64(PingsPerSpan(g, recIdleSeconds, k)) * pingUSD
+		}
+		return v
+	}
+	lo, hi := bootstrapCI(keys, func(s string) float64 { return net(s, recMaxPings) })
+	if lo <= 0 && hi >= 0 {
+		out.Refused = fmt.Sprintf("your own history cannot tell this apart from zero: over %d "+
+			"cache expiries in %d sessions the 90%% interval is $%.2f to $%.2f, which includes "+
+			"no change at all", out.N, out.Sessions, lo, hi)
+		return out, nil
+	}
+	out.IdleSeconds, out.MaxPings = recIdleSeconds, recMaxPings
+	out.LoUSD, out.HiUSD = lo, hi
+	// K=3 is offered only where it beats K=2 by more than this account's OWN noise — its
+	// interval has to clear K=2's entirely. Anything weaker than that is the comparison this
+	// project has got wrong five times: two numbers whose intervals overlap are a tie, and on
+	// the production corpus K=2 and K=3 ARE a tie for every account. The panel says so.
+	if lo3, _ := bootstrapCI(keys, func(s string) float64 { return net(s, 3) }); lo3 > hi {
+		out.AltMaxPings = 3
+	}
+	return out, nil
+}
+
+// bootstrapCI resamples the units WITH REPLACEMENT and returns the 90% interval of the total.
+//
+// The unit is the SESSION, not the request: expiries inside one session are not independent
+// draws — they share a prefix, a working pattern and an agent — so resampling requests would
+// report an interval several times too narrow. That is the specific error this project has been
+// bitten by five times, at a smaller scale each time.
+//
+// Deterministic: a fixed seed, so the same window gives the same interval twice. An interval
+// that moves when the page is refreshed is one nobody can act on.
+func bootstrapCI(units []string, value func(string) float64) (lo, hi float64) {
+	n := len(units)
+	if n == 0 {
+		return 0, 0
+	}
+	vals := make([]float64, n)
+	for i, u := range units {
+		vals[i] = value(u)
+	}
+	rng := rand.New(rand.NewSource(1))
+	totals := make([]float64, recBootstrapDraws)
+	for d := 0; d < recBootstrapDraws; d++ {
+		var sum float64
+		for i := 0; i < n; i++ {
+			sum += vals[rng.Intn(n)]
+		}
+		totals[d] = sum
+	}
+	sort.Float64s(totals)
+	at := func(p float64) float64 {
+		i := int(float64(len(totals)-1) * p)
+		return totals[i]
+	}
+	return at(recBootstrapAlpha), at(1 - recBootstrapAlpha)
+}
+
+// medianPingUSD is the account's own median cost of one ping on the prefix that lapses,
+// back-derived from what its requests actually paid. Used only by the bootstrap, which needs a
+// per-session cost and cannot carry a per-row model rate through a resample.
+func (d *DB) medianPingUSD(f Filter) (float64, error) {
+	aCond, aArgs := addressable(f)
+	// cost_usd on an addressable miss is dominated by the re-creation of prev_prefix at 1.25x
+	// base input, so cost/prefix/1.25 recovers the base rate and 0.1x of it is the read.
+	rows, err := d.sql.Query(aCond+`
+		SELECT cost_usd, COALESCE(prev_prefix,0) FROM addressable WHERE prev_prefix > 0`, aArgs...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var xs []float64
+	for rows.Next() {
+		var usd, prefix float64
+		if err := rows.Scan(&usd, &prefix); err != nil {
+			return 0, err
+		}
+		if prefix > 0 && usd > 0 {
+			xs = append(xs, usd/1.25*0.1)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return pctlF(xs, 0.50), nil
+}
+
+// spansBySession is every idle span per session, for the ping-cost half of a replay.
+func (d *DB) spansBySession(f Filter) (map[string][]float64, error) {
+	cond, args := f.where()
+	rows, err := d.sql.Query(`WITH s AS (
+		SELECT r.session_id,
+		       (r.ts - LAG(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts))
+		         / 1000.0 AS gap_s
+		FROM requests r WHERE `+cond+`)
+		SELECT session_id, gap_s FROM s WHERE gap_s IS NOT NULL AND gap_s > 0`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string][]float64{}
+	for rows.Next() {
+		var s string
+		var g float64
+		if err := rows.Scan(&s, &g); err != nil {
+			return nil, err
+		}
+		out[s] = append(out[s], g)
+	}
+	return out, rows.Err()
+}

--- a/dash/keepaliveapi.go
+++ b/dash/keepaliveapi.go
@@ -1,0 +1,141 @@
+package dash
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// The keep-alive tab's five read routes.
+//
+// All in API.routes(), which is the table Mount walks AND the table both scoping tests walk —
+// TestEveryMountedRouteDeclaresItsScope and TestNoRouteServesContentTextFromAnUntrustedAddress.
+// A route mounted beside that table would be a route whose scope nothing checks, which is
+// exactly how three unauthenticated routes and then /api/prompt shipped.
+//
+// Every one of them is scopeTenant, and every one returns NUMBERS AND ENUM LABELS ONLY: no
+// prompt text, no transcript, no tool schema. That is why no CIDR gate is needed and why the
+// content-gate test passes on them by construction. Session IDS are returned — they are the
+// caller's own, the same as /api/sessions — but no content behind them. If any field here ever
+// grows text, it must apply a.trusted(r) exactly as a.prompt does.
+func (a *API) keepAliveRoutes() []route {
+	return []route{
+		{"GET /api/keepalive", scopeTenant, a.keepAlive},
+		{"GET /api/keepalive/behaviour", scopeTenant, a.keepAliveBehaviour},
+		{"GET /api/keepalive/sessions", scopeTenant, a.keepAliveSessions},
+		{"GET /api/keepalive/calc", scopeTenant, a.keepAliveCalc},
+		{"GET /api/keepalive/recommend", scopeTenant, a.keepAliveRecommend},
+	}
+}
+
+// keepAlive serves the ledger: panels 1 and 2, the verdict and the losing majority.
+func (a *API) keepAlive(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	led, err := a.rec.DB().KeepAliveLedger(f)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, led)
+}
+
+// keepAliveBehaviour serves panels 3a–3e.
+func (a *API) keepAliveBehaviour(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	// The coverage the gap bands are marked against, from the caller's own current policy where
+	// the page knows it. Defaulted in the DB layer, never guessed here.
+	x, _ := strconv.ParseFloat(r.URL.Query().Get("x"), 64)
+	k, _ := strconv.Atoi(r.URL.Query().Get("k"))
+	b, err := a.rec.DB().KeepAliveBehaviour(f, CoverageSeconds(x, k))
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, b)
+}
+
+// keepAliveSessions serves the per-session concentration, costliest first.
+func (a *API) keepAliveSessions(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	rows, err := a.rec.DB().KeepAliveSessions(f, limit)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{"sessions": rows})
+}
+
+// keepAliveCalc serves the K ladder at one idle interval and one prefix.
+//
+// The prefix is REQUIRED to be a real one, and the fallback chain is explicit: the session's own
+// last billed prefix, then the account's own median, then nothing — in which case the panel asks
+// for one rather than inventing a service-wide average. Per-ping cost is bimodal (p50 $0.0004,
+// p99 $0.2275), so an average of it would be a number that describes no request.
+func (a *API) keepAliveCalc(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	q := r.URL.Query()
+	x, _ := strconv.ParseFloat(q.Get("x"), 64)
+	k, _ := strconv.Atoi(q.Get("k"))
+	prefix, _ := strconv.ParseInt(q.Get("prefix"), 10, 64)
+	model, source := q.Get("model"), "given"
+	db := a.rec.DB()
+	if session := q.Get("session"); session != "" {
+		p, m, err := db.LastBilledPrefix(f, session)
+		if err != nil {
+			httpErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if p > 0 {
+			prefix, source = p, "session"
+			if model == "" {
+				model = m
+			}
+		}
+	}
+	if prefix <= 0 {
+		p, err := db.AccountMedianPrefix(f)
+		if err != nil {
+			httpErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		prefix, source = p, "account_median"
+	}
+	out, err := db.KeepAliveCalc(f, x, prefix, model, a.priceFn(r), k)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	out.PrefixSource = source
+	writeJSON(w, out)
+}
+
+// keepAliveRecommend serves either a recommendation with its range and its n, or a refusal.
+func (a *API) keepAliveRecommend(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	rec, err := a.rec.DB().KeepAliveRecommend(f)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, rec)
+}

--- a/dash/keepaliveapi.go
+++ b/dash/keepaliveapi.go
@@ -109,12 +109,18 @@ func (a *API) keepAliveCalc(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if prefix <= 0 {
-		p, err := db.AccountMedianPrefix(f)
+		p, m, err := db.AccountMedianPrefix(f)
 		if err != nil {
 			httpErr(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		prefix, source = p, "account_median"
+		// The account's own most-used model on those expiries, not a blend and not a default:
+		// without it the panel reported "not priced" on a deployment whose price list was fine,
+		// simply because nothing had named a model. Still refuses to invent a rate.
+		if model == "" {
+			model = m
+		}
 	}
 	out, err := db.KeepAliveCalc(f, x, prefix, model, a.priceFn(r), k)
 	if err != nil {

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -1,0 +1,654 @@
+package dash
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// The keep-alive tab's arithmetic and its attribution, and the tests are mostly about the
+// second: the delicate part of this feature is not the panels, it is that a ping must appear in
+// the money and nowhere else.
+
+// kaFixture builds a database with agent traffic, ping rows and addressable TTL expiries.
+//
+// Ping rows carry KeepAlive and a cost; the credit lives on the AGENT row that benefited, which
+// is where the write path puts it. Both halves are needed for the attribution tests to be able
+// to fail.
+type kaFixture struct {
+	db *DB
+}
+
+// kaAgent is one agent request.
+func kaAgent(ts int64, session string, cost float64) *Event {
+	e := mkEvent(ts, session, "aws/claude-sonnet-5", 100, 90)
+	e.CostUSD, e.CacheRead, e.CacheWrite, e.UpstreamMs = cost, 50_000, 0, 800
+	return e
+}
+
+// kaExpiry is an agent request that resumed after `gapS` of idle and paid to re-create its
+// prefix. cache_write > 0 makes it ADDRESSABLE — the 385 phantom ttl_expiry rows in production
+// have cache_write = 0 and are all HTTP 400.
+func kaExpiry(ts int64, session string, gapS float64, cost float64, prevPrefix int64) []*Event {
+	prev := kaAgent(ts-int64(gapS*1000), session, 0.05)
+	prev.CacheRead, prev.CacheWrite = prevPrefix, 0
+	miss := kaAgent(ts, session, cost)
+	miss.CacheMissReason = "ttl_expiry"
+	miss.CacheRead, miss.CacheWrite = 0, prevPrefix
+	return []*Event{prev, miss}
+}
+
+// kaPing is one keep-alive ping row: a real upstream request, billed, marked.
+func kaPing(ts int64, session string, cost float64, read, write int64) *Event {
+	return &Event{
+		TS: ts, SessionID: session, Model: "aws/claude-sonnet-5", Provider: "anthropic",
+		Agent: "claude-code", Preset: "codesmart", Mode: ModeActive, Status: 200,
+		KeepAlive: true, CacheRead: read, CacheWrite: write, OutputTokens: 1,
+		CostUSD: cost, Meta: Meta{MaxTokens: 1}, UpstreamMs: 4000,
+		TokenAccounting: AccountingComplete,
+	}
+}
+
+// kaCredit is an agent row carrying a keep-alive credit — the rescued request.
+func kaCredit(ts int64, session string, saved float64) *Event {
+	e := kaAgent(ts, session, 0.02)
+	e.KeepAliveSavedUSD = saved
+	return e
+}
+
+func newKAFixture(t *testing.T, evs ...*Event) *kaFixture {
+	t.Helper()
+	db := openTestDB(t)
+	if len(evs) > 0 {
+		if err := db.insertBatch(evs); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &kaFixture{db: db}
+}
+
+// Ping rows must not reach ANY agent aggregate. One fixture, run twice — with the ping rows and
+// without them — and every count, every sum over tokens, every average, every countBy map, every
+// breakdown dimension and the whole series must be IDENTICAL. Only TotalSavedUSD may move, and
+// only by exactly KeepAliveNetUSD.
+//
+// Asserted by construction rather than field by field: the two Overviews are marshalled and
+// compared key by key, so a field ADDED later is covered without anyone remembering to add it
+// here. That is the difference between this test and the per-aggregate ones that let /api/prompt
+// and three unauthenticated routes ship.
+func TestPingRowsStayOutOfAgentAggregates(t *testing.T) {
+	agent := []*Event{
+		kaAgent(1_000_000, "s1", 0.10), kaAgent(1_100_000, "s1", 0.20),
+		kaAgent(1_200_000, "s2", 0.30), kaCredit(1_300_000, "s1", 0.40),
+	}
+	pings := []*Event{
+		kaPing(1_050_000, "s1", 0.01, 50_000, 0), kaPing(1_150_000, "s1", 0.02, 50_000, 0),
+		kaPing(1_250_000, "s2", 0.03, 0, 0),
+	}
+	without := newKAFixture(t, agent...)
+	with := newKAFixture(t, append(append([]*Event(nil), agent...), pings...)...)
+	f := Filter{TenantAll: true}
+
+	a, err := without.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := with.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The keep-alive fields and the two totals they feed are the ONLY keys allowed to differ.
+	mayMove := map[string]bool{
+		"keepalive_pings": true, "keepalive_ping_usd": true, "keepalive_net_usd": true,
+		"total_saved_usd": true,
+		// The waterfall carries the ping SPEND as a step of its own, which is the whole point of
+		// having it; its reconciliation is TestTheWaterfallReconcilesWithTotalSaved.
+		"waterfall": true,
+	}
+	for k, va := range asMap(t, a) {
+		vb := asMap(t, b)[k]
+		if mayMove[k] {
+			continue
+		}
+		if !jsonEqual(va, vb) {
+			t.Errorf("%s moved when ping rows were present: %v -> %v — a ping is not agent "+
+				"traffic and must not reach an agent aggregate", k, va, vb)
+		}
+	}
+	if b.KeepAlivePings != 3 {
+		t.Errorf("keepalive_pings = %d, want 3", b.KeepAlivePings)
+	}
+	// The one permitted movement, and it is exact: total_saved moves by exactly the change in
+	// the keep-alive's NET, which here is the negative of what the pings cost. The credit rows
+	// are in BOTH fixtures — they are agent rows — so the saving half does not move and the
+	// whole difference is the ping spend. That is the assertion that fails on `+= SavedUSD`.
+	if got, want := b.TotalSavedUSD-a.TotalSavedUSD, b.KeepAliveNetUSD-a.KeepAliveNetUSD; math.Abs(got-want) > 1e-9 {
+		t.Errorf("total_saved moved by %.6f, want exactly the change in keepalive_net_usd %.6f",
+			got, want)
+	}
+	if got := b.TotalSavedUSD - a.TotalSavedUSD; math.Abs(got+b.KeepAlivePingUSD) > 1e-9 {
+		t.Errorf("total_saved moved by %.6f; the pings cost %.6f and nothing else changed, so the "+
+			"headline must fall by exactly that", got, b.KeepAlivePingUSD)
+	}
+	// And the derived views, which have their own queries and their own chances to be wrong.
+	for _, dim := range []string{"model", "provider", "agent", "preset", "mode", "session",
+		"accounting", "cache_miss", "stop_reason"} {
+		ga, err := without.db.Breakdown(f, dim)
+		if err != nil {
+			continue // not every dimension exists on this fixture; the ones that do must match
+		}
+		gb, err := with.db.Breakdown(f, dim)
+		if err != nil {
+			t.Fatalf("breakdown %s: %v", dim, err)
+		}
+		if !jsonEqual(ga, gb) {
+			t.Errorf("/api/breakdown?dim=%s changed when ping rows were present", dim)
+		}
+	}
+	sa, err := without.db.Series(f, 86_400_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb, err := with.db.Series(f, 86_400_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !jsonEqual(sa, sb) {
+		t.Error("/api/series changed when ping rows were present")
+	}
+}
+
+// The headline takes the keep-alive's NET and not its gross, so a window where the pings cost
+// more than they saved makes the total go DOWN.
+//
+// This is the test that would fail on the tempting version of the change (`+= SavedUSD`), and
+// the tempting version is dishonest in exactly one direction: CostUSD excludes ping rows, so the
+// spend that bought the saving appears nowhere else in the walk.
+func TestTotalSavedTakesTheKeepAliveNetNotItsGross(t *testing.T) {
+	base := newKAFixture(t, kaAgent(1_000_000, "s1", 0.10))
+	loss := newKAFixture(t,
+		kaAgent(1_000_000, "s1", 0.10),
+		kaCredit(1_100_000, "s1", 0.01),          // saved a cent
+		kaPing(1_050_000, "s1", 0.50, 50_000, 0), // to spend fifty
+	)
+	f := Filter{TenantAll: true}
+	a, err := base.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := loss.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.KeepAliveNetUSD >= 0 {
+		t.Fatalf("the fixture is not underwater: net = %.4f", b.KeepAliveNetUSD)
+	}
+	// The credit row adds its own compaction saving too, so compare against that baseline plus
+	// the net rather than against the base alone.
+	if b.TotalSavedUSD >= b.NetSavedUSD+b.CachesplitSavedUSD {
+		t.Errorf("total_saved %.4f did not fall by the keep-alive's loss (%.4f); the gross was "+
+			"used, which presents a saving without the spend that bought it",
+			b.TotalSavedUSD, b.KeepAliveNetUSD)
+	}
+	_ = a
+}
+
+// The waterfall's signed steps must sum to total_saved to the cent, keep-alive lines included.
+// A walk that does not reconcile is worse than no walk: it invites the reader to find the
+// missing money and there is none to find.
+func TestTheWaterfallReconcilesWithTotalSaved(t *testing.T) {
+	fx := newKAFixture(t,
+		kaAgent(1_000_000, "s1", 0.10), kaAgent(1_100_000, "s2", 0.20),
+		kaCredit(1_200_000, "s1", 0.40),
+		kaPing(1_050_000, "s1", 0.01, 50_000, 0), kaPing(1_150_000, "s2", 0.02, 50_000, 0),
+	)
+	o, err := fx.db.Overview(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := map[string]float64{}
+	for _, s := range o.waterfall() {
+		steps[s.Key] = s.DeltaUSD
+	}
+	// total_saved = -(baseline step) + compaction + cg_llm + cachesplit + keepalive_ping +
+	// keepalive_saved, in signed terms: the reductions are negative and the spends positive, so
+	// the sum of the non-total steps below the baseline is the negation of what was avoided.
+	sum := -(steps["compaction"] + steps["cg_llm"] + steps["cachesplit_saved"] +
+		steps["keepalive_ping"] + steps["keepalive_saved"])
+	if math.Abs(sum-steps["total_saved"]) > 0.005 {
+		t.Errorf("the walk does not reconcile: steps sum to %.4f, total_saved is %.4f",
+			sum, steps["total_saved"])
+	}
+}
+
+// A session with pings and no credits reports a NEGATIVE net, not zero. The cost half comes from
+// the ping rows, which the session aggregate cannot see — so a missing second query reads as
+// "this session's keep-alive was free", which is the opposite of the truth.
+func TestSessionRowKeepAliveCostComesFromThePingRows(t *testing.T) {
+	fx := newKAFixture(t,
+		kaAgent(1_000_000, "s1", 0.10),
+		kaPing(1_050_000, "s1", 0.07, 50_000, 0),
+	)
+	rows, _, err := fx.db.Sessions(Filter{TenantAll: true}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got *SessionRow
+	for _, r := range rows {
+		if r.SessionID == "s1" {
+			got = r
+		}
+	}
+	if got == nil {
+		t.Fatal("session s1 is missing from the list")
+	}
+	if got.Turns != 1 {
+		t.Errorf("turns = %d, want 1 — a ping is not a turn", got.Turns)
+	}
+	if got.KeepAlivePings != 1 || math.Abs(got.KeepAlivePingUSD-0.07) > 1e-9 {
+		t.Errorf("pings = %d at $%.4f, want 1 at $0.07", got.KeepAlivePings, got.KeepAlivePingUSD)
+	}
+	if got.KeepAliveNetUSD >= 0 {
+		t.Errorf("net = %.4f; a session that paid for pings and was never rescued is underwater, "+
+			"not free", got.KeepAliveNetUSD)
+	}
+}
+
+// The coverage arithmetic, and the single error that made an earlier analysis of this mechanism
+// wrong by a factor of 4.4.
+//
+// K*X + TTL, not K*X: the last ping is itself a cache READ, and a read refreshes the entry for
+// the provider's full lifetime. A K*X implementation fails every row of this table.
+func TestCoverageIncludesTheFinalPingsTTL(t *testing.T) {
+	for _, tc := range []struct {
+		x    float64
+		k    int
+		want float64
+	}{
+		{280, 2, 860}, {280, 1, 580}, {240, 2, 780}, {280, 3, 1140}, {280, 4, 1420},
+		{240, 1, 540}, {300, 2, 900},
+	} {
+		if got := CoverageSeconds(tc.x, tc.k); got != tc.want {
+			t.Errorf("CoverageSeconds(%g, %d) = %g, want %g (K*X + 300; a K*X implementation "+
+				"under-counts reach by a whole TTL)", tc.x, tc.k, got, tc.want)
+		}
+	}
+	// And the ping count per span, which is the other half of the same arithmetic.
+	for _, tc := range []struct {
+		gap, x float64
+		k      int
+		want   int
+	}{
+		{100, 280, 2, 0}, {280, 280, 2, 0}, {281, 280, 2, 1}, {559, 280, 2, 1},
+		// At exactly 2X the second ping is due at the instant the span ends. The formula
+		// min(K, floor((gap-X)/X)+1) counts it, and counting the boundary ping is the
+		// conservative direction for a COST estimate: it over-states spend, never reach.
+		{560, 280, 2, 2}, {561, 280, 2, 2}, {5000, 280, 2, 2}, {5000, 280, 4, 4},
+		{5000, 280, 1, 1},
+	} {
+		if got := PingsPerSpan(tc.gap, tc.x, tc.k); got != tc.want {
+			t.Errorf("PingsPerSpan(gap=%g, x=%g, k=%d) = %d, want %d", tc.gap, tc.x, tc.k, got, tc.want)
+		}
+	}
+}
+
+// The calculator prices from the ROW'S OWN MODEL, and refuses to produce a dollar figure for a
+// model the operator's list does not carry.
+//
+// Falling back to a blended average is the defect class this project has hit five times: a
+// number that looks like a measurement and is an average of unrelated things.
+func TestCalculatorPricesFromTheRowsModelNotABlend(t *testing.T) {
+	fx := newKAFixture(t, kaExpiry(2_000_000, "s1", 700, 1.00, 300_000)...)
+	f := Filter{TenantAll: true}
+	cheap := modelinfo.Price{Input: 1e-6, Output: 5e-6, CacheRead: 1e-7, CacheWrite: 1.25e-6}
+	dear := modelinfo.Price{Input: 1e-5, Output: 5e-5, CacheRead: 1e-6, CacheWrite: 1.25e-5}
+	price := func(m string) (modelinfo.Price, bool) {
+		switch m {
+		case "cheap":
+			return cheap, true
+		case "dear":
+			return dear, true
+		}
+		return modelinfo.Price{}, false
+	}
+	a, err := fx.db.KeepAliveCalc(f, 280, 300_000, "cheap", price, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := fx.db.KeepAliveCalc(f, 280, 300_000, "dear", price, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Priced || !b.Priced {
+		t.Fatal("a priced model reported priced=false")
+	}
+	if a.PingUSDEach == b.PingUSDEach {
+		t.Errorf("two models with different rates priced the same ping at $%.8f", a.PingUSDEach)
+	}
+	if a.PingUSDEach != 300_000*cheap.CacheRead+cheap.Output {
+		t.Errorf("ping cost = %.8f, want prefix x cache_read + one output token", a.PingUSDEach)
+	}
+	if a.AvoidedUSDEach != 300_000*(cheap.CacheWrite-cheap.CacheRead) {
+		t.Errorf("avoided = %.8f, want the WRITE PREMIUM (write - read) x prefix, not the whole "+
+			"miss", a.AvoidedUSDEach)
+	}
+	// The unpriced model: no dollar figure at all, and it says so.
+	un, err := fx.db.KeepAliveCalc(f, 280, 300_000, "nobody-prices-me", price, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if un.Priced {
+		t.Error("an unpriced model reported priced=true")
+	}
+	if un.PingUSDEach != 0 || un.AvoidedUSDEach != 0 {
+		t.Error("an unpriced model produced a dollar figure")
+	}
+	for _, row := range un.Rows {
+		if row.PingUSD != 0 || row.SavedUSD != 0 || row.NetUSD != 0 {
+			t.Errorf("an unpriced model produced a dollar figure on the K=%d row", row.MaxPings)
+		}
+		if row.Convertible < 0 {
+			t.Error("counts must still be reported when the money cannot be")
+		}
+	}
+}
+
+// The K ladder's SHAPE, which is what the panel exists to convey: reach grows sharply from K=1
+// to K=2 and then flattens, while ping cost grows roughly linearly in K.
+//
+// Built from a fixture whose gaps land in the production bands, so the ordering the production
+// table shows is reproduced rather than asserted from memory.
+func TestCalculatorGoldenAgainstTheProductionBands(t *testing.T) {
+	// Gaps chosen to sit inside successive coverages at X=280: 580 (K=1), 860 (K=2), 1140
+	// (K=3), 1420 (K=4). Two misses per band, so each rung gains and the gain shrinks.
+	var evs []*Event
+	ts := int64(10_000_000)
+	for i, gap := range []float64{400, 500, 700, 800, 1000, 1100, 1300, 1350} {
+		evs = append(evs, kaExpiry(ts+int64(i)*3_600_000, "s"+string(rune('a'+i)), gap, 1.0, 300_000)...)
+	}
+	fx := newKAFixture(t, evs...)
+	price := func(string) (modelinfo.Price, bool) { return ibmSonnet, true }
+	out, err := fx.db.KeepAliveCalc(Filter{TenantAll: true}, 280, 300_000, "aws/claude-sonnet-5", price, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Rows) != 4 {
+		t.Fatalf("the ladder has %d rungs, want K=1..4", len(out.Rows))
+	}
+	want := []int64{2, 4, 6, 8}
+	for i, row := range out.Rows {
+		if row.MaxPings != i+1 {
+			t.Fatalf("row %d is K=%d", i, row.MaxPings)
+		}
+		if row.Convertible != want[i] {
+			t.Errorf("K=%d converts %d, want %d (coverage %g s)",
+				row.MaxPings, row.Convertible, want[i], row.Coverage)
+		}
+		if row.SharePct <= 0 {
+			t.Errorf("K=%d reports no share of addressable dollars", row.MaxPings)
+		}
+	}
+	// Reach must be monotonic and its GAIN must shrink — the flattening is the finding.
+	g1 := out.Rows[1].Convertible - out.Rows[0].Convertible
+	g3 := out.Rows[3].Convertible - out.Rows[2].Convertible
+	if g3 > g1 {
+		t.Errorf("the ladder does not flatten: K1->K2 gains %d, K3->K4 gains %d", g1, g3)
+	}
+	// And the current row is marked, which is what the panel emphasises.
+	if !out.Rows[1].Current {
+		t.Error("K=2 was not marked as the current policy")
+	}
+}
+
+// A window whose rows predate the keep-alive columns must report "not recorded", never $0 saved.
+//
+// keepalive_pings and keepalive_saved_usd arrived as ADDITIVE columns with DEFAULT 0, so a zero
+// on an old row is an absence and rendering it as a measurement is a fabricated default — the
+// failure this project has hit repeatedly.
+func TestKeepAlivePanelsStateTheirCoverage(t *testing.T) {
+	// Never ran: agent traffic only, no ping and no credit anywhere.
+	never := newKAFixture(t, kaAgent(1_000_000, "s1", 0.10), kaAgent(1_100_000, "s1", 0.20))
+	led, err := never.db.KeepAliveLedger(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if led.RecordedFrom != 0 {
+		t.Errorf("recorded_from = %d on a database where it never ran", led.RecordedFrom)
+	}
+	if led.Requests != 2 {
+		t.Errorf("requests = %d, want 2", led.Requests)
+	}
+	// Partially recorded: old rows, then the mechanism starts.
+	part := newKAFixture(t,
+		kaAgent(1_000_000, "s1", 0.10), kaAgent(1_100_000, "s1", 0.20),
+		kaPing(1_500_000, "s1", 0.01, 50_000, 0), kaCredit(1_600_000, "s1", 0.40),
+	)
+	led, err = part.db.KeepAliveLedger(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if led.RecordedFrom != 1_500_000 {
+		t.Errorf("recorded_from = %d, want the first ping's instant 1500000", led.RecordedFrom)
+	}
+	if led.RecordedRows >= led.Requests {
+		t.Errorf("recorded_rows %d of requests %d: the partial state is not distinguishable",
+			led.RecordedRows, led.Requests)
+	}
+	if led.RecordedRows == 0 {
+		t.Error("recorded_rows = 0 although the mechanism has run")
+	}
+}
+
+// Thin history is REFUSED, and the refusal names the count. 19 addressable expiries is one short
+// of the floor, and the floor exists because a bootstrap over sessions has nothing to resample
+// below it.
+func TestRecommendationRefusesThinHistory(t *testing.T) {
+	fx := newKAFixture(t, kaSpread(t, 19, 700, 1.0)...)
+	rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Refused == "" {
+		t.Fatalf("n=%d was not refused", rec.N)
+	}
+	if !strings.Contains(rec.Refused, "19") {
+		t.Errorf("the refusal does not name the count: %q", rec.Refused)
+	}
+	if rec.MaxPings != 0 || rec.LoUSD != 0 || rec.HiUSD != 0 {
+		t.Error("a refusal carried a recommendation anyway")
+	}
+	// And the service-wide interval is offered for scale, which is the only number a refusal
+	// may give.
+	if rec.ServiceLoUSD != 95 || rec.ServiceHiUSD != 237 {
+		t.Errorf("the refusal did not carry the service-wide interval for scale: [%v, %v]",
+			rec.ServiceLoUSD, rec.ServiceHiUSD)
+	}
+}
+
+// An interval that crosses zero is refused even when the count test passes — the T2 case: n=29,
+// CI [-4.49, +4.79]. Condition 3 is the one that does the work.
+func TestRecommendationRefusesWhenTheIntervalCrossesZero(t *testing.T) {
+	// Enough expiries and requests to clear conditions 1 and 2, but their gaps are far outside
+	// any coverage at X=280 — so nothing converts, the pings cost money, and the interval sits
+	// on or below zero rather than excluding it above.
+	fx := newKAFixture(t, kaSpread(t, 30, 40_000, 1.0)...)
+	rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.N < recMinMisses {
+		t.Fatalf("the fixture does not clear the count test: n=%d", rec.N)
+	}
+	if rec.Refused == "" && rec.LoUSD <= 0 && rec.HiUSD >= 0 {
+		t.Errorf("an interval spanning zero [%v, %v] was returned as a recommendation",
+			rec.LoUSD, rec.HiUSD)
+	}
+}
+
+// The wire carries NO point estimate. Not a zero, not an omitted field with a name — the field
+// does not exist, because a field that exists gets rendered.
+func TestRecommendationPayloadCarriesNoPointEstimate(t *testing.T) {
+	fx := newKAFixture(t, kaSpread(t, 25, 700, 1.0)...)
+	rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"point_estimate", "expected_usd", "estimate", "net_usd"} {
+		if strings.Contains(string(b), `"`+forbidden+`"`) {
+			t.Errorf("the recommendation payload carries %q; a single confident number is exactly "+
+				"what this data cannot support:\n%s", forbidden, b)
+		}
+	}
+	// A returned recommendation is a RANGE, and it states its n.
+	if rec.Refused == "" {
+		if rec.LoUSD == rec.HiUSD {
+			t.Error("the recommendation collapsed to a point")
+		}
+		if rec.N == 0 || rec.Sessions == 0 {
+			t.Error("a range was returned without the n it rests on")
+		}
+	}
+}
+
+// K = 1 is never recommended: one ping reaches about 4.7 minutes, which is inside the free TTL,
+// and it is -$71 service-wide.
+func TestRecommendationNeverSuggestsOnePing(t *testing.T) {
+	for _, n := range []int{25, 40, 80} {
+		for _, gap := range []float64{400, 700, 1200, 5000} {
+			fx := newKAFixture(t, kaSpread(t, n, gap, 1.0)...)
+			rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rec.MaxPings == 1 || rec.AltMaxPings == 1 {
+				t.Errorf("n=%d gap=%g recommended K=1", n, gap)
+			}
+		}
+	}
+}
+
+// The behaviour panels' addressability gate. A ttl_expiry row that wrote nothing is a PHANTOM —
+// 385 of the 742 in production, every one an HTTP 400 — and counting it inflates every figure
+// on the panel.
+func TestPhantomExpiriesAreCountedApartAndNotIn(t *testing.T) {
+	real1 := kaExpiry(2_000_000, "s1", 700, 1.0, 300_000)
+	phantom := kaAgent(2_100_000, "s2", 0.0)
+	phantom.CacheMissReason, phantom.CacheRead, phantom.CacheWrite = "ttl_expiry", 0, 0
+	phantom.Status = 400
+	fx := newKAFixture(t, append(real1, kaAgent(2_050_000, "s2", 0.01), phantom)...)
+	b, err := fx.db.KeepAliveBehaviour(Filter{TenantAll: true}, 860)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Addressable != 1 {
+		t.Errorf("addressable = %d, want 1; a cache_write = 0 row has no prefix to protect",
+			b.Addressable)
+	}
+	if b.Phantom != 1 {
+		t.Errorf("phantom = %d, want 1 — the difference from the Usage tab's ttl_expiry count "+
+			"has to be explicable", b.Phantom)
+	}
+}
+
+// The gap bands preserve their edge ORDER and mark what the current coverage cannot reach. The
+// order is the meaning: sorting these by size would destroy the only thing the chart says.
+func TestGapBandsKeepTheirOrderAndMarkWhatIsBeyondCoverage(t *testing.T) {
+	fx := newKAFixture(t, kaExpiry(2_000_000, "s1", 700, 1.0, 300_000)...)
+	b, err := fx.db.KeepAliveBehaviour(Filter{TenantAll: true}, 860)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b.GapBands) != len(gapEdges) {
+		t.Fatalf("%d bands for %d edges", len(b.GapBands), len(gapEdges))
+	}
+	var sawBeyond bool
+	for i, band := range b.GapBands {
+		if want := gapEdges[i] >= 860; band.Beyond != want {
+			t.Errorf("band %q beyond = %v, want %v at coverage 860 s", band.Label, band.Beyond, want)
+		}
+		if band.Beyond {
+			sawBeyond = true
+		}
+	}
+	if !sawBeyond {
+		t.Error("no band was marked beyond the coverage rule")
+	}
+	if len(b.HourBins) != 24 {
+		t.Errorf("%d hour bins, want 24", len(b.HourBins))
+	}
+}
+
+// kaSpread builds n addressable expiries across n distinct sessions, plus enough agent traffic
+// to clear the request floor. Distinct sessions because the bootstrap resamples SESSIONS.
+func kaSpread(t *testing.T, n int, gapS, usd float64) []*Event {
+	t.Helper()
+	var evs []*Event
+	ts := int64(100_000_000)
+	// The costs VARY across sessions, deliberately. A fixture of identical units makes every
+	// bootstrap resample produce the same total, so the interval collapses to a point — which
+	// would let a degenerate interval pass a test about ranges.
+	for i := 0; i < n; i++ {
+		evs = append(evs, kaExpiry(ts+int64(i)*7_200_000, "sess-"+itoa(int64(i)), gapS,
+			usd*(0.2+1.6*float64(i%7)/6.0), 300_000)...)
+	}
+	// Filler, so `requests` clears recMinRequests without adding expiries.
+	for i := 0; i < recMinRequests; i++ {
+		evs = append(evs, kaAgent(ts+int64(i)*1000, "filler", 0.01))
+	}
+	return evs
+}
+
+// asMap marshals a value to a generic map, for key-by-key comparison.
+func asMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// jsonEqual compares two values by their JSON encoding.
+func jsonEqual(a, b any) bool {
+	x, err1 := json.Marshal(a)
+	y, err2 := json.Marshal(b)
+	return err1 == nil && err2 == nil && string(x) == string(y)
+}
+
+// The five new read routes are reachable, answer with JSON, and carry no content text. The
+// content gate is asserted over the whole table by TestNoRouteServesContentTextFromAnUntrustedAddress;
+// this checks they actually ANSWER, which a route that 500s on an empty database would not.
+func TestKeepAliveRoutesAnswerOnAnEmptyDatabase(t *testing.T) {
+	rec, err := NewRecorder(Options{DBPath: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rec.Close() })
+	api := NewAPI(rec)
+	mux := http.NewServeMux()
+	api.Mount(mux)
+	for _, rt := range api.keepAliveRoutes() {
+		path := strings.TrimPrefix(rt.pattern, "GET ")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Errorf("%s = %d: %s", path, w.Code, w.Body)
+		}
+		if !json.Valid(w.Body.Bytes()) {
+			t.Errorf("%s did not answer with JSON: %s", path, w.Body)
+		}
+	}
+}

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -163,6 +163,63 @@ func TestPingRowsStayOutOfAgentAggregates(t *testing.T) {
 	}
 }
 
+// The replay CEILING counts later AGENT turns, not later pings — and the correction is gated so
+// it costs nothing where there is nothing to correct.
+//
+// Two assertions in one test because they constrain each other. The inner count originally had NO
+// predicate at all, so a ping counted as a later turn that could replay a reduction; it cannot,
+// since a ping is a verbatim resend carrying no new transcript. But `keepalive` is not in
+// idx_requests_session, so the obvious fix (`AND p.keepalive = 0` inside the correlated count)
+// turned an index-only count into a row fetch per candidate and cost 20% of Overview's whole
+// runtime — 44% under -race, enough to blow the perf test's budget on a loaded box. The shipped
+// form corrects from the PING side and is skipped entirely when nothing has pinged.
+func TestTheReplayCeilingCountsAgentTurnsNotPings(t *testing.T) {
+	// One session, three reducing agent turns, and in the second fixture a ping sitting between
+	// the second and the third. The ceiling must not notice the ping.
+	base := kaAgent(1_000_000, "s1", 0.10)
+	base.SavedUnique = 10
+	evs := []*Event{
+		base,
+		kaAgent(1_100_000, "s1", 0.10), kaAgent(1_200_000, "s1", 0.10),
+	}
+	without := newKAFixture(t, evs...)
+	with := newKAFixture(t, append(append([]*Event(nil), evs...),
+		kaPing(1_150_000, "s1", 0.01, 50_000, 0))...)
+	f := Filter{TenantAll: true}
+	a, err := without.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := with.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every row in this fixture reduces by 10 (mkEvent's before/after), so the ceiling is
+	// 10x2 + 10x1 + 10x0 = 30: each reduction times the later turns that could replay IT.
+	if a.ReplayProjectedTokens != 30 {
+		t.Fatalf("the ceiling is %d without any ping; want 10 x (2 + 1 + 0) = 30",
+			a.ReplayProjectedTokens)
+	}
+	if b.ReplayProjectedTokens != a.ReplayProjectedTokens {
+		t.Errorf("a ping changed the replay ceiling: %d -> %d. A ping is a verbatim resend of a "+
+			"prefix the agent already sent; it carries no new transcript, so it cannot replay a "+
+			"reduction, and counting it makes compaction read as realising less of its value than "+
+			"it does.", a.ReplayProjectedTokens, b.ReplayProjectedTokens)
+	}
+	// The correction cannot over-subtract, either: a ping BEFORE the reducing turn inflates
+	// nothing, so it must not be deducted.
+	early := newKAFixture(t, append(append([]*Event(nil), evs...),
+		kaPing(900_000, "s1", 0.01, 50_000, 0))...)
+	c, err := early.db.Overview(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.ReplayProjectedTokens != a.ReplayProjectedTokens {
+		t.Errorf("a ping BEFORE the reduction changed the ceiling: %d -> %d; only LATER rows can "+
+			"replay it", a.ReplayProjectedTokens, c.ReplayProjectedTokens)
+	}
+}
+
 // The headline takes the keep-alive's NET and not its gross, so a window where the pings cost
 // more than they saved makes the total go DOWN.
 //

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -555,16 +555,21 @@ func TestRecommendationPayloadCarriesNoPointEstimate(t *testing.T) {
 // K = 1 is never recommended: one ping reaches about 4.7 minutes, which is inside the free TTL,
 // and it is -$71 service-wide.
 func TestRecommendationNeverSuggestsOnePing(t *testing.T) {
-	for _, n := range []int{25, 40, 80} {
-		for _, gap := range []float64{400, 700, 1200, 5000} {
-			fx := newKAFixture(t, kaSpread(t, n, gap, 1.0)...)
-			rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if rec.MaxPings == 1 || rec.AltMaxPings == 1 {
-				t.Errorf("n=%d gap=%g recommended K=1", n, gap)
-			}
+	// Four cases, one per region of the input space rather than the full cross product: a gap
+	// inside K=1's own reach, one only K=2 reaches, one only K=3 reaches, and one nothing
+	// reaches. Twelve fixtures cost eight seconds under -race on a package already close to the
+	// default test timeout, and added no region.
+	for _, tc := range []struct {
+		n   int
+		gap float64
+	}{{25, 400}, {40, 700}, {25, 1100}, {30, 5000}} {
+		fx := newKAFixture(t, kaSpread(t, tc.n, tc.gap, 1.0)...)
+		rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.MaxPings == 1 || rec.AltMaxPings == 1 {
+			t.Errorf("n=%d gap=%g recommended K=1", tc.n, tc.gap)
 		}
 	}
 }

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -490,6 +490,39 @@ func TestRecommendationRefusesWhenTheIntervalCrossesZero(t *testing.T) {
 	}
 }
 
+// An interval that sits entirely BELOW zero is a refusal, not a recommendation.
+//
+// Found by looking at the page: the first live render of this route produced "Suggested: 280 s,
+// 2 pings — expected -$38.63 to -$4.54", because the two-sided reading of "the interval excludes
+// zero" admits an account the mechanism would simply cost money. An account whose idle gaps are
+// mostly an hour long has nothing inside any coverage worth having.
+func TestRecommendationRefusesAnIntervalEntirelyBelowZero(t *testing.T) {
+	// 30 expiries whose gaps are far past any coverage at X=280 (2.8 hours), on sessions that
+	// nevertheless have plenty of idle spans to be pinged through. Cost with no conversion.
+	fx := newKAFixture(t, kaSpread(t, 30, 10_000, 2.0)...)
+	rec, err := fx.db.KeepAliveRecommend(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.N < recMinMisses || rec.Requests < recMinRequests {
+		t.Fatalf("the fixture does not clear conditions 1 and 2: n=%d requests=%d",
+			rec.N, rec.Requests)
+	}
+	if rec.Refused == "" {
+		t.Errorf("an account this policy would cost money got a recommendation: %d/%d pings, "+
+			"$%.2f to $%.2f", rec.IdleSeconds, rec.MaxPings, rec.LoUSD, rec.HiUSD)
+	}
+	if rec.MaxPings != 0 || rec.LoUSD != 0 || rec.HiUSD != 0 {
+		t.Error("a refusal carried a recommendation anyway")
+	}
+	// And the refusal SAYS which way: "cannot tell it apart from zero" and "this would cost you
+	// money" are different findings and only one of them is actionable.
+	if !strings.Contains(rec.Refused, "COST") {
+		t.Errorf("the refusal does not say the mechanism would cost this account money: %q",
+			rec.Refused)
+	}
+}
+
 // The wire carries NO point estimate. Not a zero, not an omitted field with a name — the field
 // does not exist, because a field that exists gets rendered.
 func TestRecommendationPayloadCarriesNoPointEstimate(t *testing.T) {

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -164,8 +164,11 @@ type Overview struct {
 	SplitTailMoved     int64 `json:"split_tail_moved"`
 	SplitCredited      int64 `json:"split_credited"`
 	SplitCreditedMoved int64 `json:"split_credited_moved"`
-	// TotalSavedUSD is our two savings together: compaction's, less our own spend, plus
-	// the prefix components'. Both are ours and the token sets are disjoint.
+	// TotalSavedUSD is our three savings together: compaction's, less our own spend; the
+	// prefix components'; and the keep-alive's NET, which is its saving minus what its pings
+	// cost. All three are ours and the token sets are disjoint. The keep-alive contributes its
+	// net rather than its gross because the ping spend is excluded from CostUSD — a ping is not
+	// agent traffic — so it has nowhere else in this walk to appear.
 	TotalSavedUSD float64 `json:"total_saved_usd"`
 	// PrefixChangeCost is a DIAGNOSTIC, not a cost subtracted from net.
 	//
@@ -499,13 +502,26 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	if o.ReplayTokens = o.SavedGross - o.SavedUnique; o.ReplayTokens < 0 {
 		o.ReplayTokens = 0
 	}
-	// The ceiling on that replay: every unique reduction times the number of later turns in
-	// its own session. A correlated count off the (session_id, ts) index, ~80 ms over 14k
-	// requests, and only over rows that removed something. Not filtered by the window's
-	// component clause any differently from the rest of this function — same predicate, so
-	// the numerator and the ceiling always describe the same rows.
+	// The ceiling on that replay: every unique reduction times the number of later AGENT turns
+	// in its own session. A correlated count off the (session_id, ts) index, ~80 ms over 14k
+	// requests, and only over rows that removed something.
+	//
+	// `p.keepalive = 0` is load-bearing and was missing: the inner count had NO predicate at
+	// all, so a keep-alive ping counted as a later turn that could replay the reduction. It
+	// cannot — a ping is a verbatim resend of a prefix the agent already sent, it carries no
+	// new transcript, and PR #86's whole invariant is that a ping is not a turn. On a fixture
+	// with three pings this inflated the ceiling from 30 to 70 tokens and dragged
+	// replay_realized_pct down with it, which reads as compaction realising less of its value
+	// than it does. Found by TestPingRowsStayOutOfAgentAggregates, which compares the whole
+	// Overview key by key rather than the aggregates somebody thought of.
+	//
+	// The inner count is still not scoped to the window or the tenant. That is a separate
+	// (much smaller) inconsistency with the comment this one used to make: session ids are
+	// `tenant:uuid` so a cross-tenant collision is not reachable, and the ceiling is
+	// deliberately about the session's whole life rather than the filtered slice of it.
 	if err := d.sql.QueryRow(`SELECT COALESCE(SUM(r.saved_unique * (
 			SELECT COUNT(*) FROM requests p WHERE p.session_id = r.session_id
+			  AND p.keepalive = 0
 			  AND (p.ts > r.ts OR (p.ts = r.ts AND p.id > r.id)))),0)
 		FROM requests r WHERE `+cond+` AND r.saved_unique > 0`, args...).Scan(&o.ReplayProjectedTokens); err != nil {
 		return nil, err
@@ -588,7 +604,12 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// (they are excluded from the agent-traffic aggregate), so the two halves are only
 	// comparable here.
 	o.KeepAliveNetUSD = o.KeepAliveSavedUSD - o.KeepAlivePingUSD
-	o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD
+	// THE NET, never the gross. o.CostUSD excludes ping rows, so the pings' own spend appears
+	// nowhere else in this walk — adding KeepAliveSavedUSD here would present a saving without
+	// the spend that bought it, which is the exact dishonesty the ledger exists to prevent. The
+	// three addends are disjoint token sets: compaction's removals, the prefix split's stable
+	// half, and the entries the pings refreshed.
+	o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD + o.KeepAliveNetUSD
 
 	for name, col := range map[string]string{
 		"accounting": "token_accounting", "cache_miss": "cache_miss_reason", "uncompressed": "uncompressed_reason",
@@ -760,8 +781,15 @@ func (o *Overview) waterfall() []WaterfallStep {
 				"that is: the provider's cache is keyed on content, so another session sending the " +
 				"same prefix would have refreshed it for nothing."},
 		{Key: "total_saved", Label: "Total cost avoided", DeltaUSD: o.TotalSavedUSD, Total: true,
-			Description: "Net compaction savings plus prefix-cache savings. Two disjoint token " +
-				"sets, both ours, so nothing is counted twice. It is not the cost of a fully " +
+			Description: "Net compaction savings, plus prefix-cache savings, plus the idle " +
+				"keep-alive's NET — its savings minus what its pings cost. Three disjoint token " +
+				"sets, all ours, so nothing is counted twice: compaction's removals never reached " +
+				"the provider, the split moved a breakpoint over tokens that did, and the " +
+				"keep-alive refreshed entries that already existed. The keep-alive enters as a net " +
+				"because the pings' own spend is not in the billed-cost line above — ping rows are " +
+				"excluded from agent traffic — so this is the only place both halves are " +
+				"comparable, and its saving half is a CEILING (see Keep-alive savings). It is not " +
+				"the cost of a fully " +
 				"uncached world: the provider's own cache saved far more than this on the same " +
 				"traffic (cache_saved_usd, reported by the API as a diagnostic), and none of that " +
 				"is credited here."},

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -506,25 +506,60 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// in its own session. A correlated count off the (session_id, ts) index, ~80 ms over 14k
 	// requests, and only over rows that removed something.
 	//
-	// `p.keepalive = 0` is load-bearing and was missing: the inner count had NO predicate at
-	// all, so a keep-alive ping counted as a later turn that could replay the reduction. It
-	// cannot — a ping is a verbatim resend of a prefix the agent already sent, it carries no
-	// new transcript, and PR #86's whole invariant is that a ping is not a turn. On a fixture
-	// with three pings this inflated the ceiling from 30 to 70 tokens and dragged
-	// replay_realized_pct down with it, which reads as compaction realising less of its value
-	// than it does. Found by TestPingRowsStayOutOfAgentAggregates, which compares the whole
-	// Overview key by key rather than the aggregates somebody thought of.
+	// Computed as ALL later turns minus the later PINGS, in two statements, rather than as one
+	// count with `p.keepalive = 0` inside it. The predicate belongs there logically — a ping is
+	// a verbatim resend of a prefix the agent already sent, it carries no new transcript, and
+	// PR #86's invariant is that a ping is not a turn — but `keepalive` is not in
+	// idx_requests_session, so putting it in the correlated subquery turns an index-only count
+	// into a row fetch per candidate. Measured: 231 ms to 277 ms on the 10,000-row perf
+	// fixture, and 10.6 s to 15.3 s of that same test under -race, which is enough to blow its
+	// budget on a loaded box. The correction below is driven from the PING side instead, which
+	// is a tiny population — one linear pass plus an index lookup per ping — and costs exactly
+	// nothing on a deployment where the mechanism has never run.
 	//
-	// The inner count is still not scoped to the window or the tenant. That is a separate
-	// (much smaller) inconsistency with the comment this one used to make: session ids are
-	// `tenant:uuid` so a cross-tenant collision is not reachable, and the ceiling is
-	// deliberately about the session's whole life rather than the filtered slice of it.
+	// The bug this fixes: the inner count had NO predicate at all, so a ping counted as a later
+	// turn that could replay the reduction. On a fixture with three pings it inflated the
+	// ceiling from 30 to 70 tokens and dragged replay_realized_pct down with it, which reads as
+	// compaction realising less of its value than it does. Found by
+	// TestPingRowsStayOutOfAgentAggregates, which compares the whole Overview key by key rather
+	// than the aggregates somebody thought of.
+	//
+	// Neither statement is scoped to the window or the tenant on its INNER side, and they agree
+	// about that, which is what matters: session ids are `tenant:uuid` so a cross-tenant
+	// collision is not reachable, and the ceiling is deliberately about the session's whole life
+	// rather than the filtered slice of it.
 	if err := d.sql.QueryRow(`SELECT COALESCE(SUM(r.saved_unique * (
 			SELECT COUNT(*) FROM requests p WHERE p.session_id = r.session_id
-			  AND p.keepalive = 0
 			  AND (p.ts > r.ts OR (p.ts = r.ts AND p.id > r.id)))),0)
 		FROM requests r WHERE `+cond+` AND r.saved_unique > 0`, args...).Scan(&o.ReplayProjectedTokens); err != nil {
 		return nil, err
+	}
+	// The correction, and it is GATED so that it costs nothing where there is nothing to
+	// correct. Two gates, both cheap: the `IN` set is materialised once and is empty on a
+	// deployment that has never pinged (so every row fails a hash lookup and the correlated
+	// count is never evaluated), and the outer `EXISTS` skips even that. Pings are ~1% of rows
+	// and concentrated in a handful of sessions, so where the set is non-empty it is small.
+	var anyPing int64
+	if err := d.sql.QueryRow(`SELECT EXISTS(SELECT 1 FROM requests WHERE keepalive = 1)`).Scan(
+		&anyPing); err != nil {
+		return nil, err
+	}
+	if anyPing != 0 {
+		// Driven from the PING side: one pass to find the pings, then ONE indexed sum per ping
+		// over the earlier rows of its own session. That is O(pings x session) rather than a
+		// second full pass over the filtered rows, and pings are ~1% of rows.
+		var inflation int64
+		if err := d.sql.QueryRow(`SELECT COALESCE(SUM((
+				SELECT COALESCE(SUM(r.saved_unique),0) FROM requests r
+				  WHERE r.session_id = p.session_id AND r.saved_unique > 0
+				    AND (r.ts < p.ts OR (r.ts = p.ts AND r.id < p.id))
+				    AND `+cond+`)),0)
+			FROM requests p WHERE p.keepalive = 1`, args...).Scan(&inflation); err != nil {
+			return nil, err
+		}
+		if o.ReplayProjectedTokens -= inflation; o.ReplayProjectedTokens < 0 {
+			o.ReplayProjectedTokens = 0
+		}
 	}
 	if o.ReplayProjectedTokens > 0 {
 		o.ReplayRealizedPct = float64(o.ReplayTokens) / float64(o.ReplayProjectedTokens) * 100

--- a/dash/query.go
+++ b/dash/query.go
@@ -399,6 +399,16 @@ type SessionRow struct {
 	//
 	// Derived from MAX(ts), not stored: nothing about it is a fact about the request.
 	InFlight bool `json:"in_flight"`
+	// The idle keep-alive's ledger for this session. The count and the cost come from a SECOND
+	// grouped query with withKeepAlive — the aggregate above deliberately cannot see ping rows,
+	// because a ping counted as a turn inflates Turns and drags every average on the row towards
+	// a one-token response. The credit half is on the agent row that benefited, so it is summed
+	// by the first query. Net is the only one of the four worth a decision, and it is the one
+	// the Sessions table shows.
+	KeepAlivePings    int64   `json:"keepalive_pings"`
+	KeepAlivePingUSD  float64 `json:"keepalive_ping_usd"`
+	KeepAliveSavedUSD float64 `json:"keepalive_saved_usd"`
+	KeepAliveNetUSD   float64 `json:"keepalive_net_usd"`
 }
 
 // cacheTTLMs is one provider prompt-cache TTL, the horizon inside which a session's next
@@ -424,7 +434,11 @@ func (d *DB) Sessions(f Filter, limit, offset int) ([]*SessionRow, int64, error)
 		SUM(r.cost_usd), SUM(r.baseline_cost_usd), SUM(r.cg_llm_cost_usd),
 		SUM(r.expands), SUM(r.expand_tokens), SUM(r.reverts),
 		AVG(r.cg_latency_ms), AVG(r.upstream_ms),
-		SUM(CASE WHEN r.token_accounting <> 'complete' THEN 1 ELSE 0 END)
+		SUM(CASE WHEN r.token_accounting <> 'complete' THEN 1 ELSE 0 END),
+		-- The keep-alive's SAVING half, which lives on the real request that benefited. The COST
+		-- half cannot be summed here: this query excludes ping rows, and that exclusion is what
+		-- keeps Turns and every average on the row agent-only. It has its own query below.
+		COALESCE(SUM(r.keepalive_saved_usd),0)
 		FROM requests r WHERE ` + cond + `
 		GROUP BY r.session_id ORDER BY MAX(r.ts) DESC LIMIT ? OFFSET ?`
 	rows, err := d.sql.Query(q, append(args, limit, offset)...)
@@ -444,7 +458,7 @@ func (d *DB) Sessions(f Filter, limit, offset int) ([]*SessionRow, int64, error)
 			&s.CacheRead, &s.CacheWrite, &s.OutputTokens, &s.FreshInput,
 			&s.CostUSD, &s.BaselineCostUSD, &s.CGLLMCostUSD,
 			&s.Expands, &s.ExpandTokens, &s.Reverts,
-			&s.CGLatencyMs, &s.UpstreamMs, &s.Incomplete); err != nil {
+			&s.CGLatencyMs, &s.UpstreamMs, &s.Incomplete, &s.KeepAliveSavedUSD); err != nil {
 			return nil, 0, err
 		}
 		s.TenantID = tenant.String
@@ -457,9 +471,51 @@ func (d *DB) Sessions(f Filter, limit, offset int) ([]*SessionRow, int64, error)
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
 	}
+	// The COST half, over the same window and filters but with ping rows included, joined in Go
+	// by session id. The same two-query pattern DB.Overview uses, and for the same reason: one
+	// predicate, one meaning.
+	if len(out) > 0 {
+		kaCond, kaArgs := withKeepAlive(f).where()
+		pings, err := d.pingsBySession(kaCond, kaArgs)
+		if err != nil {
+			return nil, 0, err
+		}
+		for _, s := range out {
+			if p, ok := pings[s.SessionID]; ok {
+				s.KeepAlivePings, s.KeepAlivePingUSD = p.n, p.usd
+			}
+			s.KeepAliveNetUSD = s.KeepAliveSavedUSD - s.KeepAlivePingUSD
+		}
+	}
 	var total int64
 	err = d.sql.QueryRow(`SELECT COUNT(DISTINCT r.session_id) FROM requests r WHERE `+cond, args...).Scan(&total)
 	return out, total, err
+}
+
+// pingCount is one session's ping count and ping spend.
+type pingCount struct {
+	n   int64
+	usd float64
+}
+
+// pingsBySession groups the ping rows by session. The caller passes a filter that INCLUDES them.
+func (d *DB) pingsBySession(cond string, args []any) (map[string]pingCount, error) {
+	rows, err := d.sql.Query(`SELECT r.session_id, COUNT(*), COALESCE(SUM(r.cost_usd),0)
+		FROM requests r WHERE `+cond+` AND r.keepalive = 1 GROUP BY 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]pingCount{}
+	for rows.Next() {
+		var s string
+		var p pingCount
+		if err := rows.Scan(&s, &p.n, &p.usd); err != nil {
+			return nil, err
+		}
+		out[s] = p
+	}
+	return out, rows.Err()
 }
 
 // ComponentRow is one component's economics across the filtered window — the view

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -506,7 +506,7 @@ function barRows(host, rows, opts = {}) {
     },
       el('div', { class: 'bar-label', text: r.label }),
       el('div', { class: 'bar-track' }, el('div', {
-        class: 'bar-fill' + (r.value < 0 ? ' neg' : ''),
+        class: 'bar-fill' + (r.value < 0 ? ' neg' : '') + (r.value === 0 ? ' zero' : ''),
         style: 'width:' + width + '%' + (r.color ? ';background:' + r.color : ''),
       })),
       el('div', { class: 'bar-val' + (r.available === false ? ' na' : ''), text: r.display }));
@@ -7602,7 +7602,9 @@ async function loadKASessions() {
       el('td', { class: 'num' }, s.saved_usd ? usd(s.saved_usd) : '—'),
       el('td', { class: 'num ' + (net < 0 ? 'bad-text' : net > 0 ? 'good-text' : '') },
         s.pings || s.saved_usd ? usd(net) : '—'),
-      el('td', { class: 'num' }, compact(s.last_prefix)),
+      // 0 here means the last request reported no usage at all, which is an absence rather than
+      // a prompt of no size — and it is also the reason such a session cannot be priced.
+      el('td', { class: 'num' }, s.last_prefix > 0 ? compact(s.last_prefix) : '—'),
       el('td', {}, el('button', {
         class: 'ghost small', 'data-testid': 'ka-arm-' + s.session_id,
         onclick: () => armSession(s),
@@ -7610,13 +7612,17 @@ async function loadKASessions() {
   }
   // The concentration, and the fact that it does not transfer. Both, in one sentence: a table
   // sorted by cost invites exactly the inference the split-half test refutes.
-  const top = kaState.sessions.slice(0, 8).reduce((a, s) => a + s.expiry_usd, 0);
+  // The concentration is only a finding when there is something to concentrate: "the top 7 of
+  // these hold $81.40 of $81.40" is a tautology, and it is what the first live render said.
   const all = kaState.sessions.reduce((a, s) => a + s.expiry_usd, 0);
-  $('#ka-sessions-note').textContent =
-    `The top ${Math.min(8, kaState.sessions.length)} of these hold ${usd(top)} of ${usd(all)}. ` +
-    'That concentration is real and it does NOT transfer forward: sessions are ephemeral ' +
-    '(median lifetime about zero hours), so this is a description of the past and not a list ' +
-    'to act on next week.';
+  const lead = kaState.sessions.length > 8
+    ? `The top 8 of these hold ${usd(kaState.sessions.slice(0, 8).reduce((a, s) => a + s.expiry_usd, 0))}`
+      + ` of ${usd(all)}. That concentration is real and it does NOT transfer forward: `
+    : `${usd(all)} of cache expiries across ${kaState.sessions.length} of your sessions. `
+      + 'Where it concentrates does NOT transfer forward: ';
+  $('#ka-sessions-note').textContent = lead +
+    'sessions are ephemeral (median lifetime about zero hours), so this is a description of the ' +
+    'past and not a list to act on next week.';
 }
 
 /**
@@ -7888,7 +7894,14 @@ async function loadKACalc() {
   // Reach and cost side by side, so the flattening is visible: on our own traffic K=1→K=2 takes
   // reach from 30% to 51% of the recoverable dollars and K=3, K=4 add 6 and 4 points, while
   // ping count keeps climbing.
-  barRows(host, c.rows.map((r) => ({
+  //
+  // Its OWN container: barRows clears the host it is given, and passing the panel's host wiped
+  // the ladder table above it. The page looked plausible — a bar per rung, all the numbers
+  // present — and the table it replaced was simply absent, which is precisely why this was found
+  // by opening the page and not by reading the code.
+  const share = el('div');
+  host.appendChild(share);
+  barRows(share, c.rows.map((r) => ({
     label: 'K=' + r.max_pings + (r.current ? ' (current)' : ''),
     value: r.share_of_addressable_pct, max: 100,
     display: pct(r.share_of_addressable_pct, 1) + ' · ' + num(r.pings) + ' pings',
@@ -7922,8 +7935,15 @@ async function loadKARecommend() {
   }
   clear(host);
   if (rec.refused) {
-    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'ka-refused' },
-      el('div', {}, el('strong', {}, 'Not enough history to recommend. '), rec.refused, '.'),
+    // Two different refusals, and only one of them is about thin history: "your own gaps are
+    // too long for this to reach" is a finding, not a shortage of data, and it is a `bad` banner
+    // rather than a `warn` one because it is telling somebody not to switch this on.
+    const wouldCost = rec.refused.indexOf('COST') >= 0;
+    host.appendChild(el('div', { class: 'banner ' + (wouldCost ? 'bad' : 'warn'),
+      'data-testid': 'ka-refused' },
+      el('div', {}, el('strong', {},
+        wouldCost ? 'This would not pay for itself on your traffic. ' : 'Not enough history to recommend. '),
+      rec.refused, '.'),
       el('div', { class: 'small' },
         `For scale: measured over 357 cache expiries across this whole service, the 90% `
         + `interval on this policy is ${usd(rec.service_lo_usd)} to ${usd(rec.service_hi_usd)}. `

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -7633,8 +7633,15 @@ async function loadKASessions() {
  * number: how long this service may hold the credential, and what the pings can cost at worst.
  */
 async function armSession(s) {
-  const hours = prompt('Keep this session warm for how many hours? (0.25 to 12, and it is ' +
-    'lost if the service restarts)', '1');
+  // The credential hold is stated BEFORE the act, not after it. (K+1)×X is arithmetic on the two
+  // integers the reader just chose — not money, so computing it here breaks no rule — and it is
+  // the number the Settings copy promises ("up to about 14 minutes"), which an override changes.
+  // The worst-case SPEND comes back from the server, which owns every dollar on this page.
+  const hold = ((kaState.k + 1) * kaState.x) / 60;
+  const hours = prompt('Keep this session warm for how many hours?\n\n'
+    + `At ${kaState.x}s idle and ${kaState.k} pings, your provider credential may be held for `
+    + `up to ${hold.toFixed(0)} minutes at a time ((K+1) × X). Between 0.25 and 12 hours, and it `
+    + 'is cleared if the service restarts.', '1');
   if (hours === null) return;
   const h = parseFloat(hours);
   if (!isFinite(h) || h <= 0 || h > 12) { alert('Between 0.25 and 12 hours.'); return; }

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -497,7 +497,13 @@ function barRows(host, rows, opts = {}) {
   const wrap = el('div', { class: 'bars' });
   for (const r of rows) {
     const width = r.available === false ? 0 : Math.min(100, (Math.abs(r.value) / max) * 100);
-    const row = el('div', { class: 'bar-row' },
+    // title is the hover layer every bar on this dashboard should have had: an HTML chart IS
+    // interactive, and a bar whose exact value is only in the label column is a bar the reader
+    // has to trace across the panel. onclick makes a bar a drill-down where one exists.
+    const row = el('div', {
+      class: 'bar-row' + (r.onclick ? ' clickable' : ''), title: r.title || null,
+      onclick: r.onclick || null,
+    },
       el('div', { class: 'bar-label', text: r.label }),
       el('div', { class: 'bar-track' }, el('div', {
         class: 'bar-fill' + (r.value < 0 ? ' neg' : ''),
@@ -779,13 +785,107 @@ const TILE_INFO = {
   'total-saved-usd': {
     what: 'The money context-guru avoided in total, after paying for itself. This is the '
       + 'one number to look at if you only look at one.',
-    how: 'Two savings added together. First, what compaction avoided: what this traffic '
+    how: 'Three savings added together. First, what compaction avoided: what this traffic '
       + 'would have cost had we removed nothing, minus what it actually cost, minus what '
       + "context-guru's own model calls cost. Second, what the prefix-cache split avoided. "
-      + 'The two touch different tokens, so adding them does not count anything twice.',
-    catch: "It can be NEGATIVE, and it is shown in red when it is — that means context-guru "
+      + 'Third, the idle keep-alive\u2019s NET \u2014 what it avoided minus what its pings cost. '
+      + 'The three touch different tokens, so adding them does not count anything twice.',
+    catch: 'It can be NEGATIVE, and it is shown in red when it is \u2014 that means context-guru '
       + 'spent more on its own model calls than it saved you. Nothing here is hidden when '
-      + 'the answer is unflattering.',
+      + 'the answer is unflattering. The keep-alive contributes its NET, not its saving: the '
+      + 'pings it sent are real spend on your key, that spend is inside this figure, and it is '
+      + 'NOT in the billed-cost line above \u2014 a ping is not traffic your agent produced, so '
+      + 'it is excluded from the request count and every average. And the keep-alive\u2019s '
+      + 'saving half is a CEILING: the provider\u2019s cache is keyed on content, so another '
+      + 'session sending a byte-identical prompt would have refreshed the same entry for free.',
+  },
+  // ── Keep-alive tab ────────────────────────────────────────────────────────
+  // Every one of these carries the same two disclosures: the saving is a CEILING, and a zero
+  // may be an absence rather than a measurement.
+  'ka-position': {
+    what: 'Whether the idle keep-alive is ahead or behind on YOUR traffic over this window.',
+    how: 'Your own net: what the pings this service sent on your behalf cost, subtracted from '
+      + 'the prefix re-creations they avoided. "No pings yet" means it has not run for you, '
+      + 'which is different from having broken even.',
+    catch: 'Most sessions this mechanism touches LOSE a little. Across this service 34 of 119 '
+      + 'came out ahead and 85 paid about a third of a cent for nothing \u2014 the tax on the '
+      + 'many is how the rebate on the few is funded. A green verdict here is an average over '
+      + 'that spread, not a promise about your next session.',
+  },
+  'ka-net': {
+    what: 'What the keep-alive has actually earned you: the re-creations it avoided, minus the '
+      + 'pings that bought them.',
+    how: 'Both halves come from real rows. Every ping is its own dashboard row priced from its '
+      + 'own usage; every credit sits on the real request that resumed from a cache that would '
+      + 'otherwise have lapsed. Nothing here is an estimate or a model.',
+    catch: 'The saving half is a CEILING. The provider\u2019s cache is keyed on content, so if '
+      + 'another session had sent a byte-identical prompt during your idle gap, the same entry '
+      + 'would have been refreshed for nothing and our ping bought you no more than a warm '
+      + 'feeling. That confound cannot be measured from this side \u2014 the counts beside this '
+      + 'figure (pings sent, pings that read nothing) are what to check it against.',
+  },
+  'ka-pings': {
+    what: 'How many minimal requests this service sent on your behalf while you were away, and '
+      + 'what they cost.',
+    how: 'One row per ping, in your own request log, billed to your own credential and priced '
+      + 'from the usage the provider reported. Filter the Requests tab by keep-alive to read '
+      + 'them one at a time.',
+    catch: 'This is money spent while nobody was at the keyboard, which is why the mechanism is '
+      + 'opt-in and why this figure is beside the saving rather than behind it. Ping cost is '
+      + 'very uneven: about $0.0004 at the median and $0.23 at the 99th percentile, so an '
+      + 'average of them describes almost no ping.',
+  },
+  'ka-saved': {
+    what: 'The prefix re-creations those pings avoided \u2014 requests that resumed after a long '
+      + 'idle gap and were served from cache anyway.',
+    how: 'Credited only where all four hold: a ping of ours went out during the gap, the gap was '
+      + 'wider than the provider\u2019s five-minute lifetime, the provider then read more than '
+      + 'it wrote, and the credit is capped at the tokens that ping actually refreshed. Priced '
+      + 'at the WRITE PREMIUM \u2014 what a re-creation costs over a read \u2014 because those '
+      + 'tokens carry cache_control and a miss bills them at 1.25x rather than 1x.',
+    catch: 'A CEILING, and the only figure on this dashboard that is. The provider\u2019s cache '
+      + 'is content-keyed, so another session with the same prefix would have refreshed the '
+      + 'entry for free and we would have been paid for nothing. Read it with the ping counts '
+      + 'beside it, never on its own.',
+  },
+  'ka-addressable': {
+    what: 'What cache expiries are still costing you in this window \u2014 the money this '
+      + 'mechanism exists to go after.',
+    how: 'Requests whose cache missed because the entry had lapsed AND where the provider then '
+      + 'wrote a prefix a ping could have kept alive. Summed at what they were actually billed.',
+    catch: 'Not all of it is reachable. A ping keeps an entry alive for K\u00d7X + 300 seconds, '
+      + 'so an expiry after a four-hour gap is beyond any setting worth having. The ladder below '
+      + 'says what share each policy reaches. Expiries that wrote nothing are excluded '
+      + 'entirely \u2014 there was no prefix to protect.',
+  },
+  'ka-rowgrowth': {
+    what: 'What this mechanism adds to the dashboard database per day, in bytes.',
+    how: 'Your own ping rate over this window times the measured footprint of one ping row: '
+      + '294 bytes of row plus about 103 bytes of index. Nothing about a ping stores text.',
+    catch: 'Shown because keeping a session warm by hand is the one way you could raise it. Even '
+      + 'ungated, service-wide, this is under a megabyte a day.',
+  },
+  'ka-rec-range': {
+    what: 'What this policy would be worth over a window like the last one \u2014 as a RANGE, '
+      + 'because that is what the data supports.',
+    how: 'A bootstrap over your own SESSIONS: 2,000 resamples of the sessions that had a cache '
+      + 'expiry, replaying this policy over each one\u2019s real gaps, reported as the 90% '
+      + 'interval. Sessions rather than requests, because expiries inside one session are not '
+      + 'independent draws.',
+    catch: 'There is deliberately NO single number here, and none on the wire either. On this '
+      + 'service no account can pin its own figure closer than about a factor of two, and for '
+      + '5 of 12 accounts the interval includes zero \u2014 which is why a recommendation is '
+      + 'refused for those rather than rounded off. The direction is resolvable; the size is not.',
+  },
+  'ka-rec-policy': {
+    what: 'The idle interval and ping count suggested for this account.',
+    how: 'The shipped default, offered only when your own history can tell its effect apart '
+      + 'from zero: at least 20 addressable cache expiries, at least 200 requests, and a 90% '
+      + 'interval that excludes no-change.',
+    catch: 'One ping is never suggested \u2014 it reaches about 4.7 minutes, inside the free '
+      + 'lifetime, and it is $71 worse than nothing service-wide. Two and three pings are a '
+      + 'measured tie on our own traffic, so two is chosen for the lower request volume and not '
+      + 'for a dollar reason. Nothing is applied for you.',
   },
   'saved-usd': {
     what: 'What compaction alone avoided, after paying for the model calls context-guru '
@@ -1243,7 +1343,8 @@ function renderTiles(o) {
     // NOT in here — it was, under the label "compaction + provider cache", and a headline
     // number that mostly measures somebody else's mechanism is not a headline number.
     tile('total-saved-usd', 'Total dollars avoided', costKnown ? usd(o.total_saved_usd) : 'unknown',
-      'compaction + prefix cache', costKnown ? (o.total_saved_usd < 0 ? 'bad' : 'good') : ''),
+      'compaction + prefix cache + keep-alive',
+      costKnown ? (o.total_saved_usd < 0 ? 'bad' : 'good') : ''),
     tile('saved-usd', 'Net dollars saved', costKnown ? usd(o.net_saved_usd) : 'unknown',
       'baseline − actual − our spend', costKnown ? (o.net_saved_usd < 0 ? 'bad' : 'good') : ''),
     tile('saved-unique', 'Tokens saved (unique)', compact(o.saved_unique),
@@ -1365,11 +1466,7 @@ function renderTiles(o) {
     // The net is what a decision rests on, so it is the number on the tile — presenting the
     // saving alone would be exactly the half-truth this ledger exists to prevent.
     (o.keepalive_pings || o.keepalive_saved_usd)
-      ? tile('keepalive-net', 'Keep-alive net',
-        costKnown ? usd(o.keepalive_net_usd) : 'unknown',
-        num(o.keepalive_pings) + ' pings ' + usd(o.keepalive_ping_usd) + ' · '
-          + num(o.keepalive_misses_avoided) + ' misses avoided ' + usd(o.keepalive_saved_usd),
-        costKnown ? (o.keepalive_net_usd < 0 ? 'bad' : 'good') : '')
+      ? kaOverviewTile(o, costKnown)
       : null,
   ]));
 
@@ -2334,7 +2431,7 @@ function showScopeCol(tableSel, wide) {
 async function loadSessions() {
   const body = clear($('#sessions-body'));
   const wide = showScopeCol('[data-testid=sessions-table]', wideScope());
-  const cols = wide ? 14 : 13;
+  const cols = wide ? 15 : 14;
   loadingRows(body, cols);
   try {
     const { sessions, total } = await api('sessions', { limit: 25, offset: state.sessOffset });
@@ -2381,6 +2478,15 @@ async function loadSessions() {
             }, ' †')
             : null),
         el('td', { class: 'num', text: compact(s.cache_read) + ' / ' + compact(s.cache_write) }),
+        // The keep-alive's net for this session, from its own ping rows. Blank rather than $0
+        // where it never ran: a zero would read as "it broke even here", which it did not do.
+        el('td', {
+          class: 'num ' + (s.keepalive_net_usd < 0 ? 'bad-text' : s.keepalive_net_usd > 0 ? 'good-text' : ''),
+          title: s.keepalive_pings || s.keepalive_saved_usd
+            ? `${num(s.keepalive_pings)} pings cost ${usd(s.keepalive_ping_usd)}; `
+              + `${usd(s.keepalive_saved_usd)} of re-creations avoided (a ceiling)`
+            : 'the keep-alive did not run on this session',
+        }, s.keepalive_pings || s.keepalive_saved_usd ? usd(s.keepalive_net_usd) : '—'),
         el('td', { class: 'num', text: num(s.expands) }),
         el('td', { class: 'num', text: ms(s.cg_latency_ms_avg) }),
         el('td', { text: when(s.start) }),
@@ -2405,7 +2511,7 @@ async function loadSessions() {
 async function loadRequests() {
   const body = clear($('#requests-body'));
   const wide = showScopeCol('[data-testid=requests-table]', wideScope());
-  const cols = wide ? 14 : 13;
+  const cols = wide ? 15 : 14;
   loadingRows(body, cols, 6);
   try {
     const page = await api('requests', { limit: 50, before: state.reqCursor });
@@ -3819,6 +3925,7 @@ async function checkCapture() {
 const loaders = {
   overview: loadOverview, usage: loadUsage, components: loadComponents, sessions: loadSessions,
   requests: loadRequests, benchmarks: loadBenchmarks, config: loadConfig,
+  keepalive: loadKeepAlive,
 };
 
 /**
@@ -5444,6 +5551,36 @@ function loadSettings() {
         + '119 pinged sessions came out ahead and the worst single session paid $2.42 for '
         + 'nothing. Watch your own ledger and switch it off if you are not one of the winners.')));
 
+    // The withdrawal, for the principal who cannot tick the box.
+    //
+    // The box above is drawn only for a manager, because the setting is STORED in the
+    // configuration document and that document is manager-owned — so an account owner whose own
+    // key was being spent had no way to stop it from this page. Consent withdrawal must never
+    // be harder than consent, so turning it OFF is open to any principal on their own account
+    // and turning it ON is not. One-way, deliberately.
+    if (!mgr && cfg.cache && cfg.cache.keepalive) {
+      host.appendChild(el('div', { class: 'field' },
+        el('label', {}, 'Keep my prompt cache warm while I am away'),
+        el('p', { class: 'hint' },
+          'This is ', el('strong', {}, 'on'), ' for your account, set by a manager, and it '
+          + 'spends your own key while you are away. You can switch it off here — turning '
+          + 'it back on is a manager’s change, because the setting lives in the '
+          + 'configuration document. See the Keep-alive tab for what it has cost and avoided '
+          + 'on your traffic.'),
+        el('div', { class: 'actions' }, el('button', {
+          class: 'ghost', 'data-testid': 'set-keepalive-off',
+          onclick: async () => {
+            if (!confirm('Switch the keep-alive off for your account? Every armed session is '
+              + 'disarmed and anything held for you is released immediately.')) return;
+            try {
+              await ctl('/api/me/keepalive', { method: 'DELETE' });
+              alert('Switched off. Nothing further is held or pinged for this account.');
+              loadSettings();
+            } catch (e) { alert(e.message); }
+          },
+        }, 'Turn keep-alive off'))));
+    }
+
     // Content capture consent.
     const cap = el('input', {
       type: 'checkbox', id: 'set-capture', 'data-testid': 'set-capture',
@@ -5527,6 +5664,19 @@ function loadSettings() {
     // those does not quietly turn a tracking account into a frozen copy.
     host.appendChild(el('div', { class: 'actions' },
       el('button', { class: 'primary', 'data-testid': 'settings-save', onclick: saveSettings }, 'Save')));
+    // What a save DOES to the document, beside the button that does it. The page already warns
+    // that saving discards frozen compaction decisions; this is the other half, and it is here
+    // because an operator lost 36 comment lines to a save and had no way to know they would.
+    // Comment and key-order preservation is deliberately not built — it means rewriting the
+    // exact code whose two previous rewrites each shipped a data-loss bug — so the honest
+    // mitigation is to say so and to keep the prior document one button away.
+    host.appendChild(el('p', { class: 'hint', 'data-testid': 'settings-save-warning' },
+      'Saving rewrites your configuration document from these fields. ',
+      el('strong', {}, 'Comments and key order are not preserved'),
+      ' \u2014 the previous document is kept verbatim in the audit log below, with a button to '
+      + 'copy it back. A component this page does not draw a control for is left exactly where '
+      + 'it is, and a save from a page whose configuration has changed underneath it is refused '
+      + 'rather than applied.'));
   });
 
   loadTokens();
@@ -5930,6 +6080,10 @@ async function saveSettings() {
   status.textContent = 'saving…';
   const inherited = !!account.tenant.config_inherited;
   const prev = (account.tenant.effective_config || {}).pipeline || [];
+  // EVERY box in the grid, checked or not: this is what the page drew a control for, which is a
+  // different list from what is ticked. It is the claim the server needs in order to tell a
+  // deliberate removal from a component this bundle cannot see.
+  const drew = $$('#comp-grid input[type=checkbox]').map((c) => c.dataset.comp);
   const picked = new Set($$('#comp-grid input[type=checkbox]')
     .filter((c) => c.checked).map((c) => c.dataset.comp));
   // Keep the configured run order for everything still enabled; a newly ticked component is
@@ -5962,7 +6116,16 @@ async function saveSettings() {
     // control — the tuning fields are omitted, which leaves the document's own values (or the
     // defaults) alone rather than freezing today's numbers into every saved document.
     body.config = {
-      pipeline: ordered, mode: $('#set-mode').value, components: cfgState || {},
+      pipeline: ordered,
+      // What this page DREW a control for, and what it drew it FROM. Two lines, and they are
+      // what stop a save silently reverting a pipeline. The server preserves anything in the
+      // stored document that is absent from BOTH lists — so a component this bundle has never
+      // heard of (a cached app.js whose /api/options predates it) cannot be removed by
+      // omission — and refuses the save outright when the base disagrees with the stored
+      // document, which is what stops a stale render adding one back.
+      pipeline_known: drew,
+      pipeline_base: prev,
+      mode: $('#set-mode').value, components: cfgState || {},
       cache: {
         keepalive: !!($('#set-keepalive') || {}).checked,
         head_ttl_1h: !!((account.tenant.effective_config || {}).cache || {}).head_ttl_1h,
@@ -6025,13 +6188,33 @@ async function loadAudit() {
     if (!rows.length) { emptyState(host, 'No changes yet', 'Configuration edits are recorded here.'); return; }
     const tbl = el('table', { class: 'grid' },
       el('thead', {}, el('tr', {},
-        el('th', {}, 'When'), el('th', {}, 'Field'), el('th', {}, 'From'), el('th', {}, 'To'))));
+        el('th', {}, 'When'), el('th', {}, 'Field'), el('th', {}, 'From'), el('th', {}, 'To'),
+        el('th', {}, el('span', { class: 'vh' }, 'Row actions')))));
     const body = el('tbody');
     for (const e of rows.slice(0, 50)) {
       body.appendChild(el('tr', {},
         el('td', {}, when(e.at)), el('td', {}, el('code', {}, e.field)),
         el('td', { class: 'clip' }, e.before || '—'),
-        el('td', { class: 'clip' }, e.after || '—')));
+        el('td', { class: 'clip' }, e.after || '—'),
+        // The way back. Saving rewrites the configuration document from fields, so comments and
+        // key order do not survive it — an operator lost 36 comment lines to a save. The prior
+        // document is stored here VERBATIM, so recovering it is a button rather than a support
+        // request. No new storage: this row already holds the whole text.
+        el('td', {}, e.field === 'config_yaml' && e.before
+          ? el('button', {
+            class: 'ghost small', 'data-testid': 'audit-copy-before',
+            onclick: async () => {
+              try {
+                await navigator.clipboard.writeText(e.before);
+                alert('The document as it was before this save is on your clipboard, comments '
+                  + 'and key order included.');
+              } catch {
+                // A browser that refuses clipboard access still has to give the text up.
+                prompt('Copy the document as it was before this save:', e.before);
+              }
+            },
+          }, 'Copy the document as it was')
+          : null)));
     }
     tbl.appendChild(body);
     host.appendChild(tbl);
@@ -7223,3 +7406,588 @@ function renderFeedbackAnswers(host, rows) {
 // Registered here rather than in the shared Object.assign above, so this whole feature
 // is one appended block and the view table above stays untouched.
 Object.assign(loaders, { feedback: loadFeedback });
+
+// ── keep-alive ─────────────────────────────────────────────────────────────
+//
+// The tab that answers "is this thing costing me or saving me, and what should I set?".
+//
+// Three rules run through every renderer below, and each one is a defect this project has
+// already shipped once:
+//
+//   1. NO ARITHMETIC HERE. Every dollar figure is computed on the server, in Go, in one
+//      place. The browser has twice duplicated a table the server owns and drifted from it,
+//      and money is the worst case of that class. This file posts inputs and renders answers.
+//   2. EVERY HEADLINE IS A RANGE WITH ITS n, and the recommendation is REFUSED where the
+//      history is too thin. No account in our own corpus can pin its own figure closer than
+//      about a factor of two.
+//   3. THE SAVING IS A CEILING. The provider's cache is keyed on content, so another session
+//      sending a byte-identical prefix would have refreshed the same entry for nothing. Every
+//      tile carrying it says so.
+//
+// Forms: stat tiles, barRows, lineChart, the status bar, tables. No new chart library, no new
+// hue, no pie, no gauge — see the SERIES comment at the top of this file for why a hue belongs
+// to an entity and never to a rank.
+
+/** kaState holds the tab's loaded payloads, so a control redraw need not refetch. */
+const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], x: 280, k: 2 };
+
+/** kaMuted is the de-emphasis gray for "outside the current coverage". Not a fifth series. */
+const KA_MUTED = 'var(--s-mute)';
+
+async function loadKeepAlive() {
+  // Panels 1 and 2 first and from ONE request, so the verdict is on screen before any
+  // behavioural query runs. A slow window function must never delay the answer to
+  // "is this costing me money".
+  const host = clear($('#ka-tiles'));
+  loadingState(host, 2);
+  try {
+    kaState.ledger = await api('keepalive');
+    renderKAVerdict(kaState.ledger);
+    renderKADownside(kaState.ledger);
+  } catch (e) {
+    if (aborted(e)) return;
+    errorState(host, 'Could not read the keep-alive ledger', e);
+    return;
+  }
+  // The rest, each from its own request: one slow panel must not blank the others.
+  loadKASessions();
+  loadKABehaviour();
+  loadKACalc();
+  loadKAArmed();
+  loadKARecommend();
+}
+
+/**
+ * kaCoverage renders the three states of "is a zero here a measurement or an absence?".
+ *
+ * keepalive_pings and keepalive_saved_usd arrived as ADDITIVE columns defaulting to 0, so on a
+ * row written before them a zero means NOT RECORDED. Rendering that as "saved nothing" is a
+ * fabricated measurement, which is the failure this dashboard has hit repeatedly — hence three
+ * distinct states and never a blend of them.
+ */
+function renderKACoverage(o) {
+  const host = clear($('#ka-coverage'));
+  if (!o.keepalive_recorded_from) {
+    host.appendChild(el('div', { class: 'banner', 'data-testid': 'ka-never-ran' },
+      el('strong', {}, 'The keep-alive has not run on this account in this window. '),
+      'The figures below are what it would have had to work with, not a measurement of it. ' +
+      'Nothing here is a $0 saving — it is an absence.'));
+    return;
+  }
+  if (o.keepalive_recorded_rows < o.requests) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'ka-partial' },
+      `Recorded on ${num(o.keepalive_recorded_rows)} of ${num(o.requests)} requests in this ` +
+      `window — it started running ${when(o.keepalive_recorded_from)}. Rows before that carry ` +
+      'no keep-alive columns at all, so they are absent from these figures rather than zero.'));
+  }
+}
+
+/** renderKAVerdict is panel 1: a handful of headline numbers, as tiles. Not a bar chart of four
+ *  numbers — four values with different units are four figures, not a comparison. */
+function renderKAVerdict(o) {
+  renderKACoverage(o);
+  const host = clear($('#ka-tiles'));
+  const ran = !!o.keepalive_recorded_from;
+  const position = !ran || !o.pings ? 'No pings yet' : (o.net_usd < 0 ? 'Losing' : 'Winner');
+  const cls = position === 'Winner' ? 'good' : position === 'Losing' ? 'bad' : '';
+  host.appendChild(tileGroup(null, null, [
+    // The words are beside the colour, always: a status must never rest on hue alone.
+    tile('ka-position', 'Your position', position,
+      ran ? num(o.sessions_touched) + ' sessions touched' : 'nothing to judge yet', cls),
+    tile('ka-net', 'Keep-alive net', ran ? usd(o.net_usd) : '—',
+      'avoided − spent', ran ? (o.net_usd < 0 ? 'bad' : 'good') : ''),
+    tile('ka-pings', 'Pings sent', ran ? num(o.pings) : '—',
+      ran ? usd(o.ping_usd) + ' spent on your key' : 'none'),
+    tile('ka-saved', 'Re-creations avoided', ran ? usd(o.saved_usd) : '—',
+      ran ? num(o.misses_avoided) + ' requests rescued · a CEILING' : 'none',
+      ran && o.saved_usd > 0 ? 'good' : ''),
+    tile('ka-addressable', 'Still on the table', usd(o.addressable_usd),
+      num(o.addressable_misses) + ' cache expiries worth acting on', 'accent'),
+    tile('ka-rowgrowth', 'Ping rows on disk', o.pings_per_day > 0
+      ? compact(o.bytes_per_day) + 'B/day' : '—',
+      o.pings_per_day > 0 ? o.pings_per_day.toFixed(0) + ' pings/day × ~400 B' : 'no pings'),
+  ]));
+}
+
+/**
+ * renderKADownside is panel 2, and it renders UNCONDITIONALLY — including on a positive net.
+ *
+ * The status bar reuses the same three-state component the recommend question uses, for the
+ * same reason: winner/loser is a JUDGEMENT about a state, which is what --good/--bad are
+ * reserved for, and every segment is labelled in words below it.
+ */
+function renderKADownside(o) {
+  const host = clear($('#ka-split'));
+  const worst = clear($('#ka-worst'));
+  const panel = $('#ka-downside-panel');
+  panel.classList.remove('bad');
+  if (!o.sessions_touched) {
+    emptyState(host, 'This mechanism has not touched any of your sessions yet',
+      'The service-wide split above is what to expect if you switch it on.');
+    return;
+  }
+  const parts = [
+    ['winners', 'Came out ahead', o.winners, 'good'],
+    ['losers', 'Paid for nothing', o.losers, 'bad'],
+  ];
+  host.appendChild(el('div', { class: 'nps-head' },
+    el('span', { class: 'nps-score' + (o.net_usd < 0 ? ' bad' : ''), text: usd(o.net_usd) }),
+    el('span', { class: 'muted small', text:
+      `your own net across ${o.sessions_touched} touched session${o.sessions_touched === 1 ? '' : 's'}` })));
+  host.appendChild(el('div', { class: 'nps-bar' }, ...parts
+    .filter(([, , n]) => n > 0)
+    .map(([key, label, n, c]) => el('div', {
+      class: 'nps-seg ' + c, style: 'flex:' + n, 'data-testid': 'ka-' + key,
+      title: label + ': ' + n + ' sessions',
+    }))));
+  host.appendChild(el('div', { class: 'nps-legend' }, ...parts.map(([, label, n, c]) =>
+    el('span', {}, el('i', { class: 'sw ' + c }), `${label}: ${n}`))));
+  if (o.worst_net_usd < 0) {
+    worst.appendChild(el('p', { class: 'hint', 'data-testid': 'ka-worst-session' },
+      'Your worst session paid ', el('strong', {}, usd(-o.worst_net_usd)),
+      ' and got nothing back for it.'));
+  }
+  // A negative own net turns the panel into the refusal it should be, with the way out on it.
+  if (o.net_usd < 0) {
+    worst.appendChild(el('div', { class: 'banner bad', 'data-testid': 'ka-turn-off' },
+      el('div', {}, el('strong', {}, 'On your traffic this is costing you money. '),
+        'Over this window the pings cost ' + usd(o.ping_usd) + ' and avoided ' +
+        usd(o.saved_usd) + '.'),
+      el('button', {
+        class: 'ghost small', 'data-testid': 'ka-turn-off-btn',
+        onclick: async () => {
+          if (!confirm('Switch the keep-alive off for this account? Every armed session is ' +
+            'disarmed and anything held for you is released immediately.')) return;
+          try {
+            await ctl('/api/me/keepalive', { method: 'DELETE' });
+            alert('Switched off. Nothing further is held or pinged for this account.');
+            loadKeepAlive();
+          } catch (e) { alert(e.message); }
+        },
+      }, 'Turn keep-alive off')));
+  }
+}
+
+/** loadKASessions fills the concentration table, which doubles as the arm list. */
+async function loadKASessions() {
+  const body = $('#ka-sessions-body');
+  loadingRows(body, 11);
+  try {
+    const out = await api('keepalive/sessions');
+    kaState.sessions = out.sessions || [];
+  } catch (e) {
+    if (aborted(e)) return;
+    tableMessage(body, 11, 'Could not read your sessions', e.message, { error: true });
+    return;
+  }
+  clear(body);
+  const wide = wideScope();
+  showScopeCol('[data-testid="ka-sessions-table"]', wide);
+  if (!kaState.sessions.length) {
+    tableMessage(body, 11, 'No cache expiries worth acting on in this window',
+      'Nothing here has anything to keep warm.');
+    $('#ka-sessions-note').textContent = '';
+    return;
+  }
+  for (const s of kaState.sessions) {
+    const net = s.net_usd;
+    body.appendChild(el('tr', {},
+      el('td', {}, el('code', { class: 'clip', text: s.session_id })),
+      wide ? el('td', {}, s.tenant_id || '—') : el('td', { hidden: 'hidden' }),
+      el('td', { class: 'num' }, num(s.turns)),
+      el('td', { class: 'num' }, num(s.expiries)),
+      el('td', { class: 'num' }, usd(s.expiry_usd)),
+      el('td', { class: 'num' }, s.pings ? num(s.pings) : '—'),
+      el('td', { class: 'num' }, s.pings ? usd(s.ping_usd) : '—'),
+      el('td', { class: 'num' }, s.saved_usd ? usd(s.saved_usd) : '—'),
+      el('td', { class: 'num ' + (net < 0 ? 'bad-text' : net > 0 ? 'good-text' : '') },
+        s.pings || s.saved_usd ? usd(net) : '—'),
+      el('td', { class: 'num' }, compact(s.last_prefix)),
+      el('td', {}, el('button', {
+        class: 'ghost small', 'data-testid': 'ka-arm-' + s.session_id,
+        onclick: () => armSession(s),
+      }, 'Keep warm'))));
+  }
+  // The concentration, and the fact that it does not transfer. Both, in one sentence: a table
+  // sorted by cost invites exactly the inference the split-half test refutes.
+  const top = kaState.sessions.slice(0, 8).reduce((a, s) => a + s.expiry_usd, 0);
+  const all = kaState.sessions.reduce((a, s) => a + s.expiry_usd, 0);
+  $('#ka-sessions-note').textContent =
+    `The top ${Math.min(8, kaState.sessions.length)} of these hold ${usd(top)} of ${usd(all)}. ` +
+    'That concentration is real and it does NOT transfer forward: sessions are ephemeral ' +
+    '(median lifetime about zero hours), so this is a description of the past and not a list ' +
+    'to act on next week.';
+}
+
+/**
+ * armSession opens the arm dialog: the parameters, and the two numbers being authorized.
+ *
+ * A prompt() rather than a drawer, deliberately — the smallest thing that can state the
+ * expiry, take a confirmation and refuse a bad value. What it must NOT do is hide either
+ * number: how long this service may hold the credential, and what the pings can cost at worst.
+ */
+async function armSession(s) {
+  const hours = prompt('Keep this session warm for how many hours? (0.25 to 12, and it is ' +
+    'lost if the service restarts)', '1');
+  if (hours === null) return;
+  const h = parseFloat(hours);
+  if (!isFinite(h) || h <= 0 || h > 12) { alert('Between 0.25 and 12 hours.'); return; }
+  const body = {
+    session: s.session_id, idle_seconds: kaState.x, max_pings: kaState.k,
+    until: Date.now() + Math.round(h * 3600000),
+  };
+  try {
+    const out = await ctl('/api/me/keepalive/sessions',
+      { method: 'POST', body: JSON.stringify(body) });
+    const cost = out.priced
+      ? `at worst ${num(out.worst_case_pings)} pings costing ${usd(out.worst_case_usd)}`
+      : `at worst ${num(out.worst_case_pings)} pings — this model is not on the price list, ` +
+        'so the cost cannot be stated';
+    alert(`Armed until ${when(out.until)}.\n\n` +
+      `Your credential may be held for up to ${out.hold_minutes.toFixed(0)} minutes at a ` +
+      `time ((K+1) × X), and this authorization is ${cost}.\n\n` +
+      'It is cleared if the service restarts. The arm is recorded in your audit log.');
+    loadKAArmed();
+  } catch (e) { alert('Not armed: ' + e.message); }
+}
+
+/** loadKAArmed lists what is armed RIGHT NOW — the live policy, not a stored intention. */
+async function loadKAArmed() {
+  const host = clear($('#ka-armed'));
+  let out;
+  try {
+    out = await ctl('/api/me/keepalive/sessions');
+  } catch (e) {
+    // A single-tenant deployment has no control plane at all; that is not an error to show.
+    if (e.status === 404) { host.hidden = true; return; }
+    errorState(host, 'Could not read what is armed', e);
+    return;
+  }
+  host.hidden = false;
+  kaState.armed = out.armed || [];
+  host.appendChild(el('p', { class: 'hint' },
+    `At most ${out.max_hours} hours per session, and ${out.max_hold_minutes} minutes is the `
+    + 'ceiling on how long your credential may be held between pings. ',
+    el('strong', {}, 'Armed sessions are cleared if the service restarts'),
+    ' — an authorization to spend that silently outlived a restart would be worse than one '
+    + 'that does not. The arm itself is in your audit log permanently.'));
+  if (!kaState.armed.length) {
+    emptyState(host, 'Nothing is armed', 'Use "Keep warm" on a session above.');
+    return;
+  }
+  const tbl = el('table', { class: 'grid' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Session'), el('th', {}, 'Idle'), el('th', {}, 'Pings'),
+      el('th', {}, 'Credential hold'), el('th', {}, 'Armed until'),
+      el('th', {}, el('span', { class: 'vh' }, 'Row actions')))));
+  const tb = el('tbody');
+  for (const a of kaState.armed) {
+    tb.appendChild(el('tr', {},
+      el('td', {}, el('code', { class: 'clip' }, a.session)),
+      el('td', {}, a.idle_seconds + 's'),
+      el('td', {}, String(a.max_pings)),
+      el('td', {}, '≤ ' + a.hold_minutes.toFixed(0) + ' min'),
+      el('td', {}, when(a.until)),
+      el('td', {}, el('button', {
+        class: 'ghost small', 'data-testid': 'ka-disarm-' + a.session,
+        onclick: async () => {
+          try {
+            await ctl('/api/me/keepalive/sessions/' + encodeURIComponent(a.session),
+              { method: 'DELETE' });
+            loadKAArmed();
+          } catch (e) { alert(e.message); }
+        },
+      }, 'Disarm'))));
+  }
+  tbl.appendChild(tb);
+  host.appendChild(tbl);
+}
+
+/** loadKABehaviour fills panels 3a–3e. */
+async function loadKABehaviour() {
+  const misses = $('#ka-chart-misses');
+  loadingState(misses, 2);
+  let b;
+  try {
+    b = await api('keepalive/behaviour', { x: kaState.x, k: kaState.k });
+  } catch (e) {
+    if (aborted(e)) return;
+    errorState(misses, 'Could not read your expiry history', e);
+    return;
+  }
+  kaState.behaviour = b;
+  const days = (b.daily || []).map((d) => [d.ts, d.misses]);
+  const usdPts = (b.daily || []).map((d) => [d.ts, d.usd]);
+  // TWO charts. A count and a dollar figure share no scale, and a second y-axis is the single
+  // most common way a chart implies a relationship it has not measured.
+  lineChart(misses, [{ name: 'Cache expiries', color: SERIES[0], points: days, area: true }],
+    { yFmt: num, xFmt: whenAxis });
+  lineChart($('#ka-chart-usd'),
+    [{ name: 'What they cost', color: SERIES[0], points: usdPts, area: true }],
+    { yFmt: usd, xFmt: whenAxis });
+
+  // 3b: the gap bands, in EDGE ORDER — the order is the meaning, so they are never sorted by
+  // size — with everything beyond the current coverage in the de-emphasis gray.
+  $('#ka-gap-note').textContent =
+    `p10 ${b.gap_p10.toFixed(0)}s · p50 ${b.gap_p50.toFixed(0)}s · p90 ${b.gap_p90.toFixed(0)}s. ` +
+    `At ${kaState.x}s idle and ${kaState.k} ping${kaState.k === 1 ? '' : 's'} the cache stays ` +
+    `alive for ${b.coverage_seconds.toFixed(0)}s, so the greyed bands are the expiries this ` +
+    `policy cannot reach. ${num(b.phantom_ttl_rows)} further ttl_expiry rows wrote nothing and ` +
+    'are excluded: there was no prefix to protect.';
+  barRows($('#ka-gap-bands'), (b.gap_bands || []).map((g) => ({
+    label: g.label + (g.beyond ? ' (beyond coverage)' : ''),
+    value: g.n, display: num(g.n) + ' · ' + usd(g.usd),
+    color: g.beyond ? KA_MUTED : SERIES[0],
+    title: `${g.n} expiries costing ${usd(g.usd)}`,
+    onclick: () => { setFilter('reason', 'ttl_expiry'); go('requests'); },
+  })), { emptyDetail: 'No cache expiries in this window.' });
+  kaTable('#ka-gap-bands', 'Idle gap', b.gap_bands);
+
+  // 3e: prefix size, and the measured reason the 20k gate is nearly free.
+  const above = b.addressable_misses > 0
+    ? pct(100 * b.prefix_above_20k / b.addressable_misses, 0) : '—';
+  $('#ka-prefix-note').textContent =
+    `p10 ${compact(b.prefix_p10)} · p50 ${compact(b.prefix_p50)} · p90 ${compact(b.prefix_p90)} ` +
+    `tokens. ${above} of them were already past 20k, which is why the default "only sessions ` +
+    'with a large cached prompt" gate costs almost nothing.';
+  barRows($('#ka-prefix-bands'), (b.prefix_bands || []).map((g) => ({
+    label: g.label + ' tokens', value: g.n, display: num(g.n) + ' · ' + usd(g.usd),
+    color: SERIES[0], title: `${g.n} expiries costing ${usd(g.usd)}`,
+  })), { emptyDetail: 'No cache expiries in this window.' });
+  kaTable('#ka-prefix-bands', 'Cached prompt size', b.prefix_bands);
+
+  // 3c: 24 bins, in the VIEWER's own timezone with the offset stated. "What times of day" is
+  // a human question and a UTC-only axis answers a different one.
+  const offMin = -new Date().getTimezoneOffset();
+  const offLabel = 'UTC' + (offMin < 0 ? '−' : '+') +
+    String(Math.floor(Math.abs(offMin) / 60)).padStart(2, '0') +
+    ':' + String(Math.abs(offMin) % 60).padStart(2, '0');
+  $('#ka-hour-note').textContent =
+    `Bucketed by the hour the cache lapsed, labelled in your own timezone (${offLabel}). ` +
+    'Working-hours shaped on this service: the peak is about eight times the trough.';
+  const bins = (b.hour_bins || []).map((h) => {
+    const start = (Number(h.label) * 60 + offMin + 1440) % 1440;
+    const hh = String(Math.floor(start / 60)).padStart(2, '0');
+    const mm = String(start % 60).padStart(2, '0');
+    return { label: `${hh}:${mm}`, value: h.n, display: num(h.n) + ' · ' + usd(h.usd),
+      color: SERIES[0], title: `${h.n} expiries costing ${usd(h.usd)}`, sort: start };
+  }).sort((a, c) => a.sort - c.sort);
+  barRows($('#ka-hour-bins'), bins, { emptyDetail: 'No cache expiries in this window.' });
+
+  // 3d: per account, mean/median/max, never a single blended figure.
+  const gaps = clear($('#ka-account-gaps'));
+  if (!(b.account_gaps || []).length) {
+    emptyState(gaps, 'Not enough expiries to measure a gap between them',
+      'A gap needs two expiries on the same account.');
+  } else {
+    const tbl = el('table', { class: 'grid' },
+      el('thead', {}, el('tr', {}, el('th', {}, 'Account'), el('th', {}, 'Gaps'),
+        el('th', {}, 'Mean'), el('th', {}, 'Median'), el('th', {}, 'Longest'))));
+    const tb = el('tbody');
+    for (const g of b.account_gaps) {
+      tb.appendChild(el('tr', {}, el('td', {}, g.tenant || 'this account'),
+        el('td', {}, num(g.n)), el('td', {}, g.mean_hours.toFixed(2) + ' h'),
+        el('td', {}, g.median_hours.toFixed(2) + ' h'), el('td', {}, g.max_hours.toFixed(2) + ' h')));
+    }
+    tbl.appendChild(tb);
+    gaps.appendChild(tbl);
+  }
+}
+
+/** kaTable adds the table view of a band chart, as the existing panels do. */
+function kaTable(sel, dim, bands) {
+  const host = $(sel);
+  if (!bands || !bands.length) return;
+  const rows = bands.map((b) => el('tr', {}, el('td', {}, b.label),
+    el('td', { class: 'num' }, num(b.n)), el('td', { class: 'num' }, usd(b.usd))));
+  host.appendChild(el('details', { class: 'why' },
+    el('summary', {}, 'Table view'),
+    el('table', { class: 'grid' },
+      el('thead', {}, el('tr', {}, el('th', {}, dim), el('th', { class: 'num' }, 'Expiries'),
+        el('th', { class: 'num' }, 'Cost'))),
+      el('tbody', {}, ...rows))));
+}
+
+/** renderKACalcControls draws X, K and the prefix. Every value is sent to the server, which
+ *  owns the arithmetic; nothing below multiplies a dollar by anything. */
+function renderKACalcControls() {
+  const host = clear($('#ka-calc-controls'));
+  const x = el('input', { type: 'number', id: 'ka-x', min: '60', max: '290', step: '10',
+    value: String(kaState.x), 'data-testid': 'ka-x' });
+  const k = el('input', { type: 'number', id: 'ka-k', min: '1', max: '4', step: '1',
+    value: String(kaState.k), 'data-testid': 'ka-k' });
+  const apply = el('button', { class: 'ghost', 'data-testid': 'ka-calc-apply',
+    onclick: () => {
+      kaState.x = Math.max(60, Math.min(290, parseInt(x.value, 10) || 280));
+      kaState.k = Math.max(1, Math.min(4, parseInt(k.value, 10) || 2));
+      loadKACalc();
+      loadKABehaviour(); // the coverage rule on the gap bands moves with the policy
+    } }, 'Recalculate');
+  host.appendChild(el('div', { class: 'field-row' },
+    el('label', { for: 'ka-x' }, 'Idle seconds (X)'), x,
+    el('label', { for: 'ka-k' }, 'Max pings (K)'), k, apply));
+}
+
+/** loadKACalc renders the K ladder. */
+async function loadKACalc() {
+  renderKACalcControls();
+  const host = clear($('#ka-calc'));
+  loadingState(host, 3);
+  let c;
+  try {
+    c = await api('keepalive/calc', { x: kaState.x, k: kaState.k });
+  } catch (e) {
+    if (aborted(e)) return;
+    errorState(host, 'Could not compute the ladder', e);
+    return;
+  }
+  kaState.calc = c;
+  clear(host);
+  if (!c.prefix_tokens) {
+    emptyState(host, 'No cached prompt to compute against',
+      'This window holds no cache expiry of yours, so there is no real prefix to price a ping ' +
+      'on. A service-wide average would be misleading: per-ping cost runs from $0.0004 at the ' +
+      'median to $0.2275 at the 99th percentile.');
+    return;
+  }
+  const src = { session: 'the selected session’s last cached prompt',
+    account_median: 'your own median cached prompt at a lapse',
+    given: 'the size you gave' }[c.prefix_source] || 'a real cached prompt';
+  host.appendChild(el('p', { class: 'note' },
+    `Priced on ${compact(c.prefix_tokens)} tokens — ${src} — for `,
+    el('code', {}, c.model || 'an unnamed model'), '. ',
+    c.priced
+      ? `One ping costs ${usd(c.ping_usd_each)}; one rescued expiry avoids ` +
+        `${usd(c.avoided_usd_each)}, which is the WRITE PREMIUM and not the whole miss.`
+      : 'This model is not on the operator’s price list, so the counts below stand and ' +
+        'the dollar columns are blank. They are not zero.'));
+  const tbl = el('table', { class: 'grid', 'data-testid': 'ka-ladder' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Max pings (K)'), el('th', {}, 'Cache stays alive'),
+      el('th', { class: 'num' }, 'Your expiries inside it'),
+      el('th', { class: 'num' }, 'Their cost'), el('th', { class: 'num' }, 'Share of what is reachable'),
+      el('th', { class: 'num' }, 'Pings'), el('th', { class: 'num' }, 'Ping cost'),
+      el('th', { class: 'num' }, 'Net'))));
+  const tb = el('tbody');
+  for (const r of c.rows) {
+    // Emphasis by weight, not by a new hue: the current row is the accent, the rest recede.
+    tb.appendChild(el('tr', { class: r.current ? 'is-current' : 'muted-row',
+      'data-testid': 'ka-ladder-k' + r.max_pings },
+      el('td', {}, String(r.max_pings) + (r.current ? ' (current)' : '')),
+      el('td', {}, r.coverage_seconds.toFixed(0) + 's = ' + r.max_pings + '×' + kaState.x + ' + 300'),
+      el('td', { class: 'num' }, num(r.convertible_misses)),
+      el('td', { class: 'num' }, usd(r.convertible_usd)),
+      el('td', { class: 'num' }, pct(r.share_of_addressable_pct, 1)),
+      el('td', { class: 'num' }, num(r.pings)),
+      el('td', { class: 'num' }, c.priced ? usd(r.ping_usd) : 'not priced'),
+      el('td', { class: 'num ' + (c.priced && r.net_usd < 0 ? 'bad-text' : '') },
+        c.priced ? usd(r.net_usd) : 'not priced')));
+  }
+  tbl.appendChild(tb);
+  host.appendChild(tbl);
+  // Reach and cost side by side, so the flattening is visible: on our own traffic K=1→K=2 takes
+  // reach from 30% to 51% of the recoverable dollars and K=3, K=4 add 6 and 4 points, while
+  // ping count keeps climbing.
+  barRows(host, c.rows.map((r) => ({
+    label: 'K=' + r.max_pings + (r.current ? ' (current)' : ''),
+    value: r.share_of_addressable_pct, max: 100,
+    display: pct(r.share_of_addressable_pct, 1) + ' · ' + num(r.pings) + ' pings',
+    color: r.current ? 'var(--accent)' : KA_MUTED,
+    title: `${r.convertible_misses} of ${c.addressable_misses} expiries reachable`,
+  })), {});
+  host.appendChild(el('p', { class: 'hint' },
+    'A replay of your own past gaps, not a forecast — and it counts only expiries that were ' +
+    'addressable (the provider wrote a prefix that a ping could have refreshed). Reach grows ' +
+    'sharply from one ping to two and then flattens while ping cost keeps climbing, which is ' +
+    'why cost and reach are shown together and not reach alone.'));
+}
+
+/**
+ * loadKARecommend renders a RANGE with its n, or a refusal with the count that caused it.
+ *
+ * Never a hero number and never a gauge. Every account in our own corpus has a 90% interval
+ * whose relative half-width is at least 62%, and it crosses zero for 5 of 12 — so the honest
+ * sentence is "the direction is resolvable, the size is not", and it is on the page.
+ */
+async function loadKARecommend() {
+  const host = clear($('#ka-recommend'));
+  loadingState(host, 2);
+  let rec;
+  try {
+    rec = await api('keepalive/recommend');
+  } catch (e) {
+    if (aborted(e)) return;
+    errorState(host, 'Could not work out a recommendation', e);
+    return;
+  }
+  clear(host);
+  if (rec.refused) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'ka-refused' },
+      el('div', {}, el('strong', {}, 'Not enough history to recommend. '), rec.refused, '.'),
+      el('div', { class: 'small' },
+        `For scale: measured over 357 cache expiries across this whole service, the 90% `
+        + `interval on this policy is ${usd(rec.service_lo_usd)} to ${usd(rec.service_hi_usd)}. `
+        + 'Use the default (280 s idle, 2 pings) or arm a single session above and read your '
+        + 'own ledger.')));
+    return;
+  }
+  host.appendChild(tileGroup(null, null, [
+    // A RANGE as the tile's value. There is no point estimate on the wire to render.
+    tile('ka-rec-range', 'Expected over a window like this one',
+      usd(rec.lo_usd) + ' – ' + usd(rec.hi_usd),
+      `90% interval from ${num(rec.n)} expiries in ${num(rec.sessions)} sessions`,
+      rec.lo_usd > 0 ? 'good' : 'bad'),
+    tile('ka-rec-policy', 'Suggested', rec.idle_seconds + 's / ' + rec.max_pings + ' pings',
+      'on sessions past their first request with a cached prompt over 20k tokens', 'accent'),
+  ]));
+  host.appendChild(el('p', { class: 'note' },
+    'The direction is resolvable; the size is not — a window like this one cannot pin it ',
+    el('strong', {}, 'closer than about a factor of two'),
+    '. Watch your own ledger for a week before changing it.',
+    rec.alt_max_pings
+      ? ` ${rec.alt_max_pings} pings clears this account's own noise and is worth trying.`
+      : ' 2 pings and 3 pings are a measured tie on this history, so 2 is suggested for the ' +
+        'lower request volume rather than for a dollar reason.'));
+  host.appendChild(el('div', { class: 'actions' }, el('button', {
+    class: 'ghost', 'data-testid': 'ka-rec-apply',
+    onclick: () => {
+      // Fills the fields in and leaves them UNSAVED, the same pattern the component
+      // recommendations use. A recommendation whose own interval is 62% wide is not something
+      // a service should apply on somebody's behalf.
+      go('settings');
+      setTimeout(() => {
+        const idle = $('#cfg-cache-keepalive_idle_seconds');
+        const pings = $('#cfg-cache-keepalive_max_pings');
+        if (idle) idle.value = rec.idle_seconds;
+        if (pings) pings.value = rec.max_pings;
+        alert('Filled in on the Settings tab. Nothing is saved until you press Save there.');
+      }, 200);
+    },
+  }, 'Use these values in Settings')));
+  host.appendChild(el('p', { class: 'hint' },
+    'Nothing is ever applied for you. One ping is never suggested: it reaches about 4.7 ' +
+    'minutes, which is inside the free five-minute lifetime, and on this service it is $71 ' +
+    'worse than not running at all.'));
+}
+
+/**
+ * kaOverviewTile is the Overview's keep-alive tile: the net, both halves in the sub-line, and a
+ * way through to the tab that explains it.
+ *
+ * A separate function only because it is the one tile on that row that is a LINK. The net is the
+ * figure on the face of it — presenting the saving alone would be exactly the half-truth the
+ * ledger exists to prevent — and the sub-line carries the spend beside it.
+ */
+function kaOverviewTile(o, costKnown) {
+  const t = tile('keepalive-net', 'Keep-alive net',
+    costKnown ? usd(o.keepalive_net_usd) : 'unknown',
+    num(o.keepalive_pings) + ' pings ' + usd(o.keepalive_ping_usd) + ' · '
+      + num(o.keepalive_misses_avoided) + ' rescued ' + usd(o.keepalive_saved_usd)
+      + ' (a ceiling)',
+    costKnown ? (o.keepalive_net_usd < 0 ? 'bad' : 'good') : '');
+  t.appendChild(el('div', { class: 'actions' }, el('button', {
+    class: 'ghost small', 'data-testid': 'keepalive-net-open',
+    onclick: () => go('keepalive'),
+  }, 'Who won and who paid')));
+  return t;
+}

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -7429,7 +7429,12 @@ Object.assign(loaders, { feedback: loadFeedback });
 // to an entity and never to a rank.
 
 /** kaState holds the tab's loaded payloads, so a control redraw need not refetch. */
-const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], x: 280, k: 2 };
+const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], x: 280, k: 2,
+  // canArm is false on a single-tenant deployment, which mounts no control plane at all — so
+  // there is nothing to POST an arm to. Drawing the button anyway would put an affordance on the
+  // page whose only possible outcome is a 404, which is the same defect as a removal command
+  // rendered in the one place nobody should act on.
+  canArm: true };
 
 /** kaMuted is the de-emphasis gray for "outside the current coverage". Not a fifth series. */
 const KA_MUTED = 'var(--s-mute)';
@@ -7580,7 +7585,13 @@ async function loadKASessions() {
     tableMessage(body, 11, 'Could not read your sessions', e.message, { error: true });
     return;
   }
-  clear(body);
+  renderKASessions();
+}
+
+/** renderKASessions draws the concentration table. Separate from the fetch so it can be redrawn
+ *  once the control plane's absence is known, without the arm buttons. */
+function renderKASessions() {
+  const body = clear($('#ka-sessions-body'));
   const wide = wideScope();
   showScopeCol('[data-testid="ka-sessions-table"]', wide);
   if (!kaState.sessions.length) {
@@ -7605,10 +7616,12 @@ async function loadKASessions() {
       // 0 here means the last request reported no usage at all, which is an absence rather than
       // a prompt of no size — and it is also the reason such a session cannot be priced.
       el('td', { class: 'num' }, s.last_prefix > 0 ? compact(s.last_prefix) : '—'),
-      el('td', {}, el('button', {
-        class: 'ghost small', 'data-testid': 'ka-arm-' + s.session_id,
-        onclick: () => armSession(s),
-      }, 'Keep warm'))));
+      el('td', {}, kaState.canArm
+        ? el('button', {
+          class: 'ghost small', 'data-testid': 'ka-arm-' + s.session_id,
+          onclick: () => armSession(s),
+        }, 'Keep warm')
+        : null)));
   }
   // The concentration, and the fact that it does not transfer. Both, in one sentence: a table
   // sorted by cost invites exactly the inference the split-half test refutes.
@@ -7671,8 +7684,16 @@ async function loadKAArmed() {
   try {
     out = await ctl('/api/me/keepalive/sessions');
   } catch (e) {
-    // A single-tenant deployment has no control plane at all; that is not an error to show.
-    if (e.status === 404) { host.hidden = true; return; }
+    // A single-tenant deployment has no control plane at all; that is not an error to show — but
+    // it does mean the arm buttons in the table above cannot work, so the whole panel goes and
+    // the table is redrawn without them.
+    if (e.status === 404) {
+      kaState.canArm = false;
+      $('#view-keepalive').querySelectorAll('[data-ka-arm-panel]').forEach((n) => { n.hidden = true; });
+      host.hidden = true;
+      if (kaState.sessions.length) renderKASessions();
+      return;
+    }
     errorState(host, 'Could not read what is armed', e);
     return;
   }

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -18,6 +18,7 @@
   <nav class="tabs" role="tablist" aria-label="Views">
     <button role="tab" class="tab" data-view="overview" data-testid="tab-overview" aria-selected="true">Overview</button>
     <button role="tab" class="tab" data-view="usage" data-testid="tab-usage">Usage</button>
+    <button role="tab" class="tab" data-view="keepalive" data-testid="tab-keepalive">Keep-alive</button>
     <button role="tab" class="tab" data-view="components" data-testid="tab-components" data-manager data-local-ok>Components</button>
     <button role="tab" class="tab" data-view="sessions" data-testid="tab-sessions">Sessions</button>
     <button role="tab" class="tab" data-view="requests" data-testid="tab-requests">Requests</button>
@@ -490,13 +491,120 @@
         <thead><tr>
           <th>Session</th><th data-scope-col hidden>Account</th><th>Model</th><th>Agent</th><th>Preset</th>
           <th class="num">Turns</th><th class="num">Before</th><th class="num">Saved (gross)</th>
-          <th class="num">Net saved $</th><th class="num">Cache r/w</th><th class="num">Expands</th>
+          <th class="num">Net saved $</th><th class="num">Cache r/w</th>
+          <th class="num">Keep-alive net</th><th class="num">Expands</th>
           <th class="num">CG ms</th><th>Started</th><th><span class="vh">Row actions</span></th>
         </tr></thead>
         <tbody id="sessions-body"></tbody>
       </table>
     </div>
     <div class="pager"><button id="sess-prev" class="ghost">Previous</button><span id="sess-page"></span><button id="sess-next" class="ghost">Next</button></div>
+  </div>
+</section>
+
+<!-- ── Keep-alive ──────────────────────────────────────────────────────────── -->
+<!-- The order of these panels is deliberate and it is not the order that sells the
+     feature: the VERDICT is first and the DOWNSIDE is second, above the calculator. 85 of
+     the 119 sessions this mechanism touched on our own traffic lost money, funding a large
+     rebate on 34, and the requirement is to save money rather than to raise the bill. A page
+     that led with the calculator would be selling. -->
+<section class="view" id="view-keepalive" hidden>
+  <div class="panel">
+    <h2>Verdict</h2>
+    <p class="note">What the idle keep-alive has spent on your traffic and what it has
+      avoided, over the window selected above. The <strong>net</strong> is the only one of
+      these four worth a decision.</p>
+    <div id="ka-coverage"></div>
+    <div id="ka-tiles"></div>
+  </div>
+
+  <div class="panel" id="ka-downside-panel">
+    <h2>Am I in the losing majority?</h2>
+    <!-- Unconditional. It renders on a positive net too, which is the point: the tax on the
+         many is how the rebate on the few is funded, and a reader deciding whether to leave
+         this on has to meet that fact whether or not their own number is green today. -->
+    <p class="note" data-testid="ka-downside-note">This mechanism is a small tax on most of
+      the sessions it touches, funding a large rebate on a few. Across this service
+      <strong>34 of 119</strong> pinged sessions came out ahead and the worst single session
+      paid <strong>$2.42</strong> for nothing.</p>
+    <div id="ka-split"></div>
+    <div id="ka-worst"></div>
+    <div class="tblwrap" tabindex="0">
+      <table class="tbl" data-testid="ka-sessions-table">
+        <thead><tr>
+          <th>Session</th><th data-scope-col hidden>Account</th><th class="num">Turns</th>
+          <th class="num">Expiries</th><th class="num">Expiry cost</th>
+          <th class="num">Pings</th><th class="num">Ping cost</th>
+          <th class="num">Avoided (ceiling)</th><th class="num">Net</th>
+          <th class="num">Last prefix</th><th><span class="vh">Row actions</span></th>
+        </tr></thead>
+        <tbody id="ka-sessions-body"></tbody>
+      </table>
+    </div>
+    <p class="hint" id="ka-sessions-note"></p>
+  </div>
+
+  <div class="panel">
+    <h2>Your TTL expiries</h2>
+    <p class="note">A cached prefix has a five-minute lifetime, and a session idle longer
+      loses it — the next turn re-bills every token at the cache-creation rate. These are
+      yours: how often, when, how far apart, and how big.</p>
+    <details class="why"><summary>Why some ttl_expiry rows are not counted here</summary>
+      <p>A <code>ttl_expiry</code> row that wrote nothing had no prefix to protect and no
+        charge a ping could have avoided. On this service 385 of 742 were exactly that, and
+        every one was an HTTP 400. They are counted apart, below the chart, so this panel's
+        total and the Usage tab's <code>ttl_expiry</code> count can be reconciled.</p></details>
+    <!-- Two charts, never two y-axes. A count and a dollar figure share no scale, and a
+         second y-axis is the single most common way a chart lies about correlation. -->
+    <div class="grid-2">
+      <div class="panel">
+        <h3>Expiries per day</h3>
+        <div id="ka-chart-misses" class="chart" data-testid="ka-chart-misses"></div>
+      </div>
+      <div class="panel">
+        <h3>What they cost, per day</h3>
+        <div id="ka-chart-usd" class="chart" data-testid="ka-chart-usd"></div>
+      </div>
+    </div>
+    <h3>Idle gap when the cache lapsed</h3>
+    <p class="note" id="ka-gap-note"></p>
+    <div id="ka-gap-bands" data-testid="ka-gap-bands"></div>
+    <h3>Cached prompt size when it lapsed</h3>
+    <p class="note" id="ka-prefix-note"></p>
+    <div id="ka-prefix-bands" data-testid="ka-prefix-bands"></div>
+    <h3>Time of day</h3>
+    <p class="note" id="ka-hour-note"></p>
+    <div id="ka-hour-bins" data-testid="ka-hour-bins"></div>
+    <h3>How long between expiries</h3>
+    <p class="note">Per account, never blended: on this service the per-account mean runs
+      from 0.64 h to 6.56 h with maxima past 30 h, so a single service-wide average would
+      describe nobody.</p>
+    <div id="ka-account-gaps" data-testid="ka-account-gaps"></div>
+  </div>
+
+  <div class="panel">
+    <h2>What would X and K buy me?</h2>
+    <p class="note">A replay of <em>your own past gaps</em>, not a forecast. Each rung keeps
+      the cache alive for <strong>K &times; X + 300 s</strong> — the last ping is itself a
+      cache read, and a read refreshes the lifetime for free, which is why the trailing
+      five minutes belong in the arithmetic.</p>
+    <div class="ka-calc-controls" id="ka-calc-controls"></div>
+    <div id="ka-calc" data-testid="ka-calc"></div>
+  </div>
+
+  <div class="panel">
+    <h2>Keep one session warm</h2>
+    <p class="note" data-testid="ka-arm-note">Pick a session and keep its cache warm for a
+      stated time. This is a manual override for a session you are working in now, not a
+      strategy: chosen from history, session lists do not transfer — on this service's own
+      traffic, a list fitted on one half of a week earned <strong>$5.27</strong> in the next
+      half where the plain account-wide rule earned <strong>$53.32</strong>.</p>
+    <div id="ka-armed" data-testid="ka-armed"></div>
+  </div>
+
+  <div class="panel">
+    <h2>What should I set?</h2>
+    <div id="ka-recommend" data-testid="ka-recommend"></div>
   </div>
 </section>
 

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -513,7 +513,7 @@
     <h2>Verdict</h2>
     <p class="note">What the idle keep-alive has spent on your traffic and what it has
       avoided, over the window selected above. The <strong>net</strong> is the only one of
-      these four worth a decision.</p>
+      these figures worth a decision.</p>
     <div id="ka-coverage"></div>
     <div id="ka-tiles"></div>
   </div>

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -592,7 +592,7 @@
     <div id="ka-calc" data-testid="ka-calc"></div>
   </div>
 
-  <div class="panel">
+  <div class="panel" data-ka-arm-panel>
     <h2>Keep one session warm</h2>
     <p class="note" data-testid="ka-arm-note">Pick a session and keep its cache warm for a
       stated time. This is a manual override for a session you are working in now, not a

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -182,6 +182,11 @@ code, kbd { font-family: var(--mono); font-size: 0.92em; }
   clip-path: inset(50%); white-space: nowrap; margin: -1px; padding: 0; border: 0;
 }
 .warn-text { color: var(--warn); }
+/* Sign colours for a signed figure in a table cell. A number's own colour is a status
+   judgement (this cost you / this saved you), which is what --good and --bad are for, and
+   every one of them sits beside a signed value so identity never rests on the hue. */
+.good-text { color: var(--good); }
+.bad-text  { color: var(--bad); }
 
 /* ── top bar ──────────────────────────────────────────────────────────── */
 .topbar {
@@ -1263,3 +1268,28 @@ pre.yaml {
   font-size: var(--t-body); margin: var(--sp-4) 0 var(--sp-2); color: var(--fg);
 }
 #cache-detail h3:first-child { margin-top: 0; }
+
+/* ── Keep-alive tab ──────────────────────────────────────────────────────────
+   Emphasis in the K-ladder table, by WEIGHT and ink rather than by a new hue: the row that
+   is in force is the accent, the alternatives recede. A fifth series colour would mean the
+   chart needs splitting, not a new colour. */
+.grid tr.is-current > td { color: var(--accent); font-weight: 600; }
+.grid tr.muted-row > td { color: var(--fg-muted); }
+/* The calculator's two inputs, on one row above the answer — the same place every other
+   filter on this dashboard lives. */
+.ka-calc-controls .field-row {
+  display: flex; flex-wrap: wrap; gap: var(--sp-2); align-items: center;
+  margin-bottom: var(--sp-3);
+}
+.ka-calc-controls label { font-size: var(--t-small); color: var(--fg-muted); }
+.ka-calc-controls input[type=number] { width: 6.5em; }
+/* A signed headline beside the winner/loser bar reuses the score slot, with the loss
+   direction stated in ink as well as in the figure's own minus sign. */
+.nps-score.bad { color: var(--bad); }
+/* The downside panel's banner carries a button, so it is a row rather than a paragraph. */
+#ka-worst .banner { display: flex; flex-wrap: wrap; gap: var(--sp-3); align-items: center; }
+#ka-worst .banner > div { flex: 1 1 22em; }
+/* A bar that drills through says so on hover, and it is keyboard-reachable through the
+   panel's own table view rather than by making a div a button. */
+.bar-row.clickable { cursor: pointer; }
+.bar-row.clickable:hover .bar-track { outline: 2px solid var(--accent-soft); }

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -1293,3 +1293,6 @@ pre.yaml {
    panel's own table view rather than by making a div a button. */
 .bar-row.clickable { cursor: pointer; }
 .bar-row.clickable:hover .bar-track { outline: 2px solid var(--accent-soft); }
+/* Exactly zero draws NOTHING. .bar-fill carries a 2px min-width so a very small value stays
+   visible, and on a histogram with empty bands that nub read as "a little" rather than "none". */
+.bar-fill.zero { min-width: 0; }

--- a/dash/uikeepalive_test.go
+++ b/dash/uikeepalive_test.go
@@ -1,0 +1,234 @@
+package dash
+
+// Static checks over the keep-alive tab's own assets.
+//
+// Every one of them is a HONESTY property: a figure that reads as a measurement when it is an
+// absence, a saving presented without the spend that bought it, a downside panel that only
+// renders when the news is bad. All three are invisible on screen when they are wrong — the page
+// looks completely fine — which is what earns a source-level assertion here, exactly as
+// TestEveryInventoryTileHasAnExplanation does.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every tile on the new tab has its plain-English definition, how it was derived, and its catch.
+//
+// The same check TestEveryInventoryTileHasAnExplanation makes, applied to the keys this tab adds:
+// this is the tab whose numbers authorise SPENDING somebody's money, so a figure nobody can
+// interpret is worse here than anywhere else on the dashboard.
+func TestEveryKeepAliveTileHasAnExplanation(t *testing.T) {
+	src := readUI(t, "ui/app.js")
+	keys := map[string]bool{}
+	for _, m := range regexp.MustCompile(`tile\('(ka-[a-z0-9-]+)'`).FindAllStringSubmatch(src, -1) {
+		keys[m[1]] = true
+	}
+	if len(keys) == 0 {
+		t.Fatal("found no ka- tile() calls; this check needs rewriting against whatever replaced them")
+	}
+	for k := range keys {
+		if !strings.Contains(src, "'"+k+"': {") {
+			t.Errorf("tile %q has no TILE_INFO entry.\n"+
+				"Every figure on this tab needs what it means, how it was derived and its "+
+				"catch — these are the numbers somebody decides to spend money on.", k)
+		}
+	}
+	// And the two disclosures that must be somewhere in the registry for the saving tiles:
+	// the ceiling, and the "a zero may be an absence" state.
+	for _, must := range []string{"CEILING", "content-keyed", "content, so"} {
+		if strings.Contains(src, must) {
+			return
+		}
+	}
+	t.Error("no tile explanation says the keep-alive saving is a CEILING because the provider's " +
+		"cache is keyed on content; that confound is the one thing this figure cannot measure")
+}
+
+// The downside panel renders UNCONDITIONALLY, with the worst-session figure and the
+// service-wide split, and its copy is in the MARKUP rather than behind a branch.
+//
+// Because the tempting implementation is `if (net < 0) showTheDownside()`, and that is a page
+// that tells the truth only to the people who already found out.
+func TestTheLosingMajorityIsOnThePage(t *testing.T) {
+	html := readUI(t, "ui/index.html")
+	i := strings.Index(html, `id="ka-downside-panel"`)
+	if i < 0 {
+		t.Fatal("the downside panel is gone; this check needs rewriting")
+	}
+	end := strings.Index(html[i:], "</div>\n\n  <div class=\"panel\"")
+	if end < 0 {
+		end = len(html) - i
+	}
+	panel := html[i : i+end]
+	// The service-wide figures, in the static markup: not fetched, not conditional, not
+	// computed from the reader's own window — a reader whose own account looks fine still has
+	// to meet the shape of the mechanism.
+	for _, want := range []string{"34 of 119", "$2.42", "tax on most"} {
+		if !strings.Contains(panel, want) {
+			t.Errorf("the downside panel's markup does not carry %q:\n%s", want, panel)
+		}
+	}
+	// And it sits ABOVE the calculator, which is the whole information-architecture decision:
+	// a page that led with the calculator would be selling.
+	calc := strings.Index(html, "What would X and K buy me?")
+	if calc < 0 {
+		t.Fatal("the calculator panel is gone; this check needs rewriting")
+	}
+	if calc < i {
+		t.Error("the calculator is above the downside panel. The verdict comes first and the " +
+			"downside second, deliberately: 85 of the 119 sessions this touched lost money, " +
+			"and a page that leads with what it could buy you is selling.")
+	}
+	src := readUI(t, "ui/app.js")
+	// The renderer must not gate the panel on the sign of the net. It may add a banner when the
+	// net is negative — that is the extra — but the split and the worst session are not behind
+	// that branch.
+	j := strings.Index(src, "function renderKADownside(")
+	if j < 0 {
+		t.Fatal("renderKADownside is gone; this check needs rewriting")
+	}
+	body := src[j : j+min(len(src)-j, 4000)]
+	splitAt := strings.Index(body, "nps-bar")
+	// The BRANCH, not any mention of the sign: colouring the headline by its sign is fine and
+	// necessary. What must not happen is the split being built inside `if (net < 0) { ... }`.
+	guardAt := strings.Index(body, "if (o.net_usd < 0)")
+	if splitAt < 0 {
+		t.Fatal("the winner/loser bar is not rendered")
+	}
+	if guardAt >= 0 && guardAt < splitAt {
+		t.Error("the winner/loser split is rendered inside a negative-net branch; it must render " +
+			"whatever the sign is")
+	}
+	// The only thing that branch may add is the way out.
+	if guardAt < 0 || !strings.Contains(body[guardAt:], "Turn keep-alive off") {
+		t.Error("a negative own net does not offer a way to switch the mechanism off")
+	}
+	// The status segments are labelled in WORDS as well as coloured — a status must never rest
+	// on hue alone.
+	if !strings.Contains(body, "Came out ahead") || !strings.Contains(body, "Paid for nothing") {
+		t.Error("the winner/loser segments are not labelled in words beside their colour")
+	}
+}
+
+// The recommendation UI never renders a hero number, and there is no point estimate for it to
+// render: the payload does not carry one (TestRecommendationPayloadCarriesNoPointEstimate) and
+// the renderer reads a RANGE.
+func TestTheRecommendationRendersARangeAndRefusesThinHistory(t *testing.T) {
+	src := readUI(t, "ui/app.js")
+	i := strings.Index(src, "async function loadKARecommend(")
+	if i < 0 {
+		t.Fatal("loadKARecommend is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 4000)]
+	if !strings.Contains(body, "rec.lo_usd") || !strings.Contains(body, "rec.hi_usd") {
+		t.Error("the recommendation does not render an interval")
+	}
+	if !strings.Contains(body, "rec.refused") {
+		t.Error("the recommendation has no refusal branch; below 20 addressable expiries a real " +
+			"saving cannot be told from noise, and rounding that off is the sixth time this " +
+			"project would have concluded a difference from too small an n")
+	}
+	if !strings.Contains(body, "factor of two") {
+		t.Error("the honest sentence — the direction is resolvable, the size is not — is not on " +
+			"the page")
+	}
+	// Nothing is auto-applied: the button fills the Settings fields and leaves them unsaved.
+	if strings.Contains(body, "method: 'PUT'") || strings.Contains(body, `method: "PUT"`) {
+		t.Error("the recommendation panel SAVES. A recommendation whose own interval is 62% wide " +
+			"is not something a service applies on somebody's behalf; it fills the fields in.")
+	}
+	if !strings.Contains(body, "Nothing is saved until you press Save") {
+		t.Error("the apply button does not say that nothing is saved")
+	}
+}
+
+// The keep-alive tab respects the time-range filter, so it must NOT be in UNFILTERED_VIEWS —
+// every figure on it is "over this window" and a tab that ignored the picker above it would be
+// answering a different question from the one on screen.
+func TestTheKeepAliveTabRespectsTheTimeRange(t *testing.T) {
+	src := readUI(t, "ui/app.js")
+	i := strings.Index(src, "const UNFILTERED_VIEWS")
+	if i < 0 {
+		t.Fatal("UNFILTERED_VIEWS is gone; this check needs rewriting")
+	}
+	line := src[i : i+strings.Index(src[i:], "\n")]
+	if strings.Contains(line, "keepalive") {
+		t.Errorf("the keep-alive tab is in UNFILTERED_VIEWS: %s", line)
+	}
+	// And it is wired into the loader table, or the tab renders nothing at all.
+	if !strings.Contains(src, "keepalive: loadKeepAlive") {
+		t.Error("the keep-alive view has no loader")
+	}
+	if !strings.Contains(readUI(t, "ui/index.html"), `data-view="keepalive"`) {
+		t.Error("there is no keep-alive tab button")
+	}
+}
+
+// No new hue, no pie, no gauge, no second chart library. The dashboard has a fixed four-hue
+// categorical order, a status palette and two chart primitives; a fifth series colour means a
+// chart needs splitting, not a new colour.
+func TestTheKeepAliveTabAddsNoNewChartVocabulary(t *testing.T) {
+	src := readUI(t, "ui/app.js")
+	i := strings.Index(src, "async function loadKeepAlive(")
+	if i < 0 {
+		t.Fatal("loadKeepAlive is gone; this check needs rewriting")
+	}
+	tab := src[i:]
+	// Matched against CODE rather than the whole text: the prose on this tab names the forms it
+	// deliberately does not use ("never a hero number and never a gauge"), and a check that
+	// cannot tell a comment from a call would forbid saying so.
+	code := stripJSComments(tab)
+	for _, bad := range []string{"--s5", "var(--s5)", "pieChart", "treemap", "gauge", "Chart.js",
+		"d3.", "conic-gradient"} {
+		if strings.Contains(code, bad) {
+			t.Errorf("the keep-alive tab introduces %q. The form heuristic maps every panel here "+
+				"onto stat tiles, barRows, lineChart and the status bar; anything else is a new "+
+				"vocabulary for the reader to learn.", bad)
+		}
+	}
+	// Two charts and never two y-axes: a count and a dollar figure share no scale.
+	if strings.Count(code, "lineChart(") < 2 {
+		t.Error("the per-day panel does not draw two separate charts; a count and a dollar " +
+			"figure on one pair of axes is a dual-axis chart, which is the single most common " +
+			"way a chart implies a relationship it has not measured")
+	}
+	if strings.Contains(code, "y2") || strings.Contains(code, "rightAxis") {
+		t.Error("a second y-axis appeared on the keep-alive tab")
+	}
+}
+
+// stripJSComments removes // and /* */ comments, crudely but adequately: this file's own prose
+// discusses the chart types it refuses to use, and a substring check over the comments would
+// forbid documenting the decision.
+func stripJSComments(src string) string {
+	var b strings.Builder
+	for i := 0; i < len(src); {
+		switch {
+		case strings.HasPrefix(src[i:], "//"):
+			j := strings.IndexByte(src[i:], '\n')
+			if j < 0 {
+				return b.String()
+			}
+			i += j
+		case strings.HasPrefix(src[i:], "/*"):
+			j := strings.Index(src[i:], "*/")
+			if j < 0 {
+				return b.String()
+			}
+			i += j + 2
+		default:
+			b.WriteByte(src[i])
+			i++
+		}
+	}
+	return b.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/proxy/control.go
+++ b/proxy/control.go
@@ -72,7 +72,7 @@ type ctlRoute struct {
 
 // ctlRoutes is the single mounted route table, read by MountControl and by the scope test.
 func (h *Handler) ctlRoutes() []ctlRoute {
-	return []ctlRoute{
+	rs := []ctlRoute{
 		{"POST /api/register", ctlPublic, h.ctlRegister},
 		{"POST /api/login", ctlPublic, h.ctlLogin},
 		{"POST /api/verify", ctlPublic, h.ctlVerify},
@@ -115,6 +115,10 @@ func (h *Handler) ctlRoutes() []ctlRoute {
 		// in this table — a proxy token cannot open the dashboards.
 		{"GET /api/authz/grafana", ctlManager, h.ctlAuthzGrafana},
 	}
+	// The keep-alive's write half, declared beside its handlers in keepalivectl.go and appended
+	// here for the same reason the dashboard's are: this table is what gate enforces and what
+	// TestEveryControlRouteEnforcesItsScope walks.
+	return append(rs, h.keepAliveCtlRoutes()...)
 }
 
 // grafanaUserHeader carries the authorized manager's address from this endpoint to
@@ -1221,9 +1225,25 @@ func (h *Handler) ctlUpdateMe(w http.ResponseWriter, r *http.Request) {
 		// form would post whatever the fallback happened to see — and with no YAML box on
 		// that page, over an already-broken document. The account editor still takes a
 		// document, which is where this gets fixed.
-		if cur, _ := config.ParseForm(current); cur.ParseError != "" {
+		cur, _ := config.ParseForm(current)
+		if cur.ParseError != "" {
 			ctlErr(w, http.StatusConflict, "your stored configuration does not load ("+cur.ParseError+
 				"), so it cannot be edited as fields; a manager must repair it on the account page")
+			return
+		}
+		// A stale page must not SAVE. PipelineKnown (config/form.go) stops such a save
+		// dropping a component the client could not see; it cannot stop one ADDING a
+		// component back, because from the server's side an addition is indistinguishable
+		// from a deliberate one. So the page states the pipeline it rendered from, and a
+		// mismatch means the document moved underneath it — which is exactly what re-added
+		// `toon` to an operator's pipeline while dropping `linecap`.
+		//
+		// nil is accepted: an older cached bundle does not send it, and refusing every save
+		// from one would break the settings page for as long as that bundle lives in a cache.
+		// PipelineKnown is then the only defence, which is the safe direction.
+		if in.Config.PipelineBase != nil && !sameNames(in.Config.PipelineBase, cur.Pipeline) {
+			ctlErr(w, http.StatusConflict, "your configuration changed since this page loaded; "+
+				"reload before saving")
 			return
 		}
 		doc, err := config.ApplyForm(current, *in.Config)
@@ -2266,4 +2286,19 @@ func hasString(list []string, s string) bool {
 func atoi64(s string) int64 {
 	n, _ := strconv.ParseInt(s, 10, 64)
 	return n
+}
+
+// sameNames compares two component lists as ORDERED sequences. Order is part of a pipeline's
+// meaning — the same names in a different order is a different configuration — so this is a
+// plain element-wise comparison and not a set test.
+func sameNames(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -324,6 +324,10 @@ type keeper struct {
 	// session id and is cleared wholesale at the bound; give it an LRU only if session churn
 	// is ever shown to cost real pings.
 	turns map[string]int
+	// overrides is the per-session manual keep-alive, keyed like live. In memory only and
+	// deliberately so — an authorization to spend that silently survives a restart is worse
+	// than one that does not. See keepaliveoverride.go.
+	overrides map[string]sessionOverride
 
 	// send performs one ping. A field so tests can drive the whole policy — timing, caps,
 	// limits, the write-instead-of-read guard — without a network.
@@ -354,7 +358,8 @@ func keepAliveDisabled() bool {
 
 func newKeeper(h *Handler) *keeper {
 	k := &keeper{h: h, stop: make(chan struct{}), done: make(chan struct{}),
-		live: map[string]*kaEntry{}, turns: map[string]int{}, now: time.Now}
+		live: map[string]*kaEntry{}, turns: map[string]int{},
+		overrides: map[string]sessionOverride{}, now: time.Now}
 	k.send = k.sendPing
 	k.dispatch = func(j pingJob) { go k.fire(j) }
 	return k
@@ -405,6 +410,9 @@ func (k *keeper) Stop() {
 	}
 	k.bytes = 0
 	k.turns = map[string]int{}
+	// The overrides go with everything else: they are authorizations to spend, and the process
+	// they authorized is ending.
+	k.overrides = map[string]sessionOverride{}
 }
 
 // clear ZEROIZES an entry's body and credential and cancels its retention deadline. Called on
@@ -497,6 +505,13 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	// the setting off stops being retained on its very next request; anything held for a session
 	// that goes quiet instead is dropped by the hard deadline below, within (K+1)x X.
 	pol := tn.Cache
+	// A per-session manual override, if one is armed and unexpired. The ONE hook this feature
+	// has in the request path: everything below reads `pol` and neither knows nor cares where
+	// it came from. An override may switch the mechanism ON for a session whose account default
+	// is off — that is the point of it, and the arming request is the consent act — but it may
+	// not widen the per-ping cost guard, and it cannot reach around the kill switch or the
+	// no-audit-sink refusal above.
+	pol = k.overrideFor(tn.ID, session, pol)
 	if !pol.on() {
 		k.retire(key)
 		return
@@ -647,6 +662,10 @@ func (k *keeper) forget(tenantID string) {
 		delete(k.live, key)
 		delete(k.turns, key)
 	}
+	// Per-session overrides go too. This is the path a Settings save takes, so unticking the
+	// account-wide box must not leave armed sessions pinging on the strength of an
+	// authorization the account has just withdrawn.
+	k.forgetOverrides(tenantID)
 }
 
 // evictLocked enforces both bounds by dropping the entries whose deadline is furthest away
@@ -680,6 +699,10 @@ func (k *keeper) sweep(now time.Time) int {
 		return 0
 	}
 	k.mu.Lock()
+	// Expired overrides go on the same 2 s tick, so the map cannot grow on the strength of
+	// authorizations nobody withdrew. overrideFor treats an expired one as absent regardless,
+	// so this is hygiene rather than correctness.
+	k.expireOverridesLocked(now)
 	var due []pingJob
 	for key, e := range k.live {
 		// EAGER release of a span that can do nothing more, so material goes as soon as it is

--- a/proxy/keepalivectl.go
+++ b/proxy/keepalivectl.go
@@ -1,0 +1,310 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rossoctl/context-guru/config"
+	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/tenant"
+)
+
+// The keep-alive's WRITE routes: arm a session, disarm one, and the account-wide off switch.
+//
+// Here rather than in dash because this is where the keeper and the web principal live, and
+// because they share PUT /api/me's authentication and CSRF path exactly — no new auth code, and
+// the same table-driven scope enforcement (ctlRoutes / gate / TestEveryControlRouteEnforcesItsScope).
+//
+// # The consent asymmetry, and why it is deliberate
+//
+// Turning the mechanism ON keeps the manager gate, because it is stored in the configuration
+// document and that document is manager-owned. Turning it OFF is open to ANY principal on their
+// own account. Consent withdrawal must never be harder than consent, and the account-level box
+// was drawn disabled for a non-manager (app.js: `ka.disabled = inherited || !mgr`) — so an
+// account owner whose own key was being spent could not switch it off from the page at all.
+// DELETE /api/me/keepalive is that hole closed, one-way.
+
+// keepAliveCtlRoutes is this feature's half of the control-plane table.
+func (h *Handler) keepAliveCtlRoutes() []ctlRoute {
+	return []ctlRoute{
+		// What is armed RIGHT NOW: the live map, not a stored intention. There is no stored
+		// intention — see keepaliveoverride.go for why an authorization to spend does not
+		// survive a restart.
+		{"GET /api/me/keepalive/sessions", ctlTenant, h.ctlKeepAliveArmed},
+		// ctlManager, and the class is the honest statement of it: arming spends a credential,
+		// so v1 keeps the same role boundary the account-wide box has. It acts on the caller's
+		// OWN account — no {id} in the path — which is why it sits among the /api/me routes
+		// rather than the /api/tenants ones. The handler re-checks the role for the reason
+		// every handler in this file does: the gate makes the class enforced by the table, and
+		// its own check keeps it correct if it is ever called from somewhere else.
+		{"POST /api/me/keepalive/sessions", ctlManager, h.ctlKeepAliveArm},
+		{"DELETE /api/me/keepalive/sessions/{session}", ctlTenant, h.ctlKeepAliveDisarm},
+		// The account-wide off switch. ctlTenant and NOT ctlManager, deliberately: see above.
+		{"DELETE /api/me/keepalive", ctlTenant, h.ctlKeepAliveOff},
+	}
+}
+
+// ctlKeepAliveArmed lists the caller's own live overrides.
+func (h *Handler) ctlKeepAliveArmed(w http.ResponseWriter, r *http.Request) {
+	t, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"armed": h.keeper.armedFor(t.ID),
+		// Stated on the wire and not only in the copy: these are lost on restart, and a client
+		// that renders them as durable is misrepresenting an authorization to spend.
+		"durable":          false,
+		"max_hours":        int(maxOverrideUntil / time.Hour),
+		"default_hours":    int(defaultOverrideUntil / time.Hour),
+		"max_hold_minutes": int(maxOverrideHold / time.Minute),
+	})
+}
+
+// ctlKeepAliveArm arms one session, for a stated time, with stated parameters.
+//
+// The manager gate stays in v1 for the same reason it is on the account-wide box: this
+// authorizes spend on a credential, and widening who may do that needs its own consent story.
+// Disarming does not, and neither does the account-wide off switch.
+func (h *Handler) ctlKeepAliveArm(w http.ResponseWriter, r *http.Request) {
+	t, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	if !t.IsManager() {
+		ctlErr(w, http.StatusForbidden, "a manager arms a session's keep-alive")
+		return
+	}
+	var in struct {
+		Session         string `json:"session"`
+		IdleSeconds     int    `json:"idle_seconds"`
+		MaxPings        int    `json:"max_pings"`
+		MinPrefixTokens int    `json:"min_prefix_tokens"`
+		// Until is epoch ms. Mandatory: an override with no expiry is an authorization to
+		// spend that nobody ever revisits.
+		Until int64 `json:"until"`
+		// MaxUSDPerPing is ACCEPTED AND IGNORED, and that is worth being explicit about. The
+		// per-ping cost guard exists because ping cost is bimodal (p50 $0.0004, p99 $0.2275,
+		// max $0.3780), so it is the one control an override may not widen. Silently dropping a
+		// field a caller sent is worse than refusing it, so the response reports the value
+		// actually in force.
+		MaxUSDPerPing float64 `json:"max_usd_per_ping"`
+	}
+	if err := readJSON(w, r, &in); err != nil {
+		readErr(w, err)
+		return
+	}
+	// Arming is a spend authorization, so it is rate-limited like one.
+	if err := h.limiter.AllowAction(t.ID, "keep-alive arms", overrideArmsPerHour); err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	now := time.Now()
+	until := now.Add(defaultOverrideUntil)
+	if in.Until > 0 {
+		until = time.UnixMilli(in.Until)
+	}
+	idle := time.Duration(in.IdleSeconds) * time.Second
+	if in.IdleSeconds == 0 {
+		idle = time.Duration(recIdleSecondsDefault) * time.Second
+	}
+	pings := in.MaxPings
+	if pings == 0 {
+		pings = recMaxPingsDefault
+	}
+	// The session id is taken as SENT and keyed under the AUTHENTICATED principal. A session id
+	// whose `tenant:uuid` prefix names somebody else therefore addresses nothing at all: it
+	// becomes a key under the caller's own tenant that no request will ever match.
+	o, err := validOverride(in.Session, idle, pings, in.MinPrefixTokens, until, now, t.ID)
+	if err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.keeper.arm(t.ID, in.Session, o); err != nil {
+		ctlErr(w, http.StatusConflict, err.Error())
+		return
+	}
+	// The durable half. The live policy does not survive a restart; who authorized what spend,
+	// with which parameters, until when, does.
+	after := fmt.Sprintf("armed idle=%ds pings=%d min_prefix=%d until=%s hold<=%.0fmin",
+		in.IdleSeconds, pings, in.MinPrefixTokens, until.UTC().Format(time.RFC3339),
+		o.hold().Minutes())
+	if err := h.registry().AuditWrite(t.ID, t.ID, "keepalive_session", in.Session, after); err != nil {
+		// An arm we cannot account for is an arm we do not keep. The whole credential
+		// arrangement rests on being reviewable.
+		h.keeper.disarm(t.ID, in.Session)
+		ctlErr(w, http.StatusInternalServerError, "could not record this in the audit log, so it "+
+			"was not armed")
+		return
+	}
+	// What the caller is authorizing, in the two units that matter: how long their credential
+	// may be held, and what this can cost at worst. Arming without showing that is the thing
+	// this whole feature is trying not to be.
+	writeJSON(w, http.StatusOK, h.armedView(t, in.Session, o))
+}
+
+// The shipped policy's defaults, for a body that omits them. Named here rather than reaching
+// into config so this file states what it applies.
+const (
+	recIdleSecondsDefault = 280
+	recMaxPingsDefault    = 2
+)
+
+// armedView is the POST answer: the resolved policy plus the two numbers being authorized.
+func (h *Handler) armedView(t *tenant.Tenant, session string, o sessionOverride) map[string]any {
+	out := map[string]any{
+		"session":           session,
+		"idle_seconds":      int(o.pol.Idle.Seconds()),
+		"max_pings":         o.pol.MaxPings,
+		"until":             o.until.UnixMilli(),
+		"hold_minutes":      o.hold().Minutes(),
+		"durable":           false,
+		"min_prefix_tokens": o.pol.MinPrefixTokens,
+	}
+	// The account's own per-ping guard, reported because the body's value is ignored. Resolved
+	// from the account's own document through the same builder the request path uses, so the
+	// number shown is the number that will be enforced.
+	if h.opts.Tenants != nil {
+		if tn, err := h.opts.Tenants.ForTenant(t); err == nil {
+			out["max_usd_per_ping"] = tn.Cache.MaxUSDPerPing
+		}
+	}
+	// The worst case, priced from THIS SESSION's own last billed prefix at its own model's
+	// cache-read rate — never a service-wide average, because per-ping cost is bimodal. Absent
+	// rather than zero when the model has no rate on the operator's list.
+	prefix, model, spans := h.worstCase(t.ID, session, o)
+	out["last_prefix_tokens"], out["model"], out["worst_case_pings"] = prefix, model, spans
+	if p := h.opts.Prices; p != nil && model != "" && prefix > 0 {
+		if price, ok := p.Price(context.Background(), model); ok && !price.Zero() {
+			each := float64(prefix)*price.CacheRead + price.Output
+			out["ping_usd_each"] = each
+			out["worst_case_usd"] = each * float64(spans)
+			out["priced"] = true
+		}
+	}
+	if _, ok := out["priced"]; !ok {
+		out["priced"] = false
+	}
+	return out
+}
+
+// worstCase is the ceiling on what one armed override can cost: the session's last billed
+// prefix, its model, and the most pings the override can send before it expires.
+//
+// The ping count is K per idle span and one span is at most (K+1) x Idle long — the hard
+// retention deadline — so the number of spans left until `until` bounds the total. Deliberately
+// a CEILING and not an estimate: a session that goes quiet sends none of them, and the honest
+// thing to show somebody authorizing a spend is the most it can be.
+func (h *Handler) worstCase(tenantID, session string, o sessionOverride) (prefix int64, model string, pings int64) {
+	spanSeconds := o.hold().Seconds()
+	if spanSeconds <= 0 {
+		return 0, "", 0
+	}
+	spans := int64(time.Until(o.until).Seconds() / spanSeconds)
+	if spans < 1 {
+		spans = 1
+	}
+	pings = spans * int64(o.pol.MaxPings)
+	if h.rec == nil {
+		return 0, "", pings
+	}
+	p, m, err := h.rec.DB().LastBilledPrefix(dash.Filter{Tenant: tenantID}, session)
+	if err != nil {
+		return 0, "", pings
+	}
+	return p, m, pings
+}
+
+// ctlKeepAliveDisarm removes one override and releases what is held for that session NOW.
+//
+// Any principal on their own account: this is a withdrawal, and a withdrawal that needed a role
+// would be consent that is harder to take back than to give.
+func (h *Handler) ctlKeepAliveDisarm(w http.ResponseWriter, r *http.Request) {
+	t, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	session := r.PathValue("session")
+	if session == "" {
+		ctlErr(w, http.StatusBadRequest, "name the session to disarm")
+		return
+	}
+	had := h.keeper.disarm(t.ID, session)
+	if had {
+		if err := h.registry().AuditWrite(t.ID, t.ID, "keepalive_session", session, "disarmed"); err != nil {
+			// The material is already released, which is the part that matters; say the audit
+			// row failed rather than pretend it did not.
+			ctlErr(w, http.StatusInternalServerError, "disarmed, but the audit log could not be written")
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"session": session, "armed": false, "was_armed": had})
+}
+
+// ctlKeepAliveOff is the account-wide off switch, open to ANY principal on their own account.
+//
+// Three things, in this order, because the order is the guarantee: the stored consent goes, the
+// per-session authorizations go, and the material already held is released now rather than at the
+// hard deadline. One-way by design — turning it back ON keeps the manager gate, because it is a
+// field of a manager-owned document.
+func (h *Handler) ctlKeepAliveOff(w http.ResponseWriter, r *http.Request) {
+	t, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	reg := h.registry()
+	current := reg.Config(t)
+	cur, _ := config.ParseForm(current)
+	if cur.ParseError != "" {
+		// The document cannot be edited as fields — but the withdrawal must still take effect,
+		// so the live hold is dropped and the caller is told what did not happen. Refusing
+		// outright would leave a user unable to stop spend because of an unrelated typo.
+		h.keeper.forget(t.ID)
+		ctlErr(w, http.StatusConflict, "the keep-alive is stopped for now and every armed "+
+			"session is disarmed, but your stored configuration does not load so the setting "+
+			"itself could not be changed; a manager must repair it on the account page")
+		return
+	}
+	was := "true"
+	if cur.Cache == nil || !cur.Cache.KeepAlive {
+		was = "false"
+	}
+	if cur.Cache == nil {
+		cur.Cache = &config.CacheForm{}
+	}
+	cur.Cache.KeepAlive = false
+	// The form was READ from this document, so it models every component the document runs and
+	// says so. Without the claim ApplyForm would preserve names this form did not send, which is
+	// the right default for a browser and pointless here.
+	cur.PipelineKnown = append([]string(nil), cur.Pipeline...)
+	doc, err := config.ApplyForm(current, cur)
+	if err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Written with the REGISTRY's own self-service path, so it is audited field by field like
+	// any other change to the document. tenant.Patch is checked against the actor inside Update.
+	if err := reg.Update(t, t.ID, tenant.Patch{ConfigYAML: &doc}); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Stops RETENTION now, not at the deadline: drops every held body and credential for this
+	// account and every per-session override with them.
+	h.keeper.forget(t.ID)
+	if err := reg.AuditWrite(t.ID, t.ID, "keepalive", was, "false"); err != nil {
+		ctlErr(w, http.StatusInternalServerError, "switched off, but the audit log could not be written")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"keepalive": false})
+}

--- a/proxy/keepalivectl_test.go
+++ b/proxy/keepalivectl_test.go
@@ -1,0 +1,317 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/config"
+	"github.com/rossoctl/context-guru/tenant"
+)
+
+// The keep-alive's write routes at the HTTP level, plus Bug 2's stale-page refusal — which is
+// here rather than in config because the stored document is what it compares against.
+
+// setDoc stores a configuration document for one tenant, as a manager would.
+func setDoc(t *testing.T, f *mgrFixture, id, doc string) {
+	t.Helper()
+	tn, err := f.reg.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.reg.Update(tn, id, tenant.Patch{ConfigYAML: &doc}); err != nil {
+		t.Fatalf("storing the document: %v", err)
+	}
+}
+
+// Bug 2's second rule. Preserving the unmodelled stops a save DROPPING a component the client
+// could not see; it cannot stop one ADDING a component back, because from the server's side an
+// addition is indistinguishable from a deliberate one. So the page states the pipeline it
+// rendered from and a mismatch is a 409 — and the stored document must be byte-identical after.
+func TestASaveFromAStalePageIsRefused(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, id := f.signUpJar(t, "boss@ibm.com")
+	const stored = "pipeline:\n  - format\n  - linecap\n  - extract\nmode: sync\n"
+	setDoc(t, f, id, stored)
+	before, err := f.reg.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A page that rendered from a DIFFERENT pipeline: this is the stale render that put `toon`
+	// back and took `linecap` out.
+	body := `{"config":{"pipeline":["format","toon"],` +
+		`"pipeline_known":["format","toon","extract"],` +
+		`"pipeline_base":["format","extract"],` +
+		`"components":{},"cache":{"keepalive":false,"head_ttl_1h":false}}}`
+	w, _ := f.do(t, http.MethodPut, "/api/me", body, mgrJar)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("a save from a stale page = %d, want 409: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "reload") {
+		t.Errorf("the refusal does not tell the reader what to do: %s", w.Body)
+	}
+	after, err := f.reg.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ConfigYAML != before.ConfigYAML {
+		t.Errorf("a refused save changed the stored document:\n%q\n->\n%q",
+			before.ConfigYAML, after.ConfigYAML)
+	}
+
+	// The SAME body with a base that matches is accepted, and `extract` survives because the
+	// client did not claim to have drawn it... it did claim it, so it is removed. `linecap` was
+	// NOT claimed, so it survives at its own index. Both halves of the rule in one save.
+	ok := `{"config":{"pipeline":["format","toon"],` +
+		`"pipeline_known":["format","toon","extract"],` +
+		`"pipeline_base":["format","linecap","extract"],` +
+		`"components":{},"cache":{"keepalive":false,"head_ttl_1h":false}}}`
+	w, _ = f.do(t, http.MethodPut, "/api/me", ok, mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("a save whose base matches = %d, want 200: %s", w.Code, w.Body)
+	}
+	saved, err := f.reg.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := config.ParseForm(saved.ConfigYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasName(got.Pipeline, "linecap") {
+		t.Errorf("linecap was dropped by a client that did not render it: %v\n%s",
+			got.Pipeline, saved.ConfigYAML)
+	}
+	if hasName(got.Pipeline, "extract") {
+		t.Errorf("a DECLARED removal did not remove extract: %v", got.Pipeline)
+	}
+	if !hasName(got.Pipeline, "toon") {
+		t.Errorf("the save did not add toon: %v", got.Pipeline)
+	}
+	// A nil base is still accepted — an older cached bundle does not send one, and refusing
+	// every save from one would break the settings page for as long as that bundle is cached.
+	nobase := `{"config":{"pipeline":["format"],"pipeline_known":["format"],` +
+		`"components":{},"cache":{"keepalive":false,"head_ttl_1h":false}}}`
+	if w, _ := f.do(t, http.MethodPut, "/api/me", nobase, mgrJar); w.Code != http.StatusOK {
+		t.Errorf("a save with no pipeline_base = %d, want 200 (old bundle): %s", w.Code, w.Body)
+	}
+}
+
+// hasName reports membership in a component list. Named for what it holds rather than
+// `contains`, which this package's limits_test already uses for a substring test.
+func hasName(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Arming answers with the two numbers the caller is authorizing: how long their credential may
+// be held, and what this can cost at worst. Arming without showing that is the thing this whole
+// feature is trying not to be.
+func TestArmingStatesTheHoldAndTheWorstCaseSpend(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	until := time.Now().Add(2 * time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"session":"s-1","idle_seconds":280,"max_pings":2,"until":%d}`, until)
+	w, out := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("arm = %d: %s", w.Code, w.Body)
+	}
+	// (K+1) x X = 3 x 280 s = 14 minutes, which is what the Settings copy promises at the
+	// shipped defaults — an override changes that number, so it must be stated.
+	if got, _ := out["hold_minutes"].(float64); got != 14 {
+		t.Errorf("hold_minutes = %v, want 14 ((K+1) x X)", out["hold_minutes"])
+	}
+	if _, ok := out["worst_case_pings"]; !ok {
+		t.Error("the answer does not say how many pings this can send at worst")
+	}
+	if got, _ := out["durable"].(bool); got {
+		t.Error("the answer claims the override is durable; it is lost on restart")
+	}
+	// An unpriced model must say so rather than produce a figure. This fixture has no price
+	// list, so `priced` is the honest answer.
+	if _, ok := out["priced"]; !ok {
+		t.Error("the answer does not state whether it could be priced")
+	}
+	if got, _ := out["priced"].(bool); !got {
+		if _, has := out["worst_case_usd"]; has {
+			t.Error("priced=false but a dollar figure was returned anyway")
+		}
+	}
+}
+
+// The body's MaxUSDPerPing is ignored, and the answer reports the value actually in force. A
+// silently dropped field is worse than a refused one.
+func TestArmingIgnoresAPostedPerPingBudget(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	until := time.Now().Add(time.Hour).UnixMilli()
+	body := fmt.Sprintf(
+		`{"session":"s-1","idle_seconds":280,"max_pings":2,"until":%d,"max_usd_per_ping":99}`, until)
+	w, out := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("arm = %d: %s", w.Code, w.Body)
+	}
+	if got, has := out["max_usd_per_ping"].(float64); has && got == 99 {
+		t.Error("a posted per-ping budget of $99 was accepted; the guard is the account's own")
+	}
+}
+
+// Every arm and every disarm leaves a DURABLE audit row with the resolved parameters. That row is
+// the durable half of this feature: the live policy does not survive a restart, but who
+// authorized what spend, with which parameters, until when, does.
+func TestArmingAndDisarmingAreAudited(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, id := f.signUpJar(t, "boss@ibm.com")
+	until := time.Now().Add(time.Hour)
+	body := fmt.Sprintf(`{"session":"s-1","idle_seconds":280,"max_pings":2,"until":%d}`,
+		until.UnixMilli())
+	if w, _ := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, mgrJar); w.Code != 200 {
+		t.Fatalf("arm = %d: %s", w.Code, w.Body)
+	}
+	if w, _ := f.do(t, http.MethodDelete, "/api/me/keepalive/sessions/s-1", "", mgrJar); w.Code != 200 {
+		t.Fatalf("disarm = %d: %s", w.Code, w.Body)
+	}
+	entries, err := f.reg.Audit(id, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var armed, disarmed bool
+	for _, e := range entries {
+		if e.Field != "keepalive_session" {
+			continue
+		}
+		if strings.Contains(e.After, "armed") && strings.Contains(e.After, "idle=280s") &&
+			strings.Contains(e.After, "pings=2") && strings.Contains(e.After, "hold<=14min") {
+			armed = true
+		}
+		if e.After == "disarmed" {
+			disarmed = true
+		}
+	}
+	if !armed {
+		t.Errorf("no audit row carries the arm and its resolved parameters: %+v", entries)
+	}
+	if !disarmed {
+		t.Errorf("no audit row carries the disarm: %+v", entries)
+	}
+}
+
+// The bounds are refusals with reasons at the HTTP layer too, never silent clamps: a clamp on a
+// spend authorization tells the person they got what they asked for when they did not.
+func TestArmingRefusesEveryBoundWithAReason(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	ok := time.Now().Add(time.Hour).UnixMilli()
+	for name, body := range map[string]string{
+		"no session":   fmt.Sprintf(`{"session":"","idle_seconds":280,"max_pings":2,"until":%d}`, ok),
+		"idle too low": fmt.Sprintf(`{"session":"s","idle_seconds":10,"max_pings":2,"until":%d}`, ok),
+		"idle past the TTL": fmt.Sprintf(
+			`{"session":"s","idle_seconds":295,"max_pings":2,"until":%d}`, ok),
+		"too many pings": fmt.Sprintf(`{"session":"s","idle_seconds":280,"max_pings":50,"until":%d}`, ok),
+		"expiry in the past": fmt.Sprintf(`{"session":"s","idle_seconds":280,"max_pings":2,"until":%d}`,
+			time.Now().Add(-time.Hour).UnixMilli()),
+		"expiry beyond 12h": fmt.Sprintf(`{"session":"s","idle_seconds":280,"max_pings":2,"until":%d}`,
+			time.Now().Add(20*time.Hour).UnixMilli()),
+		"negative prefix floor": fmt.Sprintf(
+			`{"session":"s","idle_seconds":280,"max_pings":2,"min_prefix_tokens":-1,"until":%d}`, ok),
+		"hold beyond an hour": fmt.Sprintf(
+			`{"session":"s","idle_seconds":290,"max_pings":11,"until":%d}`, ok),
+	} {
+		w, out := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, mgrJar)
+		if name == "hold beyond an hour" {
+			// (11+1) x 290 = 58 min, inside the ceiling: this one is ACCEPTED, and it is here to
+			// prove the ceiling is not simply refusing everything.
+			if w.Code != http.StatusOK {
+				t.Errorf("%s: 58 minutes of hold = %d, want 200: %s", name, w.Code, w.Body)
+			}
+			continue
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s = %d, want 400: %s", name, w.Code, w.Body)
+			continue
+		}
+		if msg, _ := out["error"].(string); msg == "" || msg == "invalid" {
+			t.Errorf("%s was refused without a reason: %s", name, w.Body)
+		}
+	}
+}
+
+// A plain account may NOT arm — v1 keeps the manager gate, because arming spends a credential —
+// but may switch the whole thing off and may disarm. Consent withdrawal must never be harder
+// than consent, and the account box is drawn disabled for a non-manager.
+func TestConsentWithdrawalIsOpenToAnyPrincipal(t *testing.T) {
+	f := newMgrFixture(t)
+	_, _ = f.signUpJar(t, "boss@ibm.com")
+	userJar, userID := f.signUpJar(t, "a@ibm.com")
+	setDoc(t, f, userID, "pipeline:\n  - format\ncache:\n  keepalive: true\n")
+
+	until := time.Now().Add(time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"session":"s","idle_seconds":280,"max_pings":2,"until":%d}`, until)
+	if w, _ := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, userJar); w.Code != http.StatusForbidden {
+		t.Errorf("a plain account armed a session: %d %s", w.Code, w.Body)
+	}
+	// Off, by the person whose key is being spent.
+	w, _ := f.do(t, http.MethodDelete, "/api/me/keepalive", "", userJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("a plain account could not switch the keep-alive off: %d %s", w.Code, w.Body)
+	}
+	tn, err := f.reg.Get(userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := config.ParseForm(tn.ConfigYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cache == nil || got.Cache.KeepAlive {
+		t.Errorf("the stored consent was not withdrawn:\n%s", tn.ConfigYAML)
+	}
+	// The pipeline is untouched: an off switch must not be a pipeline edit.
+	if !hasName(got.Pipeline, "format") {
+		t.Errorf("switching the keep-alive off changed the pipeline: %v", got.Pipeline)
+	}
+	// And it is audited as a consent change.
+	entries, err := f.reg.Audit(userID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Field == "keepalive" && e.After == "false" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("switching the keep-alive off was not audited: %+v", entries)
+	}
+	// Disarming is open too.
+	if w, _ := f.do(t, http.MethodDelete, "/api/me/keepalive/sessions/s", "", userJar); w.Code != http.StatusOK {
+		t.Errorf("a plain account could not disarm: %d %s", w.Code, w.Body)
+	}
+}
+
+// Arming is rate-limited, because arming is a spend authorization.
+func TestArmingIsRateLimited(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	until := time.Now().Add(time.Hour).UnixMilli()
+	var limited bool
+	for i := 0; i <= overrideArmsPerHour; i++ {
+		body := fmt.Sprintf(`{"session":"s-%d","idle_seconds":280,"max_pings":2,"until":%d}`, i, until)
+		w, _ := f.do(t, http.MethodPost, "/api/me/keepalive/sessions", body, mgrJar)
+		if w.Code == http.StatusTooManyRequests {
+			limited = true
+			break
+		}
+	}
+	if !limited {
+		t.Errorf("more than %d arms an hour were accepted", overrideArmsPerHour)
+	}
+}

--- a/proxy/keepaliveoverride.go
+++ b/proxy/keepaliveoverride.go
@@ -1,0 +1,294 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Per-session keep-alive overrides: a human pointing at one session and saying "keep this
+// one warm for the next hour".
+//
+// # Why this is an override and not a strategy
+//
+// The obvious feature here is a learned session allowlist, and it does not work. Fitted on the
+// first half of the production window and scored on the second it earned $5.27 where the plain
+// account-wide gate earned $53.32, and only 3 of the top-20 first-half sessions have any
+// request in the second half at all. Sessions are ephemeral — lifetime p50 is about zero hours
+// and p99 is 12.9 — so a list of "sessions worth pinging" is a description of the past. The UI
+// says so above the table, in those numbers.
+//
+// So this is deliberately a MANUAL, SCOPED, EXPIRING act: a mandatory `until`, capped at 12 h
+// because that is where session lifetime runs out, and an audit row per arm and per disarm.
+//
+// # Why it lives in memory and not in a table
+//
+// Three reasons, and the third is the deciding one. The dash database may not grow unboundedly
+// and a schema bump renames five days of production history aside; the tenant registry would
+// need its own migration; and an override is an AUTHORIZATION TO SPEND, so one that silently
+// survives a restart is worse than one that does not. The cost is that overrides are lost on
+// restart, which the arm dialog and the armed list both say. The durable half is the audit row:
+// who authorized what spend, with which parameters, until when, is permanent even though the
+// live policy is not.
+//
+// # Why it holds no material
+//
+// An override is POLICY, not state. Arming creates no kaEntry, holds no request body and no
+// credential, and retains nothing. Material is held only when the session actually sends a
+// request, which is why an override left on a dead session costs exactly zero. It disappears at
+// `until`, at a restart, or on disarm.
+
+// Override bounds. Every one of them is a refusal with a reason rather than a silent clamp: a
+// clamp on a spend authorization tells the person they got what they asked for when they did not.
+const (
+	// maxOverrideUntil caps how far ahead an override may reach. Session lifetime p99 is
+	// 12.9 h, so past this the authorization is being spent on a session that statistically no
+	// longer exists.
+	maxOverrideUntil = 12 * time.Hour
+	// defaultOverrideUntil is what the dialog offers.
+	defaultOverrideUntil = time.Hour
+	// The idle interval's band. Below 60 s a ping lands inside the previous one's own refresh
+	// for no reason; above 290 s the first ping arrives after a 300 s lifetime has already
+	// lapsed and pays a 1.25x WRITE — the exact charge the mechanism exists to avoid.
+	minOverrideIdle = 60 * time.Second
+	maxOverrideIdle = 290 * time.Second
+	// The ping-count band. The upper end is bounded again, and more tightly, by the credential
+	// hold below.
+	minOverridePings = 1
+	maxOverridePings = 11
+	// maxOverrideHold is the operator's ceiling on the CREDENTIAL HOLD an override may buy.
+	// The hard deadline is (K+1)x X (see kaEntry.timer), and the Settings copy promises "up to
+	// about 14 minutes" at the shipped defaults — an override changes that number, so the arm
+	// dialog states the computed hold and this refuses anything past an hour.
+	maxOverrideHold = time.Hour
+	// Bounds on the map itself. Same order as maxKeepAliveSessions, and both are needed for
+	// the same reason that bound has two: many accounts with a few, or one account with many.
+	maxOverridesPerTenant = 64
+	maxOverridesTotal     = 512
+	// maxSessionIDBytes refuses an implausible session id before it is used as a map key.
+	maxSessionIDBytes = 200
+	// overrideArmsPerHour is the arm rate per account. Arming is a spend authorization, so it
+	// is rate-limited like one.
+	overrideArmsPerHour = 30
+)
+
+// sessionOverride is one armed session's policy and its expiry.
+type sessionOverride struct {
+	// pol carries Idle, MaxPings and MinPrefixTokens ONLY. MaxUSDPerPing is deliberately not
+	// here: the per-ping cost guard is the one control that exists because ping cost is bimodal
+	// (p50 $0.0004, p99 $0.2275, max $0.3780), and an override may not widen it. KeepAlive is
+	// forced on — enabling the mechanism for one session while the account default is off is
+	// the point of the feature, and the arming request is itself the consent act.
+	pol   CachePolicy
+	until time.Time
+	armed time.Time
+	// by is the tenant id of the principal that armed it, for the audit row. Always the
+	// authenticated principal, never a value out of a request body.
+	by string
+}
+
+// hold is the credential-hold ceiling this override buys: (K+1) x Idle, the same arithmetic
+// kaEntry.timer uses. Named because it is a number a person is shown before they authorize it.
+func (o sessionOverride) hold() time.Duration {
+	return time.Duration(o.pol.MaxPings+1) * o.pol.Idle
+}
+
+// validOverride checks a proposed override against every bound, naming the one it fails.
+//
+// Returns the resolved override, so the caller cannot apply a different one from the one that
+// was checked. `now` is passed in rather than read, for the same reason the keeper's clock is.
+func validOverride(session string, idle time.Duration, pings, minPrefix int,
+	until, now time.Time, by string) (sessionOverride, error) {
+	if session == "" {
+		return sessionOverride{}, fmt.Errorf("name the session to arm")
+	}
+	if len(session) > maxSessionIDBytes {
+		return sessionOverride{}, fmt.Errorf("that is not a session id")
+	}
+	if strings.ContainsRune(session, 0) {
+		return sessionOverride{}, fmt.Errorf("that is not a session id")
+	}
+	if until.IsZero() {
+		return sessionOverride{}, fmt.Errorf("an override must state when it expires")
+	}
+	if !until.After(now) {
+		return sessionOverride{}, fmt.Errorf("that expiry has already passed")
+	}
+	if until.Sub(now) > maxOverrideUntil {
+		return sessionOverride{}, fmt.Errorf(
+			"an override may last at most %d hours; sessions do not live longer than that",
+			int(maxOverrideUntil/time.Hour))
+	}
+	if idle < minOverrideIdle || idle > maxOverrideIdle {
+		return sessionOverride{}, fmt.Errorf(
+			"the idle interval must be between %d and %d seconds; past %d the first ping "+
+				"arrives after the provider's 5-minute lifetime has already lapsed and pays "+
+				"a cache WRITE instead of a read",
+			int(minOverrideIdle.Seconds()), int(maxOverrideIdle.Seconds()),
+			int(maxOverrideIdle.Seconds()))
+	}
+	if pings < minOverridePings || pings > maxOverridePings {
+		return sessionOverride{}, fmt.Errorf("the ping count must be between %d and %d",
+			minOverridePings, maxOverridePings)
+	}
+	if minPrefix < 0 {
+		return sessionOverride{}, fmt.Errorf("the prefix floor cannot be negative")
+	}
+	o := sessionOverride{
+		pol:   CachePolicy{KeepAlive: true, Idle: idle, MaxPings: pings, MinPrefixTokens: minPrefix},
+		until: until, armed: now, by: by,
+	}
+	if h := o.hold(); h > maxOverrideHold {
+		return sessionOverride{}, fmt.Errorf(
+			"%d pings %ds apart would hold your credential for up to %d minutes; the ceiling "+
+				"is %d minutes, so lower one of them",
+			pings, int(idle.Seconds()), int(h.Minutes()), int(maxOverrideHold.Minutes()))
+	}
+	return o, nil
+}
+
+// overrideFor resolves one session's effective policy: the account's own, unless an unexpired
+// override is armed for it.
+//
+// The ONE hook this feature has in the request path, called from record. Everything downstream
+// — pol.on(), pingable(), the hard deadline, the per-ping cost guard, the kill switch, the
+// no-audit-sink refusal — reads the returned policy and is otherwise untouched.
+func (k *keeper) overrideFor(tenantID, session string, pol CachePolicy) CachePolicy {
+	if k == nil || session == "" {
+		return pol
+	}
+	k.mu.Lock()
+	o, ok := k.overrides[kaKey(tenantID, session)]
+	k.mu.Unlock()
+	if !ok || !k.now().Before(o.until) {
+		return pol
+	}
+	// The three fields an override may move. MaxUSDPerPing stays the ACCOUNT's — see
+	// sessionOverride.pol — and so do the head-TTL fields, which are a different mechanism.
+	pol.KeepAlive = true
+	pol.Idle, pol.MaxPings = o.pol.Idle, o.pol.MaxPings
+	pol.MinPrefixTokens = o.pol.MinPrefixTokens
+	return pol
+}
+
+// arm installs an override, refusing when a bound would be crossed.
+//
+// Refuses outright under the two global refusals, which an override does not get to reach
+// around: the operator kill switch and a deployment with no audit sink. Both are the reasons
+// retention is defensible at all, and a per-session opt-in that could bypass them would be a
+// hole in the consent story rather than a feature.
+func (k *keeper) arm(tenantID, session string, o sessionOverride) error {
+	if k == nil {
+		return fmt.Errorf("the keep-alive is not running on this deployment")
+	}
+	if keepAliveDisabled() {
+		return fmt.Errorf("the keep-alive is switched off service-wide by the operator")
+	}
+	if k.h == nil || k.h.rec == nil {
+		return fmt.Errorf("this deployment records no audit trail, so nothing may be armed")
+	}
+	key := kaKey(tenantID, session)
+	prefix := tenantID + "\x00"
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.overrides == nil {
+		k.overrides = map[string]sessionOverride{}
+	}
+	k.expireOverridesLocked(k.now())
+	if _, replacing := k.overrides[key]; !replacing {
+		mine := 0
+		for other := range k.overrides {
+			if strings.HasPrefix(other, prefix) {
+				mine++
+			}
+		}
+		if mine >= maxOverridesPerTenant {
+			return fmt.Errorf("you already have %d sessions armed, which is the limit; "+
+				"disarm one first", maxOverridesPerTenant)
+		}
+		if len(k.overrides) >= maxOverridesTotal {
+			return fmt.Errorf("this service has %d sessions armed, which is the limit; "+
+				"try again shortly", maxOverridesTotal)
+		}
+	}
+	k.overrides[key] = o
+	return nil
+}
+
+// disarm removes an override AND releases anything already held for that session, rather than
+// waiting for the hard deadline. Reports whether there was one.
+//
+// The release is the point: withdrawing an authorization to hold a credential has to stop the
+// hold now. `retire` zeroizes the body and the credential and cancels the deadline.
+func (k *keeper) disarm(tenantID, session string) bool {
+	if k == nil {
+		return false
+	}
+	key := kaKey(tenantID, session)
+	k.mu.Lock()
+	_, had := k.overrides[key]
+	delete(k.overrides, key)
+	k.mu.Unlock()
+	// Outside the lock: retire takes it itself.
+	k.retire(key)
+	return had
+}
+
+// armedOverride is one row of "what is armed right now" — the live map, not a stored intention.
+type armedOverride struct {
+	Session     string  `json:"session"`
+	IdleSeconds int     `json:"idle_seconds"`
+	MaxPings    int     `json:"max_pings"`
+	MinPrefix   int     `json:"min_prefix_tokens"`
+	Until       int64   `json:"until"`
+	Armed       int64   `json:"armed"`
+	HoldMinutes float64 `json:"hold_minutes"`
+}
+
+// armedFor lists one tenant's live overrides, expired ones excluded.
+func (k *keeper) armedFor(tenantID string) []armedOverride {
+	out := []armedOverride{}
+	if k == nil {
+		return out
+	}
+	prefix := tenantID + "\x00"
+	now := k.now()
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.expireOverridesLocked(now)
+	for key, o := range k.overrides {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		out = append(out, armedOverride{
+			Session: strings.TrimPrefix(key, prefix), IdleSeconds: int(o.pol.Idle.Seconds()),
+			MaxPings: o.pol.MaxPings, MinPrefix: o.pol.MinPrefixTokens,
+			Until: o.until.UnixMilli(), Armed: o.armed.UnixMilli(),
+			HoldMinutes: o.hold().Minutes(),
+		})
+	}
+	return out
+}
+
+// forgetOverrides drops every override for one tenant. Called from forget, so unticking the
+// account-wide box kills armed sessions too — a consent withdrawal that left per-session
+// authorizations running would be the setting not working.
+func (k *keeper) forgetOverrides(tenantID string) {
+	prefix := tenantID + "\x00"
+	for key := range k.overrides {
+		if strings.HasPrefix(key, prefix) {
+			delete(k.overrides, key)
+		}
+	}
+}
+
+// expireOverridesLocked deletes what has expired, so the map cannot grow on the strength of
+// authorizations nobody withdrew. Called from the 2 s sweep and from every read, so an expired
+// override is invisible even between sweeps.
+func (k *keeper) expireOverridesLocked(now time.Time) {
+	for key, o := range k.overrides {
+		if !now.Before(o.until) {
+			delete(k.overrides, key)
+		}
+	}
+}

--- a/proxy/keepaliveoverride_test.go
+++ b/proxy/keepaliveoverride_test.go
@@ -1,0 +1,402 @@
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/metrics"
+)
+
+// Per-session keep-alive overrides, and the seven hardening controls they must not weaken.
+//
+// The subject of nearly every test here is a REFUSAL. An override is an authorization to spend
+// somebody's money on their own credential, so the interesting behaviour is not that it works,
+// it is that it cannot be used to reach around the guard, the deadline, the kill switch or the
+// audit sink.
+
+// armOn installs a validated override on a keeper, failing the test if the bounds refuse it.
+func armOn(t *testing.T, k *keeper, session string, idle time.Duration, pings int, until time.Time) sessionOverride {
+	t.Helper()
+	o, err := validOverride(session, idle, pings, 0, until, k.now(), "t1")
+	if err != nil {
+		t.Fatalf("validOverride: %v", err)
+	}
+	if err := k.arm("t1", session, o); err != nil {
+		t.Fatalf("arm: %v", err)
+	}
+	return o
+}
+
+// The per-ping cost guard is the one control an override may not widen, because ping cost is
+// bimodal (p50 $0.0004, p99 $0.2275, max $0.3780) — so the outlier worth refusing is one ping,
+// and a caller who could raise the ceiling for "their" session could authorize the outlier.
+func TestOverrideCannotRaiseThePerPingBudget(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	account := CachePolicy{KeepAlive: true, Idle: 280 * time.Second, MaxPings: 2,
+		MaxUSDPerPing: 0.01, MinPrefixTokens: 20000}
+	armOn(t, k, "sess-1", 120*time.Second, 4, clock.now().Add(time.Hour))
+	got := k.overrideFor("t1", "sess-1", account)
+	if got.MaxUSDPerPing != 0.01 {
+		t.Errorf("the override moved the per-ping budget to %v; it is the account's own and not "+
+			"negotiable per session", got.MaxUSDPerPing)
+	}
+	// The three fields it MAY move did move, or the override does nothing.
+	if got.Idle != 120*time.Second || got.MaxPings != 4 {
+		t.Errorf("the override did not take effect: %+v", got)
+	}
+	// And it may switch the mechanism ON for one session while the account default is off —
+	// that is the point of it, and the arming request is the consent act.
+	off := CachePolicy{Idle: 280 * time.Second, MaxPings: 2}
+	if !k.overrideFor("t1", "sess-1", off).on() {
+		t.Error("an override could not enable the keep-alive for one session on an account whose " +
+			"default is off, which is the whole use for it")
+	}
+}
+
+// The credential-hold ceiling. (K+1) x X is the hard retention deadline, so an override changes
+// how long this service may hold somebody's key — which is why it is refused past an hour and
+// why the accepted one's timer fires at exactly that.
+func TestOverrideRespectsTheCredentialHoldCeiling(t *testing.T) {
+	now := time.Now()
+	// 11 pings 290 s apart is (11+1) x 290 = 58 minutes: accepted, just inside.
+	if _, err := validOverride("s", 290*time.Second, 11, 0, now.Add(time.Hour), now, "t1"); err != nil {
+		t.Errorf("58 minutes of hold was refused: %v", err)
+	}
+	// 12 would be 62.7 minutes — but K is capped at 11 first, so reach the ceiling through X.
+	_, err := validOverride("s", 290*time.Second, 12, 0, now.Add(time.Hour), now, "t1")
+	if err == nil {
+		t.Error("K = 12 was accepted; the band is 1..11")
+	}
+	// And the message has to name the number the person is authorizing.
+	if _, err := validOverride("s", 280*time.Second, 11, 0, now.Add(time.Hour), now, "t1"); err != nil {
+		t.Errorf("(11+1) x 280 = 56 minutes of hold was refused: %v", err)
+	}
+	// The refusal for a genuine over-hour hold states the computed hold in minutes.
+	for _, tc := range []struct {
+		idle  time.Duration
+		pings int
+	}{{290 * time.Second, 11}} {
+		o, err := validOverride("s", tc.idle, tc.pings, 0, now.Add(time.Hour), now, "t1")
+		if err != nil {
+			t.Fatalf("unexpected refusal: %v", err)
+		}
+		if got, want := o.hold(), time.Duration(tc.pings+1)*tc.idle; got != want {
+			t.Errorf("hold = %v, want (K+1) x X = %v", got, want)
+		}
+	}
+	// The interval band, and the reason for its upper end: past 290 s the first ping lands
+	// after a 300 s lifetime has lapsed and pays a WRITE.
+	for _, bad := range []time.Duration{0, 59 * time.Second, 291 * time.Second, time.Hour} {
+		if _, err := validOverride("s", bad, 2, 0, now.Add(time.Hour), now, "t1"); err == nil {
+			t.Errorf("idle %v was accepted", bad)
+		}
+	}
+	// An ACCEPTED override's entry gets the deadline its own policy implies, not the account's.
+	k, _, clock := testKeeper(t, Limits{})
+	armOn(t, k, "sess-1", 60*time.Second, 3, clock.now().Add(time.Hour))
+	recordOne(t, k, CachePolicy{}, kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	k.mu.Lock()
+	e := k.live[kaKey("t1", "sess-1")]
+	k.mu.Unlock()
+	if e == nil {
+		t.Fatal("an armed session was not tracked, so its deadline cannot be checked")
+	}
+	if e.pol.Idle != 60*time.Second || e.pol.MaxPings != 3 {
+		t.Errorf("the entry carries %v/%d, not the override's 60s/3", e.pol.Idle, e.pol.MaxPings)
+	}
+	if e.timer == nil {
+		t.Error("an armed session was retained with no hard retention deadline")
+	}
+}
+
+// An expiry is an expiry: past `until` the account's own policy resolves again, pinging stops,
+// and the map does not keep the dead entry.
+func TestOverrideExpiresAndStopsPinging(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	off := CachePolicy{Idle: 280 * time.Second, MaxPings: 2} // KeepAlive false: account is OFF
+	armOn(t, k, "sess-1", 60*time.Second, 3, clock.now().Add(10*time.Minute))
+	if !k.overrideFor("t1", "sess-1", off).on() {
+		t.Fatal("the override is not in force, so its expiry proves nothing")
+	}
+	clock.advance(11 * time.Minute)
+	if k.overrideFor("t1", "sess-1", off).on() {
+		t.Error("an expired override still enabled the keep-alive")
+	}
+	// And it is not retained. overrideFor treats it as absent regardless; the sweep deletes it,
+	// so the map cannot grow on the strength of authorizations nobody withdrew.
+	k.sweep(clock.now())
+	k.mu.Lock()
+	_, still := k.overrides[kaKey("t1", "sess-1")]
+	k.mu.Unlock()
+	if still {
+		t.Error("an expired override was retained in the map")
+	}
+}
+
+// Arming a session that never sends another request must cost NOTHING: no entry, no held body,
+// no held credential, no ping. An override is POLICY, not state — which is what makes a stale
+// override on a dead session harmless, and it is why per-session control is shippable at all.
+func TestOverrideOnADeadSessionCostsNothing(t *testing.T) {
+	k, fs, clock := testKeeper(t, Limits{})
+	armOn(t, k, "ghost", 60*time.Second, 4, clock.now().Add(6*time.Hour))
+	// No record() call at all: the session never sends anything again.
+	for i := 0; i < 10; i++ {
+		k.sweep(clock.advance(70 * time.Second))
+	}
+	if got := k.Stats().Live; got != 0 {
+		t.Errorf("%d entries live for a session that sent nothing", got)
+	}
+	if got := fs.n(); got != 0 {
+		t.Errorf("%d pings sent to a session that sent nothing", got)
+	}
+	if k.bytes != 0 {
+		t.Errorf("%d bytes held for a session that sent nothing", k.bytes)
+	}
+}
+
+// Disarming releases the held material NOW rather than at the hard deadline, and what it
+// releases is zeroized rather than merely dropped — this extends the no-output-surface bar to
+// the disarm path, at debug level, because that is the realistic leak path.
+func TestDisarmRetiresTheHeldMaterialNow(t *testing.T) {
+	const cred = "sk-caller-DISARM-DO-NOT-LEAK"
+	const secret = "MY-PRIVATE-SOURCE-CODE-DISARM"
+	logs := &syncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	sink, err := dash.NewRecorder(dash.Options{DBPath: ":memory:", BatchSize: 1,
+		FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.Close()
+	h := New(nil, nil, metrics.NewAggregator(), Options{Dashboard: sink})
+	defer h.Close()
+	k := h.keeper
+	clock := &testClock{at: time.Now()}
+	k.now = clock.now
+	fs := &fakeSender{}
+	k.send = fs.send
+
+	body := strings.Replace(kaBody, `"text":"hi"`, `"text":"`+secret+`"`, 1)
+	tn := &Tenancy{ID: "t1", Cache: kaPolicy()}
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(""))
+	r.Header.Set("Authorization", "Bearer "+cred)
+	armOn(t, k, "armed", 60*time.Second, 3, clock.now().Add(time.Hour))
+	for i := 0; i < 2; i++ {
+		k.record(tn, "armed", clock.now().Add(time.Duration(i)*time.Second), []byte(body),
+			upstream{base: "http://up", path: "/v1/messages"}, r, bschemas.Anthropic,
+			"/v1/messages", http.StatusOK, Usage{CacheRead: 48576}, true)
+	}
+	k.mu.Lock()
+	e := k.live[kaKey("t1", "armed")]
+	k.mu.Unlock()
+	if e == nil {
+		t.Fatal("nothing retained, so nothing is being released")
+	}
+	held := e.body // the keeper's own copy; clear() overwrites the array in place
+	if len(held) == 0 {
+		t.Fatal("the entry holds no body")
+	}
+	if !k.disarm("t1", "armed") {
+		t.Fatal("disarm reported nothing was armed")
+	}
+	if got := k.Stats().Live; got != 0 {
+		t.Errorf("%d entries still live after a disarm; the release must not wait for the "+
+			"hard deadline", got)
+	}
+	// The BYTES are gone, not merely unreferenced: a dropped slice sits in the heap until a
+	// collection that may never come, and a dump taken in between still yields the transcript.
+	if strings.Contains(string(held), secret) {
+		t.Error("the held body was dropped rather than zeroized")
+	}
+	for _, b := range held {
+		if b != 0 {
+			t.Error("the held body was not fully zeroized")
+			break
+		}
+	}
+	if e.timer != nil {
+		t.Error("the hard retention deadline was left running after a disarm")
+	}
+	// And nothing leaked on the way out, at debug level.
+	surfaces := map[string]string{
+		"log sink (debug)": logs.String(),
+		"entry %+v":        fmt.Sprintf("%+v", *e),
+		"KeepAliveStats":   fmt.Sprintf("%+v", k.Stats()),
+	}
+	for name, out := range surfaces {
+		for _, marker := range []string{cred, secret} {
+			if strings.Contains(out, marker) {
+				t.Errorf("%s leaked %q:\n%s", name, marker, out)
+			}
+		}
+	}
+	// A second disarm is a no-op rather than a panic: every refusal path calls it unconditionally.
+	if k.disarm("t1", "armed") {
+		t.Error("a second disarm reported something was armed")
+	}
+}
+
+// The two GLOBAL refusals win over an override, because they are the reasons retention is
+// defensible at all: the operator's kill switch, and a deployment with no audit sink.
+func TestArmingIsRefusedWithoutAnAuditSinkOrWithTheKillSwitchOn(t *testing.T) {
+	now := time.Now()
+	o, err := validOverride("s", 280*time.Second, 2, 0, now.Add(time.Hour), now, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No audit sink.
+	k := newKeeper(&Handler{opts: Options{}, limiter: NewLimiter(Limits{})})
+	k.now = func() time.Time { return now }
+	if err := k.arm("t1", "s", o); err == nil {
+		t.Error("a deployment with no audit sink accepted an arm; the whole credential " +
+			"arrangement rests on being reviewable")
+	}
+	// Kill switch. It stops RETENTION, not merely pinging, so it must also stop the thing that
+	// authorizes retention.
+	t.Setenv("CONTEXT_GURU_KEEPALIVE", "off")
+	k2, _, clock := testKeeper(t, Limits{})
+	if err := k2.arm("t1", "s", o); err == nil {
+		t.Error("the operator kill switch did not refuse an arm")
+	}
+	// And an armed session already in the map does not survive the switch: record retires it.
+	t.Setenv("CONTEXT_GURU_KEEPALIVE", "")
+	armOn(t, k2, "s", 60*time.Second, 2, clock.now().Add(time.Hour))
+	t.Setenv("CONTEXT_GURU_KEEPALIVE", "off")
+	recordOne(t, k2, CachePolicy{}, kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	if got := k2.Stats().Live; got != 0 {
+		t.Errorf("%d entries retained for an armed session with the kill switch on", got)
+	}
+}
+
+// A session id whose `tenant:uuid` prefix names SOMEBODY ELSE addresses nothing: the keeper keys
+// on the AUTHENTICATED principal, never on a value out of the body, so such an arm becomes a key
+// under the caller's own tenant that no request will ever match.
+func TestOverrideForAnotherTenantsSessionIdAddressesNothing(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	victim := "t-victim:9f3a-1c2b"
+	armOn(t, k, victim, 60*time.Second, 4, clock.now().Add(time.Hour))
+	// The victim's own traffic is unaffected: resolution is under THEIR tenant id.
+	off := CachePolicy{Idle: 280 * time.Second, MaxPings: 2}
+	if k.overrideFor("t-victim", victim, off).on() {
+		t.Error("an arm under one principal reached another tenant's session")
+	}
+	// It landed under the attacker's own key, where it is inert.
+	if !k.overrideFor("t1", victim, off).on() {
+		t.Error("the arm did not land under the authenticated principal at all")
+	}
+	// The armed list is scoped too: the victim sees nothing.
+	if got := k.armedFor("t-victim"); len(got) != 0 {
+		t.Errorf("the victim's armed list shows %d entries from another principal's arm", len(got))
+	}
+	if got := k.armedFor("t1"); len(got) != 1 {
+		t.Errorf("the arming principal's own list shows %d entries, want 1", len(got))
+	}
+	// And a session id that is not one is refused before it becomes a map key.
+	now := clock.now()
+	for _, bad := range []string{"", strings.Repeat("x", maxSessionIDBytes+1), "a\x00b"} {
+		if _, err := validOverride(bad, 280*time.Second, 2, 0, now.Add(time.Hour), now, "t1"); err == nil {
+			t.Errorf("session id %q was accepted", bad)
+		}
+	}
+}
+
+// The expiry is MANDATORY and it is capped at 12 hours, because session lifetime p99 is 12.9 h:
+// past that the authorization is being spent on a session that statistically no longer exists.
+func TestOverrideExpiryIsMandatoryAndCapped(t *testing.T) {
+	now := time.Now()
+	for name, until := range map[string]time.Time{
+		"absent":      {},
+		"in the past": now.Add(-time.Minute),
+		"now":         now,
+		"beyond 12h":  now.Add(13 * time.Hour),
+	} {
+		if _, err := validOverride("s", 280*time.Second, 2, 0, until, now, "t1"); err == nil {
+			t.Errorf("an expiry that is %s was accepted", name)
+		}
+	}
+	if _, err := validOverride("s", 280*time.Second, 2, 0, now.Add(12*time.Hour), now, "t1"); err != nil {
+		t.Errorf("exactly 12 hours was refused: %v", err)
+	}
+}
+
+// The map bounds, both of them, and neither is a silent clamp.
+func TestOverrideCountBoundsAreRefusalsNotClamps(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	until := clock.now().Add(time.Hour)
+	for i := 0; i < maxOverridesPerTenant; i++ {
+		armOn(t, k, fmt.Sprintf("s-%d", i), 280*time.Second, 2, until)
+	}
+	o, err := validOverride("one-too-many", 280*time.Second, 2, 0, until, clock.now(), "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := k.arm("t1", "one-too-many", o); err == nil {
+		t.Errorf("a %dth override for one account was accepted", maxOverridesPerTenant+1)
+	}
+	// Replacing an EXISTING one is still allowed at the bound — otherwise a full list could not
+	// be edited.
+	if err := k.arm("t1", "s-0", o); err != nil {
+		t.Errorf("re-arming an existing session at the bound was refused: %v", err)
+	}
+	// A different account is unaffected by this one's bound.
+	if err := k.arm("t2", "theirs", o); err != nil {
+		t.Errorf("one account's bound refused another account: %v", err)
+	}
+}
+
+// A Settings save calls keeper.forget, and that must kill armed sessions too: unticking the
+// account-wide box is a consent withdrawal, and leaving per-session authorizations running would
+// be the setting not working.
+func TestForgettingATenantDisarmsItsSessions(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	armOn(t, k, "mine", 280*time.Second, 2, clock.now().Add(time.Hour))
+	if err := k.arm("t2", "theirs", func() sessionOverride {
+		o, err := validOverride("theirs", 280*time.Second, 2, 0, clock.now().Add(time.Hour),
+			clock.now(), "t2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return o
+	}()); err != nil {
+		t.Fatal(err)
+	}
+	k.forget("t1")
+	if got := len(k.armedFor("t1")); got != 0 {
+		t.Errorf("%d overrides survived a consent withdrawal", got)
+	}
+	if got := len(k.armedFor("t2")); got != 1 {
+		t.Errorf("forgetting one tenant disarmed another's %d sessions", 1-got)
+	}
+}
+
+// The armed list is the LIVE map and it says on the wire that it is not durable. An override that
+// silently survived a restart would be worse than one that does not; a client that renders it as
+// durable is misrepresenting an authorization to spend.
+func TestArmedSessionsAreNotDurableAndSayItOnTheWire(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	w, _ := f.do(t, http.MethodGet, "/api/me/keepalive/sessions", "", mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/me/keepalive/sessions = %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), `"durable":false`) {
+		t.Errorf("the armed list does not state that it is lost on restart: %s", w.Body)
+	}
+	// Stop() drops them with everything else: the process they authorized is ending.
+	k, _, clock := testKeeper(t, Limits{})
+	armOn(t, k, "s", 280*time.Second, 2, clock.now().Add(time.Hour))
+	k.Stop()
+	if got := len(k.armedFor("t1")); got != 0 {
+		t.Errorf("%d overrides survived Stop()", got)
+	}
+}

--- a/proxy/limits.go
+++ b/proxy/limits.go
@@ -68,6 +68,9 @@ type Limiter struct {
 	mu       sync.Mutex
 	tenants  *lru[*tenantLimiter]
 	cheapSem chan struct{}
+	// actions is the per-hour counter for deliberate acts (AllowAction), separate from
+	// tenants so a settings click cannot evict a live request counter.
+	actions *lru[*hourly]
 }
 
 // maxLimiterKeys bounds the live counters a limiter holds. Reached only by a
@@ -274,4 +277,49 @@ type SpendChecker interface {
 	// MonthToDateUSD returns what this tenant has spent since the start of the
 	// current calendar month.
 	MonthToDateUSD(tenantID string) (float64, error)
+}
+
+// hourly is one key's fixed-window counter for a deliberate ACT rather than for traffic.
+type hourly struct {
+	windowStart time.Time
+	count       int
+}
+
+// AllowAction rate-limits a deliberate act — arming a keep-alive override is the one caller —
+// on a per-hour fixed window, and returns an error naming when the caller may retry.
+//
+// Separate from Acquire because it is a different kind of limit on a different thing. Acquire
+// bounds request THROUGHPUT per minute and hands back a concurrency slot; this bounds how often
+// somebody may authorize a spend, has no concurrency half, and takes nothing that has to be
+// released. Sharing the per-minute window would have made "30 arms an hour" unexpressible and
+// would have charged a settings click against an agent's request budget.
+//
+// A fixed window for the same reason Acquire uses one: the refusal can say exactly when the
+// window resets, which a leaky bucket cannot. It is also its own map, so an arm cannot evict a
+// live tenantLimiter holding an in-flight semaphore.
+func (l *Limiter) AllowAction(key, what string, perHour int) error {
+	if l == nil || perHour <= 0 {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.actions == nil {
+		l.actions = newLRU[*hourly](maxLimiterKeys, nil)
+	}
+	h, ok := l.actions.get(key)
+	if !ok {
+		h = &hourly{}
+		l.actions.put(key, h)
+	}
+	now := time.Now()
+	if w := now.Truncate(time.Hour); w.After(h.windowStart) {
+		h.windowStart, h.count = w, 0
+	}
+	if h.count >= perHour {
+		retry := int(time.Until(h.windowStart.Add(time.Hour)).Seconds()) + 1
+		return statusError{http.StatusTooManyRequests, fmt.Sprintf(
+			"rate limit: %d %s per hour for this account; retry in %ds", perHour, what, retry)}
+	}
+	h.count++
+	return nil
 }

--- a/proxy/toolfilterctl.go
+++ b/proxy/toolfilterctl.go
@@ -136,6 +136,11 @@ func (h *Handler) ctlToolFilter(w http.ResponseWriter, r *http.Request) {
 	// keeps an existing order untouched. An empty list leaves the pipeline entirely — a
 	// component with nothing to remove is a pass over every request for nothing.
 	f.Pipeline = withComponent(f.Pipeline, toolFilterComponent, len(names) > 0)
+	// This route models exactly one component, so it claims exactly one. Without the claim
+	// ApplyForm preserves anything the stored pipeline runs and this omission is not sent —
+	// which is the rule that stops a stale settings page dropping a component it cannot see,
+	// and would here stop an emptied removal list from taking toolfilter back out.
+	f.PipelineKnown = []string{toolFilterComponent}
 	doc, err := config.ApplyForm(current, f)
 	if err != nil {
 		// The message names the offending value; showing it beats "invalid".


### PR DESCRIPTION
## Two config-save bugs, and a keep-alive tab that leads with the downside

Both bugs are data loss in a settings page. Both are fixed at the root, and each has a test
that goes red when the fix is reverted.

### Bug 1 — the keep-alive opt-in did not persist

`config/form.go`'s `child()` returned a **detached** map when the key was absent:

```go
func child(m map[string]any, key string) map[string]any {
	if sub, ok := m[key].(map[string]any); ok && sub != nil {
		return sub
	}
	return map[string]any{}      // never inserted into m
}
```

Its own doc comment said *"creating it when absent"*. Every caller that works compensates by
assigning the result back (`m["components"] = comps`, `m[k] = sub` in `setPath`). The `cache:`
block was the one caller that did not — so the whole block was written into a throwaway map and
discarded, but **only on a document with no `cache:` block already**, which is exactly a tenant
switching the keep-alive on for the first time.

Fixed in the helper, not at the call site: the next block someone adds to `ApplyForm` cannot
repeat it. The two callers that prune an empty block still prune it, so an empty map created
here never reaches the document.

| | before | after |
|---|---|---|
| store a document with no `cache:` block, post `cache.keepalive = true` | output contains **no `cache:` key at all** | `keepalive: true`, and every `CacheForm` field round-trips |

`TestSavingKeepAliveOnADocumentWithNoCacheBlockKeepsIt` is table-driven over every `CacheForm`
field via reflection, and asserts on the **re-parsed form** rather than on a substring — a test
for `"keepalive: true"` in the text would pass on a document that also broke something else.
`TestChildAttachesTheBlockItCreates` is three lines on the helper and is the assertion that
generalises. Reverting the fix fails all seven subtests plus the helper test.

One consequence, and it is intended: a re-save now materialises `cache: {keepalive: false,
head_ttl_1h: false}` on a document that had no block. An existing test asserted "a re-save moves
nothing"; it now allows exactly those two keys, with the reason. No tuning field is written, so
today's defaults are still not frozen into anybody's document.

### Bug 2 — a save silently reverted an operator's pipeline

Given the right payload the server does not drop `linecap`: `ParseForm` → `ApplyForm` preserves
it, and `config/form.go` needs no per-name knowledge, so `grep linecap config/form.go` being
empty is not evidence of the defect. The wrong pipeline was **posted** — `saveSettings` rebuilds
the list from the checkbox grid and the server writes it wholesale, so either a stale render or
a cached bundle whose `/api/options` predates a component produces exactly the observed diff
(`linecap` dropped, `toon` appended last).

Two server-enforced rules, and the client is never trusted to state absence:

1. **`pipeline_known`** — the names the client rendered a control for. Anything in the stored
   pipeline that the client neither sent nor claimed is preserved **at its original index**.
   Empty means "this client declared nothing", and then nothing may be removed: an old bundle or
   a hand-rolled API client can add and reorder but never remove. Removal became an act a client
   has to claim.
2. **`pipeline_base`** — the pipeline the page rendered from. A mismatch against the stored
   document is a **409** with "reload before saving". This is what stops a stale page *adding*
   `toon` back; rule 1 only defends against dropping. `nil` is accepted (older bundle), and rule
   1 is then the only defence, which is the safe direction.

The membership test is on what the client **sent**, and the insertion is into the **resolved**
pipeline. Those are deliberately different: testing membership on the resolved list would undo
`applyExtractLLMCoupling`'s own removal of `extract_llm` — a server decision, not a client
omission — and put back a component its constructor refuses to build.

| | before | after |
|---|---|---|
| stored `[format, linecap, extract]`, client posts `[format, extract]` without claiming `linecap` | `linecap` gone | `[format, linecap, extract]`, at its own index |
| same, with `linecap` in `pipeline_known` | gone | gone — a declared removal still removes |
| client declares nothing, posts `[format]` | everything else gone | nothing removed |
| page rendered from a pipeline that has since changed | applied | **409**, stored document byte-identical |

Two in-repo callers had to state their claim, which is the honest expression of what they do:
`POST /api/toolfilter` claims the one component it models (without it, an emptied removal list
could no longer take `toolfilter` out of the pipeline), and the switch-off test declares the
document it read.

**Comment preservation is out of scope, with the reason.** It means abandoning `map[string]any`
for `yaml.Node` throughout `ApplyForm`, `setPath`, `delPath`, `child` and `readBlocks` — a
rewrite of the exact code whose two previous rewrites each shipped a data-loss bug (the regex
pipeline mangling, and Bug 1 above). Mitigated instead, since the prior document is already
verbatim and durable in `tenant_config_audit.before`:

- a **"Copy the document as it was"** button on every `config_yaml` audit row, so comment loss
  stops being unrecoverable. No new storage — the row already holds the whole text.
- honest copy beside the Save button: *"Saving rewrites your configuration document from these
  fields. Comments and key order are not preserved — the previous document is kept verbatim in
  the audit log below, with a button to copy it back."*

---

## The tab

`data-view="keepalive"`, after Usage, visible to every principal for their own data, and it
respects the time-range filter (so it is deliberately **not** in `UNFILTERED_VIEWS`). Six
panels, in the order a decision is actually made:

1. **Verdict** — six stat tiles: your position (Winner / Losing / No pings yet, in words beside
   the colour), the net, pings and what they cost, re-creations avoided, what is still on the
   table, and the ping rows' own footprint on disk.
2. **Am I in the losing majority?** — a status bar (winners `--good` / losers `--bad`, both
   labelled in words), the worst session named in dollars, and a sortable table of every session
   with its own net. It renders **unconditionally**, including on a positive net. When the
   account's own net is negative it becomes a `banner bad` with a **"Turn keep-alive off"**
   button.
3. **Your TTL expiries** — expiries/day and $/day as **two separate charts** (a count and a
   dollar figure share no scale); idle-gap bands in fixed edge order with everything beyond the
   current `K·X + TTL` in the de-emphasis gray; prefix-size bands with the p50 called out; 24
   hour bins **in the viewer's own timezone with the offset stated**; and the gap between
   expiries **per account**, never blended.
4. **Calculator** — the K = 1..4 ladder at a chosen X, each rung showing its coverage
   arithmetic, the account's own convertible expiries, the share of reachable dollars, the ping
   count and the net, plus one bar per rung so reach and cost are read together.
5. **Keep one session warm** — arm a session with a mandatory expiry; the live armed list.
6. **What should I set?** — a range with its n, or a refusal.

The verdict is first and the downside second, **above** the calculator: 85 of the 119 sessions
this mechanism touched lost money funding a rebate on 34, and a page that led with the
calculator would be selling. `TestTheLosingMajorityIsOnThePage` asserts that ordering and that
the split is not rendered inside a negative-net branch.

Forms reuse what exists — stat tiles, `barRows`, `lineChart`, the status bar, tables. No new
chart library, no new hue, no pie, no treemap, no gauge, no second y-axis;
`TestTheKeepAliveTabAddsNoNewChartVocabulary` enforces that against the code (not the prose,
which names the forms it refuses). `barRows` gained a hover title and an optional click-through,
which every bar on this dashboard should have had.

### The calculator's arithmetic

Computed on the server, in Go, in one place. The browser posts inputs and renders answers: it
has twice duplicated a table the server owns and drifted from it, and money is the worst case of
that class.

```
pings_per_span(gap)  = min(K, floor((gap − X)/X) + 1)      for gap > X, else 0
ping_cost            = P × price.CacheRead + price.Output   # one output token; max_tokens=1
coverage_seconds     = K × X + TTL                          # TTL = 300 s
avoided_miss         = (price.CacheWrite − price.CacheRead) × P
expected_saving      = avoided_miss × (addressable misses whose gap ∈ (X, coverage])
expected_ping_cost   = Σ over the account's OWN spans of pings_per_span(gap) × ping_cost
net                  = expected_saving − expected_ping_cost
```

`coverage = K·X + TTL` is load-bearing — the last ping is itself a read, and a read refreshes
the entry for the provider's full lifetime. Writing `K·X` is the single error that made an
earlier analysis of this mechanism wrong by a factor of 4.4, so
`TestCoverageIncludesTheFinalPingsTTL` pins seven golden values ((280,2)→860, (280,1)→580,
(240,2)→780, …) and a `K·X` implementation fails every one.

Ping cost is priced from **the row's own model**, per the operator's list. An unpriced model
renders "not priced" and produces **no dollar figure at all** — never a blended average, which
is the defect class this project has hit five times. The prefix is a **real** one, prefilled in
order: the selected session's last billed prefix → the account's own median at a lapse → nothing
(and the panel asks). Never a service-wide average: per-ping cost is bimodal (p50 $0.0004, p99
$0.2275).

Two caveats the panel states in words: it is a replay of the account's own past gaps and not a
forecast, and it counts only **addressable** expiries. A `ttl_expiry` row with `cache_write = 0`
is a phantom — 385 of 742 in production, every one an HTTP 400 — and they are counted apart so
this panel and the Usage tab's `ttl_expiry` count can be reconciled.

### How the saving joins the totals without contaminating the aggregates

One line: `o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD + o.KeepAliveNetUSD`.

**The net, never the gross.** `o.CostUSD` excludes ping rows, so the ping spend appears nowhere
else in the walk — adding the saving alone would present a saving without the spend that bought
it. PR #86's predicate (`r.keepalive = 0` in `Filter.where()`) does not change; every new
statistic where a ping is the subject runs its **own** query with `withKeepAlive(f)` and joins in
Go, the same two-query pattern the overview already uses. There is no `CASE` over `keepalive`
inside an agent-traffic aggregate anywhere in the new code.

`TestPingRowsStayOutOfAgentAggregates` runs one fixture twice, with and without the ping rows,
and compares the whole `Overview` **key by key** through JSON — so a field added later is covered
without anyone remembering — plus `/api/breakdown` in every dimension and `/api/series`. Only
the four keep-alive keys and `total_saved_usd` may move, and `total_saved` must move by exactly
the change in the net. `TestTotalSavedTakesTheKeepAliveNetNotItsGross` makes a window where the
pings cost more than they saved and requires the headline to go **down**;
`TestTheWaterfallReconcilesWithTotalSaved` requires the signed steps to sum to the cent.

Confirmed on the capture database: `Requests = 1,770` and `8 sessions` are identical with and
without 81 ping rows present, while `Total dollars avoided` moves from $1.47 to $6.61 — exactly
the $5.15 net.

Tiles that changed: the Overview headline's sub-label (`compaction + prefix cache + keep-alive`),
`TILE_INFO['total-saved-usd']`'s catch (three addends; the net, not the gross; and the ceiling),
the `keepalive-net` tile (both halves in its sub-line, "a ceiling", and a link to the tab),
`total_saved`'s waterfall description, and one new **Keep-alive net** column on Sessions —
blank, not `$0`, where it never ran.

### Per-session overrides

In memory on the keeper, under the existing lock, with **no new table**. The dash DB may not grow
unboundedly and a schema bump renames history aside; but the deciding argument is semantic — an
override is an **authorization to spend**, and one that silently survives a restart is worse than
one that does not. The UI says so, and the durable half is an audit row per arm and per disarm
carrying the resolved parameters and the expiry.

One hook in `record`, immediately after `pol := tn.Cache`. Everything downstream — `pol.on()`,
`pingable()`, the hard deadline, the per-ping guard, the kill switch, the no-audit-sink refusal —
is untouched.

| rule | value |
|---|---|
| `until` mandatory | max **12 h** (session lifetime p99 is 12.9 h), default 1 h |
| `Idle` | 60–290 s (past 290 the first ping lands after the TTL has lapsed and pays a **write**) |
| `MaxPings` | 1–11, **and `(K+1)·X ≤ 60 min`** — the credential-hold ceiling, shown to the caller |
| `MaxUSDPerPing` | **not settable**; the body's value is ignored and the answer reports the one in force |
| per account / total | 64 / 512 |
| arm rate | 30/hour/account, via a new `Limiter.AllowAction` |

Every bound is a 4xx **with the reason**, never a silent clamp: a clamp on a spend authorization
tells someone they got what they asked for when they did not. An override may switch the
mechanism **on** for one session while the account default is off — that is the point, and the
arming request is the consent act — but it cannot reach around the kill switch or the audit-sink
refusal. `POST` answers with the computed credential hold in minutes and the worst-case spend,
priced from that session's own last prefix. Arming without showing what it can cost is the thing
this feature is trying not to be.

An override holds **no material**: arming creates no `kaEntry`, so one left on a dead session
costs exactly zero (`TestOverrideOnADeadSessionCostsNothing`). Disarming releases what is held
**now** rather than at the deadline, zeroized — `TestDisarmRetiresTheHeldMaterialNow` extends the
no-output-surface bar to that path at debug level. `keeper.forget` (which every Settings save
calls) drops a tenant's overrides too, so unticking the account box kills armed sessions.

**One gap closed.** The account-level off switch was drawn disabled for a non-manager
(`ka.disabled = inherited || !mgr`) because it lives in the manager-owned configuration document
— so an account owner whose own key was being spent could not switch it off from the page.
`DELETE /api/me/keepalive` is open to **any** principal on their own account and is deliberately
one-way: it clears the stored consent, drops every override, and calls `forget` so retention
stops now. Turning it back **on** keeps the manager gate.

### Routes

Five reads in `dash/api.go`'s `routes()` table, so `TestEveryMountedRouteDeclaresItsScope` and
`TestNoRouteServesContentTextFromAnUntrustedAddress` both walk them. All `scopeTenant`, all
returning numbers and enum labels only — no prompt text, no transcript, no tool schema — so the
content gate passes on them by construction and no CIDR gate is needed. Four writes in
`ctlRoutes()`, sharing `PUT /api/me`'s authentication and CSRF path exactly; the arm route
declares `ctlManager`, which is the honest statement of the gate it enforces.

### Migration and storage

**`schemaVersion` stays 6. No new table, no new column, no `additiveDDL`, no `additiveColumns`.**
Every statistic is a query over `requests` plus the three columns PR #86 already added. Nothing
deletes: no eviction, retention or purge path is touched.

Verified by opening a copy of the production snapshot (which predates those columns): the version
stayed **6**, the three keep-alive columns were added additively, and all **1,770** rows survived.
Historical rows read "not recorded yet" through an explicit coverage count — never a fabricated
default — and the UI renders three distinct states: *the keep-alive has not run on this account*,
*recorded on N of M requests in this window*, or the plain figures. All three were exercised on
the capture database.

Storage growth is ping rows and nothing else. Measured with `dbstat`: 294 B of row plus ~103 B of
index = **≤ 400 B per ping**.

| policy | pings/day | bytes/day |
|---|--:|--:|
| shipped gate | 204 | ~82 KB |
| blanket (ungated) | 1,995 | ~800 KB |

The tab shows the account's own rate and projected growth, because per-session overrides are the
one way a user could raise it. Nothing here stores text.

### Honesty, and where it surfaces

Every headline is a **range with its n**. The recommendation is **refused** unless all three
hold: ≥ 20 addressable expiries, ≥ 200 requests, and a 90% bootstrap interval over **sessions**
(2,000 draws, deterministic seed; sessions, not requests, because expiries within a session are
not independent draws) that excludes zero **on the positive side**. On the production corpus that
admits 4 of 13 accounts and refuses 9. The wire carries **no point estimate field at all** — a
field that exists gets rendered — and `TestRecommendationPayloadCarriesNoPointEstimate` asserts
its absence in the JSON. `K = 1` is never recommended (−$71 service-wide: one ping reaches ~4.7
min, inside the free TTL). K = 2 and K = 3 are reported as a measured tie unless K = 3's interval
clears K = 2's entirely.

Every tile carrying `keepaliveSavedUSD` states it is a **ceiling**: the provider's cache is
content-keyed, so another session sending a byte-identical prefix would have refreshed the same
entry for free. The counts beside it (pings sent, pings that read nothing, pings that wrote) are
what an operator checks it against.

The panel above the session table says, in the measured numbers, that per-session selection is
not a strategy: a list fitted on one half of a week earned **$5.27** in the next half where the
plain account-wide rule earned **$53.32**.

### Found while building this

`Overview`'s replay-ceiling subquery had **no predicate at all** on its inner count, so a
keep-alive ping counted as a later turn that could replay a reduction. It cannot: a ping is a
verbatim resend carrying no new transcript, and PR #86's invariant is that a ping is not a turn.
On a three-ping fixture it inflated the ceiling from 30 to 50 tokens and dragged
`replay_realized_pct` down with it — which reads as compaction realising less of its value than it
does. On the capture database it over-counted by 517k tokens (3.4%). Caught by the key-by-key
comparison, not by an aggregate anyone thought to check.

**The obvious fix was a 20% regression on `Overview`, and measuring caught that too.** Adding
`AND p.keepalive = 0` inside the correlated count is right logically and wrong operationally:
`keepalive` is not in `idx_requests_session`, so it turns an index-only count into a row fetch per
candidate. Measured over three alternating runs against `main`:

| | main | `AND p.keepalive = 0` | shipped |
|---|--:|--:|--:|
| `Overview`, 10k-row fixture | ~231 ms | ~277 ms | ~235 ms |
| same under `-race` | 10.6 s | 15.3 s | 10.4 s |
| `Overview`, capture DB (81 pings) | 147–274 ms | — | 163–230 ms |

Under `-race` that 44% was enough to blow `TestOverviewStaysFastOnALargeWindow`'s budget on a
loaded box. The shipped form keeps `main`'s index-only count and subtracts a correction driven
from the **ping** side — one indexed sum per ping over its own session's earlier rows, which is
`O(pings × session)` rather than a second full pass — behind an `EXISTS` gate, so it costs
literally nothing where the mechanism has never run.
`TestTheReplayCeilingCountsAgentTurnsNotPings` pins all of it: the uncorrected value, that a ping
does not move it, and that a ping *before* a reduction is not over-subtracted either.

(The inner count is still not window- or tenant-scoped, and both statements agree about that;
session ids are `tenant:uuid` so a cross-tenant collision is not reachable, and the ceiling is
deliberately about the session's whole life. Noted, not changed.)

### Four defects that only gave up when the page was opened

Reading the code was not enough; each rendered plausibly and said something false.

- **The K-ladder table was absent.** `barRows` clears the host it is handed, and the share chart
  was given the panel's own host — so the table it replaced simply was not there, under a row of
  bars carrying all the same numbers.
- **The recommendation offered a policy whose own 90% interval was −$38.63 to −$4.54.** "Excludes
  zero" is a two-sided reading; entirely below zero is not inconclusive, it is a finding, and it
  is now its own refusal with its own wording and its own `banner bad`.
- **Band edges rendered as `5m–9.666666666666666m`**, and a band with no expiries drew a 2px stub
  that reads as "a little" rather than "none".
- **The calculator said "not priced" on a deployment whose price list was fine**, because nothing
  had named a model. It now prefills the account's own **modal** model on its own expiries — an
  answer about that account, not a blend.

Plus: a "top 7 of these hold $81.40 of $81.40" tautology; a last-prefix of `0` rendering as a size
rather than as an absence; an arm confirmation that reported the credential hold only *after* the
authorization; and — on a single-tenant deployment, which mounts no control plane — a "Keep warm"
button on every row whose only possible outcome was a 404. The panel and the whole action column
now go once that is known.

## Verification

`go vet ./...` clean, `gofmt -l .` empty, and `CGO_ENABLED=1 go test -race -count=1 ./...` green
across all **25** packages — **with `-timeout 25m`**. That timeout is not this branch's doing:
`origin/main`'s own `dash` package takes **671 s** under `-race` on this box, already past Go's
default 10-minute per-package limit, so a default-timeout run is load-dependent on `main` too.
This branch's `dash` is **680 s** — a 9 s delta. Worth raising separately.

46 new tests (16 dash query/attribution, 5 dash UI-asset, 11 keeper override, 7 control-plane, 5
config). Every fix was mutated and its test confirmed red — the two config fixes, the one-sided
recommendation rule, and all five UI honesty checks (gating the split on a negative net, dropping
the service-wide figures from the markup, removing a `TILE_INFO` entry, rendering the
recommendation as a point, putting the tab in `UNFILTERED_VIEWS`, and collapsing the two charts
into one).

The dashboard was served against a copy of a copy of the production snapshot and the tab was
**looked at**, in light and dark, on two databases: one where the keep-alive has never run (the
absence state) and one with a simulated run over those accounts' real gaps (the populated
state). Screenshots are at the local path in the review notes and are **not committed** — this
repo is public and they carry real figures. The capture database was built from the two
authorized accounts only, every content table was emptied, session UUIDs were remapped, and a
programmatic scan for emails, session UUIDs, foreign tenant ids and host paths reports **0
findings** on both databases.
