### PR TITLE
feat(dash): make the Inventory page actionable — prompt parts, built-ins aside, skill removal, and the total that was missing

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -370,10 +370,17 @@ func BodyOpts(ctx context.Context, pipe *components.Pipeline, st store.Store, o 
 	// envelope (82.7% of a session's declared tokens are never invoked). Deterministic,
 	// unconditional while configured, and never touching a name the account did not list:
 	// see toolfilter.go for the prose gate and the determinism argument.
+	// The skills half is the same component's other mechanism: a skill is a line of prose in a
+	// transcript message rather than an element of `tools`, so it needs its own rewrite. Both run
+	// here, from the one configured list, and both report into the same two counters — the
+	// component's ledger says "declarations no longer sent", and a reader does not care which of
+	// the two shapes each one had.
 	filteredTokens, filteredDecls := 0, 0
 	if !bypass && pipe != nil {
 		if tf, ok := pipe.Find("toolfilter").(interface{ Removed() []string }); ok {
 			body, filteredTokens, filteredDecls = filterDeclarations(body, tf.Removed())
+			sBody, sTok, sN := filterSkillListing(body, tf.Removed())
+			body, filteredTokens, filteredDecls = sBody, filteredTokens+sTok, filteredDecls+sN
 		}
 	}
 

--- a/apply/toolfilter.go
+++ b/apply/toolfilter.go
@@ -105,8 +105,10 @@ package apply
 // tool back.
 
 import (
+	"bytes"
 	"strings"
 
+	"github.com/rossoctl/context-guru/internal/skills"
 	"github.com/rossoctl/context-guru/internal/tokens"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -195,10 +197,17 @@ func filterDeclarations(body []byte, remove []string) (out []byte, removedTokens
 	return next, removedTokens, removed
 }
 
-// removeSets splits the configured list into exact names and whole-server entries.
+// removeSets splits the configured list into exact names and whole-server entries, and drops the
+// skill entries: those are removed from the listing prose by filterSkillListing, and leaving
+// `skill__foo` in the tool-name set would mean a tool actually called `skill__foo` was removed by
+// a request to remove a skill. No such tool exists today, which is exactly why the guard belongs
+// here rather than in a bug report later.
 func removeSets(remove []string) (names, servers map[string]bool) {
 	names, servers = make(map[string]bool, len(remove)), map[string]bool{}
 	for _, r := range remove {
+		if strings.HasPrefix(r, skills.RemovePrefix) {
+			continue
+		}
 		if s, ok := serverEntry(r); ok {
 			servers[s] = true
 			continue
@@ -406,4 +415,131 @@ func identByte(prose string, i int) bool {
 	}
 	c := prose[i]
 	return c == '_' || c >= '0' && c <= '9' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}
+
+// ── skills ──────────────────────────────────────────────────────────────────
+
+// filterSkillListing removes the named skills' entries from the skills listing.
+//
+// # Why this is a different mechanism from the tools filter, and a SAFER one
+//
+// The listing is prose in a role:"system" MESSAGE (measured on real traffic: messages[1], a
+// plain string, 6,867 bytes), not an element of `tools`. So the two hazards are inverted.
+//
+// The tools filter's danger is SILENCE: strip a declaration whose prose survives and the model
+// may narrate the call instead of emitting one, which nothing surfaces. A skill cannot fail that
+// way. The `Skill` tool's schema takes a free-form string with NO enum — verified against a real
+// declaration — and its description says only that names come from the listing. So an unlisted
+// skill the model names anyway still RUNS. The failure mode of over-removing here is that the
+// model does not know a skill exists, which is exactly what the account asked for, and the
+// failure mode of the model remembering one anyway is that it works. Fail-open by construction.
+//
+// # What it shares with the tools filter: determinism
+//
+// It edits a message deep inside the cached prefix, so any per-turn variation would re-anchor
+// the prefix on every turn (see §3 of this file's header). The inputs are the same
+// session-invariant ones — the configured list, and the prose region minus the listing itself —
+// so for a given account the answer is the same on every turn of every session. Switching it on
+// mid-session re-anchors ONCE, the same one-time charge the tools half pays and the same
+// arithmetic in reverse for putting a skill back.
+//
+// The prose gate is kept for consistency with the tools half, with the listing SUBTRACTED from
+// the region first: the gate has to mean "named somewhere other than its own listing entry", or
+// a client that puts its listing in messages[0] with role system would have every skill
+// permanently pinned by the entry that is the thing being removed.
+//
+// Fails open on everything: no listing, no terminator, a body shape it does not recognise, a
+// re-encode that errors — all return the input untouched and a saving of zero.
+func filterSkillListing(body []byte, remove []string) (out []byte, removedTokens, removed int) {
+	drop := map[string]bool{}
+	for _, r := range remove {
+		if n := strings.TrimPrefix(r, skills.RemovePrefix); n != r && n != "" {
+			drop[n] = true
+		}
+	}
+	if len(drop) == 0 {
+		return body, 0, 0
+	}
+	// Which message holds the listing, and — when its content is an array — which block. The
+	// FIRST match, the same choice dash's reader makes, so the page and the filter describe the
+	// same listing on a body that somehow carries two.
+	path, text := skillListingPath(body)
+	if path == "" {
+		return body, 0, 0
+	}
+	i := strings.Index(text, skills.Header)
+	if i < 0 {
+		return body, 0, 0 // path said there was one: refuse rather than guess
+	}
+	head := text[:i+len(skills.Header)]
+	rest := text[i+len(skills.Header):]
+	tail := ""
+	if j := strings.Index(rest, skills.ReminderEnd); j >= 0 {
+		rest, tail = rest[:j], rest[j:]
+	}
+	// The prose gate, with the listing itself removed from the region it tests against.
+	prose := strings.Replace(proseRegion(body), text, "", 1)
+	l := skills.Parse(rest)
+	for name := range drop {
+		if proseReferenced(prose, name) {
+			delete(drop, name)
+		}
+	}
+	if len(drop) == 0 {
+		return body, 0, 0
+	}
+	for _, e := range l.Entries {
+		if drop[e.Name] {
+			removedTokens += tokens.Count(l.Text(e))
+		}
+	}
+	next, n := l.Without(drop)
+	if n == 0 {
+		return body, 0, 0
+	}
+	nb, err := sjson.SetBytes(body, path, head+next+tail)
+	if err != nil {
+		return body, 0, 0
+	}
+	return nb, removedTokens, n
+}
+
+// skillListingPath finds the listing: the sjson path of the string that holds it, and that
+// string. "" when no message carries one.
+//
+// A byte search over the raw body first, because both anchors survive JSON escaping and the
+// overwhelming majority of requests have nothing to do here — a body with no listing must not
+// pay a walk of a multi-megabyte messages array. Only on a hit does it walk to find the path.
+func skillListingPath(body []byte) (string, string) {
+	// bytes.Contains, not strings.Contains(string(body), ...): the body runs to megabytes and the
+	// conversion would copy all of it on the request goroutine, on every request, to answer a
+	// question that is usually "no".
+	if !bytes.Contains(body, []byte(skills.Header)) {
+		return "", ""
+	}
+	path, text := "", ""
+	gjson.GetBytes(body, "messages").ForEach(func(idx, m gjson.Result) bool {
+		if !strings.Contains(m.Raw, skills.Header) {
+			return true
+		}
+		c := m.Get("content")
+		if c.Type == gjson.String {
+			if strings.Contains(c.String(), skills.Header) {
+				path, text = "messages."+idx.String()+".content", c.String()
+				return false
+			}
+			return true
+		}
+		c.ForEach(func(bidx, blk gjson.Result) bool {
+			t := blk.Get("text")
+			if t.Exists() && strings.Contains(t.String(), skills.Header) {
+				path = "messages." + idx.String() + ".content." + bidx.String() + ".text"
+				text = t.String()
+				return false
+			}
+			return true
+		})
+		return path == ""
+	})
+	return path, text
 }

--- a/apply/toolfilter_apply_test.go
+++ b/apply/toolfilter_apply_test.go
@@ -8,6 +8,7 @@ import (
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/apply"
 	_ "github.com/rossoctl/context-guru/components/all"
+	"github.com/rossoctl/context-guru/internal/skills"
 	"github.com/rossoctl/context-guru/store"
 	"github.com/tidwall/gjson"
 )
@@ -110,5 +111,215 @@ func TestToolFilterRejectsAJunkName(t *testing.T) {
 		if _, err := pipe(t, "pipeline: [toolfilter]\ncomponents:\n  toolfilter:\n    remove: [\""+name+"\"]\n").Build(nil); err == nil {
 			t.Errorf("accepted %q as a declaration name", name)
 		}
+	}
+}
+
+// skillTurn is turn(n) with a SKILLS LISTING on it: prose inside a <system-reminder> in a
+// role:"system" message, which is where Claude Code really puts it (measured: messages[1], a plain
+// string). turn() has no listing, so nothing built on it can exercise the skills half at all.
+func skillTurn(n int) string {
+	const listing = `<system-reminder>\nAvailable agent types:\n- planner: plans things\n</system-reminder>\n\n` +
+		`<system-reminder>\nThe following skills are available for use with the Skill tool:\n\n` +
+		`- dataviz: Use for charts and plots.\n` +
+		`- deep-research: A research harness.\n  With a continuation line of its own.\n` +
+		`- ponytail:ponytail: A plugin skill, colon in the name.\n</system-reminder>`
+	var b strings.Builder
+	b.WriteString(`{"model":"claude-opus-5","tools":[` +
+		`{"name":"Skill","description":"Invoke a skill.","input_schema":{"type":"object"}},` +
+		`{"name":"Bash","description":"run a command","input_schema":{"type":"object"}}],` +
+		`"system":[{"type":"text","text":"You are an agent. Prefer Bash for shell work.\nCurrent branch: main\n"}],` +
+		`"messages":[{"role":"user","content":[{"type":"text","text":"start"}]},` +
+		`{"role":"system","content":"` + listing + `"}`)
+	for i := 0; i < n; i++ {
+		b.WriteString(`,{"role":"assistant","content":[{"type":"tool_use","id":"t` + string(rune('0'+i)) +
+			`","name":"Bash","input":{"command":"ls"}}]}`)
+		b.WriteString(`,{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` +
+			string(rune('0'+i)) + `","content":"a b c"}]}`)
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}
+
+// listedSkills reads the skill names still in the body's listing, through the same parser the
+// inventory prices them with — so this test and the page cannot disagree about what "removed"
+// means.
+func listedSkills(t *testing.T, body []byte) []string {
+	t.Helper()
+	var out []string
+	gjson.GetBytes(body, "messages").ForEach(func(_, m gjson.Result) bool {
+		c := m.Get("content")
+		txt := c.String()
+		if c.IsArray() {
+			txt = ""
+			c.ForEach(func(_, blk gjson.Result) bool { txt += blk.Get("text").String(); return true })
+		}
+		i := strings.Index(txt, skills.Header)
+		if i < 0 {
+			return true
+		}
+		body := txt[i+len(skills.Header):]
+		if j := strings.Index(body, skills.ReminderEnd); j >= 0 {
+			body = body[:j]
+		}
+		for _, e := range skills.Parse(body).Entries {
+			out = append(out, e.Name)
+		}
+		return false
+	})
+	return out
+}
+
+// TestSkillFilterThroughApply is the WIRING test for the skills half, and the reason it exists is
+// that its absence was invisible: deleting the two lines in apply.Body that call
+// filterSkillListing left `go test ./...` entirely green across every package. Seven unit tests
+// cover the function and every one of them calls it directly, so none of them notices that nothing
+// in production does. A user could tick a skill, have the config written and audited, read "Opted
+// out" on the page, and go on being charged for the entry — with CI green.
+//
+// Deliberately the sibling of TestToolFilterThroughApply: same table, same pipeline strings, same
+// apply.Body call. The tools half is covered by that one; this is the half that was not.
+func TestSkillFilterThroughApply(t *testing.T) {
+	for _, tc := range []struct {
+		name, pipeline string
+		want           []string
+	}{
+		{"absent without the component", "pipeline: [format]\n",
+			[]string{"dataviz", "deep-research", "ponytail:ponytail"}},
+		{"empty list removes nothing", "pipeline: [format, toolfilter]\n",
+			[]string{"dataviz", "deep-research", "ponytail:ponytail"}},
+		{"a bare name is not a skill entry", "pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [dataviz]\n",
+			[]string{"dataviz", "deep-research", "ponytail:ponytail"}},
+		{"removes the skill it is told", "pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [skill__dataviz]\n",
+			[]string{"deep-research", "ponytail:ponytail"}},
+		{"a plugin skill's colon survives the round trip", "pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [skill__ponytail:ponytail]\n",
+			[]string{"dataviz", "deep-research"}},
+		{"several at once", "pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [skill__dataviz, skill__deep-research]\n",
+			[]string{"ponytail:ponytail"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := pipe(t, tc.pipeline).Build(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := []byte(skillTurn(2))
+			out, _ := apply.Body(context.Background(), p, store.NewMemory(store.Options{}),
+				bschemas.Anthropic, body, "s1", false)
+			if got := strings.Join(listedSkills(t, out), ","); got != strings.Join(tc.want, ",") {
+				t.Errorf("listing = [%s], want [%s]", got, strings.Join(tc.want, ","))
+			}
+			// The tools array is not this half's business and must not move.
+			if a, b := gjson.GetBytes(body, "tools").Raw, gjson.GetBytes(out, "tools").Raw; a != b {
+				t.Errorf("tools changed:\n%s\n%s", a, b)
+			}
+			// And the entry that went took its continuation line with it, rather than orphaning
+			// prose onto whichever entry followed.
+			if len(tc.want) < 3 && strings.Contains(string(out), "continuation line of its own") &&
+				!containsStr(tc.want, "deep-research") {
+				t.Error("a removed entry's continuation line was left in the prompt")
+			}
+		})
+	}
+}
+
+func containsStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSkillFilterSameListingEveryTurn is the cache-invalidation sibling of
+// TestToolFilterSameToolsEveryTurn, and it matters for the same reason and slightly more: the
+// listing sits inside the cached PREFIX, so a filter that acted on some turns of a session and not
+// others would re-anchor the whole prompt on every one of them. A session filtered from turn 1
+// must send a byte-identical listing on every turn.
+func TestSkillFilterSameListingEveryTurn(t *testing.T) {
+	p, err := pipe(t, "pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [skill__dataviz]\n").Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.NewMemory(store.Options{})
+	want := ""
+	for n := 0; n < 8; n++ {
+		out, _ := apply.Body(context.Background(), p, st, bschemas.Anthropic,
+			[]byte(skillTurn(n)), "s1", false)
+		got := gjson.GetBytes(out, "messages.1.content").Raw
+		if n == 0 {
+			want = got
+			if s := listedSkills(t, out); len(s) != 2 {
+				t.Fatalf("turn 0 did not filter: %v", s)
+			}
+			continue
+		}
+		if got != want {
+			t.Fatalf("turn %d sent a different listing:\n got %s\nwant %s", n, got, want)
+		}
+	}
+}
+
+// TestFilterRemovalIsNotInsideTheCompactionBaseline is the ORDERING guard behind the word
+// "disjoint" in Overview.TotalSavedUSD, and it lives here because the ordering does.
+//
+// TotalSavedUSD adds the declaration filter's saving to compaction's. For the TOOLS half that is
+// disjoint by construction — a tool schema is not in `messages` and tokens_before counts nothing
+// else. For the SKILLS half it is not obvious: a skill's listing entry IS in `messages`, exactly
+// where tokens_before is measured, so if the removal landed inside Saved() the same tokens would be
+// counted once in NetSavedUSD and again in DeclFilterUSD.
+//
+// It holds only because filterSkillListing runs in Body BEFORE the pipeline takes its baseline, so
+// tokens_before is measured on the already-filtered body. That is an ordering property, and the
+// assertion is therefore a COMPARISON OF TWO REAL RUNS rather than a hand-built row: with the
+// filter on, tokens_before must FALL by the entry's weight while Saved() stays 0. Move the filter
+// below the baseline and tokens_before stays put while tokens_after drops — Saved() becomes N and
+// the total double-counts.
+//
+// A dash-side test asserts the downstream arithmetic on such a row; this one is what makes that
+// row's shape true in the first place.
+func TestFilterRemovalIsNotInsideTheCompactionBaseline(t *testing.T) {
+	run := func(pipeline string) apply.Result {
+		p, err := pipe(t, pipeline).Build(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return apply.BodyOpts(context.Background(), p, store.NewMemory(store.Options{}), apply.Opts{
+			Provider: bschemas.Anthropic, Body: []byte(skillTurn(2)), Session: "s1",
+		})
+	}
+	off := run("pipeline: [format, toolfilter]\n")
+	on := run("pipeline: [format, toolfilter]\ncomponents:\n  toolfilter:\n    remove: [skill__dataviz]\n")
+
+	if on.Trace.FilteredDeclTokens <= 0 {
+		t.Fatalf("the filter reported %d removed tokens; nothing was exercised",
+			on.Trace.FilteredDeclTokens)
+	}
+	// Saved() is tokens_before − tokens_after. It must be ZERO on both runs: the filter's removal
+	// happened before the baseline, so the pipeline never saw those tokens to "save".
+	for _, c := range []struct {
+		name string
+		r    apply.Result
+	}{{"unfiltered", off}, {"filtered", on}} {
+		if got := c.r.Trace.Run.TokensBefore - c.r.Trace.Run.TokensAfter; got != 0 {
+			t.Errorf("%s: tokens_before − tokens_after = %d, want 0.\n"+
+				"A non-zero saving here is the declaration filter's removal landing inside the "+
+				"compaction baseline, where TotalSavedUSD counts it a second time.", c.name, got)
+		}
+	}
+	// And the baseline itself SHRANK by the removal, which is the positive half of the same
+	// statement: the tokens left before they were ever counted.
+	drop := off.Trace.Run.TokensBefore - on.Trace.Run.TokensBefore
+	if drop <= 0 {
+		t.Errorf("tokens_before did not fall when the filter was switched on (%d -> %d).\n"+
+			"Either the filter did not touch `messages`, or it ran after the baseline was taken.",
+			off.Trace.Run.TokensBefore, on.Trace.Run.TokensBefore)
+	}
+	// The two measurements are of the same bytes by different code, so they should agree closely.
+	// Not asserted as equality: FilteredDeclTokens counts the entry's own text, tokens_before
+	// counts the whole messages array, and BPE is not additive across a splice.
+	if d := drop - on.Trace.FilteredDeclTokens; d > 4 || d < -4 {
+		t.Errorf("tokens_before fell by %d but the filter reported %d removed; more than a "+
+			"boundary token apart, so these are not describing the same removal",
+			drop, on.Trace.FilteredDeclTokens)
 	}
 }

--- a/apply/toolfilter_skills_test.go
+++ b/apply/toolfilter_skills_test.go
@@ -185,3 +185,40 @@ func TestFilterSkillReadsABlockArrayListing(t *testing.T) {
 		t.Error("the entry survived in the block-array shape")
 	}
 }
+
+// TestRemoveSetsKeepsSkillEntriesOutOfTheToolNames is the guard in removeSets, which had none.
+//
+// A `skill__x` entry must not land in the tool-name set: it is removed from the listing prose by
+// filterSkillListing, and leaving it in `names` would mean a tool literally called `skill__x` was
+// dropped by a request to remove a SKILL called `x`. No such tool exists today, which is exactly
+// why the guard needed a test rather than a comment — nothing would have noticed its removal.
+func TestRemoveSetsKeepsSkillEntriesOutOfTheToolNames(t *testing.T) {
+	names, servers := removeSets([]string{
+		skills.RemovePrefix + "dataviz", "Workflow", "mcp__srv", "mcp__srv__tool",
+	})
+	if names[skills.RemovePrefix+"dataviz"] {
+		t.Error("a skill entry reached the tool-name set; a tool of that name would be dropped by " +
+			"a request to remove a skill")
+	}
+	for _, want := range []string{"Workflow", "mcp__srv__tool"} {
+		if !names[want] {
+			t.Errorf("%s is missing from the tool names", want)
+		}
+	}
+	if !servers["srv"] {
+		t.Error("the whole-server entry did not reach the server set")
+	}
+	if len(names) != 2 {
+		t.Errorf("tool names = %v, want exactly the two tool entries", names)
+	}
+	// The end-to-end consequence: a tool whose NAME is the skill entry survives a skill removal.
+	body := `{"model":"m","tools":[` +
+		`{"name":"skill__dataviz","description":"a tool that happens to be called this","input_schema":{"type":"object"}},` +
+		`{"name":"Bash","description":"run","input_schema":{"type":"object"}}],` +
+		`"system":[{"type":"text","text":"You are an agent."}],` +
+		`"messages":[{"role":"user","content":"hi"}]}`
+	out, tok, n := filterDeclarations([]byte(body), []string{skills.RemovePrefix + "dataviz"})
+	if n != 0 || tok != 0 || string(out) != body {
+		t.Errorf("a skill removal dropped %d tool declarations (%d tokens)", n, tok)
+	}
+}

--- a/apply/toolfilter_skills_test.go
+++ b/apply/toolfilter_skills_test.go
@@ -1,0 +1,187 @@
+package apply
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/skills"
+	"github.com/tidwall/gjson"
+)
+
+// skillBody is real Claude Code shape: the listing is prose inside a <system-reminder> in a
+// role:"system" MESSAGE, not in `system` and not in `tools` — measured on capture-tb.jsonl,
+// messages[1], a plain string. A second reminder sits ABOVE it using the identical
+// `- name: description` bullet shape, which is why the header is the anchor: an unanchored
+// scrape would count "planner" as a skill.
+const skillBody = `{"model":"claude-opus-5",` +
+	`"tools":[{"name":"Skill","description":"Invoke a skill.","input_schema":{"type":"object"}},` +
+	`{"name":"Bash","description":"run a command","input_schema":{"type":"object"}}],` +
+	`"system":[{"type":"text","text":"You are an agent. Prefer Bash for shell work.\n"}],` +
+	`"messages":[` +
+	`{"role":"user","content":"go"},` +
+	`{"role":"system","content":"<system-reminder>\nAvailable agent types:\n- planner: plans things\n</system-reminder>\n\n<system-reminder>\n` +
+	`The following skills are available for use with the Skill tool:\n\n` +
+	`- dataviz: Use for charts and plots.\n` +
+	`- deep-research: A research harness.\n  It has a continuation line that belongs to it.\n` +
+	`- ponytail:ponytail: A plugin skill, with a colon in its name.\n` +
+	`</system-reminder>"},` +
+	`{"role":"assistant","content":[{"type":"text","text":"ok"}]}]}`
+
+// listingOf returns the text of the message that carries the listing.
+func listingOf(t *testing.T, body []byte) string {
+	t.Helper()
+	_, text := skillListingPath(body)
+	return text
+}
+
+// TestFilterSkillRemovesOnlyTheNamedEntry is the mechanism: the named skill's whole entry goes,
+// including its continuation lines, and every other entry survives byte-for-byte.
+func TestFilterSkillRemovesOnlyTheNamedEntry(t *testing.T) {
+	out, tok, n := filterSkillListing([]byte(skillBody), []string{skills.RemovePrefix + "deep-research"})
+	if n != 1 {
+		t.Fatalf("removed %d entries, want 1", n)
+	}
+	if tok <= 0 {
+		t.Errorf("removed %d tokens, want a positive weight", tok)
+	}
+	got := listingOf(t, out)
+	if strings.Contains(got, "deep-research") {
+		t.Error("the named skill is still in the listing")
+	}
+	// The continuation line belongs to the entry that was removed. Left behind it would be
+	// orphaned prose attached to whichever entry followed — the exact drift internal/skills
+	// exists to prevent.
+	if strings.Contains(got, "continuation line") {
+		t.Error("the entry's continuation line was orphaned in the prompt")
+	}
+	for _, keep := range []string{"dataviz: Use for charts", "ponytail:ponytail: A plugin skill"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("%q was removed too", keep)
+		}
+	}
+	// The header, the terminator and the reminder ABOVE the listing are all untouched.
+	for _, keep := range []string{skills.Header, skills.ReminderEnd, "- planner: plans things"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("%q did not survive", keep)
+		}
+	}
+	// And nothing else in the request moved: same tools, same system prompt, same transcript.
+	if a, b := gjson.GetBytes(out, "tools").Raw, gjson.Get(skillBody, "tools").Raw; a != b {
+		t.Error("the tools array changed")
+	}
+	if a, b := gjson.GetBytes(out, "messages.2").Raw, gjson.Get(skillBody, "messages.2").Raw; a != b {
+		t.Error("a transcript message changed")
+	}
+}
+
+// TestFilterSkillHandlesAPluginNameWithAColon: `plugin:skill` is one name, and the entry parser
+// has to take the longer candidate rather than stopping at the first colon. Getting this wrong
+// removes nothing and reports success.
+func TestFilterSkillHandlesAPluginNameWithAColon(t *testing.T) {
+	out, _, n := filterSkillListing([]byte(skillBody), []string{skills.RemovePrefix + "ponytail:ponytail"})
+	if n != 1 {
+		t.Fatalf("removed %d entries, want 1", n)
+	}
+	if strings.Contains(listingOf(t, out), "A plugin skill") {
+		t.Error("the plugin skill's entry survived")
+	}
+}
+
+// TestFilterSkillIsByteStableWhenNothingMatches is the determinism rule at the byte level. The
+// listing sits inside the cached prefix, so a body that is merely EQUIVALENT after a no-op
+// re-encode still re-anchors the whole prompt at the cache-creation rate for a saving of zero.
+func TestFilterSkillIsByteStableWhenNothingMatches(t *testing.T) {
+	for _, remove := range [][]string{
+		nil,
+		{},
+		{"Bash"},    // a tool, not a skill: not this filter's business
+		{"dataviz"}, // the right name WITHOUT the prefix
+		{skills.RemovePrefix + "not-a-skill-here"}, // prefixed, but nothing declares it
+		{skills.RemovePrefix},                      // the prefix alone
+	} {
+		out, tok, n := filterSkillListing([]byte(skillBody), remove)
+		if string(out) != skillBody || tok != 0 || n != 0 {
+			t.Errorf("remove=%v changed the body (%d tokens, %d entries)", remove, tok, n)
+		}
+	}
+}
+
+// TestFilterSkillFailsOpenWithoutAListing: a request with no skills listing is returned
+// untouched rather than reshaped by a rewrite that had nothing to find.
+func TestFilterSkillFailsOpenWithoutAListing(t *testing.T) {
+	out, tok, n := filterSkillListing([]byte(bodyFixture), []string{skills.RemovePrefix + "dataviz"})
+	if string(out) != bodyFixture || tok != 0 || n != 0 {
+		t.Errorf("a body with no listing was changed (%d tokens, %d entries)", tok, n)
+	}
+}
+
+// TestFilterSkillProseGateKeepsADescribedSkill: the same gate the tools half applies. A skill the
+// agent's own hand-written instructions name is kept however loudly the configuration asks for
+// it — and the gate must test the prose OUTSIDE the listing, since the listing names every skill
+// in it by definition.
+func TestFilterSkillProseGateKeepsADescribedSkill(t *testing.T) {
+	// dataviz named in a `system` block, which is prose the gate reads.
+	described := strings.Replace(skillBody,
+		"You are an agent. Prefer Bash for shell work.",
+		"You are an agent. Always run dataviz before answering.", 1)
+	out, tok, n := filterSkillListing([]byte(described), []string{skills.RemovePrefix + "dataviz"})
+	if n != 0 || tok != 0 || string(out) != described {
+		t.Fatalf("a prose-described skill was removed: %d entries, %d tokens", n, tok)
+	}
+	// And the gate is not simply refusing everything: another skill in the same body still goes.
+	if _, _, n := filterSkillListing([]byte(described), []string{skills.RemovePrefix + "dataviz",
+		skills.RemovePrefix + "deep-research"}); n != 1 {
+		t.Errorf("removed %d entries, want 1 (deep-research, while dataviz is pinned by prose)", n)
+	}
+}
+
+// TestFilterSkillRemovesEveryNamedEntry: several at once, which is what a batch opt-out posts,
+// and the one shape where an off-by-one in the line bookkeeping shows up.
+func TestFilterSkillRemovesEveryNamedEntry(t *testing.T) {
+	out, _, n := filterSkillListing([]byte(skillBody), []string{
+		skills.RemovePrefix + "dataviz",
+		skills.RemovePrefix + "deep-research",
+		skills.RemovePrefix + "ponytail:ponytail",
+	})
+	if n != 3 {
+		t.Fatalf("removed %d entries, want 3", n)
+	}
+	got := listingOf(t, out)
+	// The header survives with nothing under it, which is the honest rendering of "this account
+	// carries no skills" and is what the agent's own `skillOverrides: off` produces too.
+	if !strings.Contains(got, skills.Header) {
+		t.Error("the header was removed with the entries")
+	}
+	for _, gone := range []string{"dataviz:", "deep-research:", "ponytail:ponytail:"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived", gone)
+		}
+	}
+	// Still valid JSON with the message in place.
+	if !gjson.ValidBytes(out) {
+		t.Fatal("the rewrite produced invalid JSON")
+	}
+	if gjson.GetBytes(out, "messages.1.role").String() != "system" {
+		t.Error("the listing message lost its role")
+	}
+}
+
+// TestFilterSkillReadsABlockArrayListing: the same listing arriving as content BLOCKS rather
+// than a bare string. Real traffic sends a string, so this is the shape that would rot
+// unnoticed — and the path it needs (`messages.N.content.M.text`) is a different sjson write.
+func TestFilterSkillReadsABlockArrayListing(t *testing.T) {
+	blocks := strings.Replace(skillBody,
+		`{"role":"system","content":"<system-reminder>`,
+		`{"role":"system","content":[{"type":"text","text":"<system-reminder>`, 1)
+	blocks = strings.Replace(blocks, `</system-reminder>"},`, `</system-reminder>"}]},`, 1)
+	if !gjson.Valid(blocks) {
+		t.Fatal("the fixture edit produced invalid JSON")
+	}
+	out, tok, n := filterSkillListing([]byte(blocks), []string{skills.RemovePrefix + "dataviz"})
+	if n != 1 || tok <= 0 {
+		t.Fatalf("removed %d entries / %d tokens from a block-array listing, want 1 and >0", n, tok)
+	}
+	if strings.Contains(listingOf(t, out), "Use for charts") {
+		t.Error("the entry survived in the block-array shape")
+	}
+}

--- a/components/reformat/toolfilter.go
+++ b/components/reformat/toolfilter.go
@@ -106,6 +106,16 @@ func (Toolfilter) Reformat(_ *schemas.BifrostChatRequest, rep *components.Report
 	return nil
 }
 
+// ponytail: this component records NO gate, so a configured name the prose gate declines is
+// invisible in /stats — the one inconsistency GROUND-TRUTH already notes against toolfilter
+// ("no gates recorded"). rep.Gate("prose_referenced") is the right home for it and the plumbing is
+// the cost: the decision is made in apply, so the count has to reach Ctx the way FilteredDecls
+// does, which means a fourth return value on filterDeclarations and filterSkillListing and their
+// 31 call sites, 28 of them in tests. Deferred deliberately rather than duplicating
+// proseReferenced at a second site, which is how the two would drift. The user-facing half is
+// already handled: the page states the condition instead of promising an outcome it has not
+// checked (dash/ui/tools.js, the opted-out row and the skills panel).
+
 func init() {
 	components.RegisterFields("toolfilter", toolfilterConfig{}, []components.Field{
 		{Key: "remove", Type: components.FieldStrings,

--- a/components/reformat/toolfilter.go
+++ b/components/reformat/toolfilter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/internal/skills"
 )
 
 func init() { components.Register("toolfilter", newToolfilter) }
@@ -17,9 +18,14 @@ func init() { components.Register("toolfilter", newToolfilter) }
 // show that a declaration was not used in the sessions it captured, and an unused tool is
 // not the same thing as an unwanted one.
 type toolfilterConfig struct {
-	// Remove names the tool and MCP-server declarations to stop sending. Exact declaration
-	// names as the inventory reports them, plus the bare form `mcp__<server>` for a whole
-	// MCP server. An empty list is a no-op, which is what the shipped default is.
+	// Remove names the declarations to stop sending, in three shapes, all of them exact and
+	// none of them a pattern:
+	//
+	//   - `<tool>` — one tool or MCP tool, by the name the inventory reports;
+	//   - `mcp__<server>` — a whole MCP server, every tool it declares;
+	//   - `skill__<skill>` — one skill, removed from the listing prose rather than from `tools`.
+	//
+	// An empty list is a no-op, which is what the shipped default is.
 	Remove []string `yaml:"remove"`
 }
 
@@ -27,6 +33,10 @@ type toolfilterConfig struct {
 // field the pipeline never sees (components operate on `messages`), so the rewrite lives in
 // apply — the same arrangement toolschema and cachesplit use. apply reads the list back
 // through Removed().
+//
+// The skills half lives there too, for a different reason: the listing IS in `messages`, but it
+// sits in the cached prefix, and every rewrite of the prefix has to happen before any byte offset
+// into the body is taken. Same place, same list, same counters. See apply.filterSkillListing.
 type Toolfilter struct{ remove []string }
 
 func newToolfilter(raw []byte) (components.Component, error) {
@@ -59,11 +69,15 @@ func newToolfilter(raw []byte) (components.Component, error) {
 	return Toolfilter{remove: out}, nil
 }
 
-// validDeclName accepts the charset a tool, MCP or skill name is drawn from. No globs, no
-// wildcards: a pattern that matches more tomorrow than it did today is exactly the
-// non-deterministic removal this component refuses to offer.
+// validDeclName accepts the charset a tool, MCP or skill name is drawn from, plus the two
+// prefixes that select a mechanism. No globs, no wildcards: a pattern that matches more tomorrow
+// than it did today is exactly the non-deterministic removal this component refuses to offer.
+//
+// The length bound is applied to the NAME, after the prefix, so `skill__` does not eat seven
+// characters of a legitimate one.
 func validDeclName(n string) bool {
-	if len(n) > 128 {
+	n = strings.TrimPrefix(n, skills.RemovePrefix)
+	if n == "" || len(n) > 128 {
 		return false
 	}
 	for _, r := range n {
@@ -95,7 +109,8 @@ func (Toolfilter) Reformat(_ *schemas.BifrostChatRequest, rep *components.Report
 func init() {
 	components.RegisterFields("toolfilter", toolfilterConfig{}, []components.Field{
 		{Key: "remove", Type: components.FieldStrings,
-			Hint: "declaration names to stop sending (`mcp__<server>` removes a whole MCP server); " +
-				"a name still described in the system prompt's prose is kept regardless"},
+			Hint: "declaration names to stop sending: a tool name, `mcp__<server>` for a whole MCP " +
+				"server, or `skill__<skill>` for one skill's listing entry; a name still described " +
+				"in the system prompt's prose is kept regardless"},
 	})
 }

--- a/dash/accounting_test.go
+++ b/dash/accounting_test.go
@@ -3,6 +3,7 @@ package dash
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
@@ -263,7 +264,7 @@ func TestSelfRemovalNeedsComparableLaterSessions(t *testing.T) {
 
 	got, err := db.SelfRemovals(Filter{TenantAll: true},
 		func(m string) (modelinfo.Price, bool) { return handPrice.Price(context.Background(), m) },
-		map[string]bool{})
+		nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +295,7 @@ func TestSelfRemovalNeedsComparableLaterSessions(t *testing.T) {
 	// Overlap with a server-side filter list is reported, never netted away.
 	got2, err := db.SelfRemovals(Filter{TenantAll: true},
 		func(m string) (modelinfo.Price, bool) { return handPrice.Price(context.Background(), m) },
-		map[string]bool{"mcp__srv__thing": true})
+		[]string{"mcp__srv__thing"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -447,6 +448,10 @@ func TestBuiltinClassification(t *testing.T) {
 		{KindMCPTool, "mcp__srv__thing", false, "mcp_tool"},
 		{KindSkill, "dataviz", false, "skill"},
 		{KindSkill, "someplugin:someskill", false, "plugin_skill"},
+		// A DIRECTORY-SCOPED skill also wears a colon and is NOT a plugin: the prefix is a path.
+		// Routing it to the plugin mechanism emitted `claude plugin disable apps/web`, which names
+		// no plugin and silently does nothing. See TestDirectoryScopedSkillIsNotAPlugin.
+		{KindSkill, "apps/web:deploy", false, "skill"},
 		{KindServerTool, "code_execution", false, "provider"},
 	} {
 		if got := IsBuiltinTool(tc.kind, tc.name); got != tc.builtin {
@@ -886,5 +891,42 @@ func TestUniqueHasThreeStatesNotTwo(t *testing.T) {
 	if m.UniqueDiffRows == 0 {
 		t.Errorf("rows did dedup, so diff must be nonzero: diff=%d of rows=%d",
 			m.UniqueDiffRows, m.UniqueRows)
+	}
+}
+
+// TestDirectoryScopedSkillIsNotAPlugin: two different things wear a colon, and conflating them
+// produced the worst output this file can emit — a command that appears to succeed and changes
+// nothing, in a panel whose whole purpose is to be pasted.
+//
+// `ponytail:ponytail` is a plugin skill and its unit is the plugin. `apps/web:deploy` is a
+// DIRECTORY-SCOPED skill; the prefix is a path, which is why it can contain a `/`, and
+// `claude plugin disable apps/web` names nothing that exists. Pre-existing in splitPluginSkill,
+// but this change claims "the exact command for each skill", so it is in scope now.
+func TestDirectoryScopedSkillIsNotAPlugin(t *testing.T) {
+	plug := RemovalFor(KindSkill, "ponytail:ponytail", "")
+	if plug.Kind != "plugin_skill" || plug.Command != "claude plugin disable ponytail" {
+		t.Errorf("plugin skill = %q / %q, want plugin_skill and the plugin command",
+			plug.Kind, plug.Command)
+	}
+	for _, name := range []string{"apps/web:deploy", "a/b/c:thing"} {
+		got := RemovalFor(KindSkill, name, "")
+		if got.Kind == "plugin_skill" {
+			t.Errorf("%s routed to the plugin mechanism (command %q): that names a path, not a "+
+				"plugin, so running it does nothing at all", name, got.Command)
+		}
+		if got.Kind != "skill" {
+			t.Errorf("%s = kind %q, want the plain skill mechanism", name, got.Kind)
+		}
+		// The snippet names the skill by the SAME string the listing prints, which is what
+		// skillOverrides is keyed by.
+		if !strings.Contains(got.Settings, name) {
+			t.Errorf("%s: the settings snippet does not name it: %q", name, got.Settings)
+		}
+	}
+	// Plain skills and degenerate colons are unaffected.
+	for _, name := range []string{"dataviz", ":x", "x:"} {
+		if got := RemovalFor(KindSkill, name, ""); got.Kind != "skill" {
+			t.Errorf("%s = kind %q, want skill", name, got.Kind)
+		}
 	}
 }

--- a/dash/api.go
+++ b/dash/api.go
@@ -643,6 +643,19 @@ func (a *API) stats(w http.ResponseWriter, r *http.Request) {
 			o.SetTiers(t)
 		}
 	}
+	// The declarations no longer sent, both halves. Needs no pricer for the token counts, so it
+	// runs outside the block above; best-effort and non-fatal, because it is an addition to the
+	// walk and a deployment where it fails should still get the walk. NEVER silent, though: an
+	// error swallowed here returns zeros, and a zero in a savings figure is a claim.
+	filtered := map[string]bool{}
+	for _, n := range a.toolFilterStateForScope(f).Removed {
+		filtered[n] = true
+	}
+	if c, err := a.rec.DB().DeclCreditFor(f, a.priceFn(r), filtered); err == nil {
+		o.SetDeclCredit(c)
+	} else {
+		slog.Warn("dash: declaration-removal credit unavailable", "err", err)
+	}
 	writeJSON(w, o)
 }
 

--- a/dash/api.go
+++ b/dash/api.go
@@ -647,11 +647,8 @@ func (a *API) stats(w http.ResponseWriter, r *http.Request) {
 	// runs outside the block above; best-effort and non-fatal, because it is an addition to the
 	// walk and a deployment where it fails should still get the walk. NEVER silent, though: an
 	// error swallowed here returns zeros, and a zero in a savings figure is a claim.
-	filtered := map[string]bool{}
-	for _, n := range a.toolFilterStateForScope(f).Removed {
-		filtered[n] = true
-	}
-	if c, err := a.rec.DB().DeclCreditFor(f, a.priceFn(r), filtered); err == nil {
+	if c, err := a.rec.DB().DeclCreditFor(f, a.priceFn(r),
+		a.toolFilterStateForScope(f).Removed); err == nil {
 		o.SetDeclCredit(c)
 	} else {
 		slog.Warn("dash: declaration-removal credit unavailable", "err", err)

--- a/dash/contentgate_test.go
+++ b/dash/contentgate_test.go
@@ -121,3 +121,53 @@ func TestPromptRouteServesTheOwningTenantOverTheNetwork(t *testing.T) {
 		t.Errorf("hosted: the owning tenant cannot read its own system prompt:\n%s", body)
 	}
 }
+
+// The system prompt's PARTS are content too, and the gate has to take them whole.
+//
+// This is the same hole /api/prompt shipped with, one field narrower. The decomposition adds a
+// list of section titles and a slice of text per section; a strip that only cleared Region.Text
+// would leave the titles behind, and a heading in somebody's CLAUDE.md names their project, their
+// employer or their incident. So the assertion is on a marker that lives in a HEADING rather than
+// in a body, because a strip that misses the titles passes a body-only test.
+func TestPromptPartsAreStrippedForAnUntrustedCaller(t *testing.T) {
+	const headingMarker = "SECRET-PROJECT-HEADING-9f3a1c"
+	f := newScopeFixture(t, nil)
+	if _, err := f.rec.DB().sql.Exec(`UPDATE requests SET tools = 1`); err != nil {
+		t.Fatal(err)
+	}
+	sys := "You are an agent.\n\n# " + headingMarker + "\n\nDeploy on Fridays.\n\n# Environment\n\ncwd\n"
+	inv := ScanInventory("anthropic", sysBody(t, sys, []string{tool("Bash", declMarker)}, skillsReminder))
+	if inv == nil {
+		t.Fatal("no inventory scanned")
+	}
+	f.rec.RecordInventory("tenant-a", "tenant-a:sess", time.Now().UnixMilli(), inv, true)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, withText := textRows(t, f.rec.DB()); withText > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("declaration text never landed; the fixture has nothing to gate")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// The fixture HOLDS the parts, from loopback. Without this the negative below passes just as
+	// well against a report that never decomposed anything.
+	_, trusted := f.getFrom(t, "/api/prompt", "127.0.0.1:1234")
+	for _, want := range []string{`"parts"`, headingMarker, `"parts_tokens"`} {
+		if !strings.Contains(trusted, want) {
+			t.Fatalf("fixture is empty: loopback /api/prompt has no %s:\n%s", want, trusted)
+		}
+	}
+	// And an untrusted peer gets neither the parts nor their titles.
+	_, body := f.get(t, "/api/prompt")
+	for _, leak := range []string{headingMarker, `"parts"`, `"parts_tokens"`} {
+		if strings.Contains(body, leak) {
+			t.Errorf("/api/prompt served %s to an untrusted address:\n%s", leak, body)
+		}
+	}
+	// The weights still come through, which is why this strips rather than refuses.
+	if !strings.Contains(body, `"kind":"system_prompt"`) {
+		t.Errorf("the strip took the system prompt's weight with its text:\n%s", body)
+	}
+}

--- a/dash/declcredit.go
+++ b/dash/declcredit.go
@@ -1,0 +1,111 @@
+package dash
+
+// Crediting the declarations that STOPPED being sent — and keeping two very different claims
+// about them apart.
+//
+// This is the one saving on this dashboard that had nowhere to appear. Everything else here is
+// measured as content a COMPONENT removed from a message, and the whole savings walk is built on
+// `tokens_before − tokens_after`, which is `schema.MessagesTokens`: message text only. A tool
+// declaration is not in `messages`. So when the declaration filter stops sending 4,000 tokens of
+// MCP schemas on every request, `tokens_before` does not move, `baseline_cost_usd` does not move,
+// and the reduction is absent from NetSavedUSD, from TotalSavedUSD and from the waterfall. It was
+// visible on the Inventory tab and in no total anywhere. That is the bug this file fixes, and it
+// hid the LARGEST measured lever in the product behind the smallest surface.
+//
+// # The two halves are not the same kind of claim, and are never added together
+//
+// FILTER — measured, and ours. `requests.filtered_decl_tokens`, written by the filter itself on
+// every request it acted on. Those requests were really sent, really smaller, and smaller because
+// of a component of ours. It goes into TotalSavedUSD, which is where our savings live.
+//
+// SELF — modelled, and the USER's. The account simply stopped declaring something: no component
+// ran, no filter fired, and the only evidence is that the inventory is a time series with the name
+// in the early part and not the late part. The reduction is real — the tokens genuinely were not
+// billed — but it is NOT ours, and TotalSavedUSD says in as many words that its three addends are
+// all ours. So this half is reported beside that total and added into a SECOND one,
+// TotalReducedUSD, which is "everything that came off this bill, including what you did
+// yourself". Two totals rather than one, because collapsing them would either overstate what the
+// product did or refuse the user the number they asked for, and both were on offer.
+//
+// # Why the modelled half is not merely a weaker version of the measured one
+//
+// Measured on the production snapshot, the largest self-removal candidate in the window is
+// `mcp__ide__executeCode` and `mcp__ide__getDiagnostics` — 224 tokens between them, last declared
+// 2026-08-20 11:40, absent from the 14 MCP-bearing sessions that followed. The account did not
+// remove those. They are the editor integration, and they are declared only when the session runs
+// INSIDE the IDE. Nothing in the data distinguishes "I ran `claude mcp remove`" from "I worked in
+// a terminal today", and no threshold fixes that, because the inference is not wrong about the
+// facts — the declaration set really did change, and the tokens really were not sent — it is wrong
+// only about WHO caused it.
+//
+// That is exactly why the halves are separated instead of being tuned. The measured half's
+// attribution is a fact (a component of ours rewrote the body); the modelled half's is a guess,
+// so it is labelled as one everywhere it appears and it is kept out of the figure that claims
+// credit. Overlap is subtracted before it is even summed: a name on the account's own filter list
+// is already counted in the measured half, and the two describe the same tokens.
+
+import "github.com/rossoctl/context-guru/internal/modelinfo"
+
+// DeclCredit is the reduction from declarations no longer sent, split by whose it is.
+type DeclCredit struct {
+	// The MEASURED half: what the declaration filter actually stopped sending.
+	FilterReads    int64   `json:"filter_reads"`
+	FilterUSD      float64 `json:"filter_usd"`
+	FilterRequests int     `json:"filter_requests"`
+	FilterSince    int64   `json:"filter_since,omitempty"`
+	// The MODELLED half: what the account stopped declaring on its own. Items is how many
+	// names, Overlap how many were dropped because the filter is already credited for them.
+	SelfReads   int64   `json:"self_reads"`
+	SelfUSD     float64 `json:"self_usd"`
+	SelfItems   int     `json:"self_items"`
+	SelfOverlap int     `json:"self_overlap"`
+	// Priced is false when any contributing model had no rates, in which case the dollar
+	// figures are the priced subset only and a consumer must show the token counts instead.
+	Priced bool `json:"priced"`
+}
+
+// DeclCreditFor totals both halves over one scope.
+//
+// filtered is the account's own server-side removal list, used ONLY to drop overlapping rows out
+// of the modelled half. It is passed in rather than read here for the reason dash reads no tenant
+// configuration anywhere: the host owns it (see API.SetToolFilterState).
+func (d *DB) DeclCreditFor(f Filter, price func(string) (modelinfo.Price, bool),
+	filtered map[string]bool) (*DeclCredit, error) {
+	out := &DeclCredit{Priced: true}
+	if price == nil {
+		// No rates: the token counts still stand and the dollars do not exist. Reported as
+		// unpriced rather than as zero, which is this dashboard's rule everywhere.
+		out.Priced = false
+	}
+	realized, err := d.DeclFilterSavings(f, price)
+	if err != nil {
+		return nil, err
+	}
+	out.FilterReads, out.FilterUSD = realized.Reads, realized.USD
+	out.FilterRequests, out.FilterSince = realized.Requests, realized.Since
+	if !realized.Priced {
+		out.Priced = false
+	}
+	if price == nil {
+		return out, nil // SelfRemovals needs a pricer to attribute a tier at all
+	}
+	self, err := d.SelfRemovals(f, price, filtered)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range self {
+		if r.Overlap {
+			// The same tokens are in the measured half. Counted as overlap so the page can say
+			// how many rows it declined to add, rather than the difference being invisible.
+			out.SelfOverlap++
+			continue
+		}
+		out.SelfItems++
+		out.SelfReads += r.AvoidedReads
+		out.SelfUSD += r.AvoidedUSD
+		if !r.Priced {
+			out.Priced = false
+		}
+	}
+	return out, nil
+}

--- a/dash/declcredit.go
+++ b/dash/declcredit.go
@@ -87,7 +87,10 @@ func (d *DB) DeclCreditFor(f Filter, price func(string) (modelinfo.Price, bool),
 		out.Priced = false
 	}
 	if price == nil {
-		return out, nil // SelfRemovals needs a pricer to attribute a tier at all
+		// SelfRemovals calls price() per session with no nil guard of its own, so this return is
+		// load-bearing rather than an optimisation. DeclFilterSavings above checks for itself,
+		// which is why the filter half is still computed here.
+		return out, nil
 	}
 	self, err := d.SelfRemovals(f, price, filtered)
 	if err != nil {

--- a/dash/declcredit.go
+++ b/dash/declcredit.go
@@ -66,11 +66,14 @@ type DeclCredit struct {
 
 // DeclCreditFor totals both halves over one scope.
 //
-// filtered is the account's own server-side removal list, used ONLY to drop overlapping rows out
-// of the modelled half. It is passed in rather than read here for the reason dash reads no tenant
-// configuration anywhere: the host owns it (see API.SetToolFilterState).
+// removed is the account's own server-side removal list, VERBATIM as the configuration stores it,
+// used ONLY to drop overlapping rows out of the modelled half. It is passed in rather than read
+// here for the reason dash reads no tenant configuration anywhere: the host owns it (see
+// API.SetToolFilterState). Raw rather than pre-keyed, because the config's vocabulary and the
+// report's differ and doing that translation per caller is what made the exclusion silently
+// inert — see declFilteredSet.
 func (d *DB) DeclCreditFor(f Filter, price func(string) (modelinfo.Price, bool),
-	filtered map[string]bool) (*DeclCredit, error) {
+	removed []string) (*DeclCredit, error) {
 	out := &DeclCredit{Priced: true}
 	if price == nil {
 		// No rates: the token counts still stand and the dollars do not exist. Reported as
@@ -92,7 +95,7 @@ func (d *DB) DeclCreditFor(f Filter, price func(string) (modelinfo.Price, bool),
 		// which is why the filter half is still computed here.
 		return out, nil
 	}
-	self, err := d.SelfRemovals(f, price, filtered)
+	self, err := d.SelfRemovals(f, price, removed)
 	if err != nil {
 		return nil, err
 	}

--- a/dash/declcredit_test.go
+++ b/dash/declcredit_test.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
@@ -165,5 +166,105 @@ func TestSetDeclCreditPutsEachHalfInTheRightTotal(t *testing.T) {
 	o.SetDeclCredit(nil)
 	if o.TotalSavedUSD != saved || o.TotalReducedUSD != reduced {
 		t.Error("a nil credit moved a total")
+	}
+}
+
+// TestTheDeclarationFilterSavingIsDisjointFromCompactions makes the word "disjoint" executable.
+//
+// TotalSavedUSD adds the filter's saving to compaction's and calls the token sets disjoint. For
+// the tools half that is true by construction — a tool schema is not in `messages` and
+// `tokens_before` counts nothing else. For the SKILLS half it is not: a skill's listing entry IS
+// in `messages`, so the two could describe the same tokens and the total would double-count them.
+//
+// It holds because both halves of the filter run in apply BEFORE the pipeline takes its baseline,
+// so `tokens_before` is measured on the already-filtered body and the removal is simply absent
+// from Saved() rather than inside it. That is an ORDERING property of a different package, which
+// is exactly the kind of thing a later refactor falsifies silently — the total would keep adding
+// and nothing would complain.
+//
+// Asserted as the invariant rather than by re-deriving the order: a request that carries a filter
+// saving and no compaction contributes to the filter half and to NOTHING else.
+func TestTheDeclarationFilterSavingIsDisjointFromCompactions(t *testing.T) {
+	db := openTestDB(t)
+	// The shape a filtered request really has, taken from a live run: tokens_before ==
+	// tokens_after (the pipeline saw an already-filtered body and removed nothing further), and a
+	// non-zero filtered_decl_tokens beside it.
+	e := mkEvent(1000, "s", "claude", 4910, 4910)
+	e.TenantID, e.Tools, e.FilteredDeclTokens = "t1", 4, 561
+	e.CacheRead, e.CacheWrite = 49132, 0
+	// mkEvent hardcodes BaselineCostUSD: 0.02 against CostUSD: 0.01 whatever tokens it is given,
+	// so its default row claims a cent of compaction saving on a request that compacted nothing.
+	// Equal is what a filtered-but-not-compacted request ACTUALLY looks like — verified on the
+	// live run, where baseline_cost_usd − cost_usd was 0.0 on all six such rows. Without this the
+	// test fails on the fixture rather than on the mechanism, which is the wrong red.
+	e.BaselineCostUSD = e.CostUSD
+	if err := db.insertBatch([]*Event{e}); err != nil {
+		t.Fatal(err)
+	}
+	o, err := db.Overview(Filter{Tenant: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compaction saw nothing, so every compaction-side figure is zero and the baseline equals the
+	// bill. If a future reordering put the filter's removal inside the baseline, this is where it
+	// would show up — as a saving compaction did not make.
+	if o.SavedGross != 0 || o.SavedUnique != 0 {
+		t.Errorf("compaction reports saved_gross=%d saved_unique=%d on a request it did not "+
+			"touch: the declaration filter's removal has entered the compaction accounting, and "+
+			"TotalSavedUSD now counts it twice", o.SavedGross, o.SavedUnique)
+	}
+	if o.BaselineCostUSD != o.CostUSD {
+		t.Errorf("baseline $%g != cost $%g on a request compaction did not touch: the filter's "+
+			"removal is inside the baseline, so it is in NetSavedUSD AND in DeclFilterUSD",
+			o.BaselineCostUSD, o.CostUSD)
+	}
+	if o.NetSavedUSD != 0 {
+		t.Errorf("net_saved_usd = $%g before any credit is attached, so the filter's saving is "+
+			"already counted once here and will be counted again by SetDeclCredit", o.NetSavedUSD)
+	}
+	// And the filter half does carry it, so this is a test of disjointness rather than of an
+	// empty fixture.
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.FilterReads != 561 {
+		t.Fatalf("filter half = %d reads, want 561 — the fixture is not exercising anything",
+			c.FilterReads)
+	}
+	o.SetDeclCredit(c)
+	if o.TotalSavedUSD != c.FilterUSD {
+		t.Errorf("total_saved $%g != the filter's $%g; something else contributed to a request "+
+			"that only the filter acted on", o.TotalSavedUSD, c.FilterUSD)
+	}
+}
+
+// TestTheWalkAndTheTotalAgreeOnHowManyAddendsThereAre.
+//
+// TotalSavedUSD's doc comment enumerates its addends in prose and the waterfall's `total_saved`
+// step enumerates them again in prose shown to the reader. Adding a fourth means updating both,
+// and the second one was missed — the page said "Three disjoint token sets" while the field summed
+// four. Prose in two places drifts; this is the cheapest thing that notices.
+func TestTheWalkAndTheTotalAgreeOnHowManyAddendsThereAre(t *testing.T) {
+	var desc string
+	for _, s := range (&Overview{}).waterfall() {
+		if s.Key == "total_saved" {
+			desc = s.Description
+		}
+	}
+	if desc == "" {
+		t.Fatal("the total_saved step is gone; this check needs rewriting")
+	}
+	// The four steps the total is built from, each of which must be described where the total is.
+	for _, want := range []string{"compaction", "prefix-cache", "keep-alive", "declarations"} {
+		if !strings.Contains(strings.ToLower(desc), want) {
+			t.Errorf("the total_saved description does not mention %q:\n%s\n\n"+
+				"Every addend of TotalSavedUSD is named here, or the page enumerates fewer "+
+				"things than it sums.", want, desc)
+		}
+	}
+	if strings.Contains(desc, "Three disjoint") {
+		t.Errorf("the description still says 'Three disjoint token sets' while TotalSavedUSD " +
+			"sums four")
 	}
 }

--- a/dash/declcredit_test.go
+++ b/dash/declcredit_test.go
@@ -87,8 +87,9 @@ func TestDeclCreditKeepsTheMeasuredAndModelledHalvesApart(t *testing.T) {
 // modelled half must drop it — and say that it did, rather than the row silently vanishing.
 func TestDeclCreditDropsWhatTheFilterIsAlreadyCreditedFor(t *testing.T) {
 	db := seedCredit(t, 1000)
-	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice,
-		map[string]bool{"mcp__gone__x": true})
+	// The list is passed VERBATIM as the configuration stores it, which for a whole MCP server is
+	// the bare `mcp__<server>` form and not the tool name.
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, []string{"mcp__gone__x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,21 +170,21 @@ func TestSetDeclCreditPutsEachHalfInTheRightTotal(t *testing.T) {
 	}
 }
 
-// TestTheDeclarationFilterSavingIsDisjointFromCompactions makes the word "disjoint" executable.
+// TestTheDeclarationFilterSavingIsDisjointFromCompactions pins the DOWNSTREAM ARITHMETIC, and the
+// title used to over-claim. It does not exercise apply and it cannot: it builds the row shape by
+// hand, so it verifies "given a request the filter acted on and compaction did not, no total counts
+// it twice" — which is a real and separate property of Overview and SetDeclCredit.
 //
-// TotalSavedUSD adds the filter's saving to compaction's and calls the token sets disjoint. For
-// the tools half that is true by construction — a tool schema is not in `messages` and
-// `tokens_before` counts nothing else. For the SKILLS half it is not: a skill's listing entry IS
-// in `messages`, so the two could describe the same tokens and the total would double-count them.
+// What it does NOT verify is that such a row is what apply actually produces. That is an ordering
+// property of another package — the filter must run before the pipeline takes its baseline
+// (components/pipeline.go:35 over the normalized request built at apply/apply.go:441) — and it is
+// guarded by TestFilterRemovalIsNotInsideTheCompactionBaseline in the apply package, which compares
+// two real runs instead of asserting a fixture.
 //
-// It holds because both halves of the filter run in apply BEFORE the pipeline takes its baseline,
-// so `tokens_before` is measured on the already-filtered body and the removal is simply absent
-// from Saved() rather than inside it. That is an ORDERING property of a different package, which
-// is exactly the kind of thing a later refactor falsifies silently — the total would keep adding
-// and nothing would complain.
-//
-// Asserted as the invariant rather than by re-deriving the order: a request that carries a filter
-// saving and no compaction contributes to the filter half and to NOTHING else.
+// The distinction is not pedantry. A reviewer showed that the only mutation that reddened THIS test
+// was deleting its own `e.BaselineCostUSD = e.CostUSD` fixture line, not changing any production
+// code — so on its own it was evidence about the fixture. The two tests together cover the claim;
+// either alone does not.
 func TestTheDeclarationFilterSavingIsDisjointFromCompactions(t *testing.T) {
 	db := openTestDB(t)
 	// The shape a filtered request really has, taken from a live run: tokens_before ==
@@ -266,5 +267,113 @@ func TestTheWalkAndTheTotalAgreeOnHowManyAddendsThereAre(t *testing.T) {
 	if strings.Contains(desc, "Three disjoint") {
 		t.Errorf("the description still says 'Three disjoint token sets' while TotalSavedUSD " +
 			"sums four")
+	}
+}
+
+// TestOverlapMatchesTheConfigVocabularyNotTheReportsIsTheF3 regression: the overlap exclusion
+// compared a REPORT name against a CONFIG list and so could never fire for two of the three shapes.
+//
+// The config stores `skill__dataviz` and `mcp__plan`; a report row is named `dataviz` with kind
+// skill, or `mcp__plan__make_plan` with server `plan`. The old test passed a bare `mcp__gone__x`
+// and passed, because an exact tool name is the ONE shape where the two vocabularies coincide.
+//
+// Not a literal double count — declarations are captured pre-filter, so a filtered item keeps
+// appearing in later sessions and does not read as self-removed. It matters because it is a
+// documented honesty guarantee (the field's doc, the waterfall description, the tile's count) that
+// was false for exactly the class this change newly made filterable, and because the case it
+// guards is real: an account can remove something locally AND have it on the server list.
+func TestOverlapMatchesTheConfigVocabularyNotTheReports(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		removed []string
+		want    int // expected SelfOverlap
+	}{
+		// A whole MCP SERVER, which is how the dashboard's own group switch writes it. `gone` is
+		// the server whose tools stopped being declared, so this must be recognised as overlap.
+		{"whole mcp server, config form", []string{"mcp__gone"}, 1},
+		// The exact tool name — the one shape that worked before.
+		{"exact mcp tool name", []string{"mcp__gone__x"}, 1},
+		// A name in the REPORT's vocabulary is not what the config holds and must NOT match, or
+		// the exclusion starts firing on things the filter is not credited for.
+		{"bare server name is not a config entry", []string{"gone"}, 0},
+		{"an unrelated entry", []string{"mcp__other"}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := seedCredit(t, 1000)
+			c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, tc.removed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.SelfOverlap != tc.want {
+				t.Errorf("removed=%v gave overlap=%d items=%d, want overlap=%d\n"+
+					"The config and the report name things differently; the comparison has to be "+
+					"made in one vocabulary.", tc.removed, c.SelfOverlap, c.SelfItems, tc.want)
+			}
+			// And the two are complementary: an excluded row leaves the modelled half.
+			if tc.want == 1 && c.SelfItems != 0 {
+				t.Errorf("overlap counted but the row is still credited: items=%d", c.SelfItems)
+			}
+		})
+	}
+}
+
+// The SKILL half of the same bug, in its own test because a skill is the class this change newly
+// made filterable and the one the reviewer reproduced: `skill__dataviz` on the list against a row
+// named `dataviz`.
+func TestOverlapFiresForASkillInTheConfigForm(t *testing.T) {
+	db := openTestDB(t)
+	var evs []*Event
+	var msgs []invMsg
+	for i := 0; i < 10; i++ {
+		s := "s" + string(rune('a'+i))
+		for k := 0; k < 5; k++ {
+			e := mkEvent(day(i)+int64(k), s, "claude", 100, 90)
+			e.TenantID, e.Tools = "t1", 4
+			evs = append(evs, e)
+		}
+		// Every session carries a skills LISTING (so a later session can testify about a missing
+		// skill), and only the first four carry the skill itself.
+		ds := []Decl{{Kind: KindSkillListing, Server: SkillsOK, Tokens: 900}}
+		if i < 4 {
+			ds = append(ds, Decl{Kind: KindSkill, Name: "dataviz", Tokens: 300})
+		}
+		msgs = append(msgs, invMsg{tenant: "t1", session: s, ts: day(i), inv: &Inventory{
+			Digest: s, Decls: ds, UseFingerprint: uint64(i)}})
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	w := &invWriter{db: db, seen: map[string]*invSession{}}
+	if err := w.write(msgs); err != nil {
+		t.Fatal(err)
+	}
+	// With nothing on the list it is credited as the account's own removal.
+	base, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.SelfItems != 1 {
+		t.Fatalf("the skill was not detected as self-removed at all (items=%d); the fixture is "+
+			"not exercising the overlap path", base.SelfItems)
+	}
+	// With the CONFIG form on the list it is overlap, not a second credit.
+	got, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, []string{"skill__dataviz"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SelfOverlap != 1 || got.SelfItems != 0 {
+		t.Errorf("skill__dataviz on the list gave overlap=%d items=%d, want 1 and 0.\n"+
+			"This is the shape the dashboard actually writes, and the exclusion has to see it.",
+			got.SelfOverlap, got.SelfItems)
+	}
+	// The bare name is the REPORT's vocabulary and is not what a config holds.
+	bare, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, []string{"dataviz"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bare.SelfOverlap != 0 {
+		t.Errorf("a bare `dataviz` matched (overlap=%d); the config stores skill__dataviz and "+
+			"matching the bare form would exclude rows the filter is not credited for",
+			bare.SelfOverlap)
 	}
 }

--- a/dash/declcredit_test.go
+++ b/dash/declcredit_test.go
@@ -1,0 +1,169 @@
+package dash
+
+import (
+	"math"
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// seedCredit builds an account that did BOTH things: an MCP server whose declarations the filter
+// is stopping (filtered_decl_tokens on real requests), and a second MCP server it stopped
+// declaring partway through the window with plenty of later MCP sessions to testify.
+//
+// Ten sessions, each five cache-hit requests. Sessions 0-3 declare both servers; 4-9 declare only
+// the first. So `mcp__gone__x` was last seen in session 3 and six qualifying sessions ran without
+// it — well past the three the analysis requires.
+func seedCredit(t *testing.T, filteredTokens int) *DB {
+	t.Helper()
+	db := openTestDB(t)
+	var evs []*Event
+	var msgs []invMsg
+	for i := 0; i < 10; i++ {
+		s := "s" + string(rune('a'+i))
+		for k := 0; k < 5; k++ {
+			e := mkEvent(day(i)+int64(k), s, "claude", 100, 90)
+			e.TenantID, e.Tools = "t1", 4
+			if i >= 4 {
+				// Only the later sessions carry a filter saving, so the two halves are
+				// distinguishable in the totals below.
+				e.FilteredDeclTokens = filteredTokens
+			}
+			evs = append(evs, e)
+		}
+		ds := []Decl{{Kind: KindMCPTool, Name: "mcp__stay__x", Server: "stay", Tokens: 500}}
+		if i < 4 {
+			ds = append(ds, Decl{Kind: KindMCPTool, Name: "mcp__gone__x", Server: "gone", Tokens: 800})
+		}
+		msgs = append(msgs, invMsg{tenant: "t1", session: s, ts: day(i), inv: &Inventory{
+			Digest: s, Decls: ds, UseFingerprint: uint64(i)}})
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	w := &invWriter{db: db, seen: map[string]*invSession{}}
+	if err := w.write(msgs); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// The two halves are computed and reported apart. Adding them would be the whole mistake this
+// type exists to prevent: one is a component of ours rewriting a body, the other is the account
+// changing its own configuration, and only the first is a saving this product may claim.
+func TestDeclCreditKeepsTheMeasuredAndModelledHalvesApart(t *testing.T) {
+	db := seedCredit(t, 1000)
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Measured: 30 requests (sessions 4-9, five each) x 1,000 tokens.
+	if c.FilterRequests != 30 || c.FilterReads != 30_000 {
+		t.Errorf("filter half = %d requests / %d reads, want 30 / 30000",
+			c.FilterRequests, c.FilterReads)
+	}
+	// 30,000 cache-read tokens at flatPrice's $0.1/MTok.
+	if math.Abs(c.FilterUSD-0.003) > 1e-9 {
+		t.Errorf("filter USD = %g, want 0.003", c.FilterUSD)
+	}
+	// Modelled: mcp__gone__x, 800 tokens x the 30 requests of the six later sessions.
+	if c.SelfItems != 1 || c.SelfReads != 24_000 {
+		t.Errorf("self half = %d items / %d reads, want 1 / 24000", c.SelfItems, c.SelfReads)
+	}
+	if math.Abs(c.SelfUSD-0.0024) > 1e-9 {
+		t.Errorf("self USD = %g, want 0.0024", c.SelfUSD)
+	}
+	if !c.Priced {
+		t.Error("priced = false on a fully priced fixture")
+	}
+	// The one thing that must NOT exist: a field holding the two added together.
+	if c.FilterUSD == c.SelfUSD {
+		t.Error("the fixture cannot tell the halves apart; it is not testing the split")
+	}
+}
+
+// A name on the account's own removal list is already counted in the MEASURED half, so the
+// modelled half must drop it — and say that it did, rather than the row silently vanishing.
+func TestDeclCreditDropsWhatTheFilterIsAlreadyCreditedFor(t *testing.T) {
+	db := seedCredit(t, 1000)
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, flatPrice,
+		map[string]bool{"mcp__gone__x": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.SelfItems != 0 || c.SelfReads != 0 || c.SelfUSD != 0 {
+		t.Errorf("self half = %d items / %d reads / $%g, want nothing: the filter is already "+
+			"credited for those tokens", c.SelfItems, c.SelfReads, c.SelfUSD)
+	}
+	if c.SelfOverlap != 1 {
+		t.Errorf("overlap = %d, want 1 — a dropped row must be counted, not silently absent",
+			c.SelfOverlap)
+	}
+	// The measured half is untouched by the overlap accounting.
+	if c.FilterReads != 30_000 {
+		t.Errorf("filter reads = %d, want 30000", c.FilterReads)
+	}
+}
+
+// No pricer: the token counts stand and the dollars do not exist. Reported unpriced rather than
+// as zero, which is this dashboard's rule everywhere — a $0.00 saving is a claim.
+func TestDeclCreditWithoutRatesReportsTokensAndNoDollars(t *testing.T) {
+	db := seedCredit(t, 1000)
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Priced {
+		t.Error("priced = true with no pricer")
+	}
+	if c.FilterReads != 30_000 {
+		t.Errorf("filter reads = %d, want 30000 even unpriced", c.FilterReads)
+	}
+	if c.FilterUSD != 0 || c.SelfUSD != 0 {
+		t.Errorf("dollars were invented without rates: %g / %g", c.FilterUSD, c.SelfUSD)
+	}
+}
+
+// An unpriced MODEL, which is different from no pricer: the figure is the priced subset and must
+// be flagged, or a reader adds it to a total it is not the total of.
+func TestDeclCreditFlagsAnUnpricedModel(t *testing.T) {
+	db := seedCredit(t, 1000)
+	c, err := db.DeclCreditFor(Filter{Tenant: "t1"},
+		func(string) (modelinfo.Price, bool) { return modelinfo.Price{}, false }, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Priced {
+		t.Error("priced = true for a model with no rates")
+	}
+}
+
+// The filter half reaches TotalSavedUSD and the self half does not; both reach TotalReducedUSD.
+// This is the field-level statement of the whole argument, and it is asserted on the Overview
+// rather than on the credit, because the totals are where a wrong answer becomes a headline.
+func TestSetDeclCreditPutsEachHalfInTheRightTotal(t *testing.T) {
+	db := seedCredit(t, 1000)
+	o, err := db.Overview(Filter{Tenant: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, baseReduced := o.TotalSavedUSD, o.TotalReducedUSD
+	if base != baseReduced {
+		t.Fatalf("the two totals differ before any credit is attached: %g vs %g", base, baseReduced)
+	}
+	o.SetDeclCredit(&DeclCredit{FilterUSD: 0.25, SelfUSD: 0.75, Priced: true})
+	if got := o.TotalSavedUSD - base; math.Abs(got-0.25) > 1e-9 {
+		t.Errorf("total_saved moved by %g, want exactly the filter's $0.25 — a self-removal is "+
+			"the account's own reduction and this total claims ours", got)
+	}
+	if got := o.TotalReducedUSD - baseReduced; math.Abs(got-1.00) > 1e-9 {
+		t.Errorf("total_reduced moved by %g, want $1.00 (both halves)", got)
+	}
+	// And a nil credit changes nothing, so a deployment where the query fails reads a total that
+	// is short rather than one that is wrong.
+	saved, reduced := o.TotalSavedUSD, o.TotalReducedUSD
+	o.SetDeclCredit(nil)
+	if o.TotalSavedUSD != saved || o.TotalReducedUSD != reduced {
+		t.Error("a nil credit moved a total")
+	}
+}

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -105,7 +105,11 @@ func TestPingRowsStayOutOfAgentAggregates(t *testing.T) {
 	// The keep-alive fields and the two totals they feed are the ONLY keys allowed to differ.
 	mayMove := map[string]bool{
 		"keepalive_pings": true, "keepalive_ping_usd": true, "keepalive_net_usd": true,
-		"total_saved_usd": true,
+		// total_reduced_usd is total_saved plus the account's own removals, so it moves with the
+		// total it is built on. Allowed, and pinned to the SAME delta below rather than merely
+		// excused: if it ever moved by a different amount, the ping spend would be reaching one
+		// total and not the other.
+		"total_saved_usd": true, "total_reduced_usd": true,
 		// The waterfall carries the ping SPEND as a step of its own, which is the whole point of
 		// having it; its reconciliation is TestTheWaterfallReconcilesWithTotalSaved.
 		"waterfall": true,
@@ -127,6 +131,10 @@ func TestPingRowsStayOutOfAgentAggregates(t *testing.T) {
 	// the keep-alive's NET, which here is the negative of what the pings cost. The credit rows
 	// are in BOTH fixtures — they are agent rows — so the saving half does not move and the
 	// whole difference is the ping spend. That is the assertion that fails on `+= SavedUSD`.
+	if got, want := b.TotalReducedUSD-a.TotalReducedUSD, b.TotalSavedUSD-a.TotalSavedUSD; math.Abs(got-want) > 1e-9 {
+		t.Errorf("total_reduced moved by %v while total_saved moved by %v: the ping spend is "+
+			"reaching one total and not the other", got, want)
+	}
 	if got, want := b.TotalSavedUSD-a.TotalSavedUSD, b.KeepAliveNetUSD-a.KeepAliveNetUSD; math.Abs(got-want) > 1e-9 {
 		t.Errorf("total_saved moved by %.6f, want exactly the change in keepalive_net_usd %.6f",
 			got, want)
@@ -268,18 +276,35 @@ func TestTheWaterfallReconcilesWithTotalSaved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The declaration-removal credit is attached with BOTH halves non-zero and DIFFERENT, which
+	// is the only configuration that can tell the two totals apart: equal halves, or a zero in
+	// either, reconcile even if the code puts the wrong one in the wrong total.
+	o.SetDeclCredit(&DeclCredit{FilterUSD: 0.11, FilterReads: 4000, FilterRequests: 7,
+		SelfUSD: 0.37, SelfReads: 9000, SelfItems: 2, SelfOverlap: 1, Priced: true})
 	steps := map[string]float64{}
 	for _, s := range o.waterfall() {
 		steps[s.Key] = s.DeltaUSD
 	}
 	// total_saved = -(baseline step) + compaction + cg_llm + cachesplit + keepalive_ping +
-	// keepalive_saved, in signed terms: the reductions are negative and the spends positive, so
-	// the sum of the non-total steps below the baseline is the negation of what was avoided.
+	// keepalive_saved + the filter's realized saving, in signed terms: the reductions are
+	// negative and the spends positive, so the sum of the non-total steps below the baseline is
+	// the negation of what was avoided.
 	sum := -(steps["compaction"] + steps["cg_llm"] + steps["cachesplit_saved"] +
-		steps["keepalive_ping"] + steps["keepalive_saved"])
+		steps["keepalive_ping"] + steps["keepalive_saved"] + steps["decl_filter_saved"])
 	if math.Abs(sum-steps["total_saved"]) > 0.005 {
 		t.Errorf("the walk does not reconcile: steps sum to %.4f, total_saved is %.4f",
 			sum, steps["total_saved"])
+	}
+	// And the second total is the first plus the account's OWN removals — the one step that is
+	// deliberately outside total_saved, because those tokens are not ours.
+	if got := steps["total_reduced"] - steps["total_saved"]; math.Abs(got-0.37) > 0.005 {
+		t.Errorf("total_reduced − total_saved = %.4f, want the $0.37 the account removed itself; "+
+			"a self-removal has leaked into the figure that claims our credit, or is missing from "+
+			"the one that does not", got)
+	}
+	if math.Abs(sum-steps["total_reduced"]) < 0.005 {
+		t.Error("the two totals are equal: the self-removal half is reaching neither total, or " +
+			"both")
 	}
 }
 

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -191,7 +191,19 @@ type Overview struct {
 
 	// TotalSavedUSD is OUR savings together: compaction's, less our own spend; the prefix
 	// components'; the keep-alive's NET, which is its saving minus what its pings cost; and the
-	// declaration filter's realized saving. All of them are ours and the token sets are disjoint.
+	// declaration filter's realized saving. FOUR addends, all ours, over disjoint token sets.
+	//
+	// The fourth one's disjointness is the only one that needs an argument, because half of what
+	// it removes (a skill's listing entry) lives in `messages`, which is exactly where
+	// `tokens_before` is measured. It holds because BOTH halves of the filter run in apply
+	// BEFORE the pipeline takes its baseline, so `tokens_before` is measured on the
+	// already-filtered body and the removal is invisible to Saved() rather than counted twice.
+	// Measured on a live run: on every request where the filter dropped 561 tokens,
+	// tokens_before == tokens_after, saved_gross == 0 and baseline_cost_usd − cost_usd == 0,
+	// while tokens_before itself fell by exactly the skill entry's weight.
+	// TestTheDeclarationFilterSavingIsDisjointFromCompactions holds it, because "disjoint" is a
+	// claim that a later reordering in apply could quietly falsify.
+	//
 	// The keep-alive contributes its net rather than its gross because the ping spend is excluded
 	// from CostUSD — a ping is not agent traffic — so it has nowhere else in this walk to appear.
 	TotalSavedUSD float64 `json:"total_saved_usd"`
@@ -878,10 +890,13 @@ func (o *Overview) waterfall() []WaterfallStep {
 				"this project."},
 		{Key: "total_saved", Label: "Total cost avoided", DeltaUSD: o.TotalSavedUSD, Total: true,
 			Description: "Net compaction savings, plus prefix-cache savings, plus the idle " +
-				"keep-alive's NET — its savings minus what its pings cost. Three disjoint token " +
+				"keep-alive's NET — its savings minus what its pings cost — plus the declarations " +
+				"the removal filter stopped sending. FOUR disjoint token " +
 				"sets, all ours, so nothing is counted twice: compaction's removals never reached " +
-				"the provider, the split moved a breakpoint over tokens that did, and the " +
-				"keep-alive refreshed entries that already existed. The keep-alive enters as a net " +
+				"the provider, the split moved a breakpoint over tokens that did, the " +
+				"keep-alive refreshed entries that already existed, and the filter's declarations " +
+				"were dropped before the compaction baseline was even measured — so they are " +
+				"absent from the first line rather than counted in it. The keep-alive enters as a net " +
 				"because the pings' own spend is not in the billed-cost line above — ping rows are " +
 				"excluded from agent traffic — so this is the only place both halves are " +
 				"comparable, and its saving half is a CEILING (see Keep-alive savings). It is not " +

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -195,9 +195,13 @@ type Overview struct {
 	//
 	// The fourth one's disjointness is the only one that needs an argument, because half of what
 	// it removes (a skill's listing entry) lives in `messages`, which is exactly where
-	// `tokens_before` is measured. It holds because BOTH halves of the filter run in apply
-	// BEFORE the pipeline takes its baseline, so `tokens_before` is measured on the
-	// already-filtered body and the removal is invisible to Saved() rather than counted twice.
+	// `tokens_before` is measured. It holds because BOTH halves of the filter run in apply BEFORE
+	// the request is normalized (apply/apply.go:441) and therefore before the pipeline baselines it
+	// (components/pipeline.go:35), so `tokens_before` is measured on the already-filtered body and
+	// the removal is invisible to Saved() rather than counted twice. The boundary is NORMALIZE, not
+	// the `msgsRaw` read above it — that one exists so a later rewrite cannot move a byte offset,
+	// and a filter placed between the two would still be safe for this purpose. Confirmed by
+	// mutation: moving the skill half past normalize reds the apply-side guard.
 	// Measured on a live run: on every request where the filter dropped 561 tokens,
 	// tokens_before == tokens_after, saved_gross == 0 and baseline_cost_usd − cost_usd == 0,
 	// while tokens_before itself fell by exactly the skill entry's weight.

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -164,12 +164,42 @@ type Overview struct {
 	SplitTailMoved     int64 `json:"split_tail_moved"`
 	SplitCredited      int64 `json:"split_credited"`
 	SplitCreditedMoved int64 `json:"split_credited_moved"`
-	// TotalSavedUSD is our three savings together: compaction's, less our own spend; the
-	// prefix components'; and the keep-alive's NET, which is its saving minus what its pings
-	// cost. All three are ours and the token sets are disjoint. The keep-alive contributes its
-	// net rather than its gross because the ping spend is excluded from CostUSD — a ping is not
-	// agent traffic — so it has nowhere else in this walk to appear.
+	// The declarations no longer sent. TWO figures, because they are two different claims about
+	// the same kind of tokens and adding them together would either overstate what this product
+	// did or refuse a number a reader has asked for. See dash/declcredit.go for the argument.
+	//
+	// DeclFilterUSD is MEASURED and OURS: `requests.filtered_decl_tokens`, written by the filter
+	// on every request it acted on, priced at the tier those requests paid. It is in
+	// TotalSavedUSD. It was in NO total before, and that was a bug rather than a policy — the
+	// savings walk is built on tokens_before, which is message text only, and a tool declaration
+	// is not in `messages`, so the biggest measured lever in the product moved none of it.
+	//
+	// SelfRemovedUSD is MODELLED and the USER's: the account stopped declaring something and no
+	// component of ours was involved. It is NOT in TotalSavedUSD, which states that its addends
+	// are all ours. SelfRemovedOverlap is how many candidate rows were dropped because the filter
+	// is already credited for the same tokens.
+	DeclFilterUSD      float64 `json:"decl_filter_usd"`
+	DeclFilterReads    int64   `json:"decl_filter_reads"`
+	DeclFilterRequests int64   `json:"decl_filter_requests"`
+	SelfRemovedUSD     float64 `json:"self_removed_usd"`
+	SelfRemovedReads   int64   `json:"self_removed_reads"`
+	SelfRemovedItems   int64   `json:"self_removed_items"`
+	SelfRemovedOverlap int64   `json:"self_removed_overlap"`
+	// DeclCreditPriced is false when a contributing model had no rates: the token counts above
+	// stand and the dollars are the priced subset, which a consumer must not read as the total.
+	DeclCreditPriced bool `json:"decl_credit_priced"`
+
+	// TotalSavedUSD is OUR savings together: compaction's, less our own spend; the prefix
+	// components'; the keep-alive's NET, which is its saving minus what its pings cost; and the
+	// declaration filter's realized saving. All of them are ours and the token sets are disjoint.
+	// The keep-alive contributes its net rather than its gross because the ping spend is excluded
+	// from CostUSD — a ping is not agent traffic — so it has nowhere else in this walk to appear.
 	TotalSavedUSD float64 `json:"total_saved_usd"`
+	// TotalReducedUSD is TotalSavedUSD plus what the ACCOUNT removed itself. It answers "how much
+	// smaller did this account's bill get", where TotalSavedUSD answers "how much of that did
+	// context-guru do". A reader wants both and they are not the same question; printing one
+	// under the other's label is how a dashboard takes credit for its user's work.
+	TotalReducedUSD float64 `json:"total_reduced_usd"`
 	// PrefixChangeCost is a DIAGNOSTIC, not a cost subtracted from net.
 	//
 	// It sums cost_usd over requests whose cache missed with reason prefix_change AND whose
@@ -645,6 +675,10 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// three addends are disjoint token sets: compaction's removals, the prefix split's stable
 	// half, and the entries the pings refreshed.
 	o.TotalSavedUSD = o.NetSavedUSD + o.CachesplitSavedUSD + o.KeepAliveNetUSD
+	// Both totals exist before the priced additions land, so a deployment with no rates — or a
+	// caller that does not attach the credit — reads a total that is short rather than one that
+	// is absent. SetDeclCredit moves both.
+	o.TotalReducedUSD = o.TotalSavedUSD
 
 	for name, col := range map[string]string{
 		"accounting": "token_accounting", "cache_miss": "cache_miss_reason", "uncompressed": "uncompressed_reason",
@@ -709,6 +743,23 @@ func (o *Overview) SetTiers(t *TierCosts) {
 	o.SafetyCost.FrozenReadUSD = t.FrozenReadUSD
 	o.SafetyCost.FrozenWriteRiskUSD = t.FrozenWriteRiskUSD
 	o.SafetyCost.Priced = true
+}
+
+// SetDeclCredit attaches the declarations-no-longer-sent credit and folds each half into the
+// total it belongs in: the filter's measured saving into TotalSavedUSD (it is ours), the account's
+// own removals into TotalReducedUSD only (they are not). Called by the API layer, which holds the
+// rates, for the same reason SetTiers is — DB.Overview deliberately cannot price anything.
+func (o *Overview) SetDeclCredit(c *DeclCredit) {
+	if c == nil {
+		return
+	}
+	o.DeclFilterUSD, o.DeclFilterReads = c.FilterUSD, c.FilterReads
+	o.DeclFilterRequests = int64(c.FilterRequests)
+	o.SelfRemovedUSD, o.SelfRemovedReads = c.SelfUSD, c.SelfReads
+	o.SelfRemovedItems, o.SelfRemovedOverlap = int64(c.SelfItems), int64(c.SelfOverlap)
+	o.DeclCreditPriced = c.Priced
+	o.TotalSavedUSD += c.FilterUSD
+	o.TotalReducedUSD = o.TotalSavedUSD + c.SelfUSD
 }
 
 // denominators builds the labelled savings ratios. Each one names its divisor.
@@ -815,6 +866,16 @@ func (o *Overview) waterfall() []WaterfallStep {
 				"at 1.25x rather than 1x. A ceiling rather than a floor, and the one figure here " +
 				"that is: the provider's cache is keyed on content, so another session sending the " +
 				"same prefix would have refreshed it for nothing."},
+		{Key: "decl_filter_saved", Label: "Declarations no longer sent", DeltaUSD: -o.DeclFilterUSD,
+			Description: "Tool and MCP schemas, and skill listing entries, that the declaration " +
+				"filter stopped sending — measured on requests that were really sent, from the " +
+				"count the filter itself wrote on each one, priced at the tier that request paid. " +
+				"It is a THIRD saving outside the compaction walk above and for a mechanical " +
+				"reason: that walk is built on tokens_before, which counts message text only, and " +
+				"a tool declaration lives in the top-level `tools` array. So this reduction moved " +
+				"no figure in it and appeared in no total on this page at all, even though 82.7% " +
+				"of a declared catalogue is never invoked and it is the largest lever measured in " +
+				"this project."},
 		{Key: "total_saved", Label: "Total cost avoided", DeltaUSD: o.TotalSavedUSD, Total: true,
 			Description: "Net compaction savings, plus prefix-cache savings, plus the idle " +
 				"keep-alive's NET — its savings minus what its pings cost. Three disjoint token " +
@@ -828,6 +889,24 @@ func (o *Overview) waterfall() []WaterfallStep {
 				"uncached world: the provider's own cache saved far more than this on the same " +
 				"traffic (cache_saved_usd, reported by the API as a diagnostic), and none of that " +
 				"is credited here."},
+		{Key: "self_removed", Label: "Removed by you, not by us", DeltaUSD: -o.SelfRemovedUSD,
+			Description: "Declarations this ACCOUNT stopped carrying on its own — an MCP server " +
+				"you removed, a skill you switched off. The tokens genuinely were not billed, and " +
+				"no component of ours was involved, so this is deliberately OUTSIDE the total " +
+				"above and inside the one below. It is also MODELLED rather than measured: the " +
+				"evidence is that the inventory is a time series and a name is in its early part " +
+				"and not its late part, which cannot tell a removal from a session that ran in a " +
+				"different environment — on the production snapshot the largest candidate is the " +
+				"editor integration, which is simply absent outside the IDE. Every row and its " +
+				"own evidence is on the Inventory tab; rows the filter is already credited for " +
+				"are excluded here rather than counted twice."},
+		{Key: "total_reduced", Label: "Total the bill came down", DeltaUSD: o.TotalReducedUSD,
+			Total: true,
+			Description: "Everything above, ours and yours: the total cost avoided plus what you " +
+				"removed yourself. It answers 'how much smaller did this bill get', where the " +
+				"total above answers 'how much of that did context-guru do'. Both are worth " +
+				"knowing and they are not the same number, so neither is printed under the " +
+				"other's label."},
 	}
 	return steps
 }

--- a/dash/promptapi.go
+++ b/dash/promptapi.go
@@ -52,6 +52,16 @@ type PromptRegion struct {
 	// the same answer as "we do not have it".
 	Text    string `json:"text,omitempty"`
 	HasText bool   `json:"has_text"`
+	// Parts decomposes the SYSTEM PROMPT region into the sections it was assembled from, so
+	// "your system prompt is 12,400 tokens" becomes a list of things a reader can act on
+	// separately. Empty for every other region: a tool schema is one JSON object and a skills
+	// listing is one block, so neither has parts to name. See splitSystemPrompt.
+	Parts []PromptPart `json:"parts,omitempty"`
+	// PartsTokens is the SUM of the parts' own measured weights, which is a few tokens off
+	// Tokens above and must be shown as its own figure rather than reconciled: BPE is not
+	// additive across a split point, so measuring the pieces and measuring the whole are two
+	// measurements of the same bytes and neither is the error.
+	PartsTokens int `json:"parts_tokens,omitempty"`
 }
 
 // PromptView is one session's prefix, decomposed.
@@ -118,6 +128,12 @@ func (a *API) prompt(w http.ResponseWriter, r *http.Request) {
 	if !trusted {
 		for i := range view.Regions {
 			view.Regions[i].Text, view.Regions[i].HasText = "", false
+			// The parts are the same content sliced up, so they go with it. Dropped whole
+			// rather than blanked field by field: a list of section TITLES is still content —
+			// a heading in a user's CLAUDE.md names their project — and leaving the titles
+			// behind would have re-opened the gate this strip exists to close, one field
+			// narrower. TestPromptPartsAreStrippedForAnUntrustedCaller holds it.
+			view.Regions[i].Parts, view.Regions[i].PartsTokens = nil, 0
 		}
 	}
 	writeJSON(w, view)
@@ -221,6 +237,15 @@ func (d *DB) PromptViewFor(f Filter) (*PromptView, error) {
 		}
 		if gz != nil {
 			reg.Text, reg.HasText = gunzipText(gz), true
+		}
+		// The system prompt gets decomposed; nothing else has parts to decompose. Done here
+		// rather than in the handler so a caller of PromptViewFor gets the same answer the
+		// route does — the whole reason the strip below is the ONLY thing the handler changes.
+		if reg.Kind == KindSystemPrompt && reg.HasText {
+			reg.Parts = splitSystemPrompt(reg.Text)
+			for _, part := range reg.Parts {
+				reg.PartsTokens += part.Tokens
+			}
 		}
 		v.Regions = append(v.Regions, reg)
 		v.Tokens += reg.Tokens

--- a/dash/promptparts.go
+++ b/dash/promptparts.go
@@ -1,0 +1,125 @@
+package dash
+
+// Splitting the system prompt into the parts it was assembled from.
+//
+// The Inventory page could show the system prompt's total weight and, once the text was stored,
+// the whole thing as one wall of text. Neither answers the question a reader actually has, which
+// is "WHICH of the things in there is costing me this". A 12,000-token prompt is not one
+// decision: it is the agent's own preamble, plus the harness rules, plus the environment block,
+// plus whatever the reader's own CLAUDE.md contributed — and only some of those are theirs to
+// change. Undivided, the page could show the number and not the answer.
+//
+// THE SPLIT IS ON HEADINGS, AND THAT IS A DELIBERATE SECOND CHOICE. The real structural seam is
+// the wire one: `system` arrives as an ARRAY of blocks, each separately cacheable. Those
+// boundaries are not recoverable here — systemTextOf joins the blocks with a blank line before
+// anything is stored, so every row already in the database has lost them, and a reader cannot be
+// shown a decomposition that only works for prompts captured after today. Markdown headings are
+// present in the text itself, are what the prompt is actually organised by, and work on every row
+// ever captured. The UI says which of the two it is showing, because "part" could mean either and
+// a reader comparing this against a cache breakpoint count would otherwise be misled.
+//
+// Everything before the first heading is a part too, named for what it is rather than dropped:
+// on Claude Code that leading chunk is the identity preamble, and it is not small.
+
+import (
+	"strings"
+
+	"github.com/rossoctl/context-guru/internal/tokens"
+)
+
+// PromptPart is one section of the system prompt, identified and measured.
+type PromptPart struct {
+	// Title is the heading text, or "Preamble" for the text ahead of the first heading. Level
+	// is the heading depth (1 for `#`, 2 for `##`, 0 for the preamble) so a UI can indent
+	// rather than present a flat list of forty equal-looking sections.
+	Title string `json:"title"`
+	Level int    `json:"level"`
+	// Tokens is this part's own measured BPE weight and Share its percentage of the parts'
+	// SUM — not of the region's stored total. The two differ, by a token or two per boundary:
+	// BPE is not additive across a split, so measuring the pieces and measuring the whole are
+	// different measurements of the same bytes. PromptRegion.PartsTokens carries the sum so a
+	// UI can show both figures instead of implying they must agree.
+	Tokens int     `json:"tokens"`
+	Share  float64 `json:"share"`
+	Text   string  `json:"text"`
+}
+
+// splitSystemPrompt divides a system prompt at its top-level markdown headings.
+//
+// `#` and `##` only. Deeper levels are left inside their parent: a prompt with forty `###`
+// subsections split at every one of them is the same wall of text with more furniture, and the
+// question this answers ("which region owns my prompt") is answered at the top level.
+//
+// A heading is recognised only at the start of a line and only with a space after the hashes,
+// so a `#` inside a fenced code block or a shell comment does not open a section. Fences are
+// tracked for exactly that reason — Claude Code's own prompt contains ``` blocks with comments
+// in them, and without the fence check its environment block split into fragments named after
+// somebody's example command.
+func splitSystemPrompt(text string) []PromptPart {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	type seam struct {
+		at    int // byte offset of the heading line
+		title string
+		level int
+	}
+	var seams []seam
+	inFence := false
+	for off := 0; off < len(text); {
+		end := strings.IndexByte(text[off:], '\n')
+		line := text[off:]
+		next := len(text)
+		if end >= 0 {
+			line = text[off : off+end]
+			next = off + end + 1
+		}
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "```"), strings.HasPrefix(trimmed, "~~~"):
+			inFence = !inFence
+		case inFence:
+		case strings.HasPrefix(line, "## ") && len(strings.TrimSpace(line[3:])) > 0:
+			seams = append(seams, seam{off, strings.TrimSpace(line[3:]), 2})
+		case strings.HasPrefix(line, "# ") && len(strings.TrimSpace(line[2:])) > 0:
+			seams = append(seams, seam{off, strings.TrimSpace(line[2:]), 1})
+		}
+		off = next
+	}
+	// No headings at all: one part, which is still worth returning. It tells the UI "this prompt
+	// has no sections" rather than "the splitter found nothing", and those read differently.
+	if len(seams) == 0 {
+		return []PromptPart{{Title: wholeTitle, Tokens: tokens.Count(text), Text: text}}
+	}
+	out := make([]PromptPart, 0, len(seams)+1)
+	if head := text[:seams[0].at]; strings.TrimSpace(head) != "" {
+		out = append(out, PromptPart{Title: preambleTitle, Tokens: tokens.Count(head), Text: head})
+	}
+	for i, s := range seams {
+		end := len(text)
+		if i+1 < len(seams) {
+			end = seams[i+1].at
+		}
+		body := text[s.at:end]
+		out = append(out, PromptPart{
+			Title: s.title, Level: s.level, Tokens: tokens.Count(body), Text: body,
+		})
+	}
+	var sum int
+	for _, p := range out {
+		sum += p.Tokens
+	}
+	if sum > 0 {
+		for i := range out {
+			out[i].Share = 100 * float64(out[i].Tokens) / float64(sum)
+		}
+	}
+	return out
+}
+
+// The two synthesised titles. Named constants because the UI does not special-case them and a
+// reader must be able to tell a section the prompt actually names from one this code named.
+const (
+	preambleTitle = "Preamble — everything before the first heading"
+	wholeTitle    = "The whole prompt — it has no headings to split on"
+)

--- a/dash/promptparts_test.go
+++ b/dash/promptparts_test.go
@@ -1,0 +1,136 @@
+package dash
+
+import (
+	"strings"
+	"testing"
+)
+
+// ccPrompt is the shape of a real Claude Code system prompt: an identity preamble with no
+// heading, then top-level sections, a fenced code block that contains a `#` COMMENT, and the
+// user's own CLAUDE.md pasted in with its own headings.
+const ccPrompt = `You are Claude Code, Anthropic's official CLI for Claude.
+
+# Harness
+
+Text you output outside of tool use is displayed to the user.
+
+## Git
+
+Use the gh CLI. Example:
+
+` + "```" + `bash
+# this is a shell comment, not a heading
+git status
+` + "```" + `
+
+# Environment
+
+Working directory: /home/user/project
+
+# Memory
+
+You have a persistent file-based memory.
+`
+
+func partTitles(ps []PromptPart) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.Title)
+	}
+	return out
+}
+
+func TestSplitSystemPromptNamesEverySection(t *testing.T) {
+	ps := splitSystemPrompt(ccPrompt)
+	got := partTitles(ps)
+	want := []string{preambleTitle, "Harness", "Git", "Environment", "Memory"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("parts = %v, want %v", got, want)
+	}
+	// The fenced `# this is a shell comment` did NOT open a section. Without the fence check the
+	// Git section splits in two and one of them is named after somebody's example command.
+	for _, p := range ps {
+		if strings.HasPrefix(p.Title, "this is a shell comment") {
+			t.Error("a heading inside a fenced code block opened a section")
+		}
+	}
+	// The code block stays with the section it belongs to, whole.
+	var git string
+	for _, p := range ps {
+		if p.Title == "Git" {
+			git = p.Text
+		}
+	}
+	if !strings.Contains(git, "git status") || !strings.Contains(git, "shell comment") {
+		t.Errorf("the Git section lost its code block: %q", git)
+	}
+	// Levels, so a UI can nest rather than print a flat list of equals.
+	byTitle := map[string]int{}
+	for _, p := range ps {
+		byTitle[p.Title] = p.Level
+	}
+	if byTitle["Harness"] != 1 || byTitle["Git"] != 2 || byTitle[preambleTitle] != 0 {
+		t.Errorf("levels = %v, want Harness 1 / Git 2 / preamble 0", byTitle)
+	}
+}
+
+// The parts must reassemble into the original prompt, exactly. This is the assertion that makes
+// the decomposition trustworthy: a reader is being shown pieces and told they are the whole, so
+// nothing may be dropped, duplicated or reordered by the split.
+func TestSplitSystemPromptLosesNothing(t *testing.T) {
+	var b strings.Builder
+	for _, p := range splitSystemPrompt(ccPrompt) {
+		b.WriteString(p.Text)
+	}
+	if b.String() != ccPrompt {
+		t.Errorf("the parts do not reassemble into the prompt:\n--- got ---\n%q\n--- want ---\n%q",
+			b.String(), ccPrompt)
+	}
+}
+
+func TestSplitSystemPromptSharesSumTo100(t *testing.T) {
+	var sum, tok float64
+	ps := splitSystemPrompt(ccPrompt)
+	for _, p := range ps {
+		sum += p.Share
+		tok += float64(p.Tokens)
+		if p.Tokens <= 0 {
+			t.Errorf("part %q measured %d tokens", p.Title, p.Tokens)
+		}
+	}
+	if sum < 99.9 || sum > 100.1 {
+		t.Errorf("shares sum to %.3f, want 100", sum)
+	}
+	if tok <= 0 {
+		t.Fatal("the parts measured nothing")
+	}
+}
+
+// A prompt with no headings is ONE part that says so, not zero parts. "This prompt has no
+// sections" and "the splitter found nothing" read differently to a reader, and only one of them
+// is true.
+func TestSplitSystemPromptWithNoHeadings(t *testing.T) {
+	ps := splitSystemPrompt("just some instructions, no headings at all")
+	if len(ps) != 1 || ps[0].Title != wholeTitle {
+		t.Fatalf("parts = %v, want one part titled %q", partTitles(ps), wholeTitle)
+	}
+	if ps[0].Tokens <= 0 {
+		t.Error("the single part measured nothing")
+	}
+}
+
+func TestSplitSystemPromptOnEmptyText(t *testing.T) {
+	for _, s := range []string{"", "   ", "\n\n\t\n"} {
+		if ps := splitSystemPrompt(s); ps != nil {
+			t.Errorf("splitSystemPrompt(%q) = %v, want nil", s, partTitles(ps))
+		}
+	}
+}
+
+// A prompt that OPENS on a heading has no preamble, and must not get an empty one.
+func TestSplitSystemPromptWithNoPreamble(t *testing.T) {
+	ps := splitSystemPrompt("# First\n\nbody\n")
+	if len(ps) != 1 || ps[0].Title != "First" {
+		t.Fatalf("parts = %v, want just First", partTitles(ps))
+	}
+}

--- a/dash/toolapi.go
+++ b/dash/toolapi.go
@@ -180,6 +180,15 @@ type ToolCoverage struct {
 }
 
 // ToolTotals is the summary line.
+//
+// EVERY FIGURE HERE EXCEPT DeclaredSetTokens AND THE TWO Aside FIELDS COVERS THE CONTROLLABLE
+// SET ONLY — MCP tools and skills. It used to cover everything declared, and that made the
+// headline of this page a number nobody could act on: Claude Code's own tools are the largest
+// group here by weight and removing one breaks the agent, so a "you never touch 82.7% of what
+// you carry" assembled mostly out of Read, Bash and Grep was, in effect, advice to break your
+// agent. The built-ins are still reported — in Aside, and in their own section at the end of
+// the page — they are simply not inside the statistics a reader is invited to act on.
+// See ToolReport.Aside.
 type ToolTotals struct {
 	// DeclaredTokens / UnusedTokens are per-session averages over the CAPTURED sessions.
 	DeclaredTokens int     `json:"declared_tokens"`
@@ -190,6 +199,13 @@ type ToolTotals struct {
 	UnusedReads int64   `json:"unused_reads"`
 	UnusedUSD   float64 `json:"unused_usd"`
 	Priced      bool    `json:"priced"`
+	// AsideTokens is the per-session mean weight of the declarations kept OUT of every figure
+	// above: Claude Code's own tools, another agent's client tools, the provider's. Reported so
+	// the page can state what it left out and how large it is, instead of leaving a reader to
+	// discover that the composition bar below is bigger than the headline and wonder which lied.
+	AsideTokens int `json:"aside_tokens"`
+	// AsideSetTokens is that group's set total, the counterpart of DeclaredSetTokens.
+	AsideSetTokens int `json:"aside_set_tokens"`
 	// RequestsPerSession is a MEAN over every TOOL-BEARING session in scope, captured or not,
 	// while Median and Typical below are over the CAPTURED ones only — a different and smaller
 	// population. That is deliberate (this one answers "how many requests does a session make",
@@ -203,9 +219,11 @@ type ToolTotals struct {
 	// full session" projection must use — see the comment where it is computed for why the
 	// mean and the median both answer a different question and both understate it badly.
 	RequestsPerSessionTypical float64 `json:"requests_per_session_typical"`
-	// DeclaredSetTokens is the summed weight of everything declared, once — the whole that
-	// every SharePct is a part of. DeclaredTokens above is a per-session MEAN and is a
-	// different quantity; the two were conflated and produced shares over 100%.
+	// DeclaredSetTokens is the summed weight of everything declared, once — INCLUDING the
+	// aside group, because it is the whole that every SharePct is a part of and a share has to
+	// be a share of the actual prompt. DeclaredTokens above is a per-session MEAN over the
+	// controllable set and is a different quantity twice over; the two were conflated once and
+	// produced shares over 100%.
 	DeclaredSetTokens int `json:"declared_set_tokens"`
 }
 
@@ -239,9 +257,28 @@ type PromptStat struct {
 type ToolReport struct {
 	Coverage ToolCoverage `json:"coverage"`
 	Totals   ToolTotals   `json:"totals"`
-	Tools    []ToolStat   `json:"tools"`
-	Servers  []ServerStat `json:"servers"`
-	Skills   SkillStat    `json:"skills"`
+	// Tools is the CONTROLLABLE set: MCP tools. Skills are the other half and are in Skills.
+	//
+	// It used to be every client-side declaration, which put Claude Code's own tools at the top
+	// of a page whose whole purpose is to recommend removals. They are not a candidate for
+	// removal, they are the largest group by weight, and they therefore dominated the headline,
+	// the composition, the totals and the sortable table with a number no reader should act on.
+	// They are in Aside instead.
+	Tools   []ToolStat   `json:"tools"`
+	Servers []ServerStat `json:"servers"`
+	Skills  SkillStat    `json:"skills"`
+	// Aside is everything declared that is NOT the reader's to remove, in the same row shape:
+	// Claude Code's own tools (Builtin true), a third-party agent's or SDK application's client
+	// tools, and the provider's server-side tools.
+	//
+	// It is REPORTED and it is not in any figure in Totals. Both halves of that matter. Hiding
+	// it would be a lie about what the prompt contains — it is the majority of it — and folding
+	// it into the totals was the older lie, that a reader could act on the majority of it.
+	// The three sub-groups are told apart by Builtin and Kind, not by their position here,
+	// because the page shows them under different warnings: the built-ins break the agent, an
+	// unknown client tool needs its declarer identified first, a provider tool cannot be
+	// touched from Claude Code at all.
+	Aside []ToolStat `json:"aside"`
 	// Models is every model this scope ran on, with its cache-write and cache-read rates, so
 	// "what would removing this save me" can be answered per model instead of at one blended
 	// rate that describes none of them.
@@ -494,7 +531,12 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 
 	stats := map[statKey]*ToolStat{}
 	captured := map[string]bool{}
+	// declTok / unusedTok are the CONTROLLABLE set's per-session weights (MCP tools and the
+	// skills listing); asideTok is everything else's. Split here, in the one loop that sees each
+	// declaration, rather than re-derived later from the output lists: the same classification
+	// then decides the totals and the lists, so the two cannot disagree.
 	declTok, unusedTok := map[string]int{}, map[string]int{}
+	asideTok := map[string]int{}
 	listingTok, listingSessions, unknownListings := 0, 0, 0
 	skillsSeen := false
 	for _, dr := range decls {
@@ -549,19 +591,30 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 		}
 		st.HasText = st.HasText || dr.hasText
 		st.SessionsDeclared++
-		declTok[dr.session] += dr.tokens
+		aside := isAside(dr.kind, dr.name)
+		if aside {
+			asideTok[dr.session] += dr.tokens
+		} else {
+			declTok[dr.session] += dr.tokens
+		}
 		calls := usedIn[dr.session][k]
 		if calls > 0 {
 			st.SessionsUsed++
 			st.Calls += calls
 			continue
 		}
-		unusedTok[dr.session] += dr.tokens
+		// UnusedReads and UnusedUSD are computed for every row, aside included: the row-level
+		// figures are what the built-ins section prints, and withholding them there would only
+		// mean the page could not say how much the group it is warning about actually costs.
+		// What the aside group stays out of is the TOTALS, below.
 		st.UnusedReads += int64(dr.tokens) * int64(sc.requests())
 		if sc.priced {
 			st.UnusedUSD += sc.usd(dr.tokens)
 		} else {
 			st.Priced = false
+		}
+		if !aside {
+			unusedTok[dr.session] += dr.tokens
 		}
 	}
 
@@ -581,13 +634,15 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 	}
 	rep.Totals.Priced = rep.Coverage.Captured > 0 && rep.Coverage.UnpricedSessions == 0
 	if n := rep.Coverage.Captured; n > 0 {
-		var dsum, usum int
+		var dsum, usum, asum int
 		for id := range captured {
 			dsum += declTok[id]
 			usum += unusedTok[id]
+			asum += asideTok[id]
 		}
 		rep.Totals.DeclaredTokens = dsum / n
 		rep.Totals.UnusedTokens = usum / n
+		rep.Totals.AsideTokens = asum / n
 		if dsum > 0 {
 			rep.Totals.UnusedPct = 100 * float64(usum) / float64(dsum)
 		}
@@ -634,6 +689,12 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 	rep.Models = modelRates(sessions)
 
 	for _, st := range stats {
+		if isAside(st.Kind, st.Name) {
+			rep.Aside = append(rep.Aside, *st)
+			continue
+		}
+		// Only the controllable set reaches the totals. This is the same restriction the loop
+		// above put on unusedTok, applied to the scope-wide sum.
 		rep.Totals.UnusedReads += st.UnusedReads
 		rep.Totals.UnusedUSD += st.UnusedUSD
 		if st.Kind == KindSkill {
@@ -666,6 +727,7 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 	rep.Servers = serverRollup(rep.Tools)
 	sortStats(rep.Tools)
 	sortStats(rep.Skills.Skills)
+	sortStats(rep.Aside)
 	// Classification, share and removal advice, applied to every row once the list is final.
 	// On READ rather than at capture: the built-in/user-added split is a name allowlist that
 	// will gain entries as Claude Code does, and re-capturing history to learn a new name is
@@ -678,14 +740,42 @@ func buildToolReport(sessions map[string]*sessionCost, decls []declRow, uses []u
 	// inventory, so the mean is far smaller than a single large declaration and shares came out
 	// at 650%. A percentage over 100 is not a rounding problem, it is proof the denominator is
 	// not the whole the numerator is part of.
+	// The denominator is the WHOLE declared set, aside group included, and every row's share is
+	// a share of that one whole. Two denominators — "share of what you control" for one list and
+	// "share of everything" for the other — would put two incompatible percentages in one column
+	// name, and the page prints them in the same table.
 	whole := rep.Skills.ListingTokens
 	for _, t := range rep.Tools {
 		whole += t.Tokens
 	}
+	for _, t := range rep.Aside {
+		whole += t.Tokens
+		rep.Totals.AsideSetTokens += t.Tokens
+	}
 	annotate(rep.Tools, whole)
 	annotate(rep.Skills.Skills, whole)
+	annotate(rep.Aside, whole)
 	rep.Totals.DeclaredSetTokens = whole
 	return rep
+}
+
+// isAside reports whether a declaration belongs to the group the reader cannot act on: Claude
+// Code's OWN tools, and the provider's server-side tools.
+//
+// A third-party client tool — KindTool with a name that is not one of Claude Code's — stays in
+// the main set, and that boundary is the whole point of this function rather than an oversight.
+// The first cut of this split keyed on KIND, so every KindTool row went aside; that is correct on
+// a Claude Code account (all of them are built-ins there, which is the account this was written
+// for) and quietly wrong on any other, because it took the removable declarations of every SDK
+// application and agent off the page — out of the totals, out of the sortable table, and out of
+// the suggestion engine and therefore out of the filter, which is a capability regression dressed
+// as a presentation change. Three tests caught it, which is why they exist.
+//
+// So the rule is the one the reader's decision actually turns on: a built-in must not be in the
+// statistics because acting on it breaks the agent, and a provider tool must not be because it
+// cannot be acted on at all. Everything else is somebody's choice and belongs in front of them.
+func isAside(kind, name string) bool {
+	return kind == KindServerTool || IsBuiltinTool(kind, name)
 }
 
 // annotate fills the three read-time fields on a row: whether it is a built-in, its share of
@@ -819,7 +909,7 @@ func (a *API) tools(w http.ResponseWriter, r *http.Request) {
 		// The account's own server-side removal list, so a reduction that the tool filter is
 		// ALREADY credited for can be marked as overlapping instead of counted twice.
 		filtered := map[string]bool{}
-		for _, n := range a.toolFilterState(f.Tenant).Removed {
+		for _, n := range a.toolFilterStateForScope(f).Removed {
 			filtered[n] = true
 		}
 		sr, err := a.rec.DB().SelfRemovals(f, price, filtered)

--- a/dash/toolapi.go
+++ b/dash/toolapi.go
@@ -908,11 +908,7 @@ func (a *API) tools(w http.ResponseWriter, r *http.Request) {
 	if price != nil {
 		// The account's own server-side removal list, so a reduction that the tool filter is
 		// ALREADY credited for can be marked as overlapping instead of counted twice.
-		filtered := map[string]bool{}
-		for _, n := range a.toolFilterStateForScope(f).Removed {
-			filtered[n] = true
-		}
-		sr, err := a.rec.DB().SelfRemovals(f, price, filtered)
+		sr, err := a.rec.DB().SelfRemovals(f, price, a.toolFilterStateForScope(f).Removed)
 		if err != nil {
 			// Non-fatal, but never silent: swallowing this returned an empty list that was
 			// indistinguishable from "the account removed nothing", which is a claim.
@@ -968,7 +964,11 @@ func (d *DB) countInventoryRows() (decls, uses int64, err error) {
 // Deliberately NOT netted into the declaration filter's realized savings: an account that both
 // removed a server locally and has it on its server-side filter list would otherwise be credited
 // twice for one reduction. Rows in that position are marked Overlap and left for the reader.
-func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), filtered map[string]bool) ([]SelfRemoval, error) {
+func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), removed []string) ([]SelfRemoval, error) {
+	// The account's raw config list, keyed the way the inventory names things. Converted HERE
+	// rather than by each caller: the two callers had identical loops building it in the CONFIG's
+	// vocabulary, and the comparison below is in the REPORT's.
+	filtered := declFilteredSet(removed)
 	where, args := f.where()
 	// Session ordering comes from the requests table (the declarations carry a ts, but one per
 	// digest, not per session start), so "before" and "after" mean the same thing here as
@@ -1103,7 +1103,8 @@ func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), 
 		r := SelfRemoval{
 			Kind: c.kind, Name: c.name, Server: c.server,
 			Tokens: c.tokens, LastSeen: c.lastSeen, SessionsBefore: c.before,
-			Overlap: filtered[c.name] || (c.server != "" && filtered[c.server]),
+			Overlap: filtered[statKey{c.kind, c.name}] ||
+				(c.server != "" && filtered[statKey{"mcp_server", c.server}]),
 		}
 		priced := true
 		for _, s := range sess {

--- a/dash/toolinventory.go
+++ b/dash/toolinventory.go
@@ -46,6 +46,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rossoctl/context-guru/internal/skills"
 	"github.com/rossoctl/context-guru/internal/tokens"
 	"github.com/tidwall/gjson"
 )
@@ -407,65 +408,27 @@ func skillDecls(text string) []Decl {
 	marker := Decl{Kind: KindSkillListing, Server: SkillsUnknown,
 		Tokens: tokens.Count(listing), Text: listing}
 	out := []Decl{marker}
-	// Entries are line-anchored `- name: description`, each running to the next such
-	// line. A description containing its own "\n- " line would truncate that entry's
-	// weight, so the span is taken to the next line that parses as a NAME.
-	lines := strings.Split(body, "\n")
-	name, start := "", 0
-	flush := func(end int) {
-		if name == "" {
-			return
-		}
-		entry := strings.Join(lines[start:end], "\n")
-		out = append(out, Decl{Kind: KindSkill, Name: name,
-			Tokens: tokens.Count(entry), Text: entry})
+	// The entry split is internal/skills's, not this file's, because the declaration FILTER cuts
+	// entries out of a real request using the same rule and the two must not drift: a filter that
+	// disagreed about where an entry ends would leave an orphaned description line in the prompt
+	// while this page reported a clean removal. Entries are line-anchored `- name: description`,
+	// each running to the next line that parses as a NAME — a description carrying its own "- "
+	// bullet must not truncate the entry's measured weight.
+	l := skills.Parse(body)
+	for _, e := range l.Entries {
+		entry := l.Text(e)
+		out = append(out, Decl{Kind: KindSkill, Name: e.Name, Tokens: tokens.Count(entry), Text: entry})
 	}
-	for n, ln := range lines {
-		if nm, ok := skillEntryName(ln); ok {
-			flush(n)
-			name, start = nm, n
-		}
-	}
-	flush(len(lines))
 	if len(out) > 1 {
 		out[0].Server = SkillsOK
 	}
 	return out
 }
 
-// skillEntryName reads a listing line's name, or reports that the line is not an entry.
-func skillEntryName(line string) (string, bool) {
-	if !strings.HasPrefix(line, "- ") {
-		return "", false
-	}
-	rest := line[2:]
-	i := strings.Index(rest, ":")
-	if i <= 0 {
-		return "", false
-	}
-	name := rest[:i]
-	// A plugin skill is `plugin:skill`, so one colon may be part of the name: take the
-	// longer candidate when the first colon is not followed by a space.
-	if !strings.HasPrefix(rest[i:], ": ") {
-		if j := strings.Index(rest[i+1:], ": "); j >= 0 {
-			name = rest[:i+1+j]
-		} else {
-			return "", false
-		}
-	}
-	if name == "" || len(name) > 128 {
-		return "", false
-	}
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-		case r == '.' || r == '_' || r == ':' || r == '-' || r == '/':
-		default:
-			return "", false
-		}
-	}
-	return name, true
-}
+// skillEntryName reads a listing line's name, or reports that the line is not an entry. Kept as
+// a name in this package because its tests are here and read as this file's contract; the rule
+// itself is internal/skills's, shared with the filter that acts on it.
+func skillEntryName(line string) (string, bool) { return skills.EntryName(line) }
 
 // usedFrom collects the tool calls of the LAST tool-using turn, plus a fingerprint of
 // that turn. Not the whole transcript: the agent resends it every request, so counting

--- a/dash/toolinventory_corpus_test.go
+++ b/dash/toolinventory_corpus_test.go
@@ -133,7 +133,8 @@ func TestCorpusInventory(t *testing.T) {
 				rep.Skills.UnusedListingReads)
 			t.Logf("  coverage: %d sessions, %d captured, %d not captured",
 				rep.Coverage.Sessions, rep.Coverage.Captured, rep.Coverage.NotCaptured)
-			t.Logf("  unused reads %d tokens", rep.Totals.UnusedReads)
+			t.Logf("  unused reads %d tokens (controllable set only); aside %d tok/session, %d tok in the set",
+				rep.Totals.UnusedReads, rep.Totals.AsideTokens, rep.Totals.AsideSetTokens)
 			// The dead-weight table, biggest first.
 			for i, s := range rep.Tools {
 				if i >= 30 {
@@ -152,12 +153,40 @@ func TestCorpusInventory(t *testing.T) {
 			if rep.Totals.DeclaredTokens == 0 || rep.Totals.UnusedTokens == 0 {
 				t.Error("declared or unused weight came out zero on real traffic")
 			}
-			names := map[string]bool{}
+			// Bash IS declared by every session in these corpora, and it must be reported — in
+			// Aside. This assertion moved rather than being deleted: the point of the report is
+			// that nothing declared goes missing, and the point of the split is that the agent's
+			// own equipment is not in the statistics a reader is invited to act on. A test that
+			// only checked the first half would pass on a report that had silently dropped it.
+			main, aside := map[string]bool{}, map[string]bool{}
 			for _, s := range rep.Tools {
-				names[s.Name] = true
+				main[s.Name] = true
 			}
-			if !names["Bash"] {
-				t.Error("Bash is declared by every session in these corpora and is missing")
+			for _, s := range rep.Aside {
+				aside[s.Name] = true
+			}
+			if !aside["Bash"] {
+				t.Error("Bash is declared by every session in these corpora and is missing from Aside")
+			}
+			if main["Bash"] {
+				t.Error("Bash is in the main statistics: the built-in split is not applied")
+			}
+			// No built-in and no provider tool in the main list, and nothing in both lists.
+			for _, s := range rep.Tools {
+				if s.Builtin || s.Kind == KindServerTool {
+					t.Errorf("main list carries %s (kind %s, builtin %v): it belongs in Aside",
+						s.Name, s.Kind, s.Builtin)
+				}
+				if aside[s.Name] {
+					t.Errorf("%s is in both the main list and Aside", s.Name)
+				}
+			}
+			// And the converse: everything in Aside is there for one of the two stated reasons.
+			for _, s := range rep.Aside {
+				if !s.Builtin && s.Kind != KindServerTool {
+					t.Errorf("Aside carries %s (kind %s): it is neither a built-in nor a provider tool",
+						s.Name, s.Kind)
+				}
 			}
 		})
 	}

--- a/dash/toolinventory_test.go
+++ b/dash/toolinventory_test.go
@@ -463,8 +463,24 @@ func TestToolReportDiffsDeclaredAgainstUsed(t *testing.T) {
 	for _, s := range rep.Tools {
 		byName[s.Name] = s
 	}
-	if s := byName["Bash"]; s.SessionsUsed != 1 || s.Calls != 7 || s.UnusedReads != 0 {
-		t.Errorf("Bash = %+v, want used with no waste", s)
+	aside := map[string]ToolStat{}
+	for _, s := range rep.Aside {
+		aside[s.Name] = s
+	}
+	// Bash is one of Claude Code's own, so it is reported in Aside and NOWHERE in the main set.
+	// Both halves are asserted: the group has to be visible (it is most of the prompt) and it has
+	// to be outside the figures the page invites the reader to act on.
+	if s := aside["Bash"]; s.SessionsUsed != 1 || s.Calls != 7 || s.UnusedReads != 0 || !s.Builtin {
+		t.Errorf("Bash in Aside = %+v, want a used built-in with no waste", s)
+	}
+	if _, ok := byName["Bash"]; ok {
+		t.Error("Bash is in the main tool list; the built-in split is not applied")
+	}
+	// Workflow is a client tool that is NOT one of Claude Code's, so it stays actionable. This is
+	// the boundary the split is drawn on, and getting it wrong the other way takes every
+	// SDK application's removable declarations off the page.
+	if _, ok := aside["Workflow"]; ok {
+		t.Error("Workflow is in Aside; only built-ins and provider tools belong there")
 	}
 	// Workflow: declared, never called, 10 requests re-read it.
 	wf := byName["Workflow"]
@@ -476,10 +492,32 @@ func TestToolReportDiffsDeclaredAgainstUsed(t *testing.T) {
 	if got := wf.UnusedUSD; got < 0.0049 || got > 0.0051 {
 		t.Errorf("Workflow unused USD = %g, want ~0.005", got)
 	}
-	// Declared weight per captured session: 100+5000+400+1000+300 = 6800; unused
-	// everything but Bash = 6700.
-	if rep.Totals.DeclaredTokens != 6800 || rep.Totals.UnusedTokens != 6700 {
-		t.Errorf("totals = %+v, want 6800 declared / 6700 unused per session", rep.Totals)
+	// Declared weight per captured session over the CONTROLLABLE set: 5000+400+1000+300 = 6700.
+	// Bash's 100 is not in it and is reported separately in AsideTokens, so the two still add up
+	// to the 6800 the session actually carried — the split moves weight between figures, it never
+	// loses any.
+	if rep.Totals.DeclaredTokens != 6700 || rep.Totals.UnusedTokens != 6700 {
+		t.Errorf("totals = %+v, want 6700 declared / 6700 unused per session", rep.Totals)
+	}
+	if rep.Totals.AsideTokens != 100 || rep.Totals.AsideSetTokens != 100 {
+		t.Errorf("aside weight = %d/%d, want 100/100 (Bash)",
+			rep.Totals.AsideTokens, rep.Totals.AsideSetTokens)
+	}
+	if got := rep.Totals.DeclaredTokens + rep.Totals.AsideTokens; got != 6800 {
+		t.Errorf("controllable + aside = %d, want the 6800 the session declared", got)
+	}
+	// The share denominator is still the WHOLE set, aside included, so a share is a share of the
+	// real prompt: the skills LISTING (1000) + Workflow (5000) + the MCP tool (400) + Bash (100)
+	// = 6500. The dataviz row's 300 is deliberately absent — a skill's weight is its ENTRY inside
+	// that listing, so adding the rows to the listing counts the same bytes twice. That is why
+	// this figure and DeclaredTokens above differ, and it predates the built-in split.
+	if rep.Totals.DeclaredSetTokens != 6500 {
+		t.Errorf("declared set = %d, want 6500 (listing + every tool row, aside included)",
+			rep.Totals.DeclaredSetTokens)
+	}
+	if rep.Totals.DeclaredSetTokens-rep.Totals.AsideSetTokens != 6400 {
+		t.Errorf("controllable share of the set = %d, want 6400",
+			rep.Totals.DeclaredSetTokens-rep.Totals.AsideSetTokens)
 	}
 	if rep.Totals.UnusedReads != 67_000 {
 		t.Errorf("unused reads = %d, want 67000", rep.Totals.UnusedReads)

--- a/dash/toolremoval.go
+++ b/dash/toolremoval.go
@@ -1,5 +1,7 @@
 package dash
 
+import "strings"
+
 // How a user actually gets rid of a capability they are paying to carry, and which of the
 // things they carry are safe to get rid of at all.
 //
@@ -264,11 +266,24 @@ func isPluginServer(server string) bool {
 
 // splitPluginSkill splits a "<plugin>:<skill>" skill name. A personal or project skill has no
 // colon and is managed by skillOverrides; a plugin's skill is managed by its plugin.
+//
+// A colon is NOT enough, because two different things wear one: a plugin skill is
+// `<plugin>:<skill>` and a DIRECTORY-SCOPED skill is `<path>:<skill>` — Claude Code lists those as
+// e.g. `apps/web:deploy`. Treating the second as the first emitted
+// `claude plugin disable apps/web`, which names no plugin and silently does nothing: the worst
+// output this file can produce, because it gets pasted and appears to succeed.
+//
+// A `/` in the prefix is the discriminator: a path segment can contain one and a plugin name
+// cannot. A directory-scoped skill therefore falls through to the plain skillOverrides mechanism,
+// which is keyed by the same name the listing prints.
 func splitPluginSkill(name string) (plugin, skill string, ok bool) {
 	for i := 0; i < len(name); i++ {
 		if name[i] == ':' {
 			if i == 0 || i == len(name)-1 {
 				return "", "", false
+			}
+			if strings.ContainsRune(name[:i], '/') {
+				return "", "", false // a directory scope, not a plugin
 			}
 			return name[:i], name[i+1:], true
 		}

--- a/dash/toolremoval.go
+++ b/dash/toolremoval.go
@@ -16,6 +16,21 @@ package dash
 // emits is therefore the bare form, and the distinction is stated to the reader rather than
 // assumed, because "I denied it and my prompt did not shrink" is the obvious next bug report.
 //
+// HOW EACH CLAIM WAS CHECKED, because a dashboard that guesses a command gets the guess pasted.
+// Every mechanism below was run through a proxy against Claude Code 2.1.241 and the resulting
+// declaration set read back off the wire, rather than inferred from the settings schema:
+//
+//   - a bare name in `permissions.deny` drops the declaration. Denying `mcp__plan__make_plan`
+//     and `WebSearch` left `mcp__plan__review_plan` and `WebFetch` in the array and removed the
+//     two named ones — so the rule works per MCP TOOL, not only per server, and works on a
+//     built-in.
+//   - `skillOverrides: {"<skill>": "off"}` drops a PLAIN skill's listing entry.
+//   - it does NOT drop a PLUGIN skill's entry. `superpowers:systematic-debugging` set to "off"
+//     in the same file as `claude-api` survived while `claude-api` vanished. Worth stating
+//     because the settings schema reads as though it should work (the override map is keyed by
+//     the same name the listing prints), and the honest answer came from the wire.
+//   - `claude mcp remove <server>` removes a hand-added server. Confirmed by the owner directly.
+//
 // Two consequences worth keeping in view:
 //
 //   - `disallowedTools` is NOT a settings.json key. It exists as a CLI flag, an Agent SDK
@@ -148,7 +163,16 @@ func RemovalFor(kind, name, server string) Removal {
 			Effect:       "Hides the skill from the listing, so its entry stops being sent.",
 			Note: "Denying a skill with `Skill(" + name + ")` instead would NOT save anything — a " +
 				"scoped rule blocks the call but leaves the entry in the prompt. Deleting " +
-				"`~/.claude/skills/" + name + "/` also works and is permanent.",
+				"`~/.claude/skills/" + name + "/` also works and is permanent. " +
+				// The middle setting, because on a real listing most of an entry's weight is its
+				// description: measured here, entries run 38-295 tokens and the name is a
+				// handful of them. So there is a large partial saving available to somebody who
+				// wants to keep the skill, and the page offering only all-or-nothing was hiding
+				// the option that most readers actually want.
+				"If you want to KEEP this skill and still stop paying for most of it, set it to " +
+				"\"name-only\" instead of \"off\": that lists the name without the description, " +
+				"which is nearly all of the weight. \"user-invocable-only\" hides it from the " +
+				"model while leaving /" + name + " working for you.",
 		}
 	case name == "EndConversation":
 		// Documented exception: a deny rule cannot remove this one while any other tool

--- a/dash/toolsuggest.go
+++ b/dash/toolsuggest.go
@@ -379,6 +379,32 @@ func excludedFrom(names []string, since int64) []ExcludedDecl {
 	return out
 }
 
+// declFilteredSet turns the account's RAW config removal list into a lookup keyed the way the
+// INVENTORY names things, so an overlap test compares like with like.
+//
+// It exists because the two vocabularies differ and the comparison was being made across them. The
+// config stores `skill__dataviz` and `mcp__plan`; a report row is named `dataviz` with kind skill,
+// or `mcp__plan__make_plan` with server `plan`. So `filtered[row.Name]` never matched a skill and
+// `filtered[row.Server]` never matched a whole MCP server — the overlap exclusion could not fire
+// for either, which made three user-facing statements false: the field's own doc, the
+// `self_removed` waterfall description, and the tile's overlap count.
+//
+// Built from excludedFrom rather than with a second mapping, because that function already knows
+// how a config name becomes a report row and a second copy is how the two drift apart. Taking the
+// raw list also deletes the identical map-building loop from both call sites, so neither can get
+// the shape wrong again.
+func declFilteredSet(removed []string) map[statKey]bool {
+	out := make(map[statKey]bool, len(removed))
+	for _, e := range excludedFrom(removed, 0) {
+		out[statKey{e.Kind, e.Name}] = true
+		if e.Kind == "mcp_server" {
+			// A whole server is matched on the SERVER, since it names no single tool.
+			out[statKey{"mcp_server", e.Server}] = true
+		}
+	}
+	return out
+}
+
 // suggest applies the sufficiency rule to one item. The ONLY place the rule lives.
 func suggest(st ToolStat, w declWindow) (Suggestion, bool) {
 	// Server-side tools (web_search, code_execution, the mcp_toolset connector) are declared

--- a/dash/toolsuggest.go
+++ b/dash/toolsuggest.go
@@ -56,6 +56,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/internal/skills"
 )
 
 // Sufficiency defaults. See the file comment for why these two numbers and not others.
@@ -70,9 +71,11 @@ type Suggestion struct {
 	Kind   string `json:"kind"`
 	Name   string `json:"name"`
 	Server string `json:"server,omitempty"`
-	// RemoveAs is the exact string to put in toolfilter's `remove` list. For an MCP tool
-	// that is its full `mcp__server__tool` name; the whole server is removable as
-	// `mcp__server`, which the servers list offers separately.
+	// RemoveAs is the exact string to put in toolfilter's `remove` list, which is NOT always
+	// Name: an MCP tool goes in as its full `mcp__server__tool` name (the whole server is
+	// `mcp__server`, offered separately by the servers list) and a skill as
+	// `skill__<name>`, because the two are removed by different mechanisms and a bare name
+	// cannot say which is meant. See internal/skills.RemovePrefix.
 	RemoveAs string `json:"remove_as"`
 	// Tokens is what carrying this costs on ONE request.
 	Tokens int `json:"tokens"`
@@ -320,16 +323,18 @@ func (d *DB) ToolFilterDocFor(f Filter, price func(string) (modelinfo.Price, boo
 	if realized.Requests > 0 {
 		out.Realized = realized
 	}
-	// Skills are reported by the inventory but NOT offered here: a skill is declared as
-	// prose inside a transcript message rather than as an element of `tools`, so removing one
-	// means editing the listing itself — and the Skill tool's schema carries no enum, so the
-	// model can still name a skill that is no longer listed. That is a different mechanism
-	// with a different failure mode; see docs/how-to/declaration-removal.md.
+	// Skills ARE offered here now, alongside the tools. They used to be excluded because the
+	// only removal mechanism was the `tools` array and a skill is not in it — that is no longer
+	// true (apply.filterSkillListing cuts the listing entry), and the reason the exclusion gave
+	// for itself turned out to argue the other way: the Skill tool's schema carries no enum, so a
+	// model that names an unlisted skill anyway still RUNS it. That makes over-removing a skill
+	// fail OPEN, where over-removing a tool fails silent. The safer of the two was the one being
+	// withheld. See docs/how-to/declaration-removal.md.
 	excluded := map[statKey]bool{}
 	for _, e := range out.Excluded {
 		excluded[statKey{e.Kind, e.Name}] = true
 	}
-	for _, st := range rep.Tools {
+	for _, st := range append(append([]ToolStat{}, rep.Tools...), rep.Skills.Skills...) {
 		if excluded[statKey{st.Kind, st.Name}] {
 			continue // already opted out: this is a realized saving, not a suggestion
 		}
@@ -355,7 +360,13 @@ func excludedFrom(names []string, since int64) []ExcludedDecl {
 	out := make([]ExcludedDecl, 0, len(names))
 	for _, n := range names {
 		e := ExcludedDecl{Kind: KindTool, Name: n, Since: since}
-		if server, _, ok := SplitMCPName(n); ok {
+		if skill := strings.TrimPrefix(n, skills.RemovePrefix); skill != n {
+			// A skill entry carries the prefix in the CONFIG and not in the report: the page
+			// matches an exclusion against an inventory row by (kind, name), and a row's name is
+			// the skill's own. Reporting the prefixed form here would leave every skill's switch
+			// permanently off-looking-on — the write would land and the checkbox would not move.
+			e.Kind, e.Name = KindSkill, skill
+		} else if server, _, ok := SplitMCPName(n); ok {
 			e.Kind, e.Server = KindMCPTool, server
 		} else if strings.HasPrefix(n, "mcp__") {
 			// The bare `mcp__<server>` form: a whole server, which is its own unit and not a
@@ -372,8 +383,16 @@ func excludedFrom(names []string, since int64) []ExcludedDecl {
 func suggest(st ToolStat, w declWindow) (Suggestion, bool) {
 	// Server-side tools (web_search, code_execution, the mcp_toolset connector) are declared
 	// by a `type` the provider resolves, not by a schema we can drop from the array without
-	// changing what the request IS. Never offered.
-	if st.Kind == KindServerTool || st.Kind == KindSkill || st.Kind == KindSkillListing {
+	// changing what the request IS. Never offered. Nor is the skills LISTING: it is one
+	// indivisible block of prose, and it shrinks by removing the skills inside it.
+	if st.Kind == KindServerTool || st.Kind == KindSkillListing {
+		return Suggestion{}, false
+	}
+	// A built-in is never offered either, and this is the second gate on that rather than the
+	// first: buildToolReport keeps them out of rep.Tools, so nothing reaches here. It stays
+	// because "suggest removing Read" is the single worst thing this API could say, and one
+	// caller's filter is not where that belongs.
+	if IsBuiltinTool(st.Kind, st.Name) {
 		return Suggestion{}, false
 	}
 	// Positive, sufficient observation, and every clause is required.
@@ -383,8 +402,12 @@ func suggest(st ToolStat, w declWindow) (Suggestion, bool) {
 		return Suggestion{}, false
 	}
 	days := span.Hours() / 24
+	removeAs := st.Name
+	if st.Kind == KindSkill {
+		removeAs = skills.RemovePrefix + st.Name
+	}
 	return Suggestion{
-		Kind: st.Kind, Name: st.Name, Server: st.Server, RemoveAs: st.Name,
+		Kind: st.Kind, Name: st.Name, Server: st.Server, RemoveAs: removeAs,
 		Tokens: st.Tokens, Sessions: w.sessions, Days: days, Since: w.first,
 		UnusedReads: st.UnusedReads, ProjectedUSD: st.UnusedUSD, Priced: st.Priced,
 		Basis: fmt.Sprintf("declared but never invoked across %d of your sessions since %s (%.0f days)",
@@ -411,6 +434,36 @@ func (a *API) toolFilterState(tenantID string) ToolFilterState {
 	return a.toolFilterFn(tenantID)
 }
 
+// toolFilterStateForScope resolves the removal configuration for the scope being VIEWED, and
+// refuses — with a reason a reader can act on — when the view spans more than one account.
+//
+// This is the read-side twin of the bug writeToolFilterDoc's comment records, and it shipped
+// unfixed while the write side was patched. A MANAGER's default scope is the whole service, so
+// f.Tenant is "" — and the registry lookup for tenant "" fails, which surfaced as
+// `enabled:false, reason:"could not read your account"`. The effect on the live page: every
+// opt-out switch on the Inventory tab rendered DISABLED for the one role permitted to use them,
+// under a message saying something had gone wrong with their account. Nothing had; the request
+// was ambiguous, and the removal list is a per-account setting with no service-wide meaning.
+//
+// Found by clicking the switch on a real hosted deployment. It is invisible from the tests
+// because every fixture that exercises the control pins a tenant, and invisible from the page
+// because a disabled switch under an explanatory paragraph looks like a deployment that has not
+// enabled the feature.
+func (a *API) toolFilterStateForScope(f Filter) ToolFilterState {
+	if f.TenantAll || f.Tenant == "" {
+		if a.auth == nil {
+			// Single-tenant: TenantAll is the only scope there is, so this is not ambiguity — it
+			// is a deployment with no per-account configuration to write to. Its own answer.
+			return a.toolFilterState("")
+		}
+		return ToolFilterState{Reason: "you are viewing every account's traffic, and a removal " +
+			"list belongs to ONE account — there is no service-wide list to switch. Pick an " +
+			"account (or your own) in the account selector and the switches become live; the " +
+			"analysis below is unaffected either way."}
+	}
+	return a.toolFilterState(f.Tenant)
+}
+
 // ToolFilterDocument builds the removal control document for a request's own scope. Exported
 // because the control plane's write route answers with it too: a switch must repaint from the
 // same document it would have read, and two builders would drift.
@@ -419,7 +472,7 @@ func (a *API) ToolFilterDocument(r *http.Request) (*ToolFilterDoc, error) {
 	if !ok {
 		return nil, errNotPermitted
 	}
-	return a.rec.DB().ToolFilterDocFor(f, a.priceFn(r), a.toolFilterState(f.Tenant))
+	return a.rec.DB().ToolFilterDocFor(f, a.priceFn(r), a.toolFilterStateForScope(f))
 }
 
 // errNotPermitted is returned to a caller that has no scope, so the control plane can tell
@@ -433,7 +486,7 @@ func (a *API) toolFilterDoc(w http.ResponseWriter, r *http.Request) {
 		unauthorized(w)
 		return
 	}
-	doc, err := a.rec.DB().ToolFilterDocFor(f, a.priceFn(r), a.toolFilterState(f.Tenant))
+	doc, err := a.rec.DB().ToolFilterDocFor(f, a.priceFn(r), a.toolFilterStateForScope(f))
 	if err != nil {
 		httpErr(w, http.StatusInternalServerError, "could not read the removal report")
 		return

--- a/dash/toolsuggest_test.go
+++ b/dash/toolsuggest_test.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -222,14 +223,32 @@ func TestRealizedSavingUnpricedIsNotZero(t *testing.T) {
 }
 
 // TestSuggestNeverOffersWhatCannotBeRemoved: a provider-side tool is resolved by its `type`
-// rather than by a schema we can drop, and a skill is prose in a message rather than an
-// element of tools[] — offering either would produce a configuration the filter refuses.
+// rather than by a schema we can drop; the skills LISTING is one indivisible block; and a
+// built-in is Claude Code's own equipment. Offering any of the three would produce either a
+// configuration the filter refuses or the worst advice this API can give.
+//
+// A SKILL is no longer on that list, and that is the point of the change rather than a
+// relaxation of it: apply.filterSkillListing removes a skill's listing entry, so the offer now
+// has a mechanism behind it. The RemoveAs assertion below is what makes the offer usable — the
+// config needs `skill__<name>`, and a suggestion carrying the bare name would write a list entry
+// that matches nothing forever.
 func TestSuggestNeverOffersWhatCannotBeRemoved(t *testing.T) {
 	w := declWindow{sessions: 50, first: day(0), last: day(60)}
-	for _, kind := range []string{KindServerTool, KindSkill, KindSkillListing} {
+	for _, kind := range []string{KindServerTool, KindSkillListing} {
 		if _, ok := suggest(ToolStat{Kind: kind, Name: "x", Tokens: 5000}, w); ok {
 			t.Errorf("%s was offered for removal", kind)
 		}
+	}
+	if _, ok := suggest(ToolStat{Kind: KindTool, Name: "Read", Tokens: 5000}, w); ok {
+		t.Error("a Claude Code built-in was offered for removal")
+	}
+	s, ok := suggest(ToolStat{Kind: KindSkill, Name: "dataviz", Tokens: 5000}, w)
+	if !ok {
+		t.Fatal("an unused skill with ample evidence was not offered")
+	}
+	if s.RemoveAs != "skill__dataviz" {
+		t.Errorf("skill RemoveAs = %q, want skill__dataviz — the bare name matches no mechanism",
+			s.RemoveAs)
 	}
 	if _, ok := suggest(ToolStat{Kind: KindTool, Name: "x", Tokens: 5000}, w); !ok {
 		t.Error("a plain unused tool with ample evidence was not offered")
@@ -306,5 +325,80 @@ func TestAnExcludedItemIsNotAlsoSuggested(t *testing.T) {
 	}
 	if _, bad := suggestionsByName(doc)["Workflow"]; bad {
 		t.Error("an already-excluded declaration was suggested again")
+	}
+}
+
+// TestTheRemovalControlIsLiveForAManagerViewingOneAccount is the read-side twin of the bug
+// writeToolFilterDoc's comment records, which shipped fixed on the write path and broken here.
+//
+// A manager's DEFAULT scope is the whole service, so f.Tenant is "". The state lookup was handed
+// that empty id, the registry had no such account, and the document came back
+// `enabled:false, reason:"could not read your account"` — so every opt-out switch on the
+// Inventory tab rendered DISABLED for the only role permitted to use them, under a message
+// claiming something was wrong with their account. Nothing was: a removal list belongs to one
+// account and the request named none.
+//
+// Both directions are asserted. The service-wide view must refuse with a reason that says what to
+// do, and the one-account view must be LIVE — a fix that disabled it everywhere would satisfy
+// half a test.
+func TestTheRemovalControlIsLiveForAManagerViewingOneAccount(t *testing.T) {
+	api := &API{auth: func(*http.Request) (Principal, bool) {
+		return Principal{TenantID: "boss", Manager: true}, true
+	}}
+	api.SetToolFilterState(func(id string) ToolFilterState {
+		if id == "" {
+			// What a real registry does with an empty id, which is the whole bug.
+			return ToolFilterState{Reason: "could not read your account"}
+		}
+		return ToolFilterState{Enabled: true, Removed: []string{"Workflow"}}
+	})
+
+	// A manager viewing ONE account — their own, or somebody's — gets a live control.
+	for _, f := range []Filter{{Tenant: "boss"}, {Tenant: "someone-else"}} {
+		st := api.toolFilterStateForScope(f)
+		if !st.Enabled {
+			t.Errorf("scope %+v: the control is disabled for a manager viewing one account "+
+				"(reason %q); the switches on the Inventory tab are dead for the only role "+
+				"allowed to use them", f, st.Reason)
+		}
+	}
+
+	// The service-wide view refuses, and the refusal has to be ACTIONABLE rather than a claim
+	// that the account could not be read.
+	st := api.toolFilterStateForScope(Filter{TenantAll: true})
+	if st.Enabled {
+		t.Error("the control is live while viewing every account: a switch there would edit one " +
+			"account's configuration from a page describing all of them")
+	}
+	if strings.Contains(st.Reason, "could not read") {
+		t.Errorf("the service-wide refusal blames the account: %q\n"+
+			"Nothing failed — the request named no account. A reader told their account cannot "+
+			"be read goes looking for a broken account.", st.Reason)
+	}
+	for _, want := range []string{"account"} {
+		if !strings.Contains(st.Reason, want) {
+			t.Errorf("the refusal does not mention %q, so it does not say what to do: %q",
+				want, st.Reason)
+		}
+	}
+	if st.Reason == "" {
+		t.Error("the refusal carries no reason at all, so the page can only guess")
+	}
+}
+
+// Single-tenant is NOT the ambiguous case: TenantAll is the only scope there is, so the answer is
+// the deployment's own ("this proxy has no per-account configuration"), not "pick an account"
+// against a selector that does not exist.
+func TestSingleTenantKeepsItsOwnReason(t *testing.T) {
+	api := &API{} // auth nil == single-tenant
+	st := api.toolFilterStateForScope(Filter{TenantAll: true})
+	if st.Enabled {
+		t.Error("enabled with no configuration hook at all")
+	}
+	if strings.Contains(st.Reason, "account selector") || strings.Contains(st.Reason, "Pick an") {
+		t.Errorf("single-tenant was told to pick an account: %q", st.Reason)
+	}
+	if !strings.Contains(st.Reason, "per-account configuration") {
+		t.Errorf("single-tenant reason = %q, want the deployment's own answer", st.Reason)
 	}
 }

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -785,11 +785,13 @@ const TILE_INFO = {
   'total-saved-usd': {
     what: 'The money context-guru avoided in total, after paying for itself. This is the '
       + 'one number to look at if you only look at one.',
-    how: 'Three savings added together. First, what compaction avoided: what this traffic '
+    how: 'Four savings added together. First, what compaction avoided: what this traffic '
       + 'would have cost had we removed nothing, minus what it actually cost, minus what '
       + "context-guru's own model calls cost. Second, what the prefix-cache split avoided. "
       + 'Third, the idle keep-alive\u2019s NET \u2014 what it avoided minus what its pings cost. '
-      + 'The three touch different tokens, so adding them does not count anything twice.',
+      + 'Fourth, the tool, MCP and skill declarations the removal filter stopped sending, counted '
+      + 'from what the filter itself recorded on each request it acted on. The four touch '
+      + 'different tokens, so adding them does not count anything twice.',
     catch: 'It can be NEGATIVE, and it is shown in red when it is \u2014 that means context-guru '
       + 'spent more on its own model calls than it saved you. Nothing here is hidden when '
       + 'the answer is unflattering. The keep-alive contributes its NET, not its saving: the '
@@ -797,7 +799,10 @@ const TILE_INFO = {
       + 'NOT in the billed-cost line above \u2014 a ping is not traffic your agent produced, so '
       + 'it is excluded from the request count and every average. And the keep-alive\u2019s '
       + 'saving half is a CEILING: the provider\u2019s cache is keyed on content, so another '
-      + 'session sending a byte-identical prompt would have refreshed the same entry for free.',
+      + 'session sending a byte-identical prompt would have refreshed the same entry for free. '
+      + 'What is NOT in here is anything YOU removed by hand \u2014 an MCP server you dropped, a '
+      + 'skill you switched off. That reduction is real and it is not ours, so it has its own '
+      + 'tile and its own total beside this one.',
   },
   // ── Keep-alive tab ────────────────────────────────────────────────────────
   // Every one of these carries the same two disclosures: the saving is a CEILING, and a zero
@@ -1116,6 +1121,52 @@ const TILE_INFO = {
       + 'component configurations it EXCEEDS what the compaction saved — check the '
       + "Components tab, which shows each component's net separately.",
   },
+  'total-reduced-usd': {
+    what: 'How much smaller this bill got in total \u2014 what context-guru avoided PLUS what you '
+      + 'removed yourself.',
+    how: '"Total dollars avoided" plus the declarations this account stopped carrying on its own: '
+      + 'an MCP server you removed, a skill you switched off. Those tokens genuinely stopped being '
+      + 'billed.',
+    catch: 'The two totals are separate on purpose. This one answers "how much smaller did my '
+      + 'bill get"; the other answers "how much of that did context-guru do". Rolling your own '
+      + 'work into the figure this product claims for itself would be taking credit for it. The '
+      + 'half that is yours is also MODELLED rather than measured \u2014 see the "Removed by you" '
+      + 'tile for exactly how, and when it is wrong.',
+  },
+  'decl-filter-saved': {
+    what: 'Money not spent because the removal filter stopped sending tool schemas, MCP tool '
+      + 'schemas and skill listing entries you opted out of.',
+    how: 'The filter records, on every request it acts on, how many declaration tokens it '
+      + 'dropped. Those are summed and priced at the tier that request actually paid \u2014 the '
+      + 'cache-read rate on a warm turn, the cache-creation rate on the turn that wrote the '
+      + 'prefix, the full input rate on a turn with no cache. Measured on requests that were '
+      + 'really sent; nothing here is a projection.',
+    catch: 'This is a saving of ours that appeared in NO total on this page until recently, and '
+      + 'the reason was mechanical rather than a decision: the whole savings walk is built on our '
+      + 'own token count of the MESSAGES, and a tool declaration is not in the messages \u2014 it '
+      + 'is a top-level field. So the largest lever measured in this project (82.7% of a declared '
+      + 'catalogue is never invoked) moved none of the figures beside it. Turning the filter on '
+      + 'also costs one cache miss per session in flight, once, because the declarations sit at '
+      + 'the front of the cached prompt; that charge is inside the billed cost and is not '
+      + 'subtracted from this figure.',
+  },
+  'self-removed': {
+    what: 'Declarations YOU stopped carrying \u2014 an MCP server removed with `claude mcp '
+      + 'remove`, a skill switched off. Real money, and not ours.',
+    how: 'The inventory is a time series. A name present in the early sessions of this window and '
+      + 'absent from the later ones stopped being declared, and its weight times the requests of '
+      + 'the sessions that followed is what carrying it would have cost. Only COMPARABLE later '
+      + 'sessions count \u2014 one that declared no MCP tool at all cannot testify about a missing '
+      + 'MCP tool \u2014 and fewer than three of them is not reported at all.',
+    catch: 'MODELLED, not measured, and the difference matters. The method sees that the '
+      + 'declaration set changed; it cannot see WHY. On this deployment\u2019s own history the '
+      + 'largest candidate was the editor integration, which is declared only when a session runs '
+      + 'inside the IDE \u2014 so "you removed it" and "you worked in a terminal that day" look '
+      + 'identical here, and no threshold separates them. The reduction is real either way; the '
+      + 'attribution is a guess. That is why this is outside "Total dollars avoided" and inside '
+      + '"Total the bill came down". Anything the removal filter is already credited for is '
+      + 'excluded rather than counted twice, and the count of exclusions is on the tile.',
+  },
   'cachesplit-saved': {
     what: 'Money saved by splitting the prompt so that the stable part stays cached when '
       + 'the volatile part changes.',
@@ -1343,8 +1394,18 @@ function renderTiles(o) {
     // NOT in here — it was, under the label "compaction + provider cache", and a headline
     // number that mostly measures somebody else's mechanism is not a headline number.
     tile('total-saved-usd', 'Total dollars avoided', costKnown ? usd(o.total_saved_usd) : 'unknown',
-      'compaction + prefix cache + keep-alive',
+      'compaction + prefix cache + keep-alive + declarations dropped',
       costKnown ? (o.total_saved_usd < 0 ? 'bad' : 'good') : ''),
+    // The second total, beside the first and only when they differ. It is the SAME money plus
+    // what the account removed itself — an MCP server they dropped, a skill they switched off.
+    // Two tiles rather than one because they answer different questions ("how much smaller did
+    // my bill get" against "how much of that did this product do") and folding the user's own
+    // work into the figure we claim credit for would be taking it.
+    costKnown && Math.abs(o.total_reduced_usd - o.total_saved_usd) > 0.00005
+      ? tile('total-reduced-usd', 'Total the bill came down', usd(o.total_reduced_usd),
+        'ours + ' + usd(o.self_removed_usd) + ' you removed yourself',
+        o.total_reduced_usd < 0 ? 'bad' : 'good')
+      : null,
     tile('saved-usd', 'Net dollars saved', costKnown ? usd(o.net_saved_usd) : 'unknown',
       'baseline − actual − our spend', costKnown ? (o.net_saved_usd < 0 ? 'bad' : 'good') : ''),
     tile('saved-unique', 'Tokens saved (unique)', compact(o.saved_unique),
@@ -1467,6 +1528,27 @@ function renderTiles(o) {
     // saving alone would be exactly the half-truth this ledger exists to prevent.
     (o.keepalive_pings || o.keepalive_saved_usd)
       ? kaOverviewTile(o, costKnown)
+      : null,
+    // Declarations no longer sent, MEASURED half. It is a saving of ours that reached no total on
+    // this page until now, and the reason was mechanical rather than a judgement: the savings walk
+    // is built on tokens_before, which counts message text only, and a tool schema lives in the
+    // top-level `tools` array. So the largest lever in the product — 82.7% of a declared catalogue
+    // is never invoked — moved none of the figures beside it.
+    o.decl_filter_requests
+      ? tile('decl-filter-saved', 'Declarations not sent',
+        o.decl_credit_priced ? usd(o.decl_filter_usd) : compact(o.decl_filter_reads) + ' tok',
+        num(o.decl_filter_requests) + ' requests sent without them',
+        o.decl_filter_usd > 0 ? 'good' : '')
+      : null,
+    // And the MODELLED half, in its own tile, labelled as the user's rather than ours. It is in
+    // total_reduced above and not in total_saved.
+    o.self_removed_items
+      ? tile('self-removed', 'Removed by you, not by us',
+        o.decl_credit_priced ? usd(o.self_removed_usd) : compact(o.self_removed_reads) + ' tok',
+        num(o.self_removed_items) + ' item' + (o.self_removed_items === 1 ? '' : 's')
+          + ' · modelled, see Inventory'
+          + (o.self_removed_overlap ? ' · ' + num(o.self_removed_overlap) + ' excluded as overlap' : ''),
+        'accent')
       : null,
   ]));
 

--- a/dash/ui/tools.css
+++ b/dash/ui/tools.css
@@ -189,3 +189,15 @@
 details.why > .inv-prompt-regions { max-width: none; }
 /* The prose inside it keeps a readable measure; only the region LIST goes full width. */
 .inv-prompt-regions > p { max-width: 78ch; }
+
+/* ── the system prompt's parts ────────────────────────────────────────────── */
+/* Indented by heading level, so a `##` reads as living inside the `#` above it rather than as a
+   sibling. Three levels is all splitSystemPrompt produces (0 for the preamble, 1 and 2). */
+.inv-parts { margin: 0.5rem 0 0.25rem; }
+.inv-part { border-left: 2px solid var(--border-soft); padding-left: 0.6rem; margin: 0.2rem 0; }
+.inv-part-l2 { margin-left: 1.1rem; }
+.inv-part > summary { cursor: pointer; display: flex; gap: 0.6rem; align-items: baseline; }
+.inv-part-name { font-weight: 600; }
+/* The per-row removal fold sits in a table cell, so it must not stretch the row. */
+.inv-removal-fold > summary { white-space: nowrap; }
+.inv-removal-fold .inv-removal { min-width: 22rem; }

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -63,6 +63,10 @@ const tools = {
   // with the reason rather than vanishing — a control that disappears looks like a page
   // that has no opinion.
   control: null,
+  // controlDoc is the same document even when it is NOT usable, kept for its `reason`. A control
+  // that vanishes with no explanation is a page with no opinion; the reason is the whole
+  // difference between "this proxy cannot do it" and "pick an account first".
+  controlDoc: null,
   sort: 'unused_reads',
   dir: 'desc',
   busy: '',
@@ -303,11 +307,12 @@ function renderHeadline(host, rep) {
     return;
   }
   const used = Math.max(0, t.declared_tokens - t.unused_tokens);
-  host.appendChild(tileGroup('What you carry, and what you use',
+  host.appendChild(tileGroup('What you carry that you can change, and what you use',
     'per session, averaged over the ' + num(c.captured) + ' session'
-    + (c.captured === 1 ? '' : 's') + ' whose inventory was captured', [
+    + (c.captured === 1 ? '' : 's') + ' whose inventory was captured — MCP tools and skills only, '
+    + 'which are the things you can actually turn off', [
     tile('inv-declared', 'Declared per session', num(t.declared_tokens),
-      'tool schemas, MCP tools and the skills listing'),
+      'your MCP tool schemas and the skills listing'),
     tile('inv-used', 'Invoked at least once', num(used),
       pct(100 - t.unused_pct) + ' of what you declare', used ? 'good' : ''),
     // The number this page exists for. Deliberately the only 'bad' tile: three red tiles
@@ -334,6 +339,18 @@ function renderHeadline(host, rep) {
       t.priced ? 'if none of it had been carried' : 'no dollar: some models here are unpriced'),
   ], 'headline'));
   host.appendChild(gauge(t));
+  // What these tiles LEFT OUT, and how big it is. Without this line the reader meets a
+  // composition bar further down that is several times larger than the headline and has to work
+  // out for themselves which of the two is lying. Neither is; they answer different questions.
+  if (t.aside_tokens) {
+    host.appendChild(el('p', { class: 'hint', 'data-testid': 'inv-aside-note' },
+      'A further ' + num(t.aside_tokens) + ' tokens per session are Claude Code\'s own tools and '
+      + 'the provider\'s. They are NOT in the four figures above, on purpose: removing one does '
+      + 'not slim your agent, it takes away equipment the model is expected to have, so counting '
+      + 'them as waste would make the headline a number whose only action breaks things. They are '
+      + 'in the composition bar below, which shows the whole prompt, and listed in full in their '
+      + 'own section at the end of this page.'));
+  }
 }
 
 /**
@@ -354,10 +371,11 @@ function gauge(t) {
   // averaged over instead of only its unit.
   const box = el('div', { class: 'panel cg-gauge', 'data-testid': 'inv-gauge' },
     el('div', { class: 'cg-gauge-head' },
-      el('h2', {}, 'What every request carries before you type anything'),
+      el('h2', {}, 'What every request carries that you could stop carrying'),
       el('span', { class: 'section-note', text: num(t.declared_tokens)
-        + ' tokens of tool and skill declarations, per request, averaged over the sessions '
-        + 'whose inventory was captured' })),
+        + ' tokens of YOUR MCP tool and skill declarations, per request, averaged over the '
+        + 'sessions whose inventory was captured — the agent\'s own tools are excluded and are '
+        + 'shown separately' })),
     el('div', { class: 'cg-gauge-track' },
       el('span', {
         class: 'cg-seg cg-used', style: 'width:' + (100 - unusedPct).toFixed(2) + '%',
@@ -522,11 +540,16 @@ function renderUnused(host, rep) {
   }
   panel.appendChild(reversibilityNote());
   if (!tools.control) {
-    // Graceful degradation, stated. The analysis and the COMMANDS are the whole value and
-    // stand on their own; only the one-click switch is missing.
+    // Graceful degradation, stated — and stated with the SERVER's reason where there is one.
+    // The generic sentence was wrong on the commonest hosted case: a manager's default view
+    // spans every account, a removal list belongs to one, and the honest answer is "pick an
+    // account", not "this proxy cannot do it".
+    const why = (tools.controlDoc && tools.controlDoc.reason) || '';
     panel.appendChild(el('div', { class: 'state', 'data-testid': 'inv-control-absent' },
       el('div', { class: 'state-body' },
-        el('strong', {}, 'One-click opt-out is not enabled on this proxy'),
+        el('strong', {}, why ? 'The one-click switches are not live in this view'
+          : 'One-click opt-out is not enabled on this proxy'),
+        why ? el('span', {}, why) : null,
         el('span', {}, 'It changes nothing about the list below. Every group carries the '
           + 'command that removes it from your own configuration, which is the more direct '
           + 'fix anyway — it stops the declaration at the source rather than filtering it '
@@ -629,8 +652,19 @@ const EXPANDED_GROUPS = 8;
  */
 function removalGroup(g, rep) {
   const many = g.items.length > 1;
+  // The group-level switch, for the group whose MECHANISM is group-wide: an MCP server. It posts
+  // one `mcp_server` exclusion, which is the same unit `claude mcp remove <server>` beside it
+  // takes and the same unit the config stores as `mcp__<server>`.
+  //
+  // It exists because the page grouped by "what one action removes" and then offered a switch per
+  // TOOL only: a reader who had decided to drop a nineteen-tool server had to tick nineteen
+  // boxes, each one a separate write, each one its own prefix rebuild — which is the one thing
+  // the reversibility note tells them not to do.
+  const srv = many && g.sub === 'MCP server'
+    ? { kind: 'mcp_server', name: '', server: g.label, tokens: g.tokens } : null;
   const head = el('div', { class: 'inv-group-head' },
     el('div', { class: 'inv-group-id' },
+      srv ? excludeToggle(srv) : null,
       el('span', { class: 'inv-group-name comp-name', text: g.label }),
       g.sub ? el('span', { class: 'pill neutral', text: g.sub }) : kindPill(g.items[0]),
       many ? el('span', { class: 'section-note', text: num(g.items.length) + ' declarations' }) : null),
@@ -683,17 +717,24 @@ function soloRowExtras(t, rep) {
 }
 
 /**
- * unusedRow is one candidate, its evidence, and its switch.
+ * unusedRow is one candidate, its evidence, its switch, and the command that removes it AT SOURCE.
  *
  * The checkbox and the name are inside a <label> and NOTHING ELSE IS. A copy button inside a
  * label is a button that toggles the checkbox when you click it, which is how an affordance
- * added for convenience becomes a change nobody meant to make.
+ * added for convenience becomes a change nobody meant to make. There were two copies of this
+ * function in this file; the older one wrapped the whole row in the label, and being second it
+ * won — so the reveal and the command below were unreachable code for as long as both existed.
+ *
+ * EVERY row carries its own command, not just the group head. A group of one already showed it,
+ * and a group of many showed the SERVER-level command once at the top — which is right for "get
+ * rid of this whole MCP server" and no answer at all to "get rid of just this one tool", the
+ * question a reader with a nineteen-tool server actually has. The server command remains at the
+ * group head; this is the per-item one beside it.
  */
 function unusedRow(t, rep) {
   const c = rep.coverage;
   const key = t.kind + '/' + t.name;
-  const off = !!(tools.control && tools.control.excluded
-    && tools.control.excluded.some((e) => e.kind === t.kind && e.name === t.name));
+  const off = isExcluded(t);
   // Only a provider-side tool is inert AS A ROW: it can never be dropped here, whatever this
   // proxy supports. A missing endpoint disables every switch, but that is one fact about the
   // page, stated once by renderUnused — repeating it under forty rows buries the evidence
@@ -703,14 +744,7 @@ function unusedRow(t, rep) {
     class: 'cg-item' + (off ? ' cg-off' : '') + (fixed ? ' cg-fixed' : ''),
     'data-testid': 'inv-item-' + key,
   });
-  const cb = el('input', {
-    type: 'checkbox', 'data-testid': 'inv-toggle-' + key,
-    id: 'inv-cb-' + key,
-    disabled: fixed || !tools.control || tools.busy === key,
-    checked: off ? 'checked' : null,
-    onchange: (ev) => toggleExcluded(t, ev.currentTarget.checked),
-  });
-  box.appendChild(cb);
+  box.appendChild(excludeToggle(t));
   box.appendChild(el('label', { class: 'cg-item-main', for: 'inv-cb-' + key },
     el('span', { class: 'cg-item-name comp-name', text: t.name }),
     kindPill(t),
@@ -732,7 +766,34 @@ function unusedRow(t, rep) {
       + 'restore it; that pays the one-time prefix rebuild again.' }));
   }
   box.appendChild(promptTextReveal(t));
+  // The per-item removal, folded: the group head already carries the one-command answer, so
+  // forty open copy-boxes under it would bury the evidence sentence that is the point of the row.
+  // Folded is not hidden — the summary names the item and the mechanism.
+  box.appendChild(removalDetails(t, 'Remove just ' + t.name + ' from your own setup'));
   return box;
+}
+
+/**
+ * removalDetails is removalCell behind a disclosure, for the places that show one row per item.
+ *
+ * The tables and the member lists have one of these per row, and removalCell renders two
+ * copy-boxes and a note — open, that is a page of snippets where a table was. The summary states
+ * the item, so a reader scanning for "how do I get rid of THIS one" does not have to open every
+ * row to find out which is which.
+ */
+function removalDetails(t, summary) {
+  const det = el('details', { class: 'why inv-removal-fold',
+    'data-testid': 'inv-removal-' + t.kind + '/' + t.name },
+  el('summary', {}, summary));
+  // Built lazily: removalCell is cheap, but forty of them per table times four tables is DOM
+  // nobody has looked at yet, and the copy buttons register listeners.
+  let built = false;
+  det.addEventListener('toggle', () => {
+    if (!det.open || built) return;
+    built = true;
+    det.appendChild(removalCell(t));
+  });
+  return det;
 }
 
 /**
@@ -759,51 +820,6 @@ function reversibilityNote() {
       + 'switch off in one pass, and why toggling an item back and forth pays it every time.'),
     el('p', {}, 'Sessions already running keep whatever they declared at their first turn. The '
       + 'change lands on the next new session, and on the next prefix rebuild of the old ones.'));
-}
-
-/** unusedRow is one candidate, its evidence, and its switch. */
-function unusedRow(t, rep) {
-  const c = rep.coverage;
-  const key = t.kind + '/' + t.name;
-  const off = !!(tools.control && tools.control.excluded
-    && tools.control.excluded.some((e) => e.kind === t.kind && e.name === t.name));
-  // A provider-side tool is declared by the API, not by the client, so there is nothing
-  // here to stop sending. Saying so beats a switch that silently does nothing.
-  // Only a provider-side tool is inert AS A ROW: it can never be dropped here, whatever
-  // this proxy supports. A missing endpoint disables every switch, but that is one fact
-  // about the page, stated once by renderUnused — repeating it under all forty rows buries
-  // the evidence sentence that is the point of the row.
-  const fixed = t.kind === 'server_tool';
-  const why = fixed ? 'Provider-side tool. It is part of the API request the agent builds, not '
-    + 'something this proxy declares, so it cannot be dropped here.' : '';
-  const box = el('label', {
-    class: 'cg-item' + (off ? ' cg-off' : '') + (fixed ? ' cg-fixed' : ''),
-    'data-testid': 'inv-item-' + key,
-  });
-  const cb = el('input', {
-    type: 'checkbox', 'data-testid': 'inv-toggle-' + key,
-    disabled: fixed || !tools.control || tools.busy === key,
-    checked: off ? 'checked' : null,
-    onchange: (ev) => toggleExcluded(t, ev.currentTarget.checked),
-  });
-  box.appendChild(cb);
-  box.appendChild(el('span', { class: 'cg-item-main' },
-    el('span', { class: 'cg-item-name comp-name', text: t.name }),
-    kindPill(t),
-    t.server ? el('span', { class: 'cg-item-srv', text: t.server }) : null,
-    el('span', { class: 'cg-item-weight' },
-      num(t.tokens) + ' tok/request · ' + compact(t.unused_reads) + ' read for nothing · '),
-    el('span', { class: 'cg-item-usd' }, money(t.unused_usd, t.priced))));
-  // The basis. One sentence, always present, always naming the denominator and the window.
-  box.appendChild(el('span', { class: 'cg-item-basis', 'data-testid': 'inv-basis-' + key },
-    'Unused across ' + num(t.sessions_declared) + ' of your ' + num(c.captured)
-    + ' captured session' + (c.captured === 1 ? '' : 's') + ' — ' + rangeLabel() + '.'));
-  if (why) box.appendChild(el('span', { class: 'comp-warn', text: why }));
-  if (off) {
-    box.appendChild(el('span', { class: 'cg-item-basis', text: 'Opted out. Switch back on to '
-      + 'restore it; that pays the one-time prefix rebuild again.' }));
-  }
-  return box;
 }
 
 /**
@@ -840,7 +856,7 @@ function renderRealized(host) {
 
 /** toggleExcluded posts one change and repaints from the server's answer, not from the DOM. */
 async function toggleExcluded(t, on) {
-  const key = t.kind + '/' + t.name;
+  const key = t.kind + '/' + (t.name || t.server || '');
   tools.busy = key;
   try {
     const res = await fetch('/api/toolfilter', {
@@ -892,32 +908,35 @@ function tsortable(table, keys, onSort) {
  */
 function toolTable(host, rep) {
   const panel = el('div', { class: 'panel' },
-    el('h2', {}, 'Every declaration, by weight'),
-    el('p', { class: 'note' }, 'Everything you added, sorted by what it cost to carry unused. '
+    el('h2', {}, 'Every declaration you control, by weight'),
+    el('p', { class: 'note' }, 'Your MCP tools, sorted by what it cost to carry them unused. '
       + '"Read for nothing" is this item\'s size times the requests that re-read it in the '
-      + "sessions that never called it. Claude Code's own tools are in their own section at "
-      + 'the end of this page.'));
+      + "sessions that never called it. Claude Code's own tools and the provider's are in their "
+      + 'own section at the end of this page, and in none of the figures above. Skills have their '
+      + 'own table below, because a skills listing can be unreadable in a way a tools array '
+      + 'cannot.'));
   const table = el('table', { class: 'tbl', 'data-testid': 'inv-tools-table' },
     el('thead', {}, el('tr', {},
       el('th', {}, 'Name'), el('th', {}, 'Kind'),
       el('th', { class: 'num' }, 'Tokens'), el('th', { class: 'num' }, 'Sessions'),
       el('th', { class: 'num' }, 'Used in'), el('th', { class: 'num' }, 'Calls'),
-      el('th', { class: 'num' }, 'Read for nothing'), el('th', { class: 'num' }, 'Cost of that'))));
+      el('th', { class: 'num' }, 'Read for nothing'), el('th', { class: 'num' }, 'Cost of that'),
+      el('th', {}, 'How to remove it'))));
   const body = el('tbody');
   table.appendChild(body);
   panel.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
   host.appendChild(panel);
   tsortable(table, TOOL_COLS, () => renderTools());
-  const listed = rep.tools.filter((x) => !x.builtin && x.kind !== 'server_tool');
-  if (!listed.length) {
-    tableMessage(body, 8, 'No declarations captured',
-      'Nothing in this scope recorded what it declared.');
+  // The server already excluded the built-ins and the provider's tools from rep.tools — they are
+  // in rep.aside, out of every total. No filter here: a second copy of that rule in the client
+  // is a second place for it to drift, and the drift is invisible because both look plausible.
+  if (!rep.tools.length) {
+    tableMessage(body, 9, 'No MCP tools captured',
+      'No session in this scope declared an MCP tool. Anything else it declared is in the '
+      + 'skills table below, or in the agent\'s own section at the end.');
     return;
   }
-  // Same exclusion as the actionable list: the agent's own tools have their own section at
-  // the end of the page, so this table is the things a reader can actually decide about.
-  for (const t of sortRows(rep.tools.filter((x) => !x.builtin && x.kind !== 'server_tool'),
-    tools.sort, tools.dir)) {
+  for (const t of sortRows(rep.tools, tools.sort, tools.dir)) {
     body.appendChild(el('tr', { class: t.sessions_used ? '' : 'cg-row-unused' },
       el('td', {}, el('span', { class: 'comp-name trunc', title: t.name, text: t.name })),
       el('td', {}, kindPill(t), t.server ? el('span', { class: 'cg-item-srv', text: t.server }) : null),
@@ -926,7 +945,10 @@ function toolTable(host, rep) {
         ? num(t.sessions_used)
         : el('span', { class: 'pill missing' }, 'never')),
       numTd(t.calls), readTd(t.unused_reads),
-      el('td', { class: 'num' }, money(t.unused_usd, t.priced))));
+      el('td', { class: 'num' }, money(t.unused_usd, t.priced)),
+      // Every row, used or not. The actionable list above covers the never-invoked ones; a reader
+      // who wants rid of something they DO use occasionally had nowhere to find the command.
+      el('td', {}, removalDetails(t, 'Command'))));
   }
 }
 
@@ -1016,22 +1038,72 @@ function skillsPanel(host, rep) {
   if (!(s.skills || []).length) return;
   const table = el('table', { class: 'tbl compact', 'data-testid': 'inv-skills-table' },
     el('thead', {}, el('tr', {},
-      el('th', {}, 'Skill'), el('th', { class: 'num' }, 'Tokens'),
+      el('th', {}, 'Off'), el('th', {}, 'Skill'), el('th', { class: 'num' }, 'Tokens'),
       el('th', { class: 'num' }, 'Sessions'), el('th', { class: 'num' }, 'Used in'),
       el('th', { class: 'num' }, 'Calls'), el('th', { class: 'num' }, 'Read for nothing'),
-      el('th', { class: 'num' }, 'Cost of that'))));
+      el('th', { class: 'num' }, 'Cost of that'), el('th', {}, 'How to remove it'))));
   const body = el('tbody');
   table.appendChild(body);
   for (const t of s.skills) {
     body.appendChild(el('tr', { class: t.sessions_used ? '' : 'cg-row-unused' },
+      // The switch, on EVERY skill and not only the never-invoked ones. A skill the reader used
+      // once and does not want to keep paying for is exactly the case the actionable list above
+      // cannot reach, and editing a config file by hand was the only route to it.
+      el('td', {}, excludeToggle(t)),
       el('td', {}, el('span', { class: 'comp-name trunc', title: t.name, text: t.name })),
       numTd(t.tokens), numTd(t.sessions_declared),
       el('td', { class: 'num' }, t.sessions_used
         ? num(t.sessions_used) : el('span', { class: 'pill missing' }, 'never')),
       numTd(t.calls), readTd(t.unused_reads),
-      el('td', { class: 'num' }, money(t.unused_usd, t.priced))));
+      el('td', { class: 'num' }, money(t.unused_usd, t.priced)),
+      el('td', {}, removalDetails(t, 'Command'))));
   }
   panel.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
+  panel.appendChild(el('p', { class: 'hint' }, 'Switching a skill off here stops context-guru '
+    + 'sending its entry in the listing, from your next session. It does not edit your own '
+    + 'configuration — the command beside each row does that, permanently and at source. One '
+    + 'caveat worth knowing: the Skill tool takes a free-form name, so a model that remembers an '
+    + 'unlisted skill can still run it. That is deliberate — it fails open — but it means this is '
+    + 'a way to stop PAYING for a skill, not a way to forbid it.'));
+}
+
+/**
+ * excludeToggle is the one-click opt-out, extracted so a table row and a card row share it.
+ *
+ * There were two copies of this checkbox and they had already diverged once (one had the id/for
+ * pairing, the other wrapped the whole row in a label). Now there is one, and the two call sites
+ * differ only in what they put beside it.
+ */
+function excludeToggle(t) {
+  const key = t.kind + '/' + (t.name || t.server || '');
+  const off = isExcluded(t);
+  const fixed = t.kind === 'server_tool' || t.builtin;
+  const cb = el('input', {
+    type: 'checkbox', 'data-testid': 'inv-toggle-' + key, id: 'inv-cb-' + key,
+    title: fixed ? 'This one is not yours to drop from here.'
+      : (tools.control ? 'Stop sending this declaration' : 'One-click opt-out is not enabled on '
+        + 'this proxy — use the command beside this row'),
+    disabled: fixed || !tools.control || tools.busy === key,
+    checked: off ? 'checked' : null,
+    onchange: (ev) => toggleExcluded(t, ev.currentTarget.checked),
+  });
+  return cb;
+}
+
+/**
+ * isExcluded matches a row against the account's removal list. One definition, three callers.
+ *
+ * An MCP SERVER is matched on its server name rather than on `name`: the config stores it as the
+ * bare `mcp__<server>` form and excludedFrom reports that back with kind `mcp_server` and an empty
+ * tool name, so a name comparison would never match and the switch would spring back off after a
+ * write that had landed.
+ */
+function isExcluded(t) {
+  const list = (tools.control && tools.control.excluded) || [];
+  if (t.kind === 'mcp_server') {
+    return list.some((e) => e.kind === 'mcp_server' && e.server === t.server);
+  }
+  return list.some((e) => e.kind === t.kind && e.name === t.name);
 }
 
 /**
@@ -1056,12 +1128,18 @@ function skillsPanel(host, rep) {
  * not answering.
  */
 function renderComposition(host, rep) {
-  const all = (rep.tools || []).concat(rep.skills.skills || []);
-  const sum = (f) => all.filter(f).reduce((n, t) => n + t.tokens, 0);
-  const mcp = sum((t) => t.kind === 'mcp_tool');
-  const provider = sum((t) => t.kind === 'server_tool');
-  const builtin = sum((t) => t.builtin);
-  const client = sum((t) => t.kind === 'tool' && !t.builtin);
+  // Two sources, because the report keeps two lists: rep.tools/rep.skills is what the reader
+  // controls, rep.aside is what they do not. This panel is the ONE place both are counted — its
+  // job is the whole prompt, and a composition that omitted the largest group would be a
+  // composition of nothing.
+  const mine = (rep.tools || []).concat(rep.skills.skills || []);
+  const aside = rep.aside || [];
+  const sum = (rows, f) => rows.filter(f).reduce((n, t) => n + t.tokens, 0);
+  const all = mine.concat(aside);
+  const mcp = sum(mine, (t) => t.kind === 'mcp_tool');
+  const provider = sum(aside, (t) => t.kind === 'server_tool');
+  const builtin = sum(aside, (t) => t.builtin);
+  const client = sum(mine, (t) => t.kind === 'tool' && !t.builtin);
   // Skills contribute their LISTING and nothing else. Each skill row's token weight is the
   // weight of its own ENTRY IN that listing — a sub-slice of the same block — so adding the
   // rows to the listing counts every skill twice. It did: the segments summed to 43,933 while
@@ -1107,7 +1185,7 @@ function renderComposition(host, rep) {
 
   // The per-item detail: ONE measure across many long-named categories, so ONE hue. Twelve
   // colours here would assert that twelve different things are being plotted.
-  const top = all.filter((t) => t.tokens > 0 && !t.builtin)
+  const top = mine.filter((t) => t.tokens > 0)
     .sort((a, b) => b.tokens - a.tokens).slice(0, 12);
   if (top.length) {
     panel.appendChild(el('h3', {}, 'The heaviest removable declarations'));
@@ -1120,8 +1198,9 @@ function renderComposition(host, rep) {
         + num(t.sessions_declared) + ' session' + (t.sessions_declared === 1 ? '' : 's')),
     })));
     panel.appendChild(el('p', { class: 'hint' }, 'Share is of the ' + num(declared)
-      + ' tokens of DECLARATIONS, not of the whole prefix above — the system prompt is not a '
-      + 'declaration and is not in that denominator.'));
+      + ' tokens of DECLARATIONS — every one of them, the agent\'s own tools included, so a '
+      + 'share here is a share of the real array. It is NOT of the whole prefix above: the '
+      + 'system prompt is not a declaration and is not in that denominator.'));
   }
 }
 
@@ -1221,7 +1300,8 @@ function renderRemovalValue(host, rep) {
   panel.appendChild(el('p', { class: 'hint' },
     'To value one item, multiply by its token weight ÷ 1,000. The heaviest removable '
     + 'declaration in this scope is '
-    + num(Math.max(0, ...((rep.tools || []).filter((t) => !t.builtin).map((t) => t.tokens))))
+    + num(Math.max(0, ...(rep.tools || []).concat(rep.skills.skills || [])
+      .map((t) => t.tokens)))
     + ' tokens.'));
 }
 
@@ -1236,7 +1316,11 @@ function renderRemovalValue(host, rep) {
  * to be made hard to act on in the same breath.
  */
 function renderBuiltins(host, rep) {
-  const rows = (rep.tools || []).filter((t) => t.builtin || t.kind === 'server_tool');
+  // rep.aside, not a filter over rep.tools: the server decides this split, because it is the same
+  // decision that keeps these rows out of every total. A client-side filter would be a second
+  // copy of the rule, and a page whose table and whose headline disagreed about which group a row
+  // was in would look right in both places.
+  const rows = rep.aside || [];
   if (!rows.length) return;
   const tok = rows.reduce((n, t) => n + t.tokens, 0);
   // The warning belongs on the CLOSED bar. It used to live only inside the expanded panel, so
@@ -1244,24 +1328,33 @@ function renderBuiltins(host, rep) {
   // indistinguishable from the collapsed detail panels elsewhere on the page, and reading as
   // "more of the same, but folded away" rather than as "this is the one section that is not a
   // saving". A danger that is only visible after you have opened the door is decoration.
+  const share = pct(100 * tok / Math.max(1, rep.totals.declared_set_tokens), 0);
+  const builtins = rows.filter((t) => t.builtin).length;
+  const provider = rows.filter((t) => t.kind === 'server_tool').length;
   const det = el('details', { class: 'panel inv-builtins', 'data-testid': 'inv-builtins' },
     el('summary', {},
       el('span', { class: 'pill bad' }, 'not a saving'),
       el('span', { class: 'inv-builtins-title' }, "The agent's own tools — " + num(rows.length)
-        + ' items, ' + num(tok) + ' tokens, ' + pct(100 * tok
-        / Math.max(1, rep.totals.declared_set_tokens), 0) + ' of what you declare'),
+        + ' items, ' + num(tok) + ' tokens, ' + share + ' of what you declare'),
       el('span', { class: 'section-note' },
         'removing any of these breaks the agent — expand only if you know why you are here')));
   det.appendChild(el('div', { class: 'state blocked', 'data-testid': 'inv-builtins-danger' },
     el('div', { class: 'state-body' },
       el('strong', {}, 'Removing any of these will break the agent'),
-      el('span', {}, 'These are Claude Code\'s own tools and the provider\'s. They are '
-        + 'not unused capacity you are wasting money on — they are the equipment the model is '
-        + 'expected to have, and a session missing one does not degrade gracefully: anything '
-        + 'that needed it simply fails.'),
-      el('span', {}, 'They are listed because they are ' + pct(100 * tok
-        / Math.max(1, rep.totals.declared_set_tokens), 0) + ' of what you carry and pretending '
-        + 'otherwise would be dishonest. Acting on that number is almost always the wrong call.'),
+      el('span', {}, 'These are Claude Code\'s own tools' + (provider
+        ? ' (' + num(builtins) + ') and the provider\'s (' + num(provider) + ')' : '')
+        + '. They are not unused capacity you are wasting money on — they are the equipment the '
+        + 'model is expected to have, and a session missing one does not degrade gracefully: '
+        + 'anything that needed it simply fails.'),
+      // The reason they are down here AND out of the numbers, stated where a reader who scrolled
+      // this far will meet it. Without this the page looks like it is hiding its biggest group.
+      el('span', {}, 'They are ' + share + ' of everything you declare, and they are in NONE of '
+        + 'the figures above — not the headline, not the bar, not the totals, not the tables. '
+        + 'That is deliberate: a "you never touch 82% of what you carry" assembled mostly out of '
+        + 'Read, Bash and Grep is a true number and useless advice, because the only action it '
+        + 'suggests is one that breaks your agent. The composition bar near the top of the page '
+        + 'is the one place they are counted, because that bar\'s job is to show the whole '
+        + 'prompt.'),
       el('span', {}, 'A low "never invoked" count here is normal and is NOT a reason to remove '
         + 'one: a tool that goes uncalled for fifty sessions is doing its job by being '
         + 'available on the fifty-first.'))));
@@ -1279,7 +1372,12 @@ function renderBuiltins(host, rep) {
       el('td', { class: 'num', text: pct(t.share_pct, 1) }),
       el('td', { class: 'num' }, t.sessions_used
         ? num(t.sessions_used) : el('span', { class: 'pill missing' }, 'never')),
-      el('td', {}, removalCell(t))));
+      // FOLDED, unlike every other command on this page, and that asymmetry is the point. The
+      // requirement for this section is that it be visible and deliberately not easy to act on;
+      // twenty-two open copy-boxes reading `claude --disallowedTools "Bash"` is the opposite of
+      // that, however loud the warning above them. A reader who means it opens the section and
+      // then opens the row.
+      el('td', {}, removalDetails(t, 'If you really must'))));
   }
   table.appendChild(body);
   det.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
@@ -1577,13 +1675,67 @@ function promptRegion(r) {
   el('summary', {},
     el('span', { class: 'inv-region-name comp-name', text: name }),
     isSys ? el('span', { class: 'pill neutral' }, 'system') : kindPill(r),
-    el('span', { class: 'section-note', text: num(r.tokens) + ' tok · ' + pct(r.share, 1) })));
-  if (r.has_text) {
-    det.appendChild(el('pre', { class: 'inv-snippet inv-text-pre', text: r.text }));
-  } else {
+    el('span', { class: 'section-note', text: num(r.tokens) + ' tok · ' + pct(r.share, 1)
+      + ((r.parts || []).length ? ' · ' + num(r.parts.length) + ' parts' : '') })));
+  if (!r.has_text) {
     notCapturedState(det.appendChild(el('div')));
+    return det;
   }
+  // The system prompt gets decomposed. Every other region is one JSON object or one block of
+  // prose, so there is nothing to decompose and the raw text IS the answer.
+  if ((r.parts || []).length) {
+    det.appendChild(promptParts(r));
+  }
+  det.appendChild(el('details', { class: 'why', 'data-testid': 'inv-whole-' + r.kind },
+    el('summary', {}, (r.parts || []).length
+      ? 'Or read the whole thing assembled, as it was sent — ' + num(r.tokens) + ' tokens'
+      : 'The text — ' + num(r.tokens) + ' tokens'),
+    el('pre', { class: 'inv-snippet inv-text-pre', text: r.text })));
   return det;
+}
+
+/**
+ * promptParts is the system prompt broken into the sections it was assembled from.
+ *
+ * This is the answer to "show me the parts". A 12,000-token system prompt is not one decision:
+ * it is the agent's identity preamble, plus the harness rules, plus the environment block, plus
+ * whatever the reader's own CLAUDE.md contributed — and only some of those are theirs to change.
+ * Undivided, the page could show the number and not the answer.
+ *
+ * The split is on HEADINGS and the panel says so, because "part" could equally mean the wire
+ * blocks (`system` is an array, each block separately cacheable) and a reader comparing this
+ * against a breakpoint count would otherwise be misled. Those boundaries are not recoverable —
+ * they are joined before anything is stored — so headings are what there is, on every row ever
+ * captured rather than only on rows written from today.
+ *
+ * The parts' weights are measured per part and their SUM is printed beside the region's own
+ * total, never reconciled with it: BPE is not additive across a split point, so the two are
+ * different measurements of the same bytes and neither is the error. Hiding that would be a
+ * small lie in the service of a tidy column.
+ */
+function promptParts(r) {
+  const wrap = el('div', { class: 'inv-parts', 'data-testid': 'inv-parts' });
+  const drift = (r.parts_tokens || 0) - r.tokens;
+  wrap.appendChild(el('p', { class: 'note' }, num(r.parts.length) + ' parts, split at the '
+    + 'prompt\'s own markdown headings — which is how it is organised, not how it is CACHED: the '
+    + 'API sends the system prompt as an array of blocks and those boundaries are not recorded. '
+    + 'Heaviest part first is NOT the order the model reads them in; that is the order below.'));
+  for (const p of r.parts) {
+    wrap.appendChild(el('details', { class: 'inv-part inv-part-l' + (p.level || 0),
+      'data-testid': 'inv-part-' + p.title },
+    el('summary', {},
+      el('span', { class: 'inv-part-name comp-name', text: p.title }),
+      el('span', { class: 'section-note', text: num(p.tokens) + ' tok · ' + pct(p.share, 1) })),
+    el('pre', { class: 'inv-snippet inv-text-pre', text: p.text })));
+  }
+  wrap.appendChild(el('p', { class: 'hint' }, 'The parts measure '
+    + num(r.parts_tokens || 0) + ' tokens against the region\'s ' + num(r.tokens)
+    + (drift === 0 ? ' — they agree here.'
+      : ', a difference of ' + num(Math.abs(drift)) + '. That is not an error in either: the '
+        + 'tokenizer is not additive across a split, so measuring the pieces and measuring the '
+        + 'whole are two measurements of the same bytes. The region\'s own figure is the one '
+        + 'every other number on this page uses.')));
+  return wrap;
 }
 
 /**
@@ -1605,10 +1757,31 @@ function renderSelfRemoved(host, rep) {
   const panel = el('div', { class: 'panel', 'data-testid': 'inv-self-removed' },
     el('h2', {}, 'You removed these yourself'),
     el('p', { class: 'note' }, num(rows.length) + ' declaration'
-      + (rows.length === 1 ? '' : 's') + ' stopped appearing partway through this window. That '
-      + 'is a real reduction and it is credited here — no component removed it, so it appears '
-      + 'in no other figure on this dashboard.'));
+      + (rows.length === 1 ? '' : 's') + ' stopped appearing partway through this window. The '
+      + 'tokens genuinely stopped being billed, no component of ours was involved, and the '
+      + 'reduction is credited to YOU — on the Overview tab it is the "Removed by you, not by us" '
+      + 'line, and it is inside "Total the bill came down" and deliberately outside "Total cost '
+      + 'avoided", which is the figure this product claims for itself.'));
   host.appendChild(panel);
+  // The honest limit of the method, up front rather than as a footnote under the weakest row.
+  // This is the finding that decided where the figure is allowed to appear: the inference is
+  // right about the facts and can be wrong about the cause, and no threshold fixes that.
+  panel.appendChild(el('details', { class: 'why', 'data-testid': 'inv-self-removed-basis' },
+    el('summary', {}, 'How this is worked out, and when it is wrong'),
+    el('p', {}, 'The inventory is a time series. A name that appears in the early sessions of '
+      + 'this window and in none of the later ones stopped being declared, and the strength of '
+      + 'the claim is the number of COMPARABLE sessions that ran afterwards without it — a '
+      + 'session that declared no MCP tool at all cannot testify about a missing MCP tool, so '
+      + 'those are not counted. Every row shows its own count and anything under a dozen is '
+      + 'marked weak.'),
+    el('p', {}, 'What it cannot tell you is WHY the name went. On this deployment\'s own history '
+      + 'the largest candidate was the editor integration, which is declared only when a session '
+      + 'runs inside the IDE — so "you removed it" and "you worked in a terminal that day" look '
+      + 'identical here, and no threshold separates them. The reduction is real either way; the '
+      + 'attribution is a guess, which is why this figure is labelled as modelled everywhere it '
+      + 'appears and is kept out of the total that claims our credit.'),
+    el('p', {}, 'A row the server-side filter is already credited for is marked, and excluded '
+      + 'from the Overview figure rather than counted twice.')));
   const table = el('table', { class: 'tbl' },
     el('thead', {}, el('tr', {},
       el('th', {}, 'Item'), el('th', { class: 'num' }, 'Was costing'),
@@ -1678,18 +1851,25 @@ function renderTools() {
 async function loadTools() {
   loadingState(toolsView, 4);
   let control = null;
+  let controlDoc = null;
   try {
     const c = await api('toolfilter');
-    // enabled:false is a proxy that has the endpoint and is not acting; treat it as absent
-    // so the copy says "not enabled" instead of offering a switch that does nothing.
+    // enabled:false is a proxy that has the endpoint and is not acting; treat it as absent so
+    // the copy says "not enabled" instead of offering a switch that does nothing. But KEEP the
+    // document either way: it carries the REASON, and discarding it is why the page could only
+    // ever say "one-click opt-out is not enabled on this proxy" — which on a hosted deployment
+    // was simply false. The proxy had it; the request was ambiguous.
+    controlDoc = c || null;
     if (c && c.enabled) control = c;
   } catch (err) {
     if (aborted(err)) return;
     control = null; // 404 on an older proxy, or the feature is not built yet
+    controlDoc = null;
   }
   try {
     tools.report = await api('tools');
     tools.control = control;
+    tools.controlDoc = controlDoc;
   } catch (err) {
     if (aborted(err)) return;
     errorState(toolsView, 'Could not read the tool inventory', err);

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -774,8 +774,16 @@ function unusedRow(t, rep) {
       + 'dropped here.'));
   }
   if (off) {
-    box.appendChild(el('span', { class: 'cg-item-basis', text: 'Opted out. Switch back on to '
-      + 'restore it; that pays the one-time prefix rebuild again.' }));
+    // NOT "this is no longer sent". The filter keeps any declaration your own system prompt still
+    // NAMES — stripping a declaration whose prose survives invites the model to narrate the call
+    // instead of making it, which nothing surfaces — so an opt-out can be recorded and correctly
+    // declined at request time. The page cannot tell which from here (the decision is per request,
+    // in apply, and nothing stores it per item), so it states the condition rather than implying
+    // an outcome it has not checked.
+    box.appendChild(el('span', { class: 'cg-item-basis', text: 'Opted out: context-guru stops '
+      + 'sending it from your next session — unless your own system prompt still names it, in '
+      + 'which case it is deliberately kept and will go on appearing here. Switching back on '
+      + 'restores it and pays the one-time prefix rebuild again.' }));
   }
   box.appendChild(promptTextReveal(t));
   // The per-item removal, folded: the group head already carries the one-command answer, so
@@ -1073,10 +1081,13 @@ function skillsPanel(host, rep) {
   panel.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
   panel.appendChild(el('p', { class: 'hint' }, 'Switching a skill off here stops context-guru '
     + 'sending its entry in the listing, from your next session. It does not edit your own '
-    + 'configuration — the command beside each row does that, permanently and at source. One '
-    + 'caveat worth knowing: the Skill tool takes a free-form name, so a model that remembers an '
-    + 'unlisted skill can still run it. That is deliberate — it fails open — but it means this is '
-    + 'a way to stop PAYING for a skill, not a way to forbid it.'));
+    + 'configuration — the command beside each row does that, permanently and at source. Two '
+    + 'caveats worth knowing. The Skill tool takes a free-form name, so a model that remembers an '
+    + 'unlisted skill can still run it: that is deliberate — it fails open — but it means this is '
+    + 'a way to stop PAYING for a skill, not a way to forbid it. And a skill your own system '
+    + 'prompt names by name is KEPT whatever you switch here, because removing a declaration '
+    + 'while the prose describing it survives is the one way this can quietly make the agent '
+    + 'worse.'));
 }
 
 /**

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -389,9 +389,21 @@ function gauge(t) {
       'invoked ' + num(t.declared_tokens - t.unused_tokens) + ' tok'),
     el('span', {}, el('i', { class: 'cg-sw cg-unused' }),
       'never invoked ' + num(t.unused_tokens) + ' tok (' + pct(t.unused_pct) + ')')));
-  if (!t.unused_tokens) {
+  // Two different zeroes, and they must not read the same. An account that declared MCP tools and
+  // skills and used all of them has nothing to remove; an account that declared NONE has nothing
+  // to remove FROM, which on a plain Claude Code session is the normal state — and saying "nothing
+  // was left unused" there implies a clean bill over an empty set while 15,000 tokens of built-ins
+  // sit in the section at the end of the page.
+  if (!t.declared_tokens) {
+    box.appendChild(el('p', { class: 'hint' }, 'No MCP tools and no skills were declared in this '
+      + 'scope, so there is nothing here you can turn off. That is not "no waste": what these '
+      + 'sessions carried was the agent\'s own tools'
+      + (t.aside_tokens ? ' — ' + num(t.aside_tokens) + ' tokens a session of them' : '')
+      + ', which are listed at the end of the page and are not yours to remove.'));
+  } else if (!t.unused_tokens) {
     box.appendChild(el('p', { class: 'hint ok' },
-      'Nothing in this scope was declared and left unused. There is nothing to remove.'));
+      'Everything you declared in this scope was invoked at least once. There is nothing to '
+      + 'remove.'));
   }
   return box;
 }

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -1465,7 +1465,7 @@ function copyBox(text, label) {
  * `state` is one of: 'idle' (not asked for yet), 'loading', 'ok', 'absent' (the endpoint is
  * not there — an older proxy), 'error'.
  */
-const prompt = { state: 'idle', view: null, byName: new Map() };
+const promptView = { state: 'idle', view: null, byName: new Map() };
 
 /**
  * loadPrompt fetches the prefix text once and repaints only the reveals that are open.
@@ -1475,20 +1475,20 @@ const prompt = { state: 'idle', view: null, byName: new Map() };
  * Each reveal registers a repaint of its own body instead.
  */
 async function loadPrompt() {
-  if (prompt.state === 'loading' || prompt.state === 'ok') return;
-  prompt.state = 'loading';
+  if (promptView.state === 'loading' || promptView.state === 'ok') return;
+  promptView.state = 'loading';
   repaintPrompt();
   try {
     const v = await api('prompt');
-    prompt.view = v;
-    prompt.byName = new Map();
-    for (const r of v.regions || []) prompt.byName.set(r.kind + '/' + r.name, r);
-    prompt.state = 'ok';
+    promptView.view = v;
+    promptView.byName = new Map();
+    for (const r of v.regions || []) promptView.byName.set(r.kind + '/' + r.name, r);
+    promptView.state = 'ok';
   } catch (err) {
     if (aborted(err)) return;
     // A 404 is an older proxy that has the report and not this route. That is "the feature
     // is not there", not "something broke", and the two must not read the same.
-    prompt.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
+    promptView.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
   }
   repaintPrompt();
 }
@@ -1521,20 +1521,20 @@ function promptTextReveal(t) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'idle' || prompt.state === 'loading') {
+    if (promptView.state === 'idle' || promptView.state === 'loading') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptView.state === 'absent') {
       body.appendChild(el('p', { class: 'hint' }, 'This proxy records the token weight of each '
         + 'declaration but not its text. The weight above is exact.'));
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptView.state === 'error') {
       body.appendChild(el('p', { class: 'hint' }, 'Could not read the prompt text.'));
       return;
     }
-    const reg = prompt.byName.get(t.kind + '/' + t.name);
+    const reg = promptView.byName.get(t.kind + '/' + t.name);
     if (reg && reg.has_text) {
       body.appendChild(el('p', { class: 'hint' }, num(reg.tokens) + ' tokens, '
         + pct(reg.share, 1) + ' of the prefix that session carried.'));
@@ -1561,7 +1561,7 @@ let promptWaiters = [];
  * prevent — the same one captureState fixes on the server.
  */
 function notCapturedState(host) {
-  const v = prompt.view || {};
+  const v = promptView.view || {};
   if (v.blocked_by === 'operator') {
     return emptyState(host, 'Prompt text is not stored on this deployment',
       'The operator has content capture switched off service-wide, so no prompt or transcript '
@@ -1650,21 +1650,21 @@ function renderPromptPanel(host, rep) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'loading' || prompt.state === 'idle') {
+    if (promptView.state === 'loading' || promptView.state === 'idle') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptView.state === 'absent') {
       emptyState(body, 'This proxy does not record prompt text',
         'It records the token weight of every region, which is what the figures above are. '
         + 'Reading the text needs a newer proxy.');
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptView.state === 'error') {
       emptyState(body, 'Could not read the prompt text', 'The figures above are unaffected.');
       return;
     }
-    const v = prompt.view || {};
+    const v = promptView.view || {};
     if (!v.captured) { notCapturedState(body); return; }
     body.appendChild(el('p', { class: 'note' }, 'One session\'s actual prefix — '
       + num(v.tokens) + ' tokens across ' + num((v.regions || []).length) + ' regions, captured '

--- a/dash/uiinventory_test.go
+++ b/dash/uiinventory_test.go
@@ -119,3 +119,131 @@ func readUI(t *testing.T, name string) string {
 	}
 	return string(b)
 }
+
+// TestNoFunctionIsDefinedTwiceInTheDashboardSource is the root-cause check for the defect the
+// owner reported as "the system prompt parts are not visible".
+//
+// tools.js defined `unusedRow` TWICE, 70 lines apart. In JavaScript the second wins, and the
+// second was the OLDER one: it wrapped the whole row in a <label> (so a copy button inside it
+// toggled the checkbox) and, decisively, it had no promptTextReveal call. The fixed version — the
+// one with the reveal, the id/for pairing and the per-item command — was unreachable code for as
+// long as both existed. Nothing failed, nothing warned, and the feature was simply absent from
+// every grouped row on the page while its code sat right there in the file being read by
+// reviewers.
+//
+// A static check earns its keep here because the failure is invisible three ways at once: the
+// page renders, the tests pass, and the dead copy looks like the live one.
+func TestNoFunctionIsDefinedTwiceInTheDashboardSource(t *testing.T) {
+	// kv in app.js is a PRE-EXISTING duplicate of exactly this shape, found by this check and
+	// deliberately not fixed here: the two bodies differ only in how they pass their text, it is
+	// 3,700 lines away from anything this change touches, and a silent edit to a shared helper is
+	// how an unrelated regression gets attributed to the wrong commit. It is listed so the check
+	// can guard everything else rather than being scoped down to one file.
+	known := map[string]bool{"ui/app.js:kv": true}
+	def := regexp.MustCompile(`(?m)^function ([A-Za-z_$][\w$]*)\s*\(`)
+	for _, name := range []string{"ui/tools.js", "ui/app.js"} {
+		seen := map[string]int{}
+		for _, m := range def.FindAllStringSubmatch(readUI(t, name), -1) {
+			seen[m[1]]++
+		}
+		if len(seen) == 0 {
+			t.Fatalf("%s: found no top-level function definitions; this check needs rewriting", name)
+		}
+		for fn, n := range seen {
+			if n > 1 && !known[name+":"+fn] {
+				t.Errorf("%s defines %s() %d times.\n"+
+					"The later definition silently wins and the earlier one becomes unreachable "+
+					"code that still reads as live. This is how the prompt-text reveal came to be "+
+					"absent from every grouped row on the Inventory page while the function that "+
+					"rendered it sat in the file.", name, fn, n)
+			}
+		}
+	}
+}
+
+// TestEveryRemovableRowCarriesItsOwnCommand: the owner asked for the exact command "for each MCP
+// tool and each skill", and the group-level command is not that.
+//
+// A group of one already showed it. A group of MANY showed the SERVER-level `claude mcp remove
+// <server>` once at the top — the right answer to "drop this whole server" and no answer at all
+// to "drop just this one tool", which is the question a reader with a nineteen-tool server has.
+// And the sortable tables, which are where a reader goes for a tool they DO use occasionally,
+// showed no command anywhere.
+func TestEveryRemovableRowCarriesItsOwnCommand(t *testing.T) {
+	src := readUI(t, "ui/tools.js")
+	if !strings.Contains(src, "function removalDetails(") {
+		t.Fatal("removalDetails is gone; this check needs rewriting against its replacement")
+	}
+	// The per-item row, the tools table and the skills table each render one.
+	for fn, why := range map[string]string{
+		"function unusedRow(":   "a member of a multi-item group has no per-item command",
+		"function toolTable(":   "the tools table has no removal command column",
+		"function skillsPanel(": "the skills table has no removal command column",
+	} {
+		i := strings.Index(src, fn)
+		if i < 0 {
+			t.Errorf("%s is gone; this check needs rewriting", fn)
+			continue
+		}
+		end := strings.Index(src[i:], "\n}\n")
+		if end < 0 {
+			end = len(src) - i
+		}
+		if !strings.Contains(src[i:i+end], "removalDetails(") {
+			t.Errorf("%s: %s", fn, why)
+		}
+	}
+	// And a skill must be switchable from the skills table, not only from the never-invoked list:
+	// a skill used once and no longer wanted is exactly the case that list cannot reach.
+	i := strings.Index(src, "function skillsPanel(")
+	end := strings.Index(src[i:], "\n}\n")
+	if !strings.Contains(src[i:i+end], "excludeToggle(") {
+		t.Error("the skills table has no opt-out switch, so turning a skill off still needs a " +
+			"config file edit")
+	}
+}
+
+// TestTheAsideGroupComesFromTheServer: the built-in/provider split decides what is in the totals,
+// so the client must not re-derive it.
+//
+// A client-side `filter((t) => t.builtin)` over rep.tools is a second copy of a rule the server
+// already applied when it kept those rows out of every total. Two copies drift, and the drift is
+// invisible: a row in the wrong group looks perfectly plausible in both places, and the headline
+// and the table would simply disagree about which one it was in.
+func TestTheAsideGroupComesFromTheServer(t *testing.T) {
+	src := readUI(t, "ui/tools.js")
+	i := strings.Index(src, "function renderBuiltins(")
+	if i < 0 {
+		t.Fatal("renderBuiltins is gone; this check needs rewriting against its replacement")
+	}
+	end := strings.Index(src[i:], "\n}\n")
+	if end < 0 {
+		end = len(src) - i
+	}
+	body := src[i : i+end]
+	if !strings.Contains(body, "rep.aside") {
+		t.Error("the built-ins section does not read rep.aside; it is re-deriving the split the " +
+			"server already made when it kept those rows out of the totals")
+	}
+	if regexp.MustCompile(`rep\.tools[^\n]*\bfilter\(`).MatchString(body) {
+		t.Errorf("the built-ins section filters rep.tools:\n%s\n\n"+
+			"rep.tools no longer holds them. A filter here would silently render an empty "+
+			"section while the whole group went unlisted.", body)
+	}
+}
+
+// TestTheHeadlineSaysWhatItLeftOut. The four headline tiles now cover MCP tools and skills only,
+// which is what makes them actionable — and it also makes them several times smaller than the
+// composition bar further down the same page. A reader who meets both and is told nothing has to
+// work out for themselves which one is lying. Neither is; they answer different questions, and the
+// page has to say so where the smaller number is.
+func TestTheHeadlineSaysWhatItLeftOut(t *testing.T) {
+	src := readUI(t, "ui/tools.js")
+	if !strings.Contains(src, "aside_tokens") {
+		t.Error("nothing on the page reads totals.aside_tokens, so the headline never says how " +
+			"much weight it excluded")
+	}
+	if !strings.Contains(src, "inv-aside-note") {
+		t.Error("the headline has no disclosure of the excluded group")
+	}
+}

--- a/dash/uiinventory_test.go
+++ b/dash/uiinventory_test.go
@@ -134,11 +134,19 @@ func readUI(t *testing.T, name string) string {
 // A static check earns its keep here because the failure is invisible three ways at once: the
 // page renders, the tests pass, and the dead copy looks like the live one.
 func TestNoFunctionIsDefinedTwiceInTheDashboardSource(t *testing.T) {
-	// kv in app.js is a PRE-EXISTING duplicate of exactly this shape, found by this check and
-	// deliberately not fixed here: the two bodies differ only in how they pass their text, it is
-	// 3,700 lines away from anything this change touches, and a silent edit to a shared helper is
-	// how an unrelated regression gets attributed to the wrong commit. It is listed so the check
-	// can guard everything else rather than being scoped down to one file.
+	// KNOWN EXCEPTION — ui/app.js:kv. A pre-existing duplicate of exactly this shape, found by
+	// this check and deliberately not fixed here.
+	//
+	// app.js defines kv() at ~2929 and ~6644. The later wins; the two bodies differ only in how
+	// they pass their text (`text: k` vs a child node, `v` vs `String(v)`), so there is no visible
+	// defect today. It is recorded rather than repaired because it sits ~3,700 lines from anything
+	// this change touches, and a silent edit to a shared helper is how an unrelated regression gets
+	// attributed to the wrong commit.
+	//
+	// TO CLEAR IT: keep one definition, delete the other, drop this entry. Everything a tracking
+	// issue would need is in this comment on purpose — the change that found it could not file one
+	// (an outbound write it had no authorisation for), and a finding whose only record is a review
+	// thread is a finding that evaporates.
 	known := map[string]bool{"ui/app.js:kv": true}
 	def := regexp.MustCompile(`(?m)^function ([A-Za-z_$][\w$]*)\s*\(`)
 	for _, name := range []string{"ui/tools.js", "ui/app.js"} {
@@ -245,5 +253,40 @@ func TestTheHeadlineSaysWhatItLeftOut(t *testing.T) {
 	}
 	if !strings.Contains(src, "inv-aside-note") {
 		t.Error("the headline has no disclosure of the excluded group")
+	}
+}
+
+// TestTheGaugeTellsTheTwoZeroesApart. With the built-ins out of these figures, "declared 0" is now
+// the NORMAL state of a plain Claude Code session that carries no MCP tools and no skills — and it
+// means something completely different from "declared plenty and used all of it".
+//
+// Both landed on one line reading "Nothing in this scope was declared and left unused", which over
+// an empty controllable set reads as a clean bill while fifteen thousand tokens of the agent's own
+// tools sit in the section at the end of the page. A static check because the branch is chosen from
+// report data the Go tests do not render.
+func TestTheGaugeTellsTheTwoZeroesApart(t *testing.T) {
+	src := readUI(t, "ui/tools.js")
+	i := strings.Index(src, "function gauge(")
+	if i < 0 {
+		t.Fatal("gauge is gone; this check needs rewriting against its replacement")
+	}
+	end := strings.Index(src[i:], "\n}\n")
+	if end < 0 {
+		end = len(src) - i
+	}
+	body := src[i : i+end]
+	// The two states are distinguished at all...
+	if !strings.Contains(body, "!t.declared_tokens") {
+		t.Error("the gauge does not branch on declared_tokens being zero, so 'you declared " +
+			"nothing controllable' and 'you used everything you declared' print the same line")
+	}
+	// ...and the empty-set branch does NOT congratulate the reader.
+	if !strings.Contains(body, "not \\\"no waste\\\"") && !strings.Contains(body, `not "no waste"`) {
+		t.Error("the declared-nothing branch does not say it is not a clean bill; a reader with " +
+			"15k tokens of built-ins would read it as one")
+	}
+	// ...and it points at where the weight actually is.
+	if !strings.Contains(body, "aside_tokens") {
+		t.Error("the declared-nothing branch does not name the weight it excluded")
 	}
 }

--- a/docs/dashboard-inventory-page.md
+++ b/docs/dashboard-inventory-page.md
@@ -39,9 +39,12 @@ one, so the whole set can be read side by side and checked for one voice.
 
 ## What this round changed, and why
 
-**The built-ins left the statistics.** They are the largest group by weight — 15,746 tokens per
-session against 12,257 of controllable declarations on a real capture, 59% of everything declared
-— and removing one breaks the agent. So a headline reading "you never touch 82% of what you
+**The built-ins left the statistics.** They are the largest group by weight — on a real capture
+**15,694 tokens per session** (`aside_tokens`) against **12,250** of controllable declarations
+(`declared_tokens`), and **15,746 of the 26,825**-token declaration SET (`aside_set_tokens` of
+`declared_set_tokens`), **58.7%** of everything declared. The per-session mean and the set total are
+different statistics over different populations and are named here as such, because this page has a
+history of printing one under the other's label — and removing any of it breaks the agent. So a headline reading "you never touch 82% of what you
 carry", assembled mostly out of `Read`, `Bash` and `Grep`, was a true number whose only available
 action was a mistake. They are now in `ToolReport.Aside`: reported in their own section at the end
 of the page and in the composition bar (whose job is the whole prompt), and in no total, no
@@ -63,11 +66,14 @@ already captured, and a decomposition that only worked for prompts recorded from
 a reader can use. The parts' summed weight is printed beside the region's own and never reconciled
 with it — BPE is not additive across a split, so they are two measurements of the same bytes.
 
-**Skills became removable, and every row carries its own command.** `removalCell` existed and was
-rendered in exactly one place — the built-ins table, the one group nobody should act on — while a
-multi-item group showed only the SERVER-level command, which is no answer at all to "get rid of
-just this one tool". Every candidate row, every row of both tables, and every built-in now carries
-its own, folded.
+**Skills became removable, and every row carries its own command.** At the previous round's HEAD
+`removalCell` was rendered in TWO places — the built-ins table, and the group HEAD in
+`removalGroup` (the earlier fix) — so a group of one already showed its command. What was missing is
+per-ITEM: a group of many showed only the SERVER-level `claude mcp remove <server>`, which is the
+right answer to "drop this whole server" and no answer at all to "drop just this one tool", the
+question a reader with a nineteen-tool server actually has; and neither sortable table showed a
+command anywhere, which is where a reader goes for a tool they DO use occasionally. Every candidate
+row, every row of both tables, and every built-in now carries its own, folded.
 
 **One duplicate function.** `unusedRow` was defined twice in `tools.js`, 70 lines apart. The second
 won, and the second was the older one: no prompt-text reveal, no `id`/`for` pairing, and the whole

--- a/docs/dashboard-inventory-page.md
+++ b/docs/dashboard-inventory-page.md
@@ -18,15 +18,17 @@ the page belongs to the same design system rather than shipping a second one.
 
 | Section | Answers |
 |---|---|
-| **Headline tiles** | declared tokens per session, how many were invoked, how many never were, and the projected cost of the difference |
+| **Headline tiles** | declared tokens per session, how many were invoked, how many never were, and the projected cost of the difference — **over the controllable set only**: your MCP tools and skills. The weight left out is stated in a line under the gauge |
 | **Gauge** | one bar, two segments, drawn to scale: invoked against never-invoked |
 | **Who owns your system prompt** | the part-to-whole bar: every region of the prefix, coloured by whether it is yours to change. Headed *"Who owns what you carry in front of every request"* until a session in scope has recorded a system prompt, because until then the bar is declarations only |
-| **Your system prompt, and what shares it** | its size, the whole prefix, and the reveal that shows the actual text region by region |
+| **Your system prompt, and what shares it** | its size, the whole prefix, and the reveal that shows the actual text region by region — with the **system prompt decomposed into its own sections**, each named, measured and readable, plus the whole thing assembled |
 | **Carried by every request, never once called** | the actionable list — grouped by what ONE action removes, each group with the command that removes it |
 | **Realized by your removals** | what a removal *actually* avoided on requests that were really sent |
 | **Every declaration, by weight** | the full table, sortable on any column |
 | **MCP servers** | the per-server rollup, because a server is the unit you add or remove |
-| **Skills** | the listing's own weight, how many skills were declared, how many were ever called |
+| **Skills** | the listing's own weight, how many skills were declared, how many were ever called, and **one switch and one command per skill** |
+| **You removed these yourself** | declarations that stopped appearing partway through the window — credited to the reader, not to us, and labelled as modelled rather than measured |
+| **The agent's own tools** | LAST, collapsed, behind the danger warning: Claude Code's built-ins and the provider's tools, in **none** of the figures above |
 | **What these numbers are computed over** | the denominator: sessions in scope, how many were captured, how many were priced, and at which tier a token became a dollar |
 | **The agent's own tools** | built-ins and provider tools, last, collapsed, behind a danger warning on the closed bar |
 
@@ -35,7 +37,46 @@ it was derived and its catch, from `TILE_INFO` in `app.js` — the same registry
 tiles read. `tools.js` adds its fourteen entries to that object rather than keeping a second
 one, so the whole set can be read side by side and checked for one voice.
 
-## Four things this round changed, and why
+## What this round changed, and why
+
+**The built-ins left the statistics.** They are the largest group by weight — 15,746 tokens per
+session against 12,257 of controllable declarations on a real capture, 59% of everything declared
+— and removing one breaks the agent. So a headline reading "you never touch 82% of what you
+carry", assembled mostly out of `Read`, `Bash` and `Grep`, was a true number whose only available
+action was a mistake. They are now in `ToolReport.Aside`: reported in their own section at the end
+of the page and in the composition bar (whose job is the whole prompt), and in no total, no
+percentage, no gauge and no sortable table. The headline says how much it left out and why.
+
+The split is drawn on `IsBuiltinTool`, **not** on the declaration kind. A third-party client tool
+is a different thing: it is somebody's choice, it is removable, and an earlier cut of this sent
+every `KindTool` row aside — correct on a Claude Code account, and on any other account it took
+every SDK application's removable declarations off the page, out of the suggestion engine and
+therefore out of the filter. Three tests caught it.
+
+**The system prompt is decomposed.** A 5,684-token prompt is not one decision, and the page could
+show the number without answering it. It is now split at its own markdown headings, each section
+named, measured and readable, with the assembled whole one disclosure below. On a real capture that
+found 17 sections and put a single one — *Types of memory*, 1,508 tokens — at 26.5% of the prompt.
+The split is on HEADINGS and the panel says so: the wire boundaries (`system` is an array of
+separately cacheable blocks) are joined before anything is stored, so they are gone from every row
+already captured, and a decomposition that only worked for prompts recorded from today is not one
+a reader can use. The parts' summed weight is printed beside the region's own and never reconciled
+with it — BPE is not additive across a split, so they are two measurements of the same bytes.
+
+**Skills became removable, and every row carries its own command.** `removalCell` existed and was
+rendered in exactly one place — the built-ins table, the one group nobody should act on — while a
+multi-item group showed only the SERVER-level command, which is no answer at all to "get rid of
+just this one tool". Every candidate row, every row of both tables, and every built-in now carries
+its own, folded.
+
+**One duplicate function.** `unusedRow` was defined twice in `tools.js`, 70 lines apart. The second
+won, and the second was the older one: no prompt-text reveal, no `id`/`for` pairing, and the whole
+row wrapped in a `<label>` so a copy button inside it toggled the checkbox. The fixed copy was
+unreachable code while both existed, which is why "the system prompt parts are not visible" was
+reported against a file that contained the code to show them.
+`TestNoFunctionIsDefinedTwiceInTheDashboardSource` is the guard.
+
+## Four things the previous round changed, and why
 
 **The removal command is visible, per group.** It existed on the API
 (`dash/toolremoval.go`) from the start and was rendered in exactly one place: the built-ins

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -62,7 +62,7 @@ tool declaration lives in the top-level `tools` array, so the filter's saving mo
 waterfall by exactly nothing. It was on the Inventory tab and in no total anywhere — the largest
 lever measured in this project (82.7% of a declared catalogue is never invoked), invisible to the
 page that adds the savings up. Demonstrated on a live run: two clicks in the dashboard UI, and
-`total_saved_usd` went from `$0.000000` to `$0.003254`.
+`total_saved_usd` went from `$0.000000` to `$0.004456`.
 
 `self_removed_usd` is kept out of the credited total because the method cannot see WHY a
 declaration stopped appearing. It sees that the declaration set changed — which is a fact, and the

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -32,7 +32,7 @@ Every headline number, with the honesty machinery visible rather than hidden:
 | Volume | requests · sessions · tokens before/after |
 | Savings | gross · unique · net-of-restores · **each reduction re-earned** (was "overcount ratio") |
 | Amortization | **replay realized · replay ceiling · % of ceiling** |
-| Money | baseline cost · actual cost · context-guru's own LLM spend · net dollars saved · **prefix-cache savings** · **total avoided** |
+| Money | baseline cost · actual cost · context-guru's own LLM spend · net dollars saved · **prefix-cache savings** · **declarations not sent** · **total avoided** · **total the bill came down** |
 | Addressable spend | **addressable (input-side) spend · saved as % of it · output-token cost · reconciliation against the bill** |
 | Tokens billed | fresh input · cache reads · cache writes · output — each **with what that tier cost** |
 | Latency | context-guru added (mean + **p95**) · upstream (mean + p95) |
@@ -43,6 +43,34 @@ See [What the value pass changed](#what-the-value-pass-changed) for which number
 meaning and why.
 
 Three of those deserve their own explanation.
+
+#### Two totals, and why they are not one
+
+`total_saved_usd` answers *how much of this did context-guru do*. `total_reduced_usd` answers
+*how much smaller did this bill get*. They differ by what the account removed **itself**, and
+folding that into the first would be taking credit for the reader's own work.
+
+| Field | What it is | Which total |
+|---|---|---|
+| `decl_filter_usd` | **Measured, ours.** `requests.filtered_decl_tokens` — what the removal filter actually stopped sending, on requests that were really sent, priced at the tier each one paid. | both |
+| `self_removed_usd` | **Modelled, the user's.** Declarations the account stopped carrying on its own. | `total_reduced_usd` only |
+
+`decl_filter_usd` reaching a total at all is a **fix**, not a new feature. The whole savings walk
+is built on `tokens_before − tokens_after`, which is `schema.MessagesTokens`: message text only. A
+tool declaration lives in the top-level `tools` array, so the filter's saving moved
+`baseline_cost_usd` by exactly nothing and appeared in `net_saved_usd`, `total_saved_usd` and the
+waterfall by exactly nothing. It was on the Inventory tab and in no total anywhere — the largest
+lever measured in this project (82.7% of a declared catalogue is never invoked), invisible to the
+page that adds the savings up. Demonstrated on a live run: two clicks in the dashboard UI, and
+`total_saved_usd` went from `$0.000000` to `$0.003254`.
+
+`self_removed_usd` is kept out of the credited total because the method cannot see WHY a
+declaration stopped appearing. It sees that the declaration set changed — which is a fact, and the
+tokens genuinely were not billed — and infers a removal, which is a guess. On the production
+snapshot the largest candidate in the window was the editor integration, declared only when a
+session runs inside the IDE: "you removed it" and "you worked in a terminal that day" are
+indistinguishable in the data, and no threshold separates them. Rows the filter is already credited
+for are excluded rather than counted twice, and the count of exclusions is reported.
 
 #### Four savings denominators, not one
 

--- a/docs/how-to/declaration-removal.md
+++ b/docs/how-to/declaration-removal.md
@@ -81,10 +81,26 @@ Also kept, always: the tool `tool_choice` forces (removing it would turn a force
 400), provider-side tools declared by `type` rather than by a schema, and the last remaining
 tool (a body that declares a catalogue and one that declares none are different shapes).
 
-**Skills are reported but not removable.** A skill is declared as prose inside a transcript
-message rather than as an element of `tools`, so removing one means editing that listing; and
-the `Skill` tool's schema carries no enum, so the model can still name a skill that is no
-longer listed. Different mechanism, different failure mode — see *Not done* below.
+**Skills are removable, by a different mechanism, and the failure mode is the SAFER one.** A
+skill is declared as prose inside a transcript message (measured: `messages[1]`, `role:"system"`,
+a plain string, 6,867 bytes), not as an element of `tools`, so removing one means cutting its
+entry out of that listing. List it as `skill__<name>`.
+
+An earlier version of this page gave a reason for *not* doing it, and the reason was backwards.
+It said the `Skill` tool's schema carries no enum, so removal turns "unused" into "errors when
+called". The first half is right and the second does not follow: with no enum, `skill` is a
+free-form string, so a model that names an unlisted skill anyway simply **runs it**. Verified on
+a live session. So over-removing a skill fails OPEN, where over-removing a tool fails silent —
+the model narrating a call it can no longer make, which nothing surfaces. The safer of the two
+mechanisms was the one being withheld.
+
+What that means for you: switching a skill off here stops you *paying* for it. It is not a way
+to forbid it. To actually disable one, use Claude Code's own `skillOverrides` — the command
+beside each row on the Inventory page.
+
+The prose gate applies to skills too, with the listing itself subtracted from the region it
+tests against: a skill named in your own system prompt is kept, but its own listing entry does
+not count as naming it.
 
 ## Suggestions, and what "enough evidence" means
 
@@ -256,11 +272,6 @@ definition.
 
 ## Not done, and why
 
-- **Skill removal.** Biggest remaining piece of the measured waste (all 11 skills in the
-  corpus went uninvoked). It needs a different mechanism — editing prose inside a transcript
-  message — and it cannot be made as safe: the `Skill` tool's schema has no enum, so removal
-  turns "unused" into "errors when called" rather than "unavailable". Worth doing on its own
-  evidence, not as a footnote to this.
 - **Truncating or dropping tool *descriptions*.** 110 KB of the 131 KB of `tools` on real
   traffic, and the one lever whose failure mode is a wrong tool call. See
   `components/reformat/toolschema.go`, which declines it for the same reason.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,162 @@
+// Package skills parses Claude Code's skills listing — the prose block that declares which
+// skills a request carries.
+//
+// It exists as a shared package for one reason: two places need the SAME parse and they must
+// not drift. The dashboard reads the listing to price each entry (dash/toolinventory.go); the
+// declaration filter cuts entries out of it (apply/toolfilter.go). A filter that disagreed with
+// the inventory about where an entry ENDS would leave an orphaned description line behind in a
+// real request — prose with no heading, attached to the wrong skill — while the page that
+// authorised the removal reported a clean cut. This repo has shipped that class of bug before
+// (two cost columns priced from different maps, 31.6% apart), so the rule lives once.
+//
+// The listing is not JSON and cannot be treated as though it were. It is prose inside a
+// `<system-reminder>` in a role:"system" MESSAGE — measured on real traffic: messages[1], a
+// plain string, 6,867 bytes — so everything here is line-oriented and every function fails
+// closed: a line that does not clearly parse as an entry is not one.
+package skills
+
+import "strings"
+
+// Header anchors the listing, and the anchor is load-bearing rather than cosmetic: the
+// agent-types listing sitting immediately above it in the SAME message uses the identical
+// `- name: description` shape, so an unanchored scrape counts subagents as skills.
+const Header = "The following skills are available for use with the Skill tool:"
+
+// RemovePrefix marks a declaration-removal entry as a SKILL rather than a tool.
+//
+// A skill needs its own namespace in that list because the two are removed from different places
+// and a bare name cannot say which is meant: a tool is an element of the top-level `tools` array,
+// a skill is a line of prose inside a transcript message. They can also collide — nothing stops a
+// skill being called `Monitor` — and the wrong mechanism on a name is a silent no-op, so the
+// prefix is required rather than inferred. It mirrors `mcp__<server>`, which the same list
+// already uses for "a whole MCP server, not one of its tools".
+//
+// It lives HERE, and not beside the rewrite that acts on it, because the component that validates
+// the list (components/reformat) and the code that applies it (apply) cannot import each other —
+// apply imports the components. A shared constant beats two spellings of the same string.
+const RemovePrefix = "skill__"
+
+// ReminderEnd bounds the listing. Both this and Header appear literally in the JSON-escaped
+// body (neither contains an escapable character), which is what lets a caller find the region
+// with a byte search and no unescaping.
+const ReminderEnd = "</system-reminder>"
+
+// Entry is one skill in the listing, as a LINE RANGE rather than a byte span.
+//
+// Lines, because the two callers want different bytes from the same range and a span would have
+// forced one of them to adjust it: the inventory joins the range with "\n" and stores that as
+// the entry's text (so the entry's measured weight excludes its trailing newline), while the
+// filter drops the lines and re-joins what is left. Both are exact on the same Listing.Lines.
+type Entry struct {
+	Name string
+	// From / To are the half-open line range this entry occupies in Listing.Lines.
+	From, To int
+}
+
+// Listing is a parsed listing body: its lines, and one Entry per skill.
+type Listing struct {
+	Lines   []string
+	Entries []Entry
+}
+
+// Parse splits a listing BODY — the text after Header and before ReminderEnd — into entries.
+//
+// An entry runs from its own `- name:` line to the next line that parses as a name, not to the
+// next blank line and not to the next line starting with "- ": a description containing its own
+// "\n- " bullet would otherwise truncate the entry, and several real skill descriptions do
+// exactly that.
+func Parse(body string) Listing {
+	l := Listing{Lines: strings.Split(body, "\n")}
+	for n, ln := range l.Lines {
+		name, ok := EntryName(ln)
+		if !ok {
+			continue
+		}
+		if k := len(l.Entries) - 1; k >= 0 {
+			l.Entries[k].To = n
+		}
+		l.Entries = append(l.Entries, Entry{Name: name, From: n, To: len(l.Lines)})
+	}
+	return l
+}
+
+// Text is one entry's own text, joined the way the inventory stores and measures it.
+func (l Listing) Text(e Entry) string { return strings.Join(l.Lines[e.From:e.To], "\n") }
+
+// Without returns the listing body with the named entries' lines removed, and how many entries
+// went. The result is byte-exact when nothing is dropped, because Parse split on "\n" and this
+// re-joins on "\n" — which is what lets a caller treat "removed nothing" as "changed nothing"
+// rather than having to compare the strings.
+func (l Listing) Without(drop map[string]bool) (string, int) {
+	cut := make([]bool, len(l.Lines))
+	n := 0
+	for _, e := range l.Entries {
+		if !drop[e.Name] {
+			continue
+		}
+		for i := e.From; i < e.To && i < len(cut); i++ {
+			cut[i] = true
+		}
+		n++
+	}
+	// No early return for n == 0: Parse split on "\n" and this joins on "\n", so the
+	// nothing-dropped path already reproduces the input byte for byte. A guard here would be a
+	// second code path with nothing to do, and mutation testing found it — the fast path could be
+	// deleted outright without any test noticing, which is the definition of code that is not
+	// carrying its weight.
+	kept := make([]string, 0, len(l.Lines))
+	for i, ln := range l.Lines {
+		if !cut[i] {
+			kept = append(kept, ln)
+		}
+	}
+	return strings.Join(kept, "\n"), n
+}
+
+// EntryName reads a listing line's skill name, or reports that the line is not an entry.
+func EntryName(line string) (string, bool) {
+	if !strings.HasPrefix(line, "- ") {
+		return "", false
+	}
+	rest := line[2:]
+	i := strings.Index(rest, ":")
+	if i <= 0 {
+		return "", false
+	}
+	name := rest[:i]
+	// A plugin skill is `plugin:skill` and a directory-scoped one `apps/web:deploy`, so one
+	// colon may be part of the name: take the longer candidate when the first colon is not
+	// followed by a space.
+	if !strings.HasPrefix(rest[i:], ": ") {
+		j := strings.Index(rest[i+1:], ": ")
+		if j < 0 {
+			return "", false
+		}
+		name = rest[:i+1+j]
+	}
+	if name == "" || len(name) > 128 {
+		return "", false
+	}
+	if !ValidName(name) {
+		return "", false
+	}
+	return name, true
+}
+
+// ValidName reports whether s is drawn from the charset a skill name uses. Anything else is not
+// a name this package recognises, and is skipped rather than guessed at — the listing is the
+// authority for what may be removed from a real request.
+func ValidName(s string) bool {
+	if s == "" || len(s) > 128 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.' || r == '_' || r == ':' || r == '-' || r == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,117 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+// listing is the real shape: a blank line after the header, one bullet per skill, and a
+// description that carries its OWN bullet on a continuation line — which is what makes the
+// entry span rule load-bearing rather than decorative.
+const listing = `
+
+- alpha: does alpha things.
+- beta: does beta things.
+  - and this line is part of beta's description, not a new entry
+  more of beta
+- plugin:gamma: a plugin skill.
+- apps/web:deploy: a directory-scoped one.
+`
+
+func names(l Listing) []string {
+	out := make([]string, 0, len(l.Entries))
+	for _, e := range l.Entries {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+func TestParseFindsEveryEntryAndItsSpan(t *testing.T) {
+	l := Parse(listing)
+	got := names(l)
+	want := []string{"alpha", "beta", "plugin:gamma", "apps/web:deploy"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("entries = %v, want %v", got, want)
+	}
+	// beta owns its continuation lines. A span that stopped at the next "- " line would hand
+	// them to plugin:gamma, which is how an inventory and a filter come to disagree about what
+	// removing beta actually removes.
+	beta := l.Text(l.Entries[1])
+	for _, s := range []string{"does beta things", "part of beta's description", "more of beta"} {
+		if !strings.Contains(beta, s) {
+			t.Errorf("beta's text is missing %q: %q", s, beta)
+		}
+	}
+	if strings.Contains(beta, "plugin:gamma") {
+		t.Error("beta's span ran into the next entry")
+	}
+}
+
+// Without is byte-exact when it drops nothing. The listing sits in the cached prefix, so an
+// equivalent-but-reserialized body re-anchors the whole prompt for a saving of zero.
+func TestWithoutIsByteExactWhenItDropsNothing(t *testing.T) {
+	for _, drop := range []map[string]bool{nil, {}, {"nope": true}, {"alpha": false}} {
+		got, n := Parse(listing).Without(drop)
+		if got != listing || n != 0 {
+			t.Errorf("drop=%v changed the listing (%d dropped)", drop, n)
+		}
+	}
+}
+
+func TestWithoutRemovesTheWholeEntry(t *testing.T) {
+	got, n := Parse(listing).Without(map[string]bool{"beta": true})
+	if n != 1 {
+		t.Fatalf("dropped %d, want 1", n)
+	}
+	for _, gone := range []string{"does beta things", "part of beta's description", "more of beta"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived", gone)
+		}
+	}
+	for _, keep := range []string{"- alpha:", "- plugin:gamma:", "- apps/web:deploy:"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("%q was removed too", keep)
+		}
+	}
+}
+
+func TestEntryNameRefusesWhatIsNotAnEntry(t *testing.T) {
+	for _, line := range []string{
+		"",
+		"alpha: no bullet",
+		"- no colon here",
+		"- : empty name",
+		"-  leading space then colon: x",
+		"- has space: in the name", // a space is not in the charset
+		"- <script>: markup",       // nor is markup
+		"- " + strings.Repeat("x", 200) + ": too long",
+	} {
+		if n, ok := EntryName(line); ok {
+			t.Errorf("EntryName(%q) = %q, true — want a refusal", line, n)
+		}
+	}
+	// And the shapes that ARE names, including the two-colon forms.
+	for line, want := range map[string]string{
+		"- alpha: x":           "alpha",
+		"- plugin:gamma: x":    "plugin:gamma",
+		"- apps/web:deploy: x": "apps/web:deploy",
+		"- dash-ed_name.v2: x": "dash-ed_name.v2",
+	} {
+		if n, ok := EntryName(line); !ok || n != want {
+			t.Errorf("EntryName(%q) = %q,%v; want %q,true", line, n, ok, want)
+		}
+	}
+}
+
+func TestValidNameMatchesTheListingCharset(t *testing.T) {
+	for _, ok := range []string{"a", "plugin:skill", "apps/web:deploy", "a.b_c-d2"} {
+		if !ValidName(ok) {
+			t.Errorf("ValidName(%q) = false", ok)
+		}
+	}
+	for _, bad := range []string{"", "has space", "semi;colon", "star*", "quote\"", strings.Repeat("x", 129)} {
+		if ValidName(bad) {
+			t.Errorf("ValidName(%q) = true", bad)
+		}
+	}
+}

--- a/proxy/toolfilterctl.go
+++ b/proxy/toolfilterctl.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/rossoctl/context-guru/config"
 	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/internal/skills"
 	"github.com/rossoctl/context-guru/tenant"
 )
 
@@ -197,9 +198,20 @@ func declConfigName(kind, name, server string) (string, error) {
 	case dash.KindServerTool:
 		return "", errors.New("a provider-side tool is resolved by the provider from its " +
 			"type, not by a schema we send, so it cannot be removed here")
-	case dash.KindSkill, dash.KindSkillListing:
-		return "", errors.New("a skill is declared as prose inside the transcript rather than " +
-			"as a tool, so removing one is not supported yet")
+	case dash.KindSkill:
+		if name == "" {
+			return "", errors.New("no skill name")
+		}
+		if !skills.ValidName(name) {
+			// The listing is the authority for what may be cut out of a real request, so a name
+			// that could not have come from one is refused rather than written into a config that
+			// would match nothing forever.
+			return "", errors.New("that is not a skill name")
+		}
+		return skills.RemovePrefix + name, nil
+	case dash.KindSkillListing:
+		return "", errors.New("the skills listing is one indivisible block of prose — remove the " +
+			"individual skills instead, and the listing shrinks with them")
 	case dash.KindTool, dash.KindMCPTool, "":
 		if name == "" {
 			return "", errors.New("no declaration name")

--- a/proxy/toolfilterctl.go
+++ b/proxy/toolfilterctl.go
@@ -132,11 +132,17 @@ func (h *Handler) ctlToolFilter(w http.ResponseWriter, r *http.Request) {
 		f.Components[toolFilterComponent] = map[string]any{}
 	}
 	f.Components[toolFilterComponent]["remove"] = names
-	// The component runs LAST, after cachesplit: it edits the top-level `tools` array rather
-	// than a message, so its position among the message reducers is meaningless, and appending
-	// keeps an existing order untouched. An empty list leaves the pipeline entirely — a
-	// component with nothing to remove is a pass over every request for nothing.
-	f.Pipeline = withComponent(f.Pipeline, toolFilterComponent, len(names) > 0)
+	// ADDED when absent, and never REMOVED. `toolfilter` now ships in the default pipeline with
+	// an empty removal list, so naming a tool is a settings change and not a pipeline change —
+	// and an emptied list that took the component back out would write an explicit pipeline
+	// DIVERGING from the default, for no gain: a component with nothing to remove already does
+	// nothing. The add stays because an account whose stored pipeline predates that default does
+	// not have it, and without the add that account's first exclusion would save nothing and
+	// report success.
+	//
+	// Position is meaningless here either way: the rewrite lives in apply, not in the component,
+	// because `tools` is a top-level field the message pipeline never sees.
+	f.Pipeline = withComponent(f.Pipeline, toolFilterComponent, true)
 	// This route models exactly one component, so it claims exactly one. Without the claim
 	// ApplyForm preserves anything the stored pipeline runs and this omission is not sent —
 	// which is the rule that stops a stale settings page dropping a component it cannot see,

--- a/proxy/toolfilterctl_test.go
+++ b/proxy/toolfilterctl_test.go
@@ -54,8 +54,10 @@ func TestToolFilterExcludeRoundTrip(t *testing.T) {
 		t.Fatalf("server exclusion not stored: %q", doc)
 	}
 
-	// RECOVERY: re-including both empties the list, which takes the component back out of
-	// the pipeline rather than leaving a pass over every request that removes nothing.
+	// RECOVERY: re-including both empties the LIST. The component stays in the pipeline, because
+	// it now ships in the default one with an empty list — taking it out would write an explicit
+	// pipeline diverging from the default to no effect, since a filter with nothing to remove
+	// already removes nothing. What must not survive is the NAME.
 	for _, name := range []string{`{"kind":"tool","name":"Workflow","action":"include"}`,
 		`{"kind":"mcp_server","server":"playwright","action":"include"}`} {
 		if w, _ = f.do(t, "POST", "/api/toolfilter", name, jar); w.Code != http.StatusOK {
@@ -65,8 +67,16 @@ func TestToolFilterExcludeRoundTrip(t *testing.T) {
 	_, me = f.do(t, "GET", "/api/me", "", jar)
 	tn, _ = me["tenant"].(map[string]any)
 	doc, _ = tn["effective_config_yaml"].(string)
-	if strings.Contains(doc, "Workflow") || strings.Contains(doc, "toolfilter") {
-		t.Errorf("re-including left the filter configured: %q", doc)
+	if strings.Contains(doc, "Workflow") || strings.Contains(doc, "mcp__playwright") {
+		t.Errorf("re-including left a name in the removal list: %q", doc)
+	}
+	// And the component is STILL there, which is the half a revert to the old
+	// `withComponent(..., len(names) > 0)` would break silently: the list would be right, the
+	// account's pipeline would explicitly omit a component the default ships, and nothing would
+	// notice until the default changed under it.
+	if !strings.Contains(doc, "toolfilter") {
+		t.Errorf("re-including took toolfilter out of the pipeline; it ships in the default one "+
+			"and an empty list already removes nothing: %q", doc)
 	}
 
 	// The audit trail recorded the configuration changes.
@@ -239,7 +249,7 @@ func TestToolFilterStoresASkillUnderItsOwnPrefix(t *testing.T) {
 		t.Fatalf("exclude a plugin skill = %d %s", w.Code, w.Body)
 	}
 
-	// RECOVERY: re-including empties the list and takes the component back out.
+	// RECOVERY: re-including empties the list. The component stays (see the round-trip test).
 	for _, body := range []string{
 		`{"kind":"skill","name":"dataviz","action":"include"}`,
 		`{"kind":"skill","name":"ponytail:ponytail","action":"include"}`,
@@ -251,7 +261,7 @@ func TestToolFilterStoresASkillUnderItsOwnPrefix(t *testing.T) {
 	_, me = f.do(t, "GET", "/api/me", "", jar)
 	tn, _ = me["tenant"].(map[string]any)
 	doc, _ = tn["effective_config_yaml"].(string)
-	if strings.Contains(doc, "skill__") || strings.Contains(doc, "toolfilter") {
-		t.Errorf("re-including left the filter configured: %q", doc)
+	if strings.Contains(doc, "skill__") {
+		t.Errorf("re-including left a skill in the removal list: %q", doc)
 	}
 }

--- a/proxy/toolfilterctl_test.go
+++ b/proxy/toolfilterctl_test.go
@@ -103,16 +103,19 @@ func TestToolFilterIsAManagersDecision(t *testing.T) {
 	}
 }
 
-// TestToolFilterRefusesWhatCannotBeRemoved: a provider-side tool and a skill are not elements
-// of `tools` we can drop, so the answer is a reason rather than a stored configuration the
-// filter would silently decline to act on.
+// TestToolFilterRefusesWhatCannotBeRemoved: a provider-side tool is resolved by its `type` and
+// the skills LISTING is one indivisible block of prose, so the answer for those is a reason
+// rather than a stored configuration the filter would silently decline to act on.
+//
+// A SKILL is now accepted and is asserted in TestToolFilterStoresASkillUnderItsOwnPrefix.
 func TestToolFilterRefusesWhatCannotBeRemoved(t *testing.T) {
 	f := ctlFixture(t)
 	w, _ := f.signUp(t, "boss@ibm.com", "l")
 	jar := w.Result().Cookies()
 	for _, body := range []string{
 		`{"kind":"server_tool","name":"web_search","action":"exclude"}`,
-		`{"kind":"skill","name":"dataviz","action":"exclude"}`,
+		`{"kind":"skill_listing","name":"","action":"exclude"}`,
+		`{"kind":"skill","name":"not a skill name","action":"exclude"}`,
 		`{"kind":"tool","name":"","action":"exclude"}`,
 		`{"kind":"tool","name":"Workflow","action":"maybe"}`,
 		`{"kind":"mcp_server","server":"","action":"exclude"}`,
@@ -181,5 +184,74 @@ func TestToolFilterAnswersInTheCallersOwnScope(t *testing.T) {
 	}
 	if !hasExcluded(out, "Workflow") {
 		t.Errorf("the answer to a successful save does not list the exclusion: %v", out)
+	}
+}
+
+// A SKILL goes into the stored list under its own prefix, and comes back out described the way the
+// inventory describes it.
+//
+// Two different strings, deliberately, and the mismatch is the bug this test exists to hold shut.
+// The CONFIG needs `skill__<name>`, because a skill is removed from prose in a transcript message
+// while a tool is removed from the `tools` array and a bare name cannot say which mechanism is
+// meant. The PAGE matches an exclusion against an inventory row by (kind, name), and a row's name
+// is the skill's own — so answering with the prefixed form would leave every skill's switch
+// looking untouched after a write that had in fact landed.
+func TestToolFilterStoresASkillUnderItsOwnPrefix(t *testing.T) {
+	// The MANAGER fixture with the dashboard read hook wired, because the mapping under test is
+	// the one the page consumes: ToolFilterDoc.Excluded. The no-dashboard fallback answers with
+	// the raw config list by design and would not exercise it.
+	f := newMgrFixture(t)
+	f.h.API().SetToolFilterState(f.h.DashToolFilter())
+	w, _ := f.signUp(t, "boss@ibm.com", "l")
+	jar := w.Result().Cookies()
+
+	w, out := f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"skill","name":"dataviz","action":"exclude"}`, jar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("exclude a skill = %d %s", w.Code, w.Body)
+	}
+	// The wire answer names the skill, not the config string.
+	if !hasExcluded(out, "dataviz") {
+		t.Fatalf("the answer does not list the skill as `dataviz`: %v", out)
+	}
+	if hasExcluded(out, "skill__dataviz") {
+		t.Error("the answer leaked the config form; a page matching on it will never match a row")
+	}
+	// The stored document carries the PREFIXED form, builds, and runs the component.
+	_, me := f.do(t, "GET", "/api/me", "", jar)
+	tn, _ := me["tenant"].(map[string]any)
+	doc, _ := tn["effective_config_yaml"].(string)
+	if !strings.Contains(doc, "skill__dataviz") {
+		t.Fatalf("the stored configuration does not carry `skill__dataviz`: %q", doc)
+	}
+	names, ok, reason := removedFrom(doc)
+	if !ok || len(names) != 1 || names[0] != "skill__dataviz" {
+		t.Fatalf("removedFrom(%q) = %v ok=%v %q", doc, names, ok, reason)
+	}
+	if !strings.Contains(doc, "toolfilter") {
+		t.Error("the component is not in the pipeline, so the removal would never run")
+	}
+
+	// A plugin skill's name carries a colon, which the config charset allows and a naive
+	// validator would not.
+	if w, _ = f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"skill","name":"ponytail:ponytail","action":"exclude"}`, jar); w.Code != http.StatusOK {
+		t.Fatalf("exclude a plugin skill = %d %s", w.Code, w.Body)
+	}
+
+	// RECOVERY: re-including empties the list and takes the component back out.
+	for _, body := range []string{
+		`{"kind":"skill","name":"dataviz","action":"include"}`,
+		`{"kind":"skill","name":"ponytail:ponytail","action":"include"}`,
+	} {
+		if w, _ = f.do(t, "POST", "/api/toolfilter", body, jar); w.Code != http.StatusOK {
+			t.Fatalf("include = %d %s", w.Code, w.Body)
+		}
+	}
+	_, me = f.do(t, "GET", "/api/me", "", jar)
+	tn, _ = me["tenant"].(map[string]any)
+	doc, _ = tn["effective_config_yaml"].(string)
+	if strings.Contains(doc, "skill__") || strings.Contains(doc, "toolfilter") {
+		t.Errorf("re-including left the filter configured: %q", doc)
 	}
 }


### PR DESCRIPTION
## What this is

The Inventory page rebuilt around one question a reader can act on — *what am I carrying that I
could stop carrying* — plus the accounting that was missing behind it. Six things were asked for;
all six are here, and two of them turned out to be bugs rather than features.

## 1. The system prompt, broken into its parts

`PromptRegion.Parts` decomposes the system prompt into the sections it was assembled from, each
named, measured and readable, with the assembled whole one disclosure below it. On a real capture
that found **17 sections in a 5,684-token prompt** and put a single one — *Types of memory*, 1,508
tokens — at **26.5% of the prompt**. Before this the page could show the number and not answer it.

The split is on **markdown headings**, and the panel says so. The real structural seam is the wire
one (`system` is an array of separately cacheable blocks), but those boundaries are joined before
anything is stored, so they are gone from every row already captured — a decomposition that only
worked for prompts recorded from today is not one anybody can use. Fenced code blocks are tracked,
because Claude Code's own prompt contains ``` blocks with `#` comments in them and without the
check its environment section split into fragments named after an example command.

The parts' summed weight is printed **beside** the region's own and never reconciled with it: BPE
is not additive across a split point, so they are two measurements of the same bytes and neither is
the error. On the live capture they happened to agree exactly (5,684 = 5,684); the copy handles
both cases.

The content gate is unchanged and now covers the parts. `promptapi.go` strips text for an untrusted
caller; the parts are dropped **whole** rather than blanked field by field, because a list of
section titles is still content — a heading in somebody's CLAUDE.md names their project.
`TestPromptPartsAreStrippedForAnUntrustedCaller` asserts on a marker that lives in a *heading*,
because a strip that misses the titles passes a body-only test.

## 2 & 3. The built-ins left the statistics

They are the largest group by weight — **15,694 tokens per session (`aside_tokens`) against 12,250 controllable
(`declared_tokens`)** on a real capture, 59% of everything declared — and removing one breaks the agent.
So a headline reading "you never touch 82% of what you carry", assembled mostly out of `Read`,
`Bash` and `Grep`, was a true number whose only available action was a mistake.

They are now in `ToolReport.Aside`: in their own collapsed section at the end of the page behind the
existing danger warning, in the composition bar (whose job is the whole prompt), and in **no**
total, percentage, gauge or sortable table. `ToolTotals` covers the controllable set only and
carries `AsideTokens`/`AsideSetTokens` so the page can state what it left out — which it does, in a
line under the gauge, because otherwise the composition bar further down is several times larger
than the headline and a reader has to work out for themselves which one is lying.

Their removal commands are now **folded**, unlike every other command on the page. That asymmetry is
the point: the requirement is that this section be visible and deliberately not easy to act on, and
twenty-two open copy-boxes reading `claude --disallowedTools "Bash"` is the opposite of that however
loud the warning above them.

**The split is drawn on `IsBuiltinTool`, not on the declaration kind, and that boundary is the whole
of `isAside`.** The first cut keyed on kind, so every `KindTool` row went aside. That is correct on a
Claude Code account — all of them are built-ins there — and quietly wrong on any other: it took
every SDK application's and third-party agent's removable declarations off the page, out of the
totals, out of the suggestion engine and therefore out of the filter. A presentation change that
removes a capability. Three tests caught it.

## 4. Filtering MCP tools *and skills* from the dashboard

Skills were reported and not removable. They are now, by a mechanism of their own —
`apply.filterSkillListing` cuts the entry out of the listing prose (measured on real traffic:
`messages[1]`, `role:"system"`, a plain string, 6,867 bytes) — listed in the config as
`skill__<name>`.

The doc's stated reason for *not* doing this was backwards, and that is worth recording. It said the
`Skill` tool's schema carries no enum, so removal turns "unused" into "errors when called". The
first half is right and the second does not follow: with no enum, `skill` is a free-form string, so
a model that names an unlisted skill anyway **runs it**. Verified live. Over-removing a skill fails
OPEN, where over-removing a tool fails silent — the model narrating a call it can no longer make,
which nothing surfaces. **The safer of the two mechanisms was the one being withheld.**

What it therefore is: a way to stop *paying* for a skill, not a way to forbid it. The page says so.

The entry-span rule now lives once, in `internal/skills`, shared by the inventory that prices
entries and the filter that cuts them. A filter that disagreed about where an entry *ends* would
leave orphaned description prose in a real prompt while the page that authorised the removal
reported a clean cut — and this repo has shipped that class of bug before (two cost columns priced
from different maps, 31.6% apart).

Also added: a **group-level switch for a whole MCP server**. The page grouped by "what one action
removes" and then offered a switch per *tool*, so a reader who had decided to drop a nineteen-tool
server had to tick nineteen boxes — nineteen writes, nineteen prefix rebuilds, which is the one
thing the reversibility note tells them not to do.

### What "filterable from the dashboard" does and does not mean

The switches are live **once an account is selected**. At a manager's default scope — the whole
service — a removal list belongs to no single account, so the control is correctly unavailable
there; what this PR changes is that the refusal is now an accurate, actionable reason pointing at
the account selector instead of a claim that the account could not be read. Pick an account (or
`tenant=me`) and the switches work.

The remaining half — **letting a non-manager set their own list**, which currently 403s — is owned
by `feat/user-declaration-filter`, not by this PR. That branch has verified a throwaway merge with
this one: a non-manager excluding `dataviz` drops exactly one listing entry / 1,004 bytes. Noted so
a reader does not read the ask as half-abandoned.

### A live bug this found: the switches were dead for managers

`GET /api/toolfilter` resolved the removal list from the *scope's* tenant. A manager's default scope
is the whole service, so that id is `""`, the registry had no such account, and the document came
back `enabled:false, reason:"could not read your account"`. Every opt-out switch on the Inventory
tab rendered **disabled for the only role permitted to use them**, under a message claiming
something was wrong with their account. Nothing was: a removal list belongs to one account and the
request named none. This is the read-side twin of the bug `writeToolFilterDoc`'s own comment
records; the write path was patched and the read path shipped broken.

Found by clicking the switch on a running deployment. Invisible from the tests because every fixture
that exercises the control pins a tenant, and invisible from the page because a disabled switch
under an explanatory paragraph looks like a deployment that has not enabled the feature. Compounding
it, the UI *discarded* the server's reason — so the page could only ever say "one-click opt-out is
not enabled on this proxy", which on a hosted deployment was simply false.

## 5. The exact command, on every row

At this PR's base `removalCell` was rendered in **two** places — the built-ins table and the group
HEAD in `removalGroup` — so a group of one already showed its command. (An earlier round's prose
says "exactly one place", and that is true of the state *it* fixed, not of this base; an earlier
draft of this body repeated it as though it described mine.) What was missing is per-ITEM: a group
of many showed only the SERVER-level `claude mcp remove <server>`, the right answer to "drop this
whole server" and no answer to "drop just this one tool"; and neither sortable table showed a
command at all. Every candidate row, every row of both tables, and every built-in now carries its
own, folded, with the summary naming the item.

The guard is `TestEveryRemovableRowCarriesItsOwnCommand`, not the earlier round's
`TestTheRemovalCommandIsInTheActionableList` — that one requires three `removalCell` occurrences
and one inside `removalGroup`, both of which held at this base, so it would have passed here.

**Root cause of the missing prompt reveal: `unusedRow` was defined twice in `tools.js`**, 70 lines
apart. The later definition wins in JavaScript, and the later one was the *older* copy: no
`promptTextReveal`, no `id`/`for` pairing, and the whole row wrapped in a `<label>` so a copy button
inside it toggled the checkbox. The fixed version was unreachable code for as long as both existed.
Nothing failed, nothing warned, and the dead copy read exactly like the live one — which is why
"the system prompt parts are not visible" was reported against a file that contained the code to
show them. `TestNoFunctionIsDefinedTwiceInTheDashboardSource` is the guard.

`KIND_LABEL` no longer needs fixing — it was corrected in #93 and `kindPill` checks `builtin`
first. The test that pins it is unchanged and still passing.

### Every removal mechanism re-verified on the wire

Against Claude Code 2.1.241, through the proxy, reading the resulting declaration set back off the
wire rather than inferring it from the settings schema:

| Mechanism | Result |
|---|---|
| `permissions.deny: ["mcp__plan__make_plan"]` | the tool is **gone** from `tools`; its sibling `mcp__plan__review_plan` stays |
| `permissions.deny: ["WebSearch"]` | **gone**; `WebFetch` stays. The bare-name rule works on a built-in and per MCP *tool*, not only per server |
| `skillOverrides: {"claude-api": "off"}` | the entry is **gone** from the listing |
| `skillOverrides: {"superpowers:systematic-debugging": "off"}` | **still present.** It does not work on a plugin skill |
| `claude mcp remove <server>` | confirmed by the owner directly |

The plugin-skill result is worth stating because the settings schema reads as though it *should*
work — the override map is keyed by the same name the listing prints — so the file's existing claim
looked like a guess worth re-checking. It was right, and now it is measured.

A **partial** saving the page was hiding: `skillOverrides` also takes `"name-only"`, which lists the
skill without its description. On a real listing entries run 38–295 tokens and the name is a handful
of them, so that is nearly all of the weight, kept-and-not-paid-for. Offering only all-or-nothing
withheld the option most readers actually want.

## 6. The savings after a removal — and a total that was missing one

`DeclCredit` totals the declarations no longer sent, in **two halves that are never added into one
figure**:

| | What it is | Which total |
|---|---|---|
| `decl_filter_usd` | **Measured, ours.** `requests.filtered_decl_tokens`, written by the filter on every request it acted on, priced at the tier that request paid. | `total_saved_usd` **and** `total_reduced_usd` |
| `self_removed_usd` | **Modelled, the user's.** The account stopped declaring something; no component of ours was involved. | `total_reduced_usd` only |

### `decl_filter_usd` reaching a total at all is a bug fix, not a feature

The whole savings walk is built on `tokens_before − tokens_after`, which is
`schema.MessagesTokens`: **message text only**. A tool declaration lives in the top-level `tools`
array. So the filter's saving moved `baseline_cost_usd` by exactly nothing, and appeared in
`net_saved_usd`, `total_saved_usd` and the waterfall by exactly nothing. It was visible on the
Inventory tab and in **no total anywhere** — the largest lever measured in this project (82.7% of a
declared catalogue is never invoked), invisible to the page that adds the savings up.

Measured on the live run below: `total_saved_usd` went from **$0.000000 to $0.004456**. Every other
addend was $0.00, so on this traffic the fix is the entire headline.

### Why the modelled half is kept out of the credited total

`TotalSavedUSD` documents its addends as all ours. A user's own removal is not. And the method
cannot see *why* a declaration stopped appearing: it sees that the declaration set changed — which
is a fact, and those tokens genuinely were not billed — and infers a removal, which is a guess.

On the production snapshot the largest candidate in the window is `mcp__ide__executeCode` /
`getDiagnostics`, 224 tokens, last declared 2026-08-20 11:40, absent from the 14 MCP-bearing
sessions that followed. **The account did not remove those.** They are the editor integration,
declared only when a session runs inside the IDE. "I ran `claude mcp remove`" and "I worked in a
terminal today" are indistinguishable in this data, and no threshold separates them — the inference
is not wrong about the facts, only about the cause.

So there are two totals rather than one tuned number. `total_saved_usd` answers *how much of this
did context-guru do*; `total_reduced_usd` answers *how much smaller did this bill get*. Collapsing
them would either overstate what the product did or refuse the reader the number they asked for.
Rows the filter is already credited for are excluded from the modelled half rather than counted
twice, and the count of exclusions is reported on the tile.

### Disjointness, made executable rather than asserted

`TotalSavedUSD` gained a fourth addend, so both places that enumerate its addends were updated —
the field's own comment and the waterfall's `total_saved` description, which still read "Three
disjoint token sets". `TestTheWalkAndTheTotalAgreeOnHowManyAddendsThereAre` notices if they drift
again; prose duplicated in two places is prose that diverges.

Three of the four addends are disjoint by construction. **The fourth is not obviously so**, and it
is the one that could double-count: half of what the filter removes is a skill's listing entry,
which lives in `messages` — exactly where `tokens_before` is measured. It holds because *both*
halves of the filter run in `apply` **before** the pipeline takes its baseline, so the removal is
absent from `Saved()` rather than inside it. Measured, on the same live run:

| on each request where the filter dropped 561 tokens | |
|---|---|
| `tokens_before` vs `tokens_after` | equal (4,910 / 4,910) — so `Saved()` = 0 |
| `saved_gross` | 0 |
| `baseline_cost_usd − cost_usd` | 0.0 — so the contribution to `NetSavedUSD` is nothing |
| `tokens_before` unfiltered → filtered | 5,179 → 4,910, a fall of exactly the 269-token skill entry |

That is an **ordering** property of a different package, which a later refactor would falsify in
silence while the total kept adding — so
`TestTheDeclarationFilterSavingIsDisjointFromCompactions` asserts the invariant (a request the
filter acted on and compaction did not contributes to the filter half and to nothing else) rather
than re-deriving the order.

Writing that test surfaced a fixture defect worth naming: `mkEvent` hardcodes
`BaselineCostUSD: 0.02` against `CostUSD: 0.01` whatever tokens it is handed, so its default row
claims a cent of compaction saving on a request that compacted nothing. The test failed on the
fixture before it could test the mechanism — the wrong red. The live rows say `baseline − cost`
is `0.0` on all six such requests, so the fixture is now faithful to them.

### `toolfilter` is in the default pipeline now, so the control route stopped fighting it

With the component shipping by default under an empty removal list, naming a tool is a settings
change and not a pipeline change. `ctlToolFilter` no longer takes the component **out** when the
last exclusion is re-included: that wrote an explicit pipeline *diverging from the default* for no
gain, since a filter with nothing to remove already removes nothing. It still **adds** it when
absent, because an account whose stored pipeline predates that default would otherwise have its
first exclusion save nothing and report success. Both directions are pinned by mutation.


## Evidence: a real run through a local proxy

Loopback-only hosted proxy, fresh database, real Claude Code sessions against the gateway. Not the
production service, and its database was never opened.

**The chain that was asked for.** Session with the `plan` MCP server present → **two clicks in the
dashboard UI** → second session → the saving in Inventory, in Overview, and in the total.

The two clicks produced exactly this stored configuration, and nothing else:

```yaml
components:
  toolfilter:
    remove:
      - mcp__plan
      - skill__dataviz
pipeline:
  - ...
  - toolfilter
```

**The filter fired, and the arithmetic cross-checks against the inventory's own weights:**

| | |
|---|---|
| `filtered_decl_tokens` per request, session 2 | **561** |
| the 3 `plan` MCP schemas, per the inventory | 125 + 93 + 74 = **292** |
| the `dataviz` listing entry, per the inventory | **269** |
| 292 + 269 | **561** ✅ |
| `tokens_before` (messages only), session 1 → 2 | 5,179 → 4,910, a fall of **269** — exactly the skill entry, which is the half that lives in `messages` ✅ |

**One of those is an independent check and the other is not, and the difference matters.**
`561 = 292 + 269` is a single instrument: both sides are `tokens.Count` over the same bytes through
the same `skills.Parse`, so it is an internal-consistency check — worth having, not corroboration.
The `5,179 → 4,910` figure IS independent: it comes from the pipeline's own
`schema.MessagesTokens` over the normalized request, a different code path, and it corroborates the
**269** skill entry. **The tools half's 292 has no independent check at all** — the only other
instrument that could measure it is the provider's billed input, which is confounded by everything
else in the prompt. Said plainly rather than rounded up to "two independent instruments", which is
what an earlier draft of this claimed.

**Where the money landed (11 requests, 9 sessions, $0.6877 billed):**

| Field | Value |
|---|---|
| `decl_filter_usd` | **$0.004456** over 8 requests, 4,363 tokens |
| `self_removed_usd` | **$0.000960**, 3 items, 1,455 tokens, 0 overlap |
| `net_saved_usd` / `cachesplit_saved_usd` / `keepalive_net_usd` | $0.00 / $0.00 / $0.00 |
| `total_saved_usd` | **$0.004456** (was $0.000000 before this change) |
| `total_reduced_usd` | **$0.005416** |

The self-removal half was produced by actually removing something: one session declared a second
MCP server, three later sessions did not. All three rows come back at `sessions_after: 3` — the
minimum the analysis accepts — and the page marks each one **"weak — few sessions"**, which is the
correct reading of three.

**Tier split, because a blended rate would hide it:** the realized figure is 561 cache-read + 561
cache-write tokens per session — the first turn wrote the prefix, the second read it — priced at
their own tiers, not at one average that belongs to neither.

## What did NOT pay, and what I could not do

- **`self_removed_usd` is $0.00 on the production snapshot** under any honest reading, and the one
  candidate it does find is a false attribution (the IDE integration, above). The feature's value
  on real history is currently *the candidate list with its evidence*, not the dollar.
- **`decl_filter_usd` is $0.004** on this run. It is small because the run is small; the mechanism
  is what is being demonstrated, not the magnitude. The projection for this account's own inventory
  is $0.10 over the same window, and the page keeps those in different panels with different words
  and never copies one into the other.
- **The production snapshot cannot demonstrate requirements 1 or 4.** It predates
  `declaration_text`, `text_hash` and `system_prompt` rows entirely — no prompt text, no system
  prompt — which is why everything above is a fresh live run rather than a query over history.
- **A non-manager still cannot set their own removal list.** It is the compaction configuration and
  the hosted service makes that a manager's field; loosening it here would loosen it everywhere,
  quietly. The requirement asked for the dashboard UI instead of a config file edit, and that is
  what shipped. Flagged rather than decided unilaterally.
- **Wire-block boundaries for the prompt decomposition** are not recoverable (see §1). Headings are
  a deliberate second choice.
- **`kv()` is defined twice in `app.js`** — the same latent hazard as the `unusedRow` bug, 3,700
  lines from anything here. Found by the new duplicate check, deliberately **not** fixed in this PR,
  and listed as a known exception in that test so it guards everything else. A silent edit to a
  shared helper is how an unrelated regression gets attributed to the wrong commit.

## Reconciling with the two branches landing beside this one

`dash/overview.go` — **no overlapping hunks.** Theirs are at 378/421/514/534, all inside
`Overview()`'s early section; mine are the struct (164), one line after `TotalSavedUSD` is computed
(645), `SetDeclCredit` (711) and two waterfall hunks (815, 828). Their last hunk ends ~100 lines
above my earliest one in that function. `TotalSavedUSD` and the waterfall are untouched by them.

`dash/ui/tools.js` — **the one real landmine, defused here.** Their change to this file is a pure
rename of the prompt-text state object (`prompt` → `promptView`, shadowing `window.prompt`), across
exactly the region this PR rewrites. A textual merge would have taken their renamed declaration
alongside this branch's rewritten `promptTextReveal`, `renderPromptPanel`, `promptRegion` and the
new `promptParts`, all still reading the old name: no conflict markers, no failing test, and a
`ReferenceError` the first time a reader opened a reveal. **This branch adopts their rename**, to
the same new name, so the merge is a no-op on those lines.

`dash/keepalivetab_test.go` — three hunks, all mechanically forced by the new addend, none
incidental:

| hunk | why it is required |
|---|---|
| `mayMove` gains `"total_reduced_usd": true` | `total_reduced_usd` is built on `total_saved_usd`, so it moves with it; their test fails on this branch without it |
| a 4-line paired-delta assertion | pins `total_reduced` to the SAME delta rather than merely excusing it in the allowlist — if it ever moved differently, the ping spend would be reaching one total and not the other |
| `TestTheWaterfallReconcilesWithTotalSaved` gains a `SetDeclCredit` call and `steps["decl_filter_saved"]` in the sum | the walk has a new step; without it the reconciliation fails |

Only one line is *modified* rather than added — the `sum := -(...)` expression — and their branch
does not touch it. **Test-merged both branches: zero conflicts**, and the merged tree builds,
passes `node --check`, and passes `dash`, `proxy`, `apply` and `internal/skills`. That last part is
the one worth stating, because a clean textual merge is exactly what would have hidden the rename
bug.


## Review round: what changed after the independent review

Five findings, all reproduced before fixing.

**The skills half of the filter had no wiring test.** Deleting the two lines in `apply.Body` that
call `filterSkillListing` left `go test ./...` **entirely green** — confirmed. All seven unit tests
call the function directly, so none of them notices that nothing in production does: a user could
tick a skill, have the config written and audited, read "Opted out", and go on paying, with CI
green. `TestSkillFilterThroughApply` (6 cases, the sibling of `TestToolFilterThroughApply`) and
`TestSkillFilterSameListingEveryTurn` now cover it, verified by making that exact deletion.

**The overlap exclusion could never fire for a skill — or for a whole MCP server.** The comparison
was made across two vocabularies: the config stores `skill__dataviz` and `mcp__plan`, a report row
is `dataviz` (kind skill) or `mcp__plan__make_plan` (server `plan`). Only an exact tool name — the
one shape where the two coincide — ever matched, which is why the original test passed. The review
named the skill case; the **whole-server case was broken the same way** and is fixed by the same
change. Fixed at the root: one `declFilteredSet` built from the existing `excludedFrom`, which
already knows how a config name becomes a report row, and both call sites now pass the raw list
instead of each building the map in the wrong vocabulary.

**The disjointness test did not guard what its title said.** It builds its row by hand and never
runs `apply`, so it pins the downstream arithmetic and not the ordering — and the only mutation that
reddened it was deleting its own fixture line. Both are now true: its comment says what it pins, and
`TestFilterRemovalIsNotInsideTheCompactionBaseline` in `apply` compares two real runs. Writing it
corrected my own understanding of where the boundary is: **it is `normalize` (`apply.go:441`) feeding
`pipeline.go:35`, not the `msgsRaw` read above it.** My first mutation moved the filter above
`msgsRaw` and survived, because that is not the baseline boundary. Moving it past `normalize` reds
the test with the right message.

**A directory-scoped skill got a command that does nothing.** `apps/web:deploy` produced
`claude plugin disable apps/web`, naming no plugin — the worst output this panel can emit, because
it gets pasted and appears to succeed. Two things wear a colon; a `/` in the prefix is the
discriminator. Pre-existing, and in scope because this PR claims "the exact command per skill".

**The prose gate's declines are still unrecorded**, and that half is deliberately deferred with its
cost written down: the decision is made in `apply`, so the count must reach `Ctx` the way
`FilteredDecls` does — a fourth return value on two functions with 31 call sites, 28 of them tests —
and the alternative is duplicating `proseReferenced` at a second site, which is how the two drift.
What is fixed is the half that misleads a **user**: the page no longer promises an outcome it has
not checked. "Opted out" now reads "context-guru stops sending it from your next session — unless
your own system prompt still names it, in which case it is deliberately kept and will go on
appearing here."

Also: tests for the previously untested `skill__` guard in `removeSets` and the two-zeroes gauge
branch. The duplicate `kv()` in `app.js` stays unfixed and its exception comment now carries
everything a tracking issue would need — filing one is an outbound write this change had no
authorisation for, and a finding whose only record is a review thread evaporates.


## Tests, and the ones I broke on purpose

New behaviour, new tests: `internal/skills` (parse, span, byte-exactness, charset),
`apply/toolfilter_skills_test.go` (7 cases including the block-array shape and the prose gate),
`dash/declcredit_test.go` (the two halves, overlap, unpriced, and which total each reaches),
`dash/promptparts_test.go` (including *the parts must reassemble into the prompt exactly*),
`dash/contentgate_test.go` (parts stripped, asserted on a heading marker),
`dash/uiinventory_test.go` (4 static checks: no duplicate definitions, per-row commands, the aside
group comes from the server, the headline discloses what it left out), and the manager-scope pair.

**Every one was made to fail on purpose.** A recurring defect class here is a test that cannot catch
its own subject, so each was verified by mutating the code it guards and confirming it goes red:

| Mutation | Result |
|---|---|
| entry span stops at the next bullet instead of the next NAME | caught |
| `Without` re-joins with the wrong separator | caught |
| `Without` cuts one line too many | caught |
| the skill prose gate is removed | caught |
| the skill filter re-encodes when it removed nothing | caught |
| built-ins put back into the main list and the totals | caught |
| the self-removal half added into `TotalSavedUSD` | caught |
| overlapping self-removals credited instead of excluded | caught |
| the untrusted strip leaves the part TITLES behind | caught |
| the heading splitter ignores fenced code blocks | caught |
| the manager scope fix reverted | caught |
| revert to removing the component when the list empties | caught |
| stop adding the component at all | caught |
| the walk drops back to enumerating three addends | caught |
| the filter saving folded into the compaction baseline | caught |

One mutation **survived** and it was informative: removing `Without`'s `n == 0` early return
changed nothing, because `Parse` splits on `"\n"` and `Without` joins on `"\n"`, so the
nothing-dropped path already reproduces the input byte for byte. The fast path was a second code
path with nothing to do. **It is deleted**, and the test re-verified against two genuine breaks
instead.

`gofmt -l` empty · `go vet ./...` clean · `CGO_ENABLED=1 go test -race` green across
`dash`, `apply`, `internal`, `components`, `config`, `proxy`, 0 data races.

One flake seen once and not reproducible: `TestDashboardAddsNoRequestLatencyWithContentCapture`
failed on a full-tree `go test ./...` under parallel load and passed 4/4 subsequently in its own
package. It is a wall-clock latency comparison; nothing in this diff is on its path (the skill
filter runs only when `toolfilter` is in the pipeline, which that fixture does not configure).
Reporting it rather than quietly re-running until green.
