### PR TITLE
feat(kvcache): price a KV-cache TTL policy against real trajectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,16 @@ celerybeat.pid
 # Environments
 .env
 .venv
+# Any venv, not only the one named exactly `.venv`. The KV-cache TTL tooling documents
+# `.venv-kvpred`, whose bin/ and pyvenv.cfg were otherwise untracked-but-not-ignored.
+.venv*/
+
+# Fitted survival predictors (deploy/harbor/kv_ttl_survival_predictor.py). NEVER committed:
+# joblib is pickle, so the file is executable content, and the fitted pipeline one-hot-encodes
+# user_id — which is the real tenant id — so OneHotEncoder.categories_ carries a verbatim list
+# of every account in the training window. This repo is public. One `git add -A` in the root
+# would publish the customer list.
+*.joblib
 env/
 venv/
 ENV/

--- a/deploy/harbor/kv_ttl_cost_drift_test.go
+++ b/deploy/harbor/kv_ttl_cost_drift_test.go
@@ -269,6 +269,7 @@ type pyResult struct {
 	AvoidedTokens     int64   `json:"avoided_tokens"`
 	RetainedMs        int64   `json:"retained_ms"`
 	Unpriced          int64   `json:"unpriced"`
+	Valued            bool    `json:"valued"`
 }
 
 // scoreWithPort writes the fixture and returns what the Python evaluator made of it.
@@ -433,6 +434,24 @@ func TestPythonCostModelAgreesWithTheShippedSimulator(t *testing.T) {
 		{"retained_ms", got.RetainedMs, want.RetainedMs},
 		{"unpriced", got.Unpriced, want.Unpriced},
 	} {
+		if c.got != c.exp {
+			t.Errorf("%s: port %d, kvcache.Simulate %d", c.name, c.got, c.exp)
+		}
+	}
+	// Valued gates every cost the page renders, so the two must agree about it too — and the
+	// fixture must actually be priced, or this comparison is two falses agreeing and the whole
+	// dollar comparison above is zero on both sides.
+	if got.Valued != want.Valued {
+		t.Errorf("valued: port %v, kvcache.Simulate %v", got.Valued, want.Valued)
+	}
+	if !want.Valued {
+		t.Error("the fixture prices nothing, so every dollar compared here is zero on both " +
+			"sides and this test proves nothing")
+	}
+	for _, c := range []struct {
+		name     string
+		got, exp int64
+	}{} {
 		if c.got != c.exp {
 			t.Errorf("%s: port %d, kvcache.Simulate %d", c.name, c.got, c.exp)
 		}

--- a/deploy/harbor/kv_ttl_cost_drift_test.go
+++ b/deploy/harbor/kv_ttl_cost_drift_test.go
@@ -1,0 +1,512 @@
+package harbor
+
+// The Python KV-cache cost model and the Go one must be the same arithmetic.
+//
+// kv_ttl_cost_model.py exists because the survival predictor is Python and an evaluation
+// loop that shelled into Go for every candidate threshold would not get run. But the
+// SHIPPED implementation is `kvcache.Simulate`, which is what the dashboard reports from,
+// and two implementations of one money question is precisely the drift this project has
+// been bitten by — the browser has twice duplicated a table the server owns and diverged
+// from it. So the Python file is a port, this test is the guard, and when they disagree Go
+// is right.
+//
+// It hands BOTH the same trajectory and the same per-turn action list and compares the
+// totals. Nothing is mocked: the Python side runs its real evaluator through its real
+// `--fixture` entry point, which needs only the standard library — the scientific stack is
+// imported lazily by the predictor bridge and the price-list reader, neither of which this
+// path touches. So this guard runs in a plain CI container.
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// pythonBin is the interpreter to drive the port with. KVCACHE_PYTHON overrides it for a
+// venv; the test SKIPS rather than fails when no usable interpreter is present, because a
+// missing Python is an absent guard, not a broken product.
+func pythonBin(t *testing.T) string {
+	t.Helper()
+	for _, cand := range []string{os.Getenv("KVCACHE_PYTHON"), "python3", "python"} {
+		if cand == "" {
+			continue
+		}
+		p, err := exec.LookPath(cand)
+		if err != nil {
+			continue
+		}
+		// It must be able to import the module at all; a 3.8 interpreter cannot.
+		if out, err := exec.Command(p, "-c",
+			"import sys; sys.path.insert(0,'.'); import kv_ttl_cost_model").CombinedOutput(); err != nil {
+			t.Logf("%s cannot import kv_ttl_cost_model, skipping it: %s", p, out)
+			continue
+		}
+		return p
+	}
+	return ""
+}
+
+// The fixture wire format, and it is the Python dataclass's own field names: the port is
+// the thing under test, so the bridge into it stays as thin as possible.
+type fixtureRequest struct {
+	RequestID     int64  `json:"request_id"`
+	User          string `json:"user"`
+	Conversation  string `json:"conversation"`
+	TSms          int64  `json:"ts_ms"`
+	Model         string `json:"model"`
+	InputTokens   int64  `json:"input_tokens"`
+	OutputTokens  int64  `json:"output_tokens"`
+	CachedContext int64  `json:"cached_context"`
+	MissReason    string `json:"miss_reason"`
+}
+
+type fixtureRate struct {
+	Input            float64 `json:"input"`
+	Output           float64 `json:"output"`
+	CacheRead        float64 `json:"cache_read"`
+	Write5m          float64 `json:"write_5m"`
+	Write1h          float64 `json:"write_1h"`
+	PingInputTokens  int64   `json:"ping_input_tokens"`
+	PingOutputTokens int64   `json:"ping_output_tokens"`
+	Known            bool    `json:"known"`
+}
+
+type fixture struct {
+	WindowEndMs int64                  `json:"window_end_ms"`
+	Rates       map[string]fixtureRate `json:"rates"`
+	Semantics   map[string]bool        `json:"semantics"`
+	Schedule    map[string]int64       `json:"schedule"`
+	Requests    []fixtureRequest       `json:"requests"`
+	// Actions is keyed by REQUEST ID, never positional. The fixture deliberately contains
+	// two rows with the same timestamp, and both implementations order by (ts, id) — so a
+	// positional list is assigned in a different order than the one it was written in, and
+	// the two sides silently score different action sets. That is the first thing this test
+	// caught, and it caught it in itself.
+	Actions map[string]string `json:"actions"`
+	// Policy runs a named arm instead of Actions, so the guard can lock the two exact
+	// CEILINGS together as well as the action-list evaluator. A ceiling the two sides
+	// disagree about is one neither can be quoted against.
+	Policy string `json:"policy,omitempty"`
+}
+
+// The rates are this gateway's own opus-5 and sonnet-5 numbers, per TOKEN, plus a model
+// with no rates at all — because "an unpriced request is counted and never valued" is one
+// of the behaviours the two implementations have to agree about.
+var driftRates = map[string]fixtureRate{
+	"aws/claude-opus-5": {Input: 3.8e-6, Output: 19e-6, CacheRead: 0.38e-6,
+		Write5m: 4.75e-6, Write1h: 7.6e-6, PingInputTokens: 1, PingOutputTokens: 1, Known: true},
+	"aws/claude-sonnet-5": {Input: 1.52e-6, Output: 7.6e-6, CacheRead: 0.152e-6,
+		Write5m: 1.9e-6, Write1h: 3.04e-6, PingInputTokens: 1, PingOutputTokens: 1, Known: true},
+	"no-such-model": {PingInputTokens: 1, PingOutputTokens: 1},
+}
+
+// A trajectory set built to exercise every branch the two share, and every one of these
+// rows is here because getting it wrong is invisible in a total:
+//
+//   - gaps on both sides of the 5-minute and 1-hour edges, and one EXACTLY on 5 minutes;
+//   - two accounts presenting the SAME session id, which must not be spliced;
+//   - tied timestamps, broken by id;
+//   - a `prefix_change` and a `cold_start`, which no TTL may rescue;
+//   - a conversation whose last request leaves a PINGING action open at the window's end;
+//   - a model with no rates;
+//   - a keep-alive interval wider than the lifetime it protects, so a ping lands on a
+//     lapsed entry and is billed as a re-creation rather than a read;
+//   - the write-cheap-then-extend action, whose keep-alive UPGRADES a live entry to the hourly
+//     tier and is therefore a write on purpose — the one ping that costs 20x a read by design,
+//     and the easiest thing on this page to price as if it were free.
+func driftFixture() fixture {
+	const base = int64(1_786_967_311_185)
+	const min5, hour = int64(300_000), int64(3_600_000)
+	rows := []fixtureRequest{
+		// A: short gaps, then exactly 5 minutes, then past it.
+		{1, "acct-a", "sess-1", base, "aws/claude-opus-5", 120, 40, 100_000, "cold_start"},
+		{2, "acct-a", "sess-1", base + 30_000, "aws/claude-opus-5", 90, 55, 180_000, "hit"},
+		{3, "acct-a", "sess-1", base + 30_000 + min5, "aws/claude-opus-5", 70, 30, 220_000, "hit"},
+		{4, "acct-a", "sess-1", base + 30_000 + min5 + min5 + 1, "aws/claude-opus-5", 60, 20, 240_000, "ttl_expiry"},
+		// A long gap that only a 1-hour hold or a ping schedule could survive.
+		{5, "acct-a", "sess-1", base + 40*60_000, "aws/claude-opus-5", 50, 25, 500_000, "ttl_expiry"},
+		// Past an hour: nothing on offer reaches.
+		{6, "acct-a", "sess-1", base + 40*60_000 + hour + 1, "aws/claude-opus-5", 40, 15, 520_000, "ttl_expiry"},
+
+		// B: another ACCOUNT with the SAME session id. Must never join A's trajectory.
+		{7, "acct-b", "sess-1", base + 1_000, "aws/claude-sonnet-5", 200, 60, 90_000, "cold_start"},
+		{8, "acct-b", "sess-1", base + 61_000, "aws/claude-sonnet-5", 150, 45, 140_000, "hit"},
+		// A prefix change: alive or not, this one misses.
+		{9, "acct-b", "sess-1", base + 121_000, "aws/claude-sonnet-5", 130, 35, 160_000, "prefix_change"},
+
+		// C: tied timestamps, resolved by id, and a zero-length gap.
+		{11, "acct-b", "sess-2", base + 5_000, "aws/claude-sonnet-5", 80, 20, 60_000, "cold_start"},
+		{10, "acct-b", "sess-2", base + 5_000, "aws/claude-sonnet-5", 80, 20, 60_000, "hit"},
+
+		// D: an unpriced model. Counted, never valued.
+		{12, "acct-c", "sess-3", base + 2_000, "no-such-model", 300, 90, 70_000, "cold_start"},
+		{13, "acct-c", "sess-3", base + 400_000, "no-such-model", 100, 30, 80_000, "ttl_expiry"},
+
+		// E: one turn only, and the action left open at the window's end pings.
+		{14, "acct-c", "sess-4", base + 3_000, "aws/claude-opus-5", 60, 18, 300_000, "cold_start"},
+	}
+	// One action per row, BY ID, chosen to cover all five actions and to leave a pinging
+	// action open at the window's end on two different conversations.
+	actions := map[string]string{
+		"1": "write_5m", "2": "write_5m", "3": "write_1h", "4": "expire", "5": "write_5m_ping_1h",
+		"6": "write_5m",
+		"7": "write_5m", "8": "ping_1h", "9": "write_5m",
+		"10": "write_5m", "11": "expire",
+		"12": "write_1h", "13": "write_5m_ping_1h",
+		"14": "ping_5m",
+	}
+	var end int64
+	for _, r := range rows {
+		if r.TSms > end {
+			end = r.TSms
+		}
+	}
+	return fixture{
+		WindowEndMs: end,
+		Rates:       driftRates,
+		// Anthropic's documented behaviour, stated rather than defaulted, so the two
+		// implementations cannot silently disagree about what the default IS.
+		Semantics: map[string]bool{"hit_refreshes_ttl": true, "ping_refreshes_ttl": true,
+			"zero_generation": false},
+		// A 5-minute interval WIDER than the 5-minute lifetime, deliberately: it is the only
+		// way to reach the "a keep-alive fired after the entry lapsed, so it re-created the
+		// prefix at the write rate" branch, which is the most expensive thing either
+		// implementation can do and the one a reader would never notice being wrong.
+		Schedule: map[string]int64{"idle_5m_ms": 330_000, "idle_1h_ms": 3_360_000,
+			"max_pings": 2},
+		Requests: rows,
+		Actions:  actions,
+	}
+}
+
+// goFixtureInputs turns a fixture into the dataset and config the shipped simulator takes.
+func goFixtureInputs(t *testing.T, f fixture) ([]*kvcache.Request, kvcache.Config) {
+	t.Helper()
+	// The rate table, laid in as overrides so the fixture is the only source of truth and no
+	// network price map can move this test.
+	overrides := map[string]kvcache.Override{}
+	models := make([]string, 0, len(f.Rates))
+	for name, r := range f.Rates {
+		models = append(models, name)
+		if !r.Known {
+			continue
+		}
+		in, out, cr, w5, w1 := r.Input, r.Output, r.CacheRead, r.Write5m, r.Write1h
+		pin, pout := r.PingInputTokens, r.PingOutputTokens
+		overrides[name] = kvcache.Override{Input: &in, Output: &out, CacheRead: &cr,
+			Write5m: &w5, Write1h: &w1, PingInputTokens: &pin, PingOutputTokens: &pout}
+	}
+	book := kvcache.NewPriceList(t.Context(), models, nil, kvcache.Multipliers{}, overrides)
+
+	reqs := make([]*kvcache.Request, 0, len(f.Requests))
+	act := map[int64]kvcache.Action{}
+	for _, r := range f.Requests {
+		reqs = append(reqs, &kvcache.Request{
+			ID: r.RequestID, User: r.User, ConversationID: r.Conversation, TS: r.TSms,
+			HourUTC: time.UnixMilli(r.TSms).UTC().Hour(), Bucket: kvcache.BucketAt(r.TSms),
+			Model: r.Model, InputTokens: r.InputTokens, OutputTokens: r.OutputTokens,
+			CachedContext: r.CachedContext, MissReason: r.MissReason,
+			TTL: kvcache.TTL5m, TTLSource: kvcache.TTLSourceConfigured,
+		})
+		act[r.RequestID] = kvcache.Action(f.Actions[strconv.FormatInt(r.RequestID, 10)])
+	}
+	kvcache.Derive(reqs)
+	cfg := kvcache.Config{
+		Prices: book,
+		Semantics: kvcache.Semantics{HitRefreshesTTL: f.Semantics["hit_refreshes_ttl"],
+			PingRefreshesTTL: f.Semantics["ping_refreshes_ttl"],
+			ZeroGeneration:   f.Semantics["zero_generation"]},
+		PingIdle:   time.Duration(f.Schedule["idle_5m_ms"]) * time.Millisecond,
+		PingIdle1h: time.Duration(f.Schedule["idle_1h_ms"]) * time.Millisecond,
+		MaxPings:   int(f.Schedule["max_pings"]),
+		WindowEnd:  f.WindowEndMs,
+	}
+	return reqs, cfg
+}
+
+// goTotal replays the fixture's own action list through the SHIPPED implementation.
+func goTotal(t *testing.T, f fixture) *kvcache.Result {
+	t.Helper()
+	reqs, cfg := goFixtureInputs(t, f)
+	act := map[int64]kvcache.Action{}
+	for _, r := range f.Requests {
+		act[r.RequestID] = kvcache.Action(f.Actions[strconv.FormatInt(r.RequestID, 10)])
+	}
+	return kvcache.Simulate(reqs, kvcache.NewReplay("fixture", act, kvcache.ActionExpire), cfg)
+}
+
+// pyResult is the subset of the port's output this test compares. Every field here is one
+// the two implementations could disagree about while both looking plausible.
+type pyResult struct {
+	TotalUSD          float64 `json:"total_usd"`
+	FreshInputUSD     float64 `json:"fresh_input_usd"`
+	CacheReadUSD      float64 `json:"cache_read_usd"`
+	CacheWriteUSD     float64 `json:"cache_write_usd"`
+	OutputUSD         float64 `json:"output_usd"`
+	PingUSD           float64 `json:"ping_usd"`
+	UncachedUSD       float64 `json:"uncached_usd"`
+	CachePremiumUSD   float64 `json:"cache_premium_usd"`
+	Requests          int64   `json:"requests"`
+	Conversations     int64   `json:"conversations"`
+	Hits              int64   `json:"hits"`
+	Misses            int64   `json:"misses"`
+	ForcedMisses      int64   `json:"forced_misses"`
+	Pings             int64   `json:"pings"`
+	PingsThatRewrote  int64   `json:"pings_that_rewrote"`
+	PingsThatUpgraded int64   `json:"pings_that_upgraded"`
+	PingsOnOpenSpans  int64   `json:"pings_on_open_spans"`
+	Writes5m          int64   `json:"writes_5m"`
+	Writes1h          int64   `json:"writes_1h"`
+	Expires           int64   `json:"expires"`
+	AvoidedTokens     int64   `json:"avoided_tokens"`
+	RetainedMs        int64   `json:"retained_ms"`
+	Unpriced          int64   `json:"unpriced"`
+}
+
+// scoreWithPort writes the fixture and returns what the Python evaluator made of it.
+func scoreWithPort(t *testing.T, py string, f fixture) pyResult {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.json")
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(py, "kv_ttl_cost_model.py", "--fixture", path)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("the port failed on the fixture: %v\nstdout: %s\nstderr: %s",
+			err, out, stderr.String())
+	}
+	var got pyResult
+	// The port prints one JSON object; take the last line so a stray warning cannot break it.
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &got); err != nil {
+		t.Fatalf("cannot read the port's output: %v\n%s", err, out)
+	}
+	return got
+}
+
+// Both sides solve the same dynamic program for the cheapest possible plan. If they disagree,
+// the ceiling every saving on the page is measured against is not one number.
+func TestTheTwoExactCeilingsAgree(t *testing.T) {
+	py := pythonBin(t)
+	if py == "" {
+		t.Skip("no interpreter that can import kv_ttl_cost_model")
+	}
+	f := driftFixture()
+	f.Policy = "optimal"
+	f.Actions = nil
+	got := scoreWithPort(t, py, f)
+
+	reqs, cfg := goFixtureInputs(t, f)
+	want := kvcache.Simulate(reqs, kvcache.NewOptimal(reqs, cfg), cfg)
+	if math.Abs(got.TotalUSD-want.TotalUSD) > 1e-4 {
+		t.Errorf("the exact ceilings disagree: port $%.8f, kvcache.NewOptimal $%.8f\n"+
+			"One of the two dynamic programs is wrong, and every saving quoted against the "+
+			"ceiling is wrong with it.", got.TotalUSD, want.TotalUSD)
+	}
+	// The plans need not be identical — ties exist — but the counts should line up when the
+	// costs do, and a wild divergence there means one side is solving a different problem.
+	if got.Hits != want.Hits {
+		t.Errorf("same cost, different hits: port %d, kvcache %d", got.Hits, want.Hits)
+	}
+	// And it must actually be a ceiling on the fixture, on both sides.
+	plain := kvcache.Simulate(reqs, kvcache.Fixed5m(), cfg)
+	if want.TotalUSD > plain.TotalUSD+1e-9 {
+		t.Errorf("the optimum ($%.6f) is dearer than fixed-5m ($%.6f) on the fixture",
+			want.TotalUSD, plain.TotalUSD)
+	}
+	t.Logf("both ceilings agree at $%.6f (fixed-5m costs $%.6f)", want.TotalUSD, plain.TotalUSD)
+}
+
+// The deliberate tier UPGRADE needs a keep-alive that lands while the entry is still ALIVE,
+// so it needs an interval INSIDE the five-minute lifetime — the opposite of the main
+// fixture's, which is deliberately wider so that pings land on a lapsed entry. One schedule
+// cannot reach both branches, so this is a second scenario over the same trajectory rather
+// than a compromise that reaches neither.
+func TestTheUpgradingKeepAliveAgrees(t *testing.T) {
+	py := pythonBin(t)
+	if py == "" {
+		t.Skip("no interpreter that can import kv_ttl_cost_model")
+	}
+	f := driftFixture()
+	// 280 s: inside the 300 s lifetime, which is the shipped keep-alive cadence.
+	f.Schedule["idle_5m_ms"] = 280_000
+	got := scoreWithPort(t, py, f)
+	want := goTotal(t, f)
+
+	if want.PingsThatUpgraded == 0 {
+		t.Fatal("no keep-alive upgraded a live entry; this scenario is not exercising the one " +
+			"ping that is a write on purpose")
+	}
+	if want.PingsThatRewrote != 0 {
+		t.Errorf("%d pings re-created a lapsed entry; with a cadence inside the lifetime none "+
+			"should, so this scenario is measuring the wrong branch", want.PingsThatRewrote)
+	}
+	if math.Abs(got.TotalUSD-want.TotalUSD) > 1e-4 {
+		t.Errorf("total_usd: port %.8f, kvcache.Simulate %.8f — the two disagree about what "+
+			"extending a live entry by an hour costs", got.TotalUSD, want.TotalUSD)
+	}
+	if got.PingsThatUpgraded != want.PingsThatUpgraded {
+		t.Errorf("pings_that_upgraded: port %d, kvcache %d",
+			got.PingsThatUpgraded, want.PingsThatUpgraded)
+	}
+	if got.PingUSD != 0 && math.Abs(got.PingUSD-want.PingUSD) > 1e-4 {
+		t.Errorf("ping_usd: port %.8f, kvcache %.8f", got.PingUSD, want.PingUSD)
+	}
+	// An upgrade is a WRITE. If it were priced as a read it would cost 20x less, so this pins
+	// the magnitude rather than only the agreement.
+	reqs, cfg := goFixtureInputs(t, f)
+	_ = reqs
+	price := cfg.Prices.For("aws/claude-opus-5")
+	if price.Write1h <= price.CacheRead*10 {
+		t.Errorf("the fixture's 1-hour write rate (%.9f) is not meaningfully dearer than its "+
+			"read rate (%.9f), so this test cannot tell a write from a read",
+			price.Write1h, price.CacheRead)
+	}
+	t.Logf("agreed at $%.6f with %d upgrading keep-alives", want.TotalUSD, want.PingsThatUpgraded)
+}
+
+func TestPythonCostModelAgreesWithTheShippedSimulator(t *testing.T) {
+	py := pythonBin(t)
+	if py == "" {
+		t.Skip("no interpreter that can import kv_ttl_cost_model")
+	}
+	f := driftFixture()
+	got := scoreWithPort(t, py, f)
+	want := goTotal(t, f)
+
+	// A hundredth of a cent. Both sides sum the same products of the same float64s in the
+	// same order, so the difference should be zero; the epsilon is for the JSON round trip,
+	// not for a licence to differ.
+	const eps = 1e-4
+	for _, c := range []struct {
+		name     string
+		got, exp float64
+	}{
+		{"total_usd", got.TotalUSD, want.TotalUSD},
+		{"fresh_input_usd", got.FreshInputUSD, want.FreshInputUSD},
+		{"cache_read_usd", got.CacheReadUSD, want.CacheReadUSD},
+		{"cache_write_usd", got.CacheWriteUSD, want.CacheWriteUSD},
+		{"output_usd", got.OutputUSD, want.OutputUSD},
+		{"ping_usd", got.PingUSD, want.PingUSD},
+		{"uncached_usd", got.UncachedUSD, want.UncachedUSD},
+		{"cache_premium_usd", got.CachePremiumUSD, want.CachePremium},
+	} {
+		if math.Abs(c.got-c.exp) > eps {
+			t.Errorf("%s: port %.8f, kvcache.Simulate %.8f (delta %.2e)\n"+
+				"The Python cost model has drifted from the arithmetic the dashboard ships. "+
+				"Go is right; fix deploy/harbor/kv_ttl_cost_model.py.",
+				c.name, c.got, c.exp, c.got-c.exp)
+		}
+	}
+	for _, c := range []struct {
+		name     string
+		got, exp int64
+	}{
+		{"requests", got.Requests, want.Requests},
+		{"conversations", got.Conversations, want.Conversations},
+		{"hits", got.Hits, want.Hits},
+		{"misses", got.Misses, want.Misses},
+		{"forced_misses", got.ForcedMisses, want.ForcedMisses},
+		{"pings", got.Pings, want.Pings},
+		{"pings_that_rewrote", got.PingsThatRewrote, want.PingsThatRewrote},
+		{"pings_that_upgraded", got.PingsThatUpgraded, want.PingsThatUpgraded},
+		{"pings_on_open_spans", got.PingsOnOpenSpans, want.PingsOnOpenSpans},
+		{"writes_5m", got.Writes5m, want.Writes5m},
+		{"writes_1h", got.Writes1h, want.Writes1h},
+		{"expires", got.Expires, want.Expires},
+		{"avoided_tokens", got.AvoidedTokens, want.AvoidedTokens},
+		{"retained_ms", got.RetainedMs, want.RetainedMs},
+		{"unpriced", got.Unpriced, want.Unpriced},
+	} {
+		if c.got != c.exp {
+			t.Errorf("%s: port %d, kvcache.Simulate %d", c.name, c.got, c.exp)
+		}
+	}
+	// A fixture that exercised nothing would pass this test while proving nothing, so the
+	// branches it exists for are asserted to have actually been reached.
+	if want.Pings == 0 || want.PingsThatRewrote == 0 || want.PingsOnOpenSpans == 0 {
+		t.Errorf("the fixture no longer reaches the keep-alive branches (pings=%d rewrote=%d "+
+			"open=%d); the agreement it proves is narrower than it looks",
+			want.Pings, want.PingsThatRewrote, want.PingsOnOpenSpans)
+	}
+	if want.Unpriced == 0 || want.ForcedMisses == 0 || want.Hits == 0 || want.Expires == 0 {
+		t.Errorf("the fixture no longer reaches unpriced/forced-miss/hit/expire (unpriced=%d "+
+			"forced=%d hits=%d expires=%d)",
+			want.Unpriced, want.ForcedMisses, want.Hits, want.Expires)
+	}
+	if want.Conversations != 5 {
+		t.Errorf("conversations = %d, want 5 — two accounts share a session id and must not "+
+			"be spliced into one trajectory", want.Conversations)
+	}
+	t.Logf("agreed: total $%.6f over %d requests, %d conversations, %d pings (%d re-created)",
+		want.TotalUSD, want.Requests, want.Conversations, want.Pings, want.PingsThatRewrote)
+}
+
+// The ping schedule is restated in the port; this checks the two agree over a table rather
+// than by inspection. kvcache.PingsPerSpan is the original.
+func TestPingScheduleMatchesThePort(t *testing.T) {
+	py := pythonBin(t)
+	if py == "" {
+		t.Skip("no interpreter that can import kv_ttl_cost_model")
+	}
+	// A [3]int64 rather than a struct: a struct with unexported fields marshals to `{}`, so
+	// the port would receive a list of empty objects and unpack nothing. This test caught
+	// that in itself too.
+	var cases [][3]int64
+	for _, gap := range []int64{0, 1, 279_999, 280_000, 280_001, 560_000, 560_001, 860_000,
+		3_600_000, 86_400_000} {
+		for _, idle := range []int64{0, 1_000, 280_000, 3_360_000} {
+			for _, maxPings := range []int64{0, 1, 2, 4} {
+				cases = append(cases, [3]int64{gap, idle, maxPings})
+			}
+		}
+	}
+	var script strings.Builder
+	script.WriteString("import sys,json; sys.path.insert(0,'.')\n")
+	script.WriteString("from kv_ttl_cost_model import pings_per_span as f\n")
+	script.WriteString("print(json.dumps([f(g,i,m) for g,i,m in json.load(sys.stdin)]))\n")
+	in, err := json.Marshal(cases)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(py, "-c", script.String())
+	cmd.Stdin = strings.NewReader(string(in))
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("the port's ping schedule failed: %v\nstdout: %s\nstderr: %s",
+			err, out, stderr.String())
+	}
+	var got []int
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(cases) {
+		t.Fatalf("got %d answers for %d cases", len(got), len(cases))
+	}
+	for i, c := range cases {
+		gap, idle, maxPings := c[0], c[1], c[2]
+		want := kvcache.PingsPerSpan(time.Duration(gap)*time.Millisecond,
+			time.Duration(idle)*time.Millisecond, int(maxPings))
+		if got[i] != want {
+			t.Errorf("pings_per_span(gap=%d, idle=%d, max=%d): port %d, kvcache %d",
+				gap, idle, maxPings, got[i], want)
+		}
+	}
+}

--- a/deploy/harbor/kv_ttl_cost_drift_test.go
+++ b/deploy/harbor/kv_ttl_cost_drift_test.go
@@ -448,14 +448,6 @@ func TestPythonCostModelAgreesWithTheShippedSimulator(t *testing.T) {
 		t.Error("the fixture prices nothing, so every dollar compared here is zero on both " +
 			"sides and this test proves nothing")
 	}
-	for _, c := range []struct {
-		name     string
-		got, exp int64
-	}{} {
-		if c.got != c.exp {
-			t.Errorf("%s: port %d, kvcache.Simulate %d", c.name, c.got, c.exp)
-		}
-	}
 	// A fixture that exercised nothing would pass this test while proving nothing, so the
 	// branches it exists for are asserted to have actually been reached.
 	if want.Pings == 0 || want.PingsThatRewrote == 0 || want.PingsOnOpenSpans == 0 {

--- a/deploy/harbor/kv_ttl_cost_model.py
+++ b/deploy/harbor/kv_ttl_cost_model.py
@@ -1,0 +1,1717 @@
+#!/usr/bin/env python3
+"""What a KV-cache TTL policy COSTS on a real trajectory, at the operator's real rates.
+
+Give it a trajectory and one action per turn — let the cache expire, write at 5 minutes,
+write at an hour, or hold it with keep-alive pings — and it returns the bill, decomposed.
+Nothing here decides anything. It is the scorer, so that a predictor, a threshold rule and
+a hand-written policy are all judged by the same arithmetic.
+
+It exists to answer one question: does the survival predictor in
+kv_ttl_survival_predictor.py actually save money on real traffic? A predictor emits
+probabilities; only a cost model can turn those into dollars, and only a cost model that
+replays REAL trajectories at REAL per-model rates can turn them into dollars anyone should
+act on.
+
+Usage: kv_ttl_cost_model.py [--db PATH] [--prices PATH] [--since ISO] [--until ISO]
+                            [--baseline NAME] [--split FRACTION] [--no-predictor]
+                            [--json OUT.json]
+
+       from kv_ttl_cost_model import PriceBook, load_trajectories, evaluate, POLICIES
+
+
+WHY IT IS A PORT AND NOT THE ORIGINAL
+-------------------------------------
+The shipped implementation of this arithmetic is Go: `kvcache.Simulate` in this repo,
+which is what the dashboard's KV-cache page reports from. Two implementations of one money
+question is exactly the drift this project has been bitten by, so this file is a FAITHFUL
+PORT rather than a second opinion, and `kv_ttl_cost_drift_test.go` beside it replays the
+same trajectory and the same action list through both and fails if the totals differ by
+more than a hundredth of a cent. It is in Python only because the predictor is: an ML
+evaluation loop that had to shell into Go for every candidate threshold would not get run.
+
+If the two ever disagree, Go is right and this file is the bug.
+
+
+WHICH DATA IT NEEDS
+-------------------
+One row per request. `load_trajectories` reads them from context-guru's own dashboard
+store (`DASHBOARD_DB`, `/var/lib/context-guru/cg.db` on the hosted deployment), READ-ONLY:
+
+    user             <- requests.tenant_id      the owning account
+    conversation     <- requests.session_id     the trajectory; a cache entry lives here
+    request_id       <- requests.id
+    ts_ms            <- requests.ts             epoch MILLISECONDS, UTC
+    model            <- requests.model          picks the rates; see PriceBook
+    input_tokens     <- requests.fresh_input    uncached input, billed every turn
+    output_tokens    <- requests.output_tokens
+    cached_context   <- requests.cache_read + requests.cache_write
+                        the BILLED PREFIX: the size of the entry that exists after this
+                        request, and the number every write, read and ping is priced on.
+                        NOT tokens_before, which is message text only and runs a median
+                        3.4x low.
+    miss_reason      <- requests.cache_miss_reason
+    upstream_ms      <- requests.upstream_ms    optional, for the latency figure
+    billed_usd       <- requests.cost_usd       what the deployment ACTUALLY paid, priced
+                        at write time. Carried for comparison only; never used as an input
+                        to a simulated cost.
+
+A conversation is the PAIR (user, conversation). The session id is client-supplied, so two
+accounts can present the same one, and keying on it alone would splice their traffic into
+one trajectory and derive idle gaps across the join.
+
+
+WHICH PRICING IT USES
+---------------------
+The operator's own price list — `/etc/context-guru/prices.yaml` on this deployment, the
+file `MODEL_PRICES` points at — parsed with the same rules as internal/modelinfo/table.go:
+rates are USD per MILLION tokens, a trailing `*` matches a family, the LONGEST match wins,
+an exact id beats everything, a non-`*` entry is matched by containment only when it looks
+like a qualified id (it contains `/` or `.`), and `cache_read_frac` / `cache_write_frac`
+fill in the tiers an entry does not state.
+
+That file matters rather than being a detail: this gateway bills aws/claude-sonnet-5 at
+$1.52/MTok where anthropic.com bills $3.00, so the public list price would overstate every
+figure below by about 2x.
+
+The one rate NO price list publishes is the 1-hour cache write. It is derived from the
+documented multiplier against base input (2.0x, against 1.25x for the 5-minute tier), and
+the multiplier is a parameter — see PriceBook(write_1h_multiple=...). A model the file has
+no entry for comes back `known=False`, and then it contributes to NO dollar figure at all
+and is counted in `unpriced`: an unpriced model is not a free one.
+
+
+THE COST FORMULAS
+-----------------
+Per request, under the tier the action chose:
+
+    uncached_input = input_tokens              x input_rate
+    cache_read     = read_tokens               x cache_read_rate
+    cache_write    = written_tokens            x write_rate(tier)   # 5m: 1.25x in, 1h: 2.0x in
+    output         = output_tokens             x output_rate
+    request_cost   = uncached_input + cache_read + cache_write + output
+
+`read_tokens` is min(entry held, this request's prefix) when the entry is still alive, else
+0. `written_tokens` is the rest of the prefix. With no cache_control at all the whole
+prefix is billed as fresh input instead, which is what makes "expire" a real arm and not an
+absence.
+
+Per keep-alive:
+
+    keep_alive  = cached x cache_read_rate + ping_input x input_rate + ping_output x output_rate
+    recreate    = cached x write_rate(tier) + ping_input x input_rate + ping_output x output_rate
+
+A keep-alive is a cache READ and costs the read rate — the same whether the entry is held
+at five minutes or at an hour. The difference between a 5m and a 1h keep-alive is not the
+price of one ping; it is the creation tier that put the entry there and how OFTEN a ping is
+needed (12x more often at five minutes). A keep-alive that arrives after the entry lapsed
+is not a refresh at all: it RE-CREATES the prefix at the write rate, 12.5x a read at the
+5-minute tier and 20x at the one-hour tier, and `pings_that_rewrote` counts those.
+
+`ping_output` is 1 token because Anthropic's Messages API requires max_tokens >= 1. A
+provider that accepts a zero-generation request sets Semantics(zero_generation=True) and
+the assumption disappears from the bill instead of being rounded away.
+
+Totals, and the two that are easy to conflate:
+
+    total_usd         = sum(request_cost) + sum(ping_cost)
+    uncached_usd      = the same traffic with no prompt cache at all
+    cache_premium_usd = total_usd - uncached_usd
+                        what the caching machinery itself cost. NEGATIVE means the cache
+                        paid for itself. This is not the same number as total_usd and the
+                        two must never be reported as if they were.
+
+    absolute_savings   = baseline_total - policy_total
+    percentage_savings = absolute_savings / baseline_total x 100
+
+Savings are NOT clamped. A policy that costs more than its baseline reports a negative
+saving, because that is the only way a comparison stays one.
+
+
+CACHE SEMANTICS, MADE EXPLICIT
+------------------------------
+Anthropic's documented behaviour is the default, and each part is a field so a provider
+that differs can say so rather than being silently mispriced:
+
+  * a cache HIT refreshes the entry for its tier's full lifetime, free
+    (Semantics.hit_refreshes_ttl)
+  * a keep-alive read does the same (Semantics.ping_refreshes_ttl)
+  * a refresh does not UPGRADE a tier: a five-minute entry refreshed is good for another
+    five minutes, not an hour
+  * `cache_miss_reason` of 'prefix_change' or 'cold_start' FORCES a miss whatever the
+    policy chose. No TTL rescues content that moved, and none conjures an entry that never
+    existed. Those rows are the ceiling on every arm and `forced_misses` reports them.
+
+
+WHAT AN ACTION IS
+-----------------
+Five, and they are the whole set of things a prompt-caching provider sells:
+
+    'expire'    write no cache_control; this prompt is billed as fresh input
+    'write_5m'  write/retain the prefix at the 5-minute tier
+    'write_1h'  write/retain the prefix at the 1-hour tier
+    'ping_5m'   hold at 5 minutes AND refresh with keep-alives while idle
+    'ping_1h'   hold at an hour AND refresh with keep-alives while idle
+
+`evaluate(rows, actions)` takes `actions` as either a list parallel to the chronological
+row order, or a dict keyed by `request_id`. TTL SECONDS are accepted as a convenience — 0,
+300 and 3600 mean 'expire', 'write_5m' and 'write_1h' — so a policy that thinks in
+lifetimes needs no translation layer. A row with no action defaults to 'expire', which is
+the arm that cannot flatter anything.
+
+
+INPUT AND OUTPUT
+----------------
+load_trajectories(db_path, since=None, until=None, include_keepalive=False) -> list[Request]
+    Read-only. Chronological, by (ts, id). Drops rows with no session and rows whose token
+    accounting is 'missing' (the provider never reported usage, so there is nothing to
+    price). Drops keep-alive PING rows where the column exists: a ping is a request
+    context-guru sent while nobody was at the keyboard, and counting it as a turn would
+    both invent traffic and break the idle gap it sits inside.
+
+evaluate(rows, actions, prices, semantics=..., schedule=..., window_end_ms=None) -> Cost
+    Cost carries: total_usd and its five components (fresh_input_usd, cache_read_usd,
+    cache_write_usd, output_usd, ping_usd); uncached_usd and cache_premium_usd; requests,
+    conversations, unpriced; hits, misses, hit_rate_pct, miss_rate_pct, forced_misses;
+    pings, pings_that_rewrote, pings_on_open_spans; writes_5m, writes_1h, expires;
+    avoided_recomputations, avoided_tokens; retained_ms; and per-user / per-model
+    breakdowns in by_user / by_model.
+
+compare(baseline: Cost, policy: Cost) -> Savings
+    absolute_usd (signed), percent_usd, percent_known, hit_delta.
+
+MEASURED ON REAL TRAFFIC
+------------------------
+The hosted deployment's own capture (14,407 requests, 12 accounts, 1,772 trajectories,
+2026-08-17 11:48 -> 2026-08-19 20:38 UTC) at `/etc/context-guru/prices.yaml`. The predictor
+is fitted on the first 70% of the window and its thresholds tuned there; every arm is then
+scored on the held-out 5,722 requests, whose `observed` bill is $1,857.78:
+
+    policy          total        vs observed     hit %   what it does
+    no-cache        $3,975.58    -114.00%          0.0%  never writes cache_control
+    fixed-5m        $1,857.78      +0.00%         76.4%
+    fixed-1h        $2,560.08     -37.80%         78.1%  the 2.0x premium never repays
+    keepalive-5m    $1,805.28      +2.83%         77.5%  5m tier + up to 2 refreshes
+    keepalive-1h    $2,551.24     -37.33%         78.2%
+    predictor       $1,857.91      -0.01%         76.2%  threshold ladder on the ML model
+    expected-cost   $1,857.78      +0.00%         76.4%  expected-cost rule on the same model
+    optimal         $1,718.46      +7.50%         76.6%  UNREACHABLE: exact, sees the future
+
+Three things that table settles, and the first is the one worth knowing:
+
+  1. PROMPT CACHING ITSELF IS THE WIN, AND IT IS ALREADY BANKED. no-cache costs 114% more
+     than the shipped 5-minute policy: the cache is saving 53% of this traffic's bill
+     already. Everything else on this page is a fight over the remainder.
+  2. THE WHOLE TTL HEADROOM IS 7.5%, AND THAT FIGURE REQUIRES PERFECT FORESIGHT. A blind
+     keep-alive with no model at all takes 2.83% of it — 38% of the ceiling, for free.
+  3. THE MACHINE-LEARNED ARMS TAKE NOTHING (-0.01% and +0.00%), and not because the model
+     is bad: it halves the Brier score of the base rate (see kv_ttl_survival_predictor.py).
+     They take nothing because 92.5% of production gaps close inside five minutes, so the
+     5-minute tier is right for almost every request and there is no decision left for a
+     probability to improve.
+
+Where the 7.5% actually is, by replaying the optimum's own choices one kind at a time:
+
+    only its 70 one-hour writes   +5.04%   ($93.61)
+    only its 22 keep-alive pings  +1.72%   ($31.89)
+    only its 1,246 expiries       +0.69%   ($12.85)
+
+So 93% of the reachable headroom is 92 decisions out of 5,722, on the rare conversation
+that goes quiet for longer than five minutes and comes back to a very large prefix. That
+makes this a RARE-EVENT problem, and it says what a useful predictor would have to be: not
+well calibrated on average, but precise on the tail, and weighted by prefix size. A model
+scored on average calibration will look good and buy nothing — which is exactly what the
+two ML arms above did.
+
+
+POLICIES maps a name to a callable (rows, ctx) -> list[Action], so a new arm is one
+function. 'oracle' is included and is deliberately labelled unreachable: it reads the true
+next-request time, so it is the CEILING no predictor can pass, not a result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+# ── actions and tiers ──────────────────────────────────────────────────────
+
+EXPIRE = "expire"
+WRITE_5M = "write_5m"
+WRITE_1H = "write_1h"
+PING_5M = "ping_5m"
+PING_1H = "ping_1h"
+# Write cheap, extend only if the conversation actually goes quiet: the request creates a
+# 5-minute entry at 1.25x input, and a keep-alive that comes due before it lapses extends the
+# context by an hour with a 1-hour WRITE at 2.0x. Distinct from PING_1H, which pays that 2.0x
+# on every request whether or not the hold is ever needed.
+WRITE_5M_PING_1H = "write_5m_ping_1h"
+ACTIONS = (EXPIRE, WRITE_5M, WRITE_1H, PING_5M, PING_1H, WRITE_5M_PING_1H)
+
+TTL_NONE, TTL_5M, TTL_1H = "", "ephemeral_5m", "ephemeral_1h"
+LIFETIME_MS = {TTL_NONE: 0, TTL_5M: 5 * 60 * 1000, TTL_1H: 60 * 60 * 1000}
+
+# The tier the REQUEST ITSELF writes at — not necessarily where the entry ends up.
+_TIER_OF = {EXPIRE: TTL_NONE, WRITE_5M: TTL_5M, PING_5M: TTL_5M,
+            WRITE_1H: TTL_1H, PING_1H: TTL_1H, WRITE_5M_PING_1H: TTL_5M}
+# The tier this action's keep-alives hold the entry at, which is what a ping must pay to reach.
+_PING_TIER_OF = {PING_5M: TTL_5M, PING_1H: TTL_1H, WRITE_5M_PING_1H: TTL_1H}
+# TTL seconds a caller may pass instead of an action name.
+_ACTION_OF_SECONDS = {0: EXPIRE, 300: WRITE_5M, 3600: WRITE_1H}
+
+HORIZON_5M_MS = 5 * 60 * 1000
+HORIZON_1H_MS = 60 * 60 * 1000
+
+# A miss with one of these recorded reasons could not have been prevented by any TTL: the
+# content moved, or there was no entry to begin with.
+UNRESCUABLE = frozenset({"prefix_change", "cold_start"})
+
+
+def tier_of(action: str) -> str:
+    """The TTL tier an action holds the entry at."""
+    if action not in _TIER_OF:
+        raise ValueError(f"unknown action {action!r}; expected one of {ACTIONS}")
+    return _TIER_OF[action]
+
+
+def pings(action: str) -> bool:
+    """Whether an action sends keep-alives during the idle span."""
+    return action in (PING_5M, PING_1H, WRITE_5M_PING_1H)
+
+
+def ping_tier(action: str) -> str:
+    """The tier this action's keep-alives aim to hold the entry at."""
+    return _PING_TIER_OF.get(action, TTL_NONE)
+
+
+def normalize_action(value: Any) -> str:
+    """Accept an action name or a TTL in seconds, and reject anything else loudly.
+
+    A silent fallback here would turn a typo into an arm that quietly never caches, which
+    is the most flattering possible failure for a savings figure.
+    """
+    if isinstance(value, str):
+        if value in _TIER_OF:
+            return value
+        raise ValueError(f"unknown action {value!r}; expected one of {ACTIONS}")
+    if isinstance(value, bool):
+        raise ValueError("an action is not a boolean")
+    if isinstance(value, (int, float)):
+        seconds = int(value)
+        if seconds in _ACTION_OF_SECONDS:
+            return _ACTION_OF_SECONDS[seconds]
+        raise ValueError(
+            f"{seconds}s is not a tier this provider sells; use 0, 300 or 3600, or an "
+            f"action name for the keep-alive arms")
+    raise ValueError(f"cannot read {value!r} as an action")
+
+
+# ── pricing ────────────────────────────────────────────────────────────────
+
+PER_MTOK = 1e6
+DEFAULT_CACHE_READ_MULTIPLE = 0.1
+DEFAULT_WRITE_5M_MULTIPLE = 1.25
+DEFAULT_WRITE_1H_MULTIPLE = 2.0
+DEFAULT_PING_INPUT_TOKENS = 1
+DEFAULT_PING_OUTPUT_TOKENS = 1
+
+SOURCE_PRICE_LIST = "price_list"
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """One model's per-TOKEN rates, and the two assumptions a ping forces into the open."""
+
+    model: str
+    input: float = 0.0
+    output: float = 0.0
+    cache_read: float = 0.0
+    write_5m: float = 0.0
+    write_1h: float = 0.0
+    ping_input_tokens: int = DEFAULT_PING_INPUT_TOKENS
+    ping_output_tokens: int = DEFAULT_PING_OUTPUT_TOKENS
+    source: str = ""
+    known: bool = False
+
+    def write_rate(self, tier: str) -> float:
+        """The creation rate for one tier. TTL_NONE creates nothing, so it is 0 — the
+        caller must have billed those tokens as fresh input instead."""
+        if tier == TTL_5M:
+            return self.write_5m
+        if tier == TTL_1H:
+            return self.write_1h
+        return 0.0
+
+    def request_cost(self, input_tokens: int, read: int, write: int, output: int,
+                     tier: str) -> float:
+        return (input_tokens * self.input + read * self.cache_read
+                + write * self.write_rate(tier) + output * self.output)
+
+    def keep_alive_cost(self, cached: int, sem: "Semantics") -> float:
+        return (cached * self.cache_read + self.ping_input_tokens * self.input
+                + sem.ping_output(self) * self.output)
+
+    def recreate_cost(self, cached: int, tier: str, sem: "Semantics") -> float:
+        return (cached * self.write_rate(tier) + self.ping_input_tokens * self.input
+                + sem.ping_output(self) * self.output)
+
+    def uncached_cost(self, input_tokens: int, prefix: int, output: int) -> float:
+        return (input_tokens + prefix) * self.input + output * self.output
+
+    def hold_cost(self, cached: int, tier: str, n_pings: int, sem: "Semantics") -> float:
+        """What it costs to put `cached` tokens at `tier` and hold them with n_pings
+        refreshes. The figure to quote beside a rate: a dollar amount on a real prefix."""
+        return cached * self.write_rate(tier) + n_pings * self.keep_alive_cost(cached, sem)
+
+
+@dataclass(frozen=True)
+class Semantics:
+    """The provider's cache behaviour. Defaults are Anthropic's documented behaviour."""
+
+    hit_refreshes_ttl: bool = True
+    ping_refreshes_ttl: bool = True
+    zero_generation: bool = False
+
+    def ping_output(self, price: ModelPricing) -> int:
+        if self.zero_generation:
+            return 0
+        return max(0, price.ping_output_tokens)
+
+
+@dataclass(frozen=True)
+class PingSchedule:
+    """When a keep-alive fires, per tier, and how many fire per idle span.
+
+    Both intervals sit a little INSIDE the lifetime they protect, so a refresh lands before
+    the deadline rather than on it. A one-hour entry therefore needs one twelfth as many
+    refreshes to be held for the same wall-clock span, which is the ping-count half of the
+    5m-versus-1h trade.
+    """
+
+    idle_5m_ms: int = 280 * 1000
+    idle_1h_ms: int = 3360 * 1000
+    max_pings: int = 2
+
+    def interval_ms(self, tier: str) -> int:
+        return self.idle_1h_ms if tier == TTL_1H else self.idle_5m_ms
+
+
+def pings_per_span(gap_ms: int, interval_ms: int, max_pings: int) -> int:
+    """How many keep-alives one idle span attracts.
+
+    The first fires one interval after the last activity, each subsequent one an interval
+    after that, and max_pings caps the count. A span no longer than one interval attracts
+    none. Mirrors kvcache.PingsPerSpan; the drift test asserts they agree.
+    """
+    if interval_ms <= 0 or max_pings <= 0 or gap_ms <= interval_ms:
+        return 0
+    n = math.floor((gap_ms - interval_ms) / interval_ms) + 1
+    return min(n, max_pings)
+
+
+class PriceBook:
+    """Per-model rates, resolved from the operator's price list by the model on the row.
+
+    The lookup is a port of internal/modelinfo.Table.lookup and its subtleties are load
+    bearing, not incidental:
+
+      * an EXACT match on the full id or on its last path segment wins outright;
+      * otherwise entries compete in ONE pass ordered LONGEST MATCH FIRST, so
+        `aws/claude-opus-4-8` beats `aws/claude-opus-4*` and the file's own order cannot
+        make a lookup ambiguous;
+      * a `*` entry matches only as a prefix;
+      * a non-`*` entry is matched by containment ONLY when it looks like a qualified model
+        id — it contains a `/` or a `.`. Without that, tier names that are ordinary English
+        (`fast`, `premium`) claim every unrelated id containing them, and a confidently
+        wrong price is worse than a missing one.
+    """
+
+    def __init__(self, entries: Sequence[tuple[str, bool, bool, ModelPricing]] | None = None,
+                 *, write_1h_multiple: float = DEFAULT_WRITE_1H_MULTIPLE,
+                 ping_input_tokens: int = DEFAULT_PING_INPUT_TOKENS,
+                 ping_output_tokens: int = DEFAULT_PING_OUTPUT_TOKENS):
+        self._entries = list(entries or ())
+        self.write_1h_multiple = float(write_1h_multiple)
+        self.ping_input_tokens = int(ping_input_tokens)
+        self.ping_output_tokens = int(ping_output_tokens)
+        self._overrides: dict[str, ModelPricing] = {}
+        self._cache: dict[str, ModelPricing] = {}
+
+    # -- construction -------------------------------------------------------
+
+    @classmethod
+    def from_operator_file(cls, path: str | Path, **kwargs: Any) -> "PriceBook":
+        """Load `/etc/context-guru/prices.yaml` (or whatever MODEL_PRICES names).
+
+        A missing or malformed file is an ERROR, never a silent fallback: a price list that
+        failed to load looks exactly like "every model is free".
+        """
+        import yaml  # only this constructor needs it
+
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"{path}: not a mapping")
+        read_frac = float(raw.get("cache_read_frac") or DEFAULT_CACHE_READ_MULTIPLE)
+        write_frac = float(raw.get("cache_write_frac") or DEFAULT_WRITE_5M_MULTIPLE)
+        book = cls(**kwargs)
+        entries: list[tuple[str, bool, bool, ModelPricing]] = []
+        for i, m in enumerate(raw.get("models") or ()):
+            match = str(m.get("match", "")).strip().lower()
+            if not match:
+                raise ValueError(f"{path}: entry {i} has no match")
+            prefix = match.endswith("*")
+            match = match.rstrip("*")
+            in_r, out_r = float(m.get("in") or 0.0), float(m.get("out") or 0.0)
+            cr, cw = float(m.get("cache_read") or 0.0), float(m.get("cache_write") or 0.0)
+            if min(in_r, out_r, cr, cw) < 0:
+                raise ValueError(f"{path}: {match!r} has a negative rate")
+            if in_r == 0 and out_r == 0:
+                raise ValueError(
+                    f"{path}: {match!r} has no rates; omit the entry rather than pricing "
+                    f"it free")
+            price = ModelPricing(
+                model=match, input=in_r / PER_MTOK, output=out_r / PER_MTOK,
+                cache_read=(cr / PER_MTOK) or (in_r / PER_MTOK) * read_frac,
+                write_5m=(cw / PER_MTOK) or (in_r / PER_MTOK) * write_frac,
+                ping_input_tokens=book.ping_input_tokens,
+                ping_output_tokens=book.ping_output_tokens,
+                source=SOURCE_PRICE_LIST, known=True)
+            price = replace(price, write_1h=book._derive_write_1h(price))
+            qualified = ("/" in match) or ("." in match)
+            entries.append((match, prefix, qualified, price))
+        # Longest match first: specificity is a property of the match, not of the file's
+        # ordering or of the KIND of match.
+        entries.sort(key=lambda e: len(e[0]), reverse=True)
+        book._entries = entries
+        return book
+
+    def _derive_write_1h(self, p: ModelPricing) -> float:
+        """The 1-hour creation rate, the one rate no price list publishes.
+
+        Derived from the multiplier against base INPUT, because that is how the provider
+        documents it, and never allowed below the 5-minute rate: a list that implied
+        otherwise would be a typo, and honouring it would make every 1h arm look free.
+        """
+        if p.input > 0:
+            w = p.input * self.write_1h_multiple
+        elif p.write_5m > 0:
+            w = p.write_5m * (self.write_1h_multiple / DEFAULT_WRITE_5M_MULTIPLE)
+        else:
+            w = 0.0
+        return max(w, p.write_5m)
+
+    def override(self, model: str, **rates: float) -> None:
+        """Price a model by hand — a preview id, an internal route name, a server-resolved
+        tier the file has never heard of. An override makes the model KNOWN."""
+        base = self.for_model(model)
+        p = replace(base, **rates)
+        if "write_1h" not in rates:
+            p = replace(p, write_1h=self._derive_write_1h(p))
+        p = replace(p, source="override",
+                    known=any((p.input, p.output, p.cache_read, p.write_5m, p.write_1h)))
+        self._overrides[model] = p
+        self._cache.pop(model, None)
+
+    # -- lookup -------------------------------------------------------------
+
+    def for_model(self, model: str) -> ModelPricing:
+        """The rates for one model, read off the trajectory's own `model` field.
+
+        A model with no entry comes back known=False, NAMING ITSELF, so a caller can report
+        which model it could not price rather than reporting a total that quietly excluded
+        it.
+        """
+        if model in self._overrides:
+            return self._overrides[model]
+        hit = self._cache.get(model)
+        if hit is not None:
+            return hit
+        p = self._lookup(model)
+        self._cache[model] = p
+        return p
+
+    def _lookup(self, model: str) -> ModelPricing:
+        full = (model or "").strip().lower()
+        tail = full.rsplit("/", 1)[-1]
+        for match, _prefix, _qual, price in self._entries:
+            if match == full or match == tail:
+                return replace(price, model=model)
+        for match, prefix, qualified, price in self._entries:  # longest first
+            if prefix:
+                if full.startswith(match) or tail.startswith(match):
+                    return replace(price, model=model)
+                continue
+            if qualified and match in full:
+                return replace(price, model=model)
+        return ModelPricing(model=model, ping_input_tokens=self.ping_input_tokens,
+                            ping_output_tokens=self.ping_output_tokens)
+
+
+# ── the trajectory ─────────────────────────────────────────────────────────
+
+@dataclass
+class Request:
+    """One request of a trajectory, as the cost model needs it."""
+
+    request_id: int
+    user: str
+    conversation: str
+    ts_ms: int
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_context: int = 0
+    miss_reason: str = ""
+    hit: bool = False
+    upstream_ms: float = 0.0
+    billed_usd: float = 0.0
+    # The tier this request ACTUALLY asked for, where the store recorded it (`cache_ttl`).
+    # None means the column did not exist when the row was written — a THIRD state next to
+    # "5m" and "no cache_control", and the reason the `observed` arm reports its coverage
+    # instead of quietly assuming a default.
+    ttl_recorded: str | None = None
+    # Derived by derive(): the next request in the SAME conversation.
+    next_ts_ms: int | None = None
+    idle_ms: int | None = None
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.user, self.conversation)
+
+    @property
+    def hour_utc(self) -> int:
+        return int((self.ts_ms // 3_600_000) % 24)
+
+
+def derive(rows: list[Request]) -> list[Request]:
+    """Fill next_ts_ms / idle_ms per conversation and return the rows in wall-clock order.
+
+    Three properties, each a way this has been got wrong: grouped by (user, conversation)
+    so a later request from another trajectory is never treated as this one's return;
+    ordered by (ts, id) so tied timestamps break deterministically and a zero-length gap
+    stays zero instead of going negative; and the LAST request of a conversation keeps
+    idle_ms None — not 0, which would read as "it came back instantly".
+    """
+    by_conv: dict[tuple[str, str], list[Request]] = defaultdict(list)
+    for r in rows:
+        r.next_ts_ms, r.idle_ms = None, None
+        by_conv[r.key].append(r)
+    for group in by_conv.values():
+        group.sort(key=lambda r: (r.ts_ms, r.request_id))
+        for a, b in zip(group, group[1:]):
+            a.next_ts_ms = b.ts_ms
+            a.idle_ms = max(0, b.ts_ms - a.ts_ms)
+    return sorted(rows, key=lambda r: (r.ts_ms, r.request_id))
+
+
+DEFAULT_DB = "/var/lib/context-guru/cg.db"
+DEFAULT_PRICES = "/etc/context-guru/prices.yaml"
+
+
+def load_trajectories(db_path: str | Path = DEFAULT_DB, *, since_ms: int | None = None,
+                      until_ms: int | None = None,
+                      include_keepalive: bool = False) -> list[Request]:
+    """Read the trajectories from the dashboard store, READ-ONLY, chronologically."""
+    uri = f"file:{Path(db_path).as_posix()}?mode=ro"
+    con = sqlite3.connect(uri, uri=True)
+    try:
+        have = {r[1] for r in con.execute("PRAGMA table_info(requests)")}
+        conds = ["session_id <> ''", "token_accounting <> 'missing'"]
+        args: list[Any] = []
+        # A ping is a request context-guru sent while nobody was at the keyboard. Counted as
+        # a turn it invents traffic and breaks the idle gap it sits inside. Older snapshots
+        # predate the column and contain no pings.
+        if "keepalive" in have and not include_keepalive:
+            conds.append("keepalive = 0")
+        if since_ms is not None:
+            conds.append("ts >= ?")
+            args.append(since_ms)
+        if until_ms is not None:
+            conds.append("ts < ?")
+            args.append(until_ms)
+        cols = ["id", "tenant_id", "session_id", "ts", "model", "fresh_input",
+                "output_tokens", "cache_read", "cache_write", "cache_miss_reason",
+                "upstream_ms", "cost_usd"]
+        # cache_ttl arrived as an additive column, so an older snapshot has no opinion about
+        # the tier a request asked for. Selected only where it exists; absent it stays None.
+        ttl_col = "cache_ttl" in have
+        if ttl_col:
+            cols.append("cache_ttl")
+        sql = (f"SELECT {', '.join(cols)} FROM requests WHERE {' AND '.join(conds)} "
+               f"ORDER BY ts, id")
+        rows = [
+            Request(request_id=r[0], user=r[1], conversation=r[2], ts_ms=r[3], model=r[4],
+                    input_tokens=r[5] or 0, output_tokens=r[6] or 0,
+                    cached_context=(r[7] or 0) + (r[8] or 0), miss_reason=r[9] or "",
+                    hit=(r[9] or "") == "hit", upstream_ms=r[10] or 0.0,
+                    billed_usd=r[11] or 0.0,
+                    ttl_recorded=(r[12] if ttl_col else None))
+            for r in con.execute(sql, args)
+        ]
+    finally:
+        con.close()
+    return derive(rows)
+
+
+# ── the result ─────────────────────────────────────────────────────────────
+
+@dataclass
+class Group:
+    """One user's or one model's slice of a result."""
+
+    key: str
+    requests: int = 0
+    total_usd: float = 0.0
+    hits: int = 0
+    misses: int = 0
+    pings: int = 0
+    ping_usd: float = 0.0
+    writes_5m: int = 0
+    writes_1h: int = 0
+    unpriced: int = 0
+
+    @property
+    def hit_rate_pct(self) -> float:
+        d = self.hits + self.misses
+        return 100.0 * self.hits / d if d else 0.0
+
+
+@dataclass
+class Cost:
+    """One policy's whole bill on one set of trajectories."""
+
+    policy: str = ""
+    requests: int = 0
+    conversations: int = 0
+
+    fresh_input_usd: float = 0.0
+    cache_read_usd: float = 0.0
+    cache_write_usd: float = 0.0
+    output_usd: float = 0.0
+    ping_usd: float = 0.0
+    uncached_usd: float = 0.0
+
+    hits: int = 0
+    misses: int = 0
+    forced_misses: int = 0
+
+    pings: int = 0
+    pings_that_rewrote: int = 0
+    # Keep-alives that DELIBERATELY paid a longer tier's creation rate to extend a LIVE entry
+    # — WRITE_5M_PING_1H's whole mechanism. Counted apart from pings_that_rewrote because the
+    # two mean opposite things: one is a policy buying a hold it chose, the other is a
+    # schedule repairing damage it caused.
+    pings_that_upgraded: int = 0
+    pings_on_open_spans: int = 0
+
+    writes_5m: int = 0
+    writes_1h: int = 0
+    expires: int = 0
+
+    avoided_recomputations: int = 0
+    avoided_tokens: int = 0
+    retained_ms: int = 0
+    unpriced: int = 0
+
+    decisions: dict[str, int] = field(default_factory=dict)
+    by_user: dict[str, Group] = field(default_factory=dict)
+    by_model: dict[str, Group] = field(default_factory=dict)
+
+    @property
+    def total_usd(self) -> float:
+        return (self.fresh_input_usd + self.cache_read_usd + self.cache_write_usd
+                + self.output_usd + self.ping_usd)
+
+    @property
+    def cache_premium_usd(self) -> float:
+        """total - uncached: what the caching machinery itself cost. Negative means the
+        cache paid for itself. NOT the same number as total_usd."""
+        return self.total_usd - self.uncached_usd
+
+    @property
+    def hit_rate_pct(self) -> float:
+        d = self.hits + self.misses
+        return 100.0 * self.hits / d if d else 0.0
+
+    @property
+    def miss_rate_pct(self) -> float:
+        d = self.hits + self.misses
+        return 100.0 * self.misses / d if d else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {k: v for k, v in self.__dict__.items() if k not in ("by_user", "by_model")}
+        out["total_usd"] = self.total_usd
+        out["cache_premium_usd"] = self.cache_premium_usd
+        out["hit_rate_pct"] = self.hit_rate_pct
+        out["miss_rate_pct"] = self.miss_rate_pct
+        out["by_user"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct}
+                          for k, g in self.by_user.items()}
+        out["by_model"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct}
+                           for k, g in self.by_model.items()}
+        return out
+
+
+@dataclass
+class Savings:
+    """One policy against one baseline. Nothing here is clamped."""
+
+    policy: str
+    baseline: str
+    baseline_usd: float
+    policy_usd: float
+    absolute_usd: float
+    percent_usd: float
+    percent_known: bool
+    hit_delta: int
+
+
+def compare(baseline: Cost, policy: Cost) -> Savings:
+    """absolute = baseline - policy ; percent = absolute / baseline * 100.
+
+    A percentage of a zero baseline is UNDEFINED, not 0%, and percent_known says so.
+    """
+    absolute = baseline.total_usd - policy.total_usd
+    known = baseline.total_usd != 0
+    return Savings(
+        policy=policy.policy, baseline=baseline.policy,
+        baseline_usd=baseline.total_usd, policy_usd=policy.total_usd,
+        absolute_usd=absolute,
+        percent_usd=(absolute / baseline.total_usd * 100) if known else 0.0,
+        percent_known=known, hit_delta=policy.hits - baseline.hits)
+
+
+# ── the evaluator ──────────────────────────────────────────────────────────
+
+@dataclass
+class _Entry:
+    """One conversation's simulated cache entry and the action governing its open span."""
+
+    tokens: int = 0
+    tier: str = TTL_NONE
+    expires_ms: int = 0
+    last_ts_ms: int = 0
+    turn: int = 0
+    pending: str = EXPIRE
+    covered_until_ms: int = 0
+    user: str = ""
+    model: str = ""
+
+
+def evaluate(rows: Sequence[Request], actions: Mapping[int, Any] | Sequence[Any],
+             prices: PriceBook, *, semantics: Semantics | None = None,
+             schedule: PingSchedule | None = None, window_end_ms: int | None = None,
+             policy: str = "") -> Cost:
+    """Replay a trajectory set under one action per turn and return the bill.
+
+    `actions` is either a dict keyed by request_id or a sequence parallel to the
+    chronological row order. Values are action names or TTL seconds. A row with no action
+    defaults to 'expire' — the arm that cannot flatter anything.
+
+    An OPEN idle span (a conversation whose last request is inside the window) has a length
+    nobody knows, so its keep-alives are billed only up to window_end_ms and counted apart
+    in pings_on_open_spans.
+    """
+    sem = semantics or Semantics()
+    sched = schedule or PingSchedule()
+    order = sorted(rows, key=lambda r: (r.ts_ms, r.request_id))
+    if window_end_ms is None:
+        window_end_ms = max((r.ts_ms for r in order), default=0)
+
+    if isinstance(actions, Mapping):
+        chosen = {int(k): normalize_action(v) for k, v in actions.items()}
+    else:
+        if len(actions) != len(order):
+            raise ValueError(
+                f"{len(actions)} actions for {len(order)} requests; pass a dict keyed by "
+                f"request_id when the two cannot be lined up positionally")
+        chosen = {r.request_id: normalize_action(a) for r, a in zip(order, actions)}
+
+    out = Cost(policy=policy)
+    states: dict[tuple[str, str], _Entry] = {}
+
+    def group(d: dict[str, Group], k: str) -> Group:
+        g = d.get(k)
+        if g is None:
+            g = Group(key=k)
+            d[k] = g
+        return g
+
+    for r in order:
+        st = states.get(r.key)
+        if st is None:
+            st = _Entry()
+            states[r.key] = st
+            out.conversations += 1
+        price = prices.for_model(r.model)
+        ug, mg = group(out.by_user, r.user), group(out.by_model, r.model)
+
+        # 1. close the previous span: the keep-alives it attracted, and their effect on the
+        #    entry's deadline, both of which have to land before hit/miss is decided.
+        if st.turn > 0:
+            _simulate_pings(out, ug, mg, st, price, sem, sched, r.ts_ms, window_end_ms,
+                            open_span=False)
+
+        # 2. hit or miss under THIS policy's own history.
+        alive = st.tokens > 0 and r.ts_ms < st.expires_ms
+        forced = r.miss_reason in UNRESCUABLE
+        if forced:
+            out.forced_misses += 1
+        hit = alive and not forced
+        reusable = min(st.tokens, r.cached_context) if hit else 0
+
+        # 3. the action for the span that starts now.
+        action = chosen.get(r.request_id, EXPIRE)
+        out.decisions[action] = out.decisions.get(action, 0) + 1
+        tier = tier_of(action)
+
+        # 4. bill this request under the chosen tier.
+        fresh, read, write = r.input_tokens, reusable, 0
+        if tier == TTL_NONE:
+            fresh += r.cached_context
+            read = 0
+        else:
+            write = max(0, r.cached_context - reusable)
+        out.requests += 1
+        ug.requests += 1
+        mg.requests += 1
+        if not price.known:
+            out.unpriced += 1
+            ug.unpriced += 1
+            mg.unpriced += 1
+        else:
+            out.fresh_input_usd += fresh * price.input
+            out.cache_read_usd += read * price.cache_read
+            out.cache_write_usd += write * price.write_rate(tier)
+            out.output_usd += r.output_tokens * price.output
+            out.uncached_usd += price.uncached_cost(
+                r.input_tokens, r.cached_context, r.output_tokens)
+            cost = price.request_cost(fresh, read, write, r.output_tokens, tier)
+            ug.total_usd += cost
+            mg.total_usd += cost
+        if hit:
+            out.hits += 1
+            ug.hits += 1
+            mg.hits += 1
+            out.avoided_recomputations += 1
+            out.avoided_tokens += read
+        else:
+            out.misses += 1
+            ug.misses += 1
+            mg.misses += 1
+        # A WRITE is a cache-creation event, not a decision: a request that hit and
+        # re-marked the same prefix wrote nothing. Decision counts live in `decisions`.
+        if tier == TTL_NONE:
+            out.expires += 1
+        elif write > 0 and tier == TTL_5M:
+            out.writes_5m += 1
+            ug.writes_5m += 1
+            mg.writes_5m += 1
+        elif write > 0 and tier == TTL_1H:
+            out.writes_1h += 1
+            ug.writes_1h += 1
+            mg.writes_1h += 1
+
+        # 5. the entry this request leaves behind.
+        if tier == TTL_NONE:
+            st.tokens, st.tier, st.expires_ms = 0, TTL_NONE, 0
+        else:
+            st.tokens, st.tier = r.cached_context, tier
+            life = LIFETIME_MS[tier]
+            if hit and not sem.hit_refreshes_ttl:
+                # A provider where a hit does NOT refresh keeps the entry's original
+                # deadline; only a lapsed entry gets a new one.
+                if st.expires_ms < r.ts_ms:
+                    st.expires_ms = r.ts_ms + life
+            else:
+                st.expires_ms = r.ts_ms + life
+            _retain(out, st, r.ts_ms, st.expires_ms, window_end_ms)
+        st.last_ts_ms, st.pending, st.turn = r.ts_ms, action, st.turn + 1
+        st.user, st.model = r.user, r.model
+
+    # The OPEN spans, priced at the last request's own model and counted apart.
+    for key in sorted(states):
+        st = states[key]
+        if st.turn == 0 or not pings(st.pending):
+            continue
+        price = prices.for_model(st.model)
+        _simulate_pings(out, group(out.by_user, st.user), group(out.by_model, st.model),
+                        st, price, sem, sched, window_end_ms, window_end_ms,
+                        open_span=True)
+    return out
+
+
+def _retain(out: Cost, st: _Entry, from_ms: int, until_ms: int, window_end_ms: int) -> None:
+    """Add one alive interval to the UNION already recorded, clipped to the window.
+
+    A union rather than a sum of lifetimes: overlapping refreshes would otherwise count the
+    same second twice.
+    """
+    if window_end_ms > 0 and until_ms > window_end_ms:
+        until_ms = window_end_ms
+    if st.covered_until_ms > from_ms:
+        from_ms = st.covered_until_ms
+    if until_ms > from_ms:
+        out.retained_ms += until_ms - from_ms
+    if until_ms > st.covered_until_ms:
+        st.covered_until_ms = until_ms
+
+
+@dataclass
+class _PingOutcome:
+    """What one idle span's keep-alives cost, and the entry they leave behind.
+
+    Pure: it mutates nothing. Both the accounting path (`_simulate_pings`) and the exact
+    optimum's dynamic program read this ONE implementation, so a second copy of the ping
+    arithmetic cannot drift away from the first.
+    """
+
+    cost: float = 0.0
+    fired: int = 0
+    rewrote: int = 0
+    upgraded: int = 0
+    tier: str = TTL_NONE
+    expires_ms: int = 0
+    # (fired_at, new_expires) per ping, for the retention union.
+    refreshes: list[tuple[int, int]] = field(default_factory=list)
+
+
+def _ping_span(tokens: int, tier: str, expires_ms: int, last_ts_ms: int, pending: str,
+               span_end_ms: int, price: ModelPricing, sem: Semantics,
+               sched: PingSchedule) -> _PingOutcome:
+    """The keep-alives that fire in (last_ts_ms, span_end_ms) under `pending`.
+
+    The interval follows the entry's CURRENT tier, recomputed each time round, rather than the
+    action's target tier fixed once. That matters only for WRITE_5M_PING_1H, whose entry starts
+    at five minutes and becomes hourly partway through — so its first keep-alive has to land
+    inside five minutes and the rest need only land inside an hour. For every other action the
+    tier never moves and this is the same fixed cadence as before.
+    """
+    out = _PingOutcome(tier=tier, expires_ms=expires_ms)
+    if not pings(pending) or span_end_ms <= last_ts_ms or tokens <= 0:
+        return out
+    want = ping_tier(pending)
+    at = last_ts_ms
+    for _ in range(sched.max_pings):
+        step = sched.interval_ms(out.tier)
+        if step <= 0:
+            break
+        at += step
+        if at >= span_end_ms:
+            break
+        alive = at < out.expires_ms
+        if not alive:
+            # The entry lapsed before this keep-alive fired, so the "refresh" RE-CREATES it at
+            # the tier the action was aiming for. Priced as a write, and counted, because a
+            # schedule that does this is paying 12.5x to fix a problem it caused.
+            out.tier = want
+            cost = price.recreate_cost(tokens, out.tier, sem)
+            out.rewrote += 1
+        elif want == TTL_1H and out.tier != TTL_1H:
+            # A deliberate UPGRADE of a live entry: pay the 1-hour creation rate now to hold it
+            # for an hour instead of five minutes. The one case where a keep-alive is a write
+            # on purpose rather than by accident.
+            out.tier = TTL_1H
+            cost = price.recreate_cost(tokens, TTL_1H, sem)
+            out.upgraded += 1
+        else:
+            cost = price.keep_alive_cost(tokens, sem)
+        out.fired += 1
+        if price.known:
+            out.cost += cost
+        if sem.ping_refreshes_ttl or not alive:
+            life = LIFETIME_MS[out.tier]
+            if life > 0:
+                out.expires_ms = at + life
+                out.refreshes.append((at, out.expires_ms))
+    return out
+
+
+def _simulate_pings(out: Cost, ug: Group, mg: Group, st: _Entry, price: ModelPricing,
+                    sem: Semantics, sched: PingSchedule, span_end_ms: int,
+                    window_end_ms: int, *, open_span: bool) -> None:
+    """Bill the keep-alives that fire between st.last_ts_ms and span_end_ms."""
+    # Whatever happens below, this span is now settled: clearing the pending action is what
+    # stops a conversation being charged twice when the open-span pass visits it as well.
+    pending, st.pending = st.pending, EXPIRE
+    r = _ping_span(st.tokens, st.tier, st.expires_ms, st.last_ts_ms, pending, span_end_ms,
+                   price, sem, sched)
+    if r.fired == 0:
+        return
+    st.tier, st.expires_ms = r.tier, r.expires_ms
+    out.pings += r.fired
+    out.pings_that_rewrote += r.rewrote
+    out.pings_that_upgraded += r.upgraded
+    if open_span:
+        out.pings_on_open_spans += r.fired
+    ug.pings += r.fired
+    mg.pings += r.fired
+    if price.known:
+        out.ping_usd += r.cost
+        ug.ping_usd += r.cost
+        ug.total_usd += r.cost
+        mg.ping_usd += r.cost
+        mg.total_usd += r.cost
+    for at, until in r.refreshes:
+        _retain(out, st, at, until, window_end_ms)
+
+
+# ── policies ───────────────────────────────────────────────────────────────
+#
+# A policy turns a trajectory into one action per turn. It is deliberately NOT part of the
+# evaluator: the evaluator scores an action list, so a predictor, a threshold rule and a
+# hand-written arm are all judged by identical arithmetic and a new idea is one function.
+#
+# Every policy here except `oracle` sees only what was knowable at the decision instant.
+# `oracle` reads the true next-request time and is labelled unreachable everywhere it
+# appears: it is the CEILING a predictor is measured against, not a result.
+
+
+@dataclass
+class PolicyContext:
+    """What a policy is allowed to consult."""
+
+    prices: PriceBook
+    semantics: Semantics = field(default_factory=Semantics)
+    schedule: PingSchedule = field(default_factory=PingSchedule)
+    # p5m / p1h are a predictor's answers, keyed by request_id. Absent for the arms that do
+    # not use one.
+    p5m: Mapping[int, float] = field(default_factory=dict)
+    p1h: Mapping[int, float] = field(default_factory=dict)
+    threshold_5m: float = 0.5
+    threshold_1h: float = 0.5
+    # min_prefix is the prefix below which nothing is cached: a small prefix cannot repay a
+    # write. On the production corpus the 10th-percentile prefix is 0 tokens.
+    min_prefix: int = 20_000
+    # Counters a policy may fill in for the report (e.g. the observed arm's coverage).
+    notes: dict[str, Any] = field(default_factory=dict)
+
+
+Policy = Callable[[Sequence[Request], PolicyContext], list[str]]
+
+
+def policy_no_cache(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    return [EXPIRE] * len(rows)
+
+
+def policy_fixed_5m(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    return [WRITE_5M] * len(rows)
+
+
+def policy_fixed_1h(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    return [WRITE_1H] * len(rows)
+
+
+def policy_keepalive_5m(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """The shipped keep-alive: hold at five minutes and refresh while idle."""
+    return [PING_5M] * len(rows)
+
+
+def policy_keepalive_1h(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """Hold at the one-hour tier and refresh while idle. Costs 2.0x input to create and
+    needs one twelfth as many refreshes as the five-minute arm to hold the same span."""
+    return [PING_1H] * len(rows)
+
+
+def policy_extend_1h(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """Write cheap, extend to an hour only when the conversation actually goes quiet.
+
+    The arm the other two keep-alive arms bracket, and on traffic like this deployment's it is
+    the one worth having: 92.5% of gaps close inside five minutes, so keepalive-1h pays the
+    2.0x creation premium on nearly every request for a hold nearly none of them needs, while
+    this pays 1.25x on every request and 2.0x only on the rare span that outlives five minutes.
+    """
+    return [WRITE_5M_PING_1H] * len(rows)
+
+
+def policy_observed(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """Replay the tier each request ACTUALLY asked for, where the store recorded it.
+
+    A row whose tier was never recorded falls back to the provider's own default — a
+    request that reached a prompt-caching provider with breakpoints in it got five minutes
+    whether or not we wrote the header down — and the fallback is COUNTED, so the arm's
+    coverage is reportable rather than assumed. On a snapshot predating the `cache_ttl`
+    column that coverage is zero and this arm is `fixed-5m` under another name, which the
+    report says out loud instead of presenting it as an independent result.
+    """
+    recorded = assumed = 0
+    out: list[str] = []
+    for r in rows:
+        if r.ttl_recorded == TTL_1H:
+            recorded += 1
+            out.append(WRITE_1H)
+        elif r.ttl_recorded == TTL_5M:
+            recorded += 1
+            out.append(WRITE_5M)
+        elif r.ttl_recorded == TTL_NONE and r.ttl_recorded is not None:
+            recorded += 1
+            out.append(EXPIRE)
+        else:
+            assumed += 1
+            out.append(WRITE_5M)
+    ctx.notes["observed_recorded"] = recorded
+    ctx.notes["observed_assumed"] = assumed
+    return out
+
+
+def _coverage_ms(action: str, sched: PingSchedule) -> int:
+    """How long an action keeps an entry alive, at most.
+
+        coverage = max_pings x interval + lifetime
+
+    The trailing lifetime is LOAD BEARING: the last keep-alive is itself a cache read, and a
+    read refreshes the entry for its tier's full lifetime. Leaving it out understates the
+    reach of a ping schedule — the error that made an earlier analysis of this mechanism
+    wrong by a factor of four.
+    """
+    if not pings(action):
+        return LIFETIME_MS[tier_of(action)]
+    # A pinging action's reach is set by the tier its keep-alives HOLD, not the tier the
+    # request writes: WRITE_5M_PING_1H writes five minutes and its first keep-alive extends
+    # that to an hour, so its coverage is the hourly one.
+    held = ping_tier(action)
+    return sched.max_pings * sched.interval_ms(held) + LIFETIME_MS[held]
+
+
+def _long_hold(r: Request, ctx: PolicyContext, need_ms: int = HORIZON_1H_MS) -> str:
+    """The cheapest action that actually holds this prefix for `need_ms`.
+
+        write_1h = prefix x write_1h_rate                          (2.0x input, once)
+        ping_5m  = prefix x write_5m_rate + K x keep_alive_cost     (1.25x plus K reads)
+
+    The comparison is only ever made between candidates that REACH the horizon. A
+    5-minute-plus-keep-alives hold with the shipped schedule (2 pings, 280 s apart) covers
+    860 s — fourteen minutes, not an hour — so treating it as an alternative to a 1-hour
+    write for an hour-long gap buys two pings AND misses anyway. That was the bug in the
+    first version of this function, and it made the arm that used it score below a plain
+    keep-alive.
+
+    Unpriced: choose the 1-hour write, because a known one-off multiple beats an unbounded
+    ping schedule at an unknown rate.
+    """
+    p = ctx.prices.for_model(r.model)
+    candidates = [a for a in (WRITE_1H, PING_5M, PING_1H)
+                  if _coverage_ms(a, ctx.schedule) >= need_ms]
+    if not candidates:
+        # Nothing on offer reaches that far; the longest reach is the honest choice.
+        candidates = [max((WRITE_1H, PING_5M, PING_1H),
+                          key=lambda a: _coverage_ms(a, ctx.schedule))]
+    if not p.known:
+        return WRITE_1H if WRITE_1H in candidates else candidates[0]
+
+    def cost(action: str) -> float:
+        n = ctx.schedule.max_pings if pings(action) else 0
+        return p.hold_cost(r.cached_context, tier_of(action), n, ctx.semantics)
+
+    return min(candidates, key=cost)
+
+
+def policy_predictor(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """Act on the survival predictor's two probabilities.
+
+    P(return within 5 minutes) >= threshold_5m  -> a plain 5-minute write is enough; the
+        entry survives on its own and a keep-alive would be pure waste.
+    else P(return within an hour) >= threshold_1h -> hold it for an hour, by whichever of a
+        1h write and a 5m write plus refreshes is cheaper on this prefix.
+    else -> let it expire.
+
+    A row the predictor has no answer for gets the provider's default rather than being
+    dropped, and `predictor_unanswered` counts those.
+    """
+    unanswered = 0
+    out: list[str] = []
+    for r in rows:
+        if r.cached_context < ctx.min_prefix:
+            out.append(EXPIRE)
+            continue
+        p5 = ctx.p5m.get(r.request_id)
+        p1 = ctx.p1h.get(r.request_id)
+        if p5 is None or p1 is None:
+            unanswered += 1
+            out.append(WRITE_5M)
+            continue
+        if p5 >= ctx.threshold_5m:
+            out.append(WRITE_5M)
+        elif p1 >= ctx.threshold_1h:
+            out.append(_long_hold(r, ctx))
+        else:
+            out.append(EXPIRE)
+    ctx.notes["predictor_unanswered"] = unanswered
+    return out
+
+
+def policy_expected_cost(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """Pick the action with the lowest EXPECTED cost, using the predictor's probability
+    and this model's own rates. The rule the survival predictor is actually for.
+
+    Why not a threshold ladder. `policy_predictor` asks "is P(return within 5m) above
+    0.5?", and on real traffic that is the wrong question twice over. First, 92% of
+    production gaps close inside five minutes, so the answer is almost always yes and the
+    arm degenerates into fixed-5m. Second, the money is not in the typical request at all:
+    it is in the rare one whose entry NOBODY WILL READ, where writing the prefix costs
+    1.25x input for nothing when simply not caching it costs 1.0x. A ladder cannot express
+    that, because the quantity it needs to compare is a cost, not a probability.
+
+    So compare costs directly. Relative to letting the prefix expire — which bills it as
+    fresh input at 1.0x — caching at tier T costs an extra
+
+        premium(T) = prefix x (write_rate(T) - input_rate)
+
+    now, and buys, IF the conversation returns while the entry is alive, a read instead of
+    a re-creation on that next request:
+
+        rescue = prefix x (write_5m_rate - cache_read_rate)
+
+    `rescue` deliberately does NOT depend on T, and that is the correction that makes this
+    rule work rather than invert. Pricing the avoided re-creation at write_rate(T) is
+    CIRCULAR: it lets a 1-hour write inflate its own payoff, on the premise that the next
+    miss would have re-created at the 1-hour rate — but the next request's tier is the next
+    request's decision, not this one's. Priced at the FIVE-MINUTE rate it is the cheapest
+    way to re-establish a prefix, so the figure is both non-circular and the conservative
+    one. With the circular version in place this arm chose a 1-hour write 3,426 times out of
+    3,699 and cost 36% MORE than a plain 5-minute policy.
+
+    So caching at T is worth it exactly when
+
+        P(return within coverage(T)) x rescue > premium(T) + ping_cost(T)
+
+    and among the actions that clear that bar the lowest expected total wins. `ctx.threshold_5m`
+    and `ctx.threshold_1h` are IGNORED here: the rates set the thresholds, which is the point.
+
+    A row the predictor has no answer for falls back to the provider's default and is
+    counted in `expected_cost_unanswered`. An unpriced model cannot be reasoned about at
+    all, so it also takes the default rather than being decided by an arithmetic on zeroes.
+    """
+    unanswered = unpriced = 0
+    out: list[str] = []
+    for r in rows:
+        price = ctx.prices.for_model(r.model)
+        p5 = ctx.p5m.get(r.request_id)
+        p1 = ctx.p1h.get(r.request_id)
+        if p5 is None or p1 is None:
+            unanswered += 1
+            out.append(WRITE_5M)
+            continue
+        if not price.known:
+            unpriced += 1
+            out.append(WRITE_5M)
+            continue
+        prefix = r.cached_context
+        best, best_cost = EXPIRE, 0.0  # expiring is the reference point: zero extra cost
+        for action in (WRITE_5M, WRITE_1H, PING_5M, PING_1H):
+            tier = tier_of(action)
+            premium = prefix * (price.write_rate(tier) - price.input)
+            # Not write_rate(tier): see the docstring. The avoided re-creation is priced at
+            # the cheapest tier that could re-establish the prefix, which is what keeps this
+            # from being an argument for its own most expensive option.
+            rescue = prefix * (price.write_5m - price.cache_read)
+            n = ctx.schedule.max_pings if pings(action) else 0
+            ping_cost = n * price.keep_alive_cost(prefix, ctx.semantics)
+            # The probability that the entry is still alive when the conversation returns is
+            # the probability of returning inside this action's COVERAGE, and the predictor
+            # answers at the two horizons it was bucketed for. A coverage BETWEEN them (a
+            # keep-alive schedule reaches 14 minutes) is bounded below by the 5-minute
+            # figure rather than interpolated: interpolating would invent a number the model
+            # never produced, and the bound errs toward spending less.
+            cov = _coverage_ms(action, ctx.schedule)
+            p = p1 if cov >= HORIZON_1H_MS else (p5 if cov <= HORIZON_5M_MS else p5)
+            expected = premium + ping_cost - p * rescue
+            if expected < best_cost:
+                best, best_cost = action, expected
+        out.append(best)
+    ctx.notes["expected_cost_unanswered"] = unanswered
+    ctx.notes["expected_cost_unpriced"] = unpriced
+    return out
+
+
+def policy_optimal(rows: Sequence[Request], ctx: PolicyContext) -> list[str]:
+    """UNREACHABLE CEILING: the cheapest action sequence that exists, computed exactly.
+
+    Why a dynamic program and not a greedy rule. The action chosen at turn t decides two
+    things at once — whether turn t itself may READ from cache (an action of 'expire' writes
+    no cache_control, so the whole prefix is billed as fresh input however warm the entry
+    was) and whether turn t+1 hits. A rule that looks only at the gap ahead therefore gets
+    the current turn wrong, and the first version of this function did: it scored BELOW a
+    plain keep-alive, which is impossible for a ceiling and is what exposed the error.
+
+    The exact optimum is cheap because the state is small. Everything about the entry
+    entering turn t — its size, its tier, its deadline, the keep-alives that fired during
+    the span — is a function of the PREVIOUS action alone, given the two rows' timestamps.
+    So the cost decomposes as a sum of f(action[t-1], action[t]) along the chain and one
+    Viterbi pass per trajectory settles it: 5 states, 5 transitions, O(25n).
+
+    It reads the true next-request time, so it is the bound a predictor is measured against
+    and never a result. Quoting it as a saving would be claiming perfect foresight.
+    """
+    sem, sched = ctx.semantics, ctx.schedule
+    by_conv: dict[tuple[str, str], list[Request]] = defaultdict(list)
+    for r in rows:
+        by_conv[r.key].append(r)
+
+    chosen: dict[int, str] = {}
+    for key in sorted(by_conv):
+        group = sorted(by_conv[key], key=lambda r: (r.ts_ms, r.request_id))
+        # best[a] = (cost so far, action list) for a trajectory whose LAST action is a.
+        best: dict[str, tuple[float, list[str]]] = {}
+        for i, r in enumerate(group):
+            prev = group[i - 1] if i else None
+            nxt: dict[str, tuple[float, list[str]]] = {}
+            for action in ACTIONS:
+                if prev is None:
+                    c = _step_cost(None, EXPIRE, r, action, ctx, sem, sched)
+                    nxt[action] = (c, [action])
+                    continue
+                pick: tuple[float, list[str]] | None = None
+                for prev_action, (sofar, path) in best.items():
+                    c = sofar + _step_cost(prev, prev_action, r, action, ctx, sem, sched)
+                    if pick is None or c < pick[0]:
+                        pick = (c, path + [action])
+                nxt[action] = pick  # type: ignore[assignment]
+            best = nxt
+        # The OPEN span after the last turn: an action that pings keeps spending, bounded by
+        # the window's end, and the optimum has to pay for that too or it would prefer a
+        # keep-alive it never settles up on.
+        last = group[-1]
+        end = ctx.notes.get("window_end_ms") or last.ts_ms
+        final: tuple[float, list[str]] | None = None
+        for action, (sofar, path) in best.items():
+            c = sofar + _open_span_cost(last, action, ctx, sem, sched, int(end))
+            if final is None or c < final[0]:
+                final = (c, path)
+        for r, a in zip(group, final[1]):  # type: ignore[index]
+            chosen[r.request_id] = a
+    return [chosen[r.request_id] for r in sorted(rows, key=lambda r: (r.ts_ms, r.request_id))]
+
+
+def _entry_after(row: Request, action: str) -> tuple[int, str, int]:
+    """The (tokens, tier, expires) a turn leaves behind. A hit refreshes, a write starts —
+    both land on the same expression, which is why this needs no hit flag."""
+    tier = tier_of(action)
+    if tier == TTL_NONE:
+        return 0, TTL_NONE, 0
+    return row.cached_context, tier, row.ts_ms + LIFETIME_MS[tier]
+
+
+def _step_cost(prev: Request | None, prev_action: str, row: Request, action: str,
+               ctx: PolicyContext, sem: Semantics, sched: PingSchedule) -> float:
+    """The cost the pair (prev_action, action) adds: the span's keep-alives plus this
+    request's own bill. The DP's transition weight, and it reads the SAME cost functions
+    and the same ping core the accounting evaluator does."""
+    tokens, tier, expires = 0, TTL_NONE, 0
+    ping_cost = 0.0
+    if prev is not None:
+        tokens, tier, expires = _entry_after(prev, prev_action)
+        span = _ping_span(tokens, tier, expires, prev.ts_ms, prev_action, row.ts_ms,
+                          ctx.prices.for_model(prev.model), sem, sched)
+        ping_cost, tier, expires = span.cost, span.tier, span.expires_ms
+    alive = tokens > 0 and row.ts_ms < expires
+    hit = alive and row.miss_reason not in UNRESCUABLE
+    reusable = min(tokens, row.cached_context) if hit else 0
+    t = tier_of(action)
+    fresh, read, write = row.input_tokens, reusable, 0
+    if t == TTL_NONE:
+        fresh += row.cached_context
+        read = 0
+    else:
+        write = max(0, row.cached_context - reusable)
+    price = ctx.prices.for_model(row.model)
+    own = price.request_cost(fresh, read, write, row.output_tokens, t) if price.known else 0.0
+    return ping_cost + own
+
+
+def _open_span_cost(last: Request, action: str, ctx: PolicyContext, sem: Semantics,
+                    sched: PingSchedule, window_end_ms: int) -> float:
+    """What a pinging action keeps spending after the trajectory's last observed request."""
+    tokens, tier, expires = _entry_after(last, action)
+    return _ping_span(tokens, tier, expires, last.ts_ms, action, window_end_ms,
+                      ctx.prices.for_model(last.model), sem, sched).cost
+
+
+POLICIES: dict[str, Policy] = {
+    "no-cache": policy_no_cache,
+    "fixed-5m": policy_fixed_5m,
+    "fixed-1h": policy_fixed_1h,
+    "keepalive-5m": policy_keepalive_5m,
+    "observed-policy": policy_observed,
+    "keepalive-1h": policy_keepalive_1h,
+    "keepalive-5m-to-1h": policy_extend_1h,
+    "predictor": policy_predictor,
+    "expected-cost": policy_expected_cost,
+    "optimal": policy_optimal,
+}
+
+# The arms whose result is not a reachable saving, and must be labelled wherever shown.
+UNREACHABLE = frozenset({"optimal"})
+
+
+def run_policy(name: str, rows: Sequence[Request], ctx: PolicyContext,
+               **kwargs: Any) -> Cost:
+    """Build the action list for one policy and score it."""
+    actions = POLICIES[name](rows, ctx)
+    return evaluate(rows, actions, ctx.prices, semantics=ctx.semantics,
+                    schedule=ctx.schedule, policy=name, **kwargs)
+
+
+# ── the predictor bridge ───────────────────────────────────────────────────
+
+def predictor_probabilities(train: Sequence[Request], score: Sequence[Request], *,
+                            bucket_seconds: int = 300, max_ttl_seconds: int = 3600,
+                            window_end_ms: int | None = None,
+                            ) -> tuple[dict[int, float], dict[int, float], dict[str, Any]]:
+    """Fit kv_ttl_survival_predictor on `train` and score `score`.
+
+    The split is the whole point: coefficients fitted over the rows they are then scored on
+    are in-sample and will flatter the model. `train` must end before `score` begins, and
+    the caller is responsible for that — see the CLI, which cuts by time.
+
+    Returns P(return within 5m), P(return within 1h), both keyed by request_id, plus the
+    fit's own summary. With the default bucketing those two are column 0 and one minus the
+    tail of the predictor's distribution, which is why that bucketing is the default:
+    they are the provider's two tiers, read straight off with no interpolation.
+    """
+    import pandas as pd  # only this bridge needs the scientific stack
+
+    from kv_ttl_survival_predictor import (KVTTLTimePredictor,
+                                          build_next_request_targets)
+
+    def frame(rows: Sequence[Request]) -> "pd.DataFrame":
+        return pd.DataFrame([{
+            "request_id": r.request_id, "user_id": r.user,
+            "conversation_id": r.conversation, "model": r.model,
+            "request_time": pd.Timestamp(r.ts_ms, unit="ms", tz="UTC"),
+        } for r in rows])
+
+    end = window_end_ms if window_end_ms is not None else max(r.ts_ms for r in train)
+    labelled = build_next_request_targets(
+        frame(train),
+        compatibility_columns=("user_id", "conversation_id", "model"),
+        observation_end=pd.Timestamp(end, unit="ms", tz="UTC"))
+    model = KVTTLTimePredictor(bucket_seconds=bucket_seconds,
+                               max_ttl_seconds=max_ttl_seconds,
+                               categorical_features=("user_id", "model"))
+    model.fit(labelled)
+
+    scored = frame(score)
+    proba = model.predict_proba(scored)
+    ids = scored["request_id"].tolist()
+    p5m = {int(i): float(v) for i, v in zip(ids, proba[:, 0])}
+    p1h = {int(i): float(1.0 - v) for i, v in zip(ids, proba[:, -1])}
+    return p5m, p1h, dict(model.training_summary_)
+
+
+def sweep_thresholds(rows: Sequence[Request], ctx: PolicyContext, *,
+                     grid: Sequence[float] = (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+                     window_end_ms: int | None = None) -> tuple[float, float, float]:
+    """Pick the thresholds that minimise cost ON THESE ROWS. Returns (t5m, t1h, best_usd).
+
+    Call it on the TRAINING half only. Tuning a threshold on the rows it is then reported
+    on is the same in-sample error as fitting the model on them, one layer up, and it is
+    the layer people forget.
+    """
+    best = (ctx.threshold_5m, ctx.threshold_1h, math.inf)
+    for t5 in grid:
+        for t1 in grid:
+            ctx.threshold_5m, ctx.threshold_1h = t5, t1
+            cost = run_policy("predictor", rows, ctx, window_end_ms=window_end_ms)
+            if cost.total_usd < best[2]:
+                best = (t5, t1, cost.total_usd)
+    ctx.threshold_5m, ctx.threshold_1h = best[0], best[1]
+    return best
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def _fmt_usd(v: float) -> str:
+    return f"${v:,.2f}" if abs(v) >= 0.005 else f"${v:.4f}"
+
+
+def _report(baseline_name: str, costs: dict[str, Cost], notes: dict[str, Any]) -> None:
+    base = costs[baseline_name]
+    print(f"\nBaseline: {baseline_name}  ({_fmt_usd(base.total_usd)} over "
+          f"{base.requests:,} requests, {base.conversations:,} trajectories)")
+    if base.unpriced:
+        print(f"  {base.unpriced:,} requests are on a model the price list cannot price; "
+              f"they are counted and contribute to NO dollar figure.")
+    # The columns say CHEAPER/MORE in words, not just a sign. A column headed "saving" that
+    # shows -$2,117.80 for the worst arm on the page reads, to a person scanning it, as
+    # "saves $2,117.80" — which inverts the whole table. It happened on the first reading.
+    head = (f"\n  {'policy':<16}{'total bill':>12}{'vs baseline':>13}{'':>9}{'%':>9}"
+            f"{'hit %':>8}{'pings':>8}{'w5m':>7}{'w1h':>6}")
+    print(head)
+    print("  " + "-" * (len(head) - 3))
+    for name, c in costs.items():
+        s = compare(base, c)
+        delta = -s.absolute_usd  # what the policy adds to the bill: + is worse
+        word = "cheaper" if delta < -0.005 else ("MORE" if delta > 0.005 else "same")
+        pct = f"{-s.percent_usd:+.2f}%" if s.percent_known else "n/a"
+        mark = " *" if name in UNREACHABLE else ""
+        print(f"  {name + mark:<16}{_fmt_usd(c.total_usd):>12}{_fmt_usd(delta):>13}"
+              f"{word:>9}{pct:>9}"
+              f"{c.hit_rate_pct:>7.1f}%{c.pings:>8,}{c.writes_5m:>7,}{c.writes_1h:>6,}")
+    if any(n in UNREACHABLE for n in costs):
+        print("\n  * optimal reads the true next-request time and is computed exactly. It is the "
+              "CEILING\n    no predictor can reach, not a result. Never quote it as a saving.")
+    print("\n  'vs baseline' and '%' are what the policy ADDS to the bill: negative is "
+          "cheaper, positive is\n  worse. Nothing is clamped. HIT RATE IS NOT THE "
+          "OBJECTIVE — see fixed-1h, which buys the\n  best hit rate on the page and is "
+          "the second most expensive arm on it.")
+    for k, v in notes.items():
+        print(f"  note: {k} = {v}")
+
+
+def _run_fixture(path: str) -> int:
+    """Score a fixture and print the result as JSON. The drift test's interface.
+
+    A fixture is {"window_end_ms":…, "rates":{model:{…}}, "semantics":{…},
+    "schedule":{…}, "requests":[…], "actions":{id: action}} — everything the evaluator
+    needs and nothing it has to look up, so kv_ttl_cost_drift_test.go can hand the SAME
+    trajectory and the SAME action list to this and to kvcache.Simulate and compare.
+
+    `"policy": "<name>"` runs a POLICY instead of a supplied list, which is how the guard
+    also locks the two exact ceilings (`optimal`) together rather than only the evaluator.
+
+    Actions are keyed by REQUEST ID, never positional: rows with equal timestamps are
+    ordered by (ts, id), so a positional list is applied in a different order than it was
+    written in and the two sides silently score different plans.
+    """
+    spec = json.loads(Path(path).read_text(encoding="utf-8"))
+    book = PriceBook()
+    for model, r in (spec.get("rates") or {}).items():
+        book._overrides[model] = ModelPricing(  # noqa: SLF001 - the fixture IS the source
+            model=model, input=r["input"], output=r["output"], cache_read=r["cache_read"],
+            write_5m=r["write_5m"], write_1h=r["write_1h"],
+            ping_input_tokens=r.get("ping_input_tokens", DEFAULT_PING_INPUT_TOKENS),
+            ping_output_tokens=r.get("ping_output_tokens", DEFAULT_PING_OUTPUT_TOKENS),
+            source="fixture", known=bool(r.get("known", True)))
+    rows = derive([Request(**r) for r in spec["requests"]])
+    sem = Semantics(**(spec.get("semantics") or {}))
+    sched = PingSchedule(**(spec.get("schedule") or {}))
+    if spec.get("policy"):
+        # Run a POLICY rather than a supplied list. The point is `optimal`: both sides solve
+        # the same dynamic program, and a ceiling the two disagree about is a ceiling neither
+        # of them can be quoted against.
+        ctx = PolicyContext(prices=book, semantics=sem, schedule=sched)
+        ctx.notes["window_end_ms"] = spec.get("window_end_ms")
+        actions = POLICIES[spec["policy"]](rows, ctx)
+    else:
+        actions = spec["actions"]
+    cost = evaluate(rows, actions, book,
+                    semantics=sem, schedule=sched,
+                    window_end_ms=spec.get("window_end_ms"),
+                    policy=spec.get("policy") or "fixture")
+    print(json.dumps(cost.to_dict(), default=str))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Cost a KV-cache TTL policy on real trajectories at real rates.")
+    ap.add_argument("--db", default=DEFAULT_DB, help=f"dashboard store (default {DEFAULT_DB})")
+    ap.add_argument("--prices", default=DEFAULT_PRICES,
+                    help=f"operator price list (default {DEFAULT_PRICES})")
+    ap.add_argument("--baseline", default="observed-policy",
+                    help="policy to measure savings against (default: observed-policy). The "
+                         "arm names are kvcache's registry (kvcache.Strategy* in Go), because "
+                         "a name that means one thing on the dashboard and another here is a "
+                         "comparison nobody can trust.")
+    ap.add_argument("--split", type=float, default=0.7,
+                    help="fraction of the WINDOW used to fit the predictor and tune its "
+                         "thresholds; every policy is then scored on the remainder "
+                         "(default 0.7)")
+    ap.add_argument("--min-prefix", type=int, default=20_000,
+                    help="prefix below which nothing is cached (default 20000)")
+    ap.add_argument("--max-pings", type=int, default=2)
+    ap.add_argument("--no-predictor", action="store_true",
+                    help="skip the ML arms (no pandas/scikit-learn needed)")
+    ap.add_argument("--no-sweep", action="store_true",
+                    help="use --threshold-5m/--threshold-1h rather than tuning on the "
+                         "training half")
+    ap.add_argument("--threshold-5m", type=float, default=0.5)
+    ap.add_argument("--threshold-1h", type=float, default=0.5)
+    ap.add_argument("--json", help="write the full result set here")
+    ap.add_argument("--fixture", help="score a JSON fixture and print it (drift test)")
+    args = ap.parse_args(argv)
+    if args.fixture:
+        return _run_fixture(args.fixture)
+
+    prices = PriceBook.from_operator_file(args.prices)
+    rows = load_trajectories(args.db)
+    if not rows:
+        print("no requests in that store")
+        return 1
+    window_end = max(r.ts_ms for r in rows)
+    lo, hi = rows[0].ts_ms, window_end
+    cut = lo + int((hi - lo) * args.split)
+    train = [r for r in rows if r.ts_ms <= cut]
+    test = [r for r in rows if r.ts_ms > cut]
+    # The test half is re-derived so that "the next request" is the next one IN THE HALF
+    # BEING SCORED. Leaving the full-window derivation in place would let a policy be
+    # credited for a return that lies outside the rows it is measured on.
+    test = derive([replace(r) for r in test])
+    print(f"store   {args.db}")
+    print(f"prices  {args.prices}")
+    print(f"window  {lo} .. {hi} ms UTC  ({len(rows):,} requests)")
+    print(f"split   fit/tune on {len(train):,} requests, score on {len(test):,}")
+
+    ctx = PolicyContext(prices=prices, min_prefix=args.min_prefix,
+                        schedule=PingSchedule(max_pings=args.max_pings),
+                        threshold_5m=args.threshold_5m, threshold_1h=args.threshold_1h)
+    # The exact optimum has to pay for the open span after each trajectory's last request,
+    # and that is bounded by the window rather than by the data. Passed through notes so the
+    # policy signature stays (rows, ctx).
+    ctx.notes["window_end_ms"] = window_end
+    names = ["no-cache", "fixed-5m", "fixed-1h", "keepalive-5m", "keepalive-1h",
+             "keepalive-5m-to-1h", "observed-policy"]
+    if not args.no_predictor:
+        p5m, p1h, summary = predictor_probabilities(train, test, window_end_ms=cut)
+        ctx.p5m, ctx.p1h = p5m, p1h
+        ctx.notes["predictor_fit"] = summary
+        if not args.no_sweep:
+            # Tuned on the TRAINING rows, scored on the test rows. The training rows need
+            # their own probabilities to be tuned against, and those come from the same
+            # fit — in-sample for the tuning step only, which is why the reported figure
+            # is the test one.
+            tp5, tp1, _ = predictor_probabilities(train, train, window_end_ms=cut)
+            tune_ctx = PolicyContext(prices=prices, min_prefix=args.min_prefix,
+                                     schedule=PingSchedule(max_pings=args.max_pings),
+                                     p5m=tp5, p1h=tp1)
+            t5, t1, _ = sweep_thresholds(derive([replace(r) for r in train]), tune_ctx,
+                                         window_end_ms=cut)
+            ctx.threshold_5m, ctx.threshold_1h = t5, t1
+        ctx.notes["thresholds"] = {"p5m": ctx.threshold_5m, "p1h": ctx.threshold_1h}
+        names += ["predictor", "expected-cost", "optimal"]
+
+    costs: dict[str, Cost] = {}
+    for name in names:
+        costs[name] = run_policy(name, test, ctx, window_end_ms=window_end)
+    if args.baseline not in costs:
+        print(f"baseline {args.baseline!r} is not one of {list(costs)}")
+        return 2
+    _report(args.baseline, costs, ctx.notes)
+
+    # What the deployment ACTUALLY paid over the same rows, for scale. Not a baseline: it
+    # was billed by a different pipeline under a policy this model does not reconstruct.
+    billed = sum(r.billed_usd for r in test)
+    print(f"\n  for scale: the deployment was actually billed {_fmt_usd(billed)} over these "
+          f"same {len(test):,} requests.")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps({
+            "window": {"since_ms": lo, "until_ms": hi, "cut_ms": cut},
+            "baseline": args.baseline,
+            "notes": ctx.notes,
+            "billed_usd": billed,
+            "policies": {n: c.to_dict() for n, c in costs.items()},
+            "savings": {n: compare(costs[args.baseline], c).__dict__
+                        for n, c in costs.items()},
+        }, indent=2, default=str), encoding="utf-8")
+        print(f"  wrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/harbor/kv_ttl_cost_model.py
+++ b/deploy/harbor/kv_ttl_cost_model.py
@@ -680,6 +680,12 @@ class Group:
         d = self.hits + self.misses
         return 100.0 * self.hits / d if d else 0.0
 
+    @property
+    def valued(self) -> bool:
+        """As Cost.valued, one level down. Here so a consumer never has to spell the predicate
+        a second time as `unpriced < requests` on every per-user and per-model row."""
+        return self.requests > 0 and self.unpriced < self.requests
+
 
 @dataclass
 class Cost:
@@ -762,9 +768,11 @@ class Cost:
         out["cache_premium_usd"] = self.cache_premium_usd
         out["hit_rate_pct"] = self.hit_rate_pct
         out["miss_rate_pct"] = self.miss_rate_pct
-        out["by_user"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct}
+        out["by_user"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct,
+                                           "valued": g.valued}
                           for k, g in self.by_user.items()}
-        out["by_model"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct}
+        out["by_model"] = {k: g.__dict__ | {"hit_rate_pct": g.hit_rate_pct,
+                                           "valued": g.valued}
                            for k, g in self.by_model.items()}
         return out
 

--- a/deploy/harbor/kv_ttl_cost_model.py
+++ b/deploy/harbor/kv_ttl_cost_model.py
@@ -723,6 +723,18 @@ class Cost:
     by_model: dict[str, Group] = field(default_factory=dict)
 
     @property
+    def valued(self) -> bool:
+        """Whether ANY of these requests could be priced at all.
+
+        False means every dollar figure here is zero because nothing had RATES — not because
+        nothing was spent. Stated rather than left to be derived from unpriced == requests,
+        because a consumer that has to derive it will forget to: a cold start with no price map
+        makes every arm cost 0.00 and turns the exact ceiling into "never cache anything",
+        rendered in the style reserved for the cheapest plan that exists.
+        """
+        return self.requests > 0 and self.unpriced < self.requests
+
+    @property
     def total_usd(self) -> float:
         return (self.fresh_input_usd + self.cache_read_usd + self.cache_write_usd
                 + self.output_usd + self.ping_usd)
@@ -746,6 +758,7 @@ class Cost:
     def to_dict(self) -> dict[str, Any]:
         out = {k: v for k, v in self.__dict__.items() if k not in ("by_user", "by_model")}
         out["total_usd"] = self.total_usd
+        out["valued"] = self.valued
         out["cache_premium_usd"] = self.cache_premium_usd
         out["hit_rate_pct"] = self.hit_rate_pct
         out["miss_rate_pct"] = self.miss_rate_pct

--- a/deploy/harbor/kv_ttl_cost_model.py
+++ b/deploy/harbor/kv_ttl_cost_model.py
@@ -585,8 +585,16 @@ class Request:
     idle_ms: int | None = None
 
     @property
-    def key(self) -> tuple[str, str]:
-        return (self.user, self.conversation)
+    def key(self) -> tuple[str, str, str]:
+        """The conversation this request belongs to: (user, conversation, MODEL).
+
+        The model is part of the key because a cache entry does not transfer between models, so
+        an opus request cannot read a sonnet request's entry. Omitting it links the two as
+        successor and grants the second a hit at 0.1x on an entry it could never have matched —
+        which is the same rule this repo's predictor states for its compatibility columns, and
+        reaches 5.7% of this deployment's trajectories.
+        """
+        return (self.user, self.conversation, self.model)
 
     @property
     def hour_utc(self) -> int:
@@ -893,13 +901,20 @@ def evaluate(rows: Sequence[Request], actions: Mapping[int, Any] | Sequence[Any]
         forced = r.miss_reason in UNRESCUABLE
         if forced:
             out.forced_misses += 1
-        hit = alive and not forced
-        reusable = min(st.tokens, r.cached_context) if hit else 0
 
         # 3. the action for the span that starts now.
         action = chosen.get(r.request_id, EXPIRE)
         out.decisions[action] = out.decisions.get(action, 0) + 1
         tier = tier_of(action)
+
+        # HIT IS DECIDED HERE, after the action, and it needs the action to be decided at all. A
+        # request whose action is EXPIRE writes no cache_control, so the provider reads nothing
+        # and bills the whole prefix as fresh input however warm the entry was. Deciding `hit`
+        # from aliveness alone counted such a turn as a hit — in hits, in hit_rate_pct and in
+        # avoided_recomputations — while it paid for a fully uncached prompt, and the tell was
+        # avoided_recomputations of 1 beside avoided_tokens of 0 in one result.
+        hit = alive and not forced and tier != TTL_NONE
+        reusable = min(st.tokens, r.cached_context) if hit else 0
 
         # 4. bill this request under the chosen tier.
         fresh, read, write = r.input_tokens, reusable, 0

--- a/deploy/harbor/kv_ttl_cost_model.py
+++ b/deploy/harbor/kv_ttl_cost_model.py
@@ -144,13 +144,16 @@ that differs can say so rather than being silently mispriced:
 
 WHAT AN ACTION IS
 -----------------
-Five, and they are the whole set of things a prompt-caching provider sells:
+Six, and they are the whole set of things a prompt-caching provider sells:
 
-    'expire'    write no cache_control; this prompt is billed as fresh input
-    'write_5m'  write/retain the prefix at the 5-minute tier
-    'write_1h'  write/retain the prefix at the 1-hour tier
-    'ping_5m'   hold at 5 minutes AND refresh with keep-alives while idle
-    'ping_1h'   hold at an hour AND refresh with keep-alives while idle
+    'expire'            write no cache_control; this prompt is billed as fresh input
+    'write_5m'          write/retain the prefix at the 5-minute tier
+    'write_1h'          write/retain the prefix at the 1-hour tier
+    'ping_5m'           hold at 5 minutes AND refresh with keep-alives while idle
+    'ping_1h'           hold at an hour AND refresh with keep-alives while idle
+    'write_5m_ping_1h'  write at the CHEAP 5-minute tier, and if a keep-alive comes due before
+                        it lapses, extend the context by an hour with a 1-hour write — so the
+                        long-hold premium is paid only on conversations that actually go quiet
 
 `evaluate(rows, actions)` takes `actions` as either a list parallel to the chronological
 row order, or a dict keyed by `request_id`. TTL SECONDS are accepted as a convenience — 0,
@@ -233,11 +236,13 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import sqlite3
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
+from urllib.parse import quote
 
 # ── actions and tiers ──────────────────────────────────────────────────────
 
@@ -617,7 +622,13 @@ def load_trajectories(db_path: str | Path = DEFAULT_DB, *, since_ms: int | None 
                       until_ms: int | None = None,
                       include_keepalive: bool = False) -> list[Request]:
     """Read the trajectories from the dashboard store, READ-ONLY, chronologically."""
-    uri = f"file:{Path(db_path).as_posix()}?mode=ro"
+    # quote() the path, do not merely concatenate it. SQLite's URI syntax gives '?' and '&'
+    # meaning, so an unescaped path containing either injects query parameters — and SQLite
+    # honours the FIRST mode it sees, which demotes the appended mode=ro to an ignored junk
+    # parameter. Demonstrated: a db_path of "new.db?mode=rwc&" opened WRITABLE and CREATED the
+    # file. "We never write to the production store" is this module's central promise, so it
+    # cannot rest on the path happening to contain no punctuation.
+    uri = f"file:{quote(Path(db_path).resolve().as_posix())}?mode=ro"
     con = sqlite3.connect(uri, uri=True)
     try:
         have = {r[1] for r in con.execute("PRAGMA table_info(requests)")}
@@ -1653,7 +1664,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                          "training half")
     ap.add_argument("--threshold-5m", type=float, default=0.5)
     ap.add_argument("--threshold-1h", type=float, default=0.5)
-    ap.add_argument("--json", help="write the full result set here")
+    ap.add_argument("--json", help="write the full result set here. CONTAINS PER-ACCOUNT "
+                                   "IDENTIFIERS (by_user is keyed by tenant id); written 0600")
     ap.add_argument("--fixture", help="score a JSON fixture and print it (drift test)")
     args = ap.parse_args(argv)
     if args.fixture:
@@ -1721,16 +1733,23 @@ def main(argv: Sequence[str] | None = None) -> int:
           f"same {len(test):,} requests.")
 
     if args.json:
-        Path(args.json).write_text(json.dumps({
-            "window": {"since_ms": lo, "until_ms": hi, "cut_ms": cut},
-            "baseline": args.baseline,
-            "notes": ctx.notes,
-            "billed_usd": billed,
-            "policies": {n: c.to_dict() for n, c in costs.items()},
-            "savings": {n: compare(costs[args.baseline], c).__dict__
-                        for n, c in costs.items()},
-        }, indent=2, default=str), encoding="utf-8")
-        print(f"  wrote {args.json}")
+        # 0600, and created that way rather than chmod'd afterwards: the payload carries
+        # by_user keyed by TENANT ID with each account's request count and dollar total, so a
+        # world-readable default (0644 minus umask) hands per-customer spend to every local
+        # user. O_CREAT|O_TRUNC with the mode set at creation leaves no window where the file
+        # exists with wider permissions.
+        fd = os.open(args.json, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "window": {"since_ms": lo, "until_ms": hi, "cut_ms": cut},
+                "baseline": args.baseline,
+                "notes": ctx.notes,
+                "billed_usd": billed,
+                "policies": {n: c.to_dict() for n, c in costs.items()},
+                "savings": {n: compare(costs[args.baseline], c).__dict__
+                            for n, c in costs.items()},
+                }, indent=2, default=str))
+        print(f"  wrote {args.json} (mode 0600: it contains per-account identifiers)")
     return 0
 
 

--- a/deploy/harbor/kv_ttl_survival_predictor.py
+++ b/deploy/harbor/kv_ttl_survival_predictor.py
@@ -121,7 +121,7 @@ HOW TO USE IT
     predictor.fit(train_events)                    # .train() is the same call
     proba = predictor.predict_proba(test_events)   # (n_rows, n_buckets + 1)
     predictor.save("kvttl.joblib")
-    predictor = KVTTLTimePredictor.load("kvttl.joblib")
+    predictor = KVTTLTimePredictor.load("kvttl.joblib")   # pickle: see the SECURITY note on load()
 
 `fit` and `train` are the same method. `predict_proba` and `inference` are the same
 method. `predict_distribution` returns the same numbers in long form for a human, and
@@ -655,14 +655,35 @@ class KVTTLTimePredictor(BaseEstimator):
         )
 
     def save(self, path: str | Path) -> None:
-        """Serialize the fitted predictor with joblib."""
+        """Serialize the fitted predictor with joblib.
+
+        The file is a PICKLE. Treat it as executable, not as data: it goes wherever the code
+        that produced it may go, and no further. See :meth:`load`.
+        """
 
         check_is_fitted(self, "pipeline_")
         joblib.dump(self, Path(path))
 
     @classmethod
     def load(cls, path: str | Path) -> "KVTTLTimePredictor":
-        """Load a predictor previously written by :meth:`save`."""
+        """Load a predictor previously written by :meth:`save`.
+
+        SECURITY: joblib is pickle, and unpickling executes arbitrary code. Loading a file
+        someone else produced is equivalent to running their program with your privileges —
+        a model pulled from an artefact store, a bucket, a CI cache or a colleague's laptop
+        is an execution boundary, not an input.
+
+        The isinstance check below is NOT a defence and must not be read as one. Pickle runs
+        the payload during deserialization, so by the time there is an object to type-check,
+        anything the file wanted to do has already happened. It catches an honest mistake —
+        the wrong file — and nothing adversarial.
+
+        Load only files this process wrote, or files whose integrity you verify out of band
+        before opening (a digest you obtained separately, not one shipped beside the file).
+        Where a model must cross a trust boundary, do not send a pickle: refit from the
+        training frame, or serialize the fitted coefficients and the preprocessor's
+        parameters as JSON and rebuild the estimator from those.
+        """
 
         predictor = joblib.load(Path(path))
         if not isinstance(predictor, cls):

--- a/deploy/harbor/kv_ttl_survival_predictor.py
+++ b/deploy/harbor/kv_ttl_survival_predictor.py
@@ -1,0 +1,850 @@
+#!/usr/bin/env python3
+"""Discrete-time survival predictor for KV-cache return times.
+
+The model estimates a distribution over the time until the next cache-compatible
+request. It deliberately does *not* choose a TTL: the returned probabilities are meant
+to be consumed by a separate cost policy, which is the only place the rates live. That
+split is the point — a model that picked a tier would bury the pricing assumption inside
+the fit, where nobody can edit it.
+
+It is the LEARNED counterpart of the hand-written arms in the `kvcache` Go package: the
+two questions it answers, P(return within 5 minutes) and P(return within an hour), are
+exactly the two `kvcache.Predictor.ReuseProbability(o, horizon)` is asked, so a service
+that wants to use this wires it in behind that interface and nothing in the simulator or
+the dashboard changes. See "Feeding the Go strategy seam" below.
+
+Usage: kv_ttl_survival_predictor.py    # self-test on synthetic traffic; see HOW TO RUN IT
+       imported as a library           # the normal case
+
+
+WHICH DATA IT NEEDS
+-------------------
+One row per request, in a pandas DataFrame. Nothing else — no request bodies, no
+transcripts, no token counts. The model is about TIMING.
+
+Required, always:
+
+    user_id           who owns the traffic. Any stable label.
+    request_time      when the request was made. Parsed with utc=True, so pass either
+                      tz-aware timestamps or UTC-naive ones; a naive LOCAL time will be
+                      read as UTC and every hour-of-day feature will be wrong.
+
+Required for fit() only, and normally produced by build_next_request_targets():
+
+    time_to_next_request_seconds  seconds until the next cache-compatible request, or —
+                                  for a right-censored row — how long the row was
+                                  observed for.
+    event_observed                True when a return was actually seen, False when the
+                                  row is right-censored. Defaults to True when the
+                                  column is absent, which is a trap: see (1) below.
+
+Optional, and worth having:
+
+    anything named in `categorical_features` (default `("user_id",)`) or in
+    `numeric_features` (default empty). `model` and `agent` are the two that carry real
+    signal on this deployment's traffic.
+
+Everything else the model uses is ENGINEERED from the two required columns, per user and
+strictly backwards in time — cyclical hour-of-day and weekday, the previous gap, a
+rolling median and an EWMA of past gaps, the past return rate at 5/15/60 minutes, the
+request counts in the previous 10 and 60 minutes, and how many requests the user has
+made so far. No engineered feature reads a row later than its own, which is what makes a
+backtest of this honest.
+
+
+WHERE THAT DATA COMES FROM IN THIS PROJECT
+------------------------------------------
+context-guru's dashboard store already holds it: one row per proxied request in the
+`requests` table of the SQLite database named by `DASHBOARD_DB` (the hosted deployment's
+is `/var/lib/context-guru/cg.db`). The mapping is a rename and a unit conversion:
+
+    user_id          <- requests.tenant_id      the owning account
+    conversation_id  <- requests.session_id     the trajectory
+    model            <- requests.model
+    agent            <- requests.agent          claude-cli | litellm | anthropic | ...
+    request_time     <- requests.ts             epoch MILLISECONDS, UTC
+    upstream_ms      <- requests.upstream_ms    optional, for a latency-aware policy
+
+Read it READ-ONLY. The extraction, in full:
+
+    import sqlite3, pandas as pd
+    con = sqlite3.connect("file:/var/lib/context-guru/cg.db?mode=ro", uri=True)
+    raw = pd.read_sql_query(
+        "SELECT tenant_id AS user_id, session_id AS conversation_id, model, agent, "
+        "       ts AS request_time_ms, upstream_ms "
+        "FROM requests "
+        "WHERE session_id <> '' AND token_accounting <> 'missing' "
+        "ORDER BY ts, id", con)
+    raw["request_time"] = pd.to_datetime(raw.pop("request_time_ms"), unit="ms", utc=True)
+
+Two filters in that WHERE clause, both deliberate. `session_id <> ''` drops rows with no
+trajectory to belong to. `token_accounting <> 'missing'` drops rows the provider never
+reported usage for. On a database that has the column, add `AND keepalive = 0`: a
+keep-alive ping is a request context-guru sent on its own initiative while nobody was at
+the keyboard, so counting it as a return would teach the model that the user came back
+when the user did not. Older snapshots predate that column and have no pings in them.
+
+Then label it — this is the step that turns a request log into survival data:
+
+    events = build_next_request_targets(
+        raw,
+        compatibility_columns=("user_id", "conversation_id", "model"),
+        observation_end=raw.request_time.max(),   # NOT optional; see (1)
+    )
+
+
+HOW TO RUN IT
+-------------
+Needs numpy, pandas, scikit-learn and joblib, none of which the rest of this repo uses.
+Keep them out of the system interpreter:
+
+    python3 -m venv .venv-kvpred
+    .venv-kvpred/bin/pip install "numpy<2" pandas scikit-learn joblib
+    .venv-kvpred/bin/python deploy/harbor/kv_ttl_survival_predictor.py
+
+Run directly, the `__main__` block fits the model on synthetic two-regime traffic (a
+short daytime scale, a long overnight one) and prints one request's distribution. It is
+a self-test, not a benchmark: it exists so that a fresh checkout can prove the pipeline
+fits, predicts, and returns rows that sum to one.
+
+Verified on python 3.9.25 with numpy 1.26.4, pandas 2.3.3, scikit-learn 1.6.1 and
+joblib 1.5.3.
+
+
+HOW TO USE IT
+-------------
+    predictor = KVTTLTimePredictor(
+        bucket_seconds=5 * 60,        # bucket 0 IS the 5-minute tier question
+        max_ttl_seconds=60 * 60,      # the tail IS the 1-hour tier question
+        categorical_features=("user_id", "model", "agent"),
+    )
+    predictor.fit(train_events)                    # .train() is the same call
+    proba = predictor.predict_proba(test_events)   # (n_rows, n_buckets + 1)
+    predictor.save("kvttl.joblib")
+    predictor = KVTTLTimePredictor.load("kvttl.joblib")
+
+`fit` and `train` are the same method. `predict_proba` and `inference` are the same
+method. `predict_distribution` returns the same numbers in long form for a human, and
+`predict_one(history, current_request)` is the single-request convenience — it appends
+the request to the history, engineers features over the concatenation so nothing from
+the future is used, and returns only that request's rows.
+
+A cache that has ALREADY been idle is handled by conditioning, not by re-fitting:
+
+    predictor.predict_proba(rows, elapsed_seconds=240)
+
+conditions on survival through every FULLY COMPLETED bucket, so with five-minute buckets
+an elapsed value anywhere in 0..299 s conditions on nothing and 300..599 s conditions on
+T > 300 s. Call it at bucket boundaries, or use smaller buckets, or the conditioning is
+coarser than the decision it feeds.
+
+Choosing `bucket_seconds` and `max_ttl_seconds`: the defaults are not a round number
+picked for tidiness, they are the provider's two tiers. With 300 s buckets and a 3600 s
+horizon, column 0 is exactly P(return inside the 5-minute lifetime) and one minus the
+tail is exactly P(return inside the 1-hour lifetime) — the two probabilities a TTL
+decision needs, read straight off, with no interpolation. Choose finer buckets only if
+something downstream needs the shape inside five minutes; `max_ttl_seconds` must stay an
+exact multiple of `bucket_seconds` (the constructor enforces it).
+
+
+INPUT AND OUTPUT
+----------------
+build_next_request_targets(events, compatibility_columns=..., observation_end=...)
+    in   a DataFrame with the compatibility columns and `request_time`
+    out  the same rows, sorted by (compatibility columns, request_time) with the index
+         reset, plus:
+           time_to_next_request_seconds  float; seconds to the next row of the same
+                                         compatibility group. For the LAST row of each
+                                         group: seconds to `observation_end`, or NaN
+                                         when no `observation_end` was given.
+           event_observed                bool; False for that last row of each group.
+         Raises ValueError on a missing column, on empty compatibility_columns, or on an
+         `observation_end` that precedes a request.
+
+KVTTLTimePredictor.fit(requests) -> self
+    Drops rows whose duration is NaN (unlabelled), engineers history over ALL rows
+    including those, expands each surviving row into one logistic-regression example per
+    bucket it was still at risk in, and fits. Afterwards `training_summary_` reports
+    `request_rows_used`, `person_period_rows`, `events_within_horizon`, `bucket_seconds`
+    and `max_ttl_seconds`. Raises ValueError if nothing is labelled, if a duration is
+    negative, if no complete risk interval exists, or if the labels have only one class.
+
+KVTTLTimePredictor.predict_hazards(requests) -> np.ndarray
+    shape (n_rows, n_buckets); entry [i, k] is P(return in bucket k | survived to k),
+    clipped into [1e-7, 1-1e-7]. A CONDITIONAL hazard — it does not sum to anything.
+
+KVTTLTimePredictor.predict_proba(requests, elapsed_seconds=0.0) -> np.ndarray
+    shape (n_rows, n_buckets + 1); a proper distribution, each row summing to 1.0.
+    Columns 0..K-1 are the buckets (0, bucket_seconds], ..., and column K is the
+    "later than max_ttl_seconds" tail. Buckets already completed per `elapsed_seconds`
+    are exactly 0. With the default settings that is 13 columns:
+
+        column   interval          what it answers
+        0        (0, 300] s        P(return inside the 5-minute lifetime)
+        1..11    (300, 3600] s     the shape between the two tiers
+        12       > 3600 s          P(the 1-hour tier expires unused)
+        sum(0..11) = 1 - column 12 = P(return inside the 1-hour lifetime)
+
+KVTTLTimePredictor.predict_distribution(...) -> pd.DataFrame
+    the same numbers, one row per (request, bucket), with `request_row`, `bucket_index`,
+    `interval`, `start_seconds`, `end_seconds`, `probability`, `cumulative_probability`
+    and `is_tail`. `end_seconds` is np.inf on the tail row.
+
+KVTTLTimePredictor.predict_one(history, current_request, elapsed_seconds=0.0)
+    -> the same frame, for the last row only, with `request_row` dropped.
+
+One request's output, from the self-test, abbreviated:
+
+    bucket_index             interval  probability  cumulative_probability  is_tail
+               0     (0, 300] seconds     0.722863                0.722863    False
+               1   (300, 600] seconds     0.213698                0.936561    False
+               2   (600, 900] seconds     0.043136                0.979697    False
+             ...
+              12       > 3600 seconds     0.000006                1.000000     True
+
+
+FEEDING THE GO STRATEGY SEAM
+----------------------------
+`kvcache.Predictor` in this repo asks one question — ReuseProbability(observation,
+horizon) — and the two horizons it asks about are 5 minutes and 1 hour. Those are
+column 0 and one-minus-the-tail above, which is why the default bucketing is what it is:
+
+    proba = predictor.predict_proba(rows)
+    p_5m  = proba[:, 0]
+    p_1h  = 1.0 - proba[:, -1]
+
+Serve those two numbers and `kvcache.Custom{Predictor: ...}` scores this model against
+the same baseline, the same prices and the same savings arithmetic as every hand-written
+arm. Nothing about the horizon set is baked in here: a third horizon is a third slice of
+the same distribution.
+
+
+MEASURED ON REAL TRAFFIC
+------------------------
+Against the hosted deployment's own capture — 14,407 requests, 12 accounts, 1,772
+trajectories, 13 models, over the 57 hours from 2026-08-17 11:48 UTC — labelled on
+(user_id, conversation_id, model) with `observation_end` at the last request:
+
+    labelled rows        14,407
+    observed returns     12,511
+    right-censored        1,896   (13.2% of rows: the last request of each group)
+    chronological split   70/30 -> 10,085 train / 4,322 test
+    person-period rows    26,093 from the 10,085 training rows
+    fit                   0.6 s
+    predict 4,322 rows    0.27 s, every row summing to 1.000000
+
+    horizon   actual   predicted   Brier    Brier of the base rate
+    <= 5m     0.7558   0.8157      0.0986   0.1846
+    <= 1h     0.8315   0.8587      0.0695   0.1401
+
+So it roughly halves the Brier score of the constant "everyone comes back" guess, and it
+discriminates rather than predicting the mean — P(return within 5m) across the test rows
+runs 0.111 at the 5th percentile to 0.982 at the 95th. It also runs about six points
+OPTIMISTIC on this split, because the training half of the window had a higher return
+rate than the test half. Re-fit and re-check the calibration before trusting a threshold
+on it; a policy tuned against a six-point bias will buy TTL it does not need.
+
+
+CORRECTNESS NOTES, EACH OF WHICH IS A WAY TO GET A WRONG ANSWER QUIETLY
+----------------------------------------------------------------------
+(1) `observation_end` is not optional in practice. Without it, the last request of every
+    compatibility group gets a NaN duration and `fit` silently drops it — and those are
+    precisely the rows that had NOT come back. On the production window that is 1,896
+    of 14,407 rows, 13.2%, all of them at the long end, so omitting it biases the model
+    toward short gaps. `event_observed` matters for the same reason and in the same
+    direction: it defaults to True when the column is absent, which would train a
+    censored row as a confirmed return.
+
+(2) `compatibility_columns` must name everything a KV cache entry is keyed on, and that
+    includes the MODEL. An entry does not transfer between models, and 101 of this
+    deployment's 1,772 trajectories use more than one — keying on (user, conversation)
+    alone merges them and derives a return that could not have hit any cache. Keying on
+    the conversation without the user is worse: the session id is client-supplied, so two
+    accounts can present the same one, and the groups would splice their traffic
+    together. Adding the model splits 1,772 conversations into 1,896 groups here.
+
+(3) The history features are per USER, the targets are per compatibility GROUP. That is
+    deliberate — how busy someone has been is informative about whether they will come
+    back to this conversation — but it means `previous_gap_seconds` can refer to a
+    different conversation of the same user. It is still strictly past information, so it
+    is not leakage; it is a modelling choice, and it is the one to revisit first if a
+    per-conversation variant is wanted.
+
+(4) Split by TIME, never at random. Every engineered feature is backward-looking, so a
+    single row leaks nothing — but the coefficients are fitted over the whole frame it is
+    given, so scoring on rows inside that frame is in-sample and will flatter the model.
+    The numbers above come from a chronological cut for exactly this reason.
+
+(5) Judge it by CALIBRATION, not accuracy. 75.6% of production rows return within five
+    minutes, so "yes" is right three times in four while knowing nothing. Brier score
+    against the base rate (above) or a reliability curve is the comparison that means
+    something; a hazard model's value is the probability, not the label.
+
+(6) `predict_one` re-engineers features over history + the new request on every call, so
+    it is O(len(history)) per prediction. Fine interactively, wrong in a request path and
+    wrong in a backtest — pass the whole frame to `predict_proba` and read the rows.
+
+(7) `elapsed_seconds` conditions on completed buckets only, so it is exact at bucket
+    boundaries and rounds DOWN in between. With the default 300 s buckets, asking at 299
+    seconds idle conditions on nothing at all.
+
+
+Example
+-------
+>>> predictor = KVTTLTimePredictor(
+...     bucket_seconds=5 * 60,
+...     max_ttl_seconds=60 * 60,
+...     categorical_features=("user_id", "model"),
+... )
+>>> predictor.fit(training_requests)
+>>> distribution = predictor.predict_one(history, current_request)
+>>> print(distribution[["interval", "probability"]])
+
+``history`` excludes the current request. ``current_request`` is a mapping or Series
+containing the request-time features used during training.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.base import BaseEstimator
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.utils.validation import check_is_fitted
+
+
+def build_next_request_targets(
+    events: pd.DataFrame,
+    *,
+    compatibility_columns: Sequence[str],
+    time_column: str = "request_time",
+    observation_end: str | pd.Timestamp | None = None,
+    duration_column: str = "time_to_next_request_seconds",
+    event_column: str = "event_observed",
+) -> pd.DataFrame:
+    """Add next-compatible-request durations to a request-event table.
+
+    ``compatibility_columns`` must identify requests that can reuse the same
+    cache, for example ``("user_id", "conversation_id", "model")``.
+
+    The final event in each compatibility group is right-censored when
+    ``observation_end`` is supplied. Without it, its duration is unknown and the
+    predictor will omit that row during fitting.
+    """
+
+    required = [*compatibility_columns, time_column]
+    missing = [column for column in required if column not in events.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+    if not compatibility_columns:
+        raise ValueError("compatibility_columns must contain at least one column")
+
+    result = events.copy()
+    result[time_column] = pd.to_datetime(result[time_column], utc=True)
+    result = result.sort_values([*compatibility_columns, time_column]).reset_index(drop=True)
+
+    grouped = result.groupby(list(compatibility_columns), sort=False, dropna=False)
+    next_time = grouped[time_column].shift(-1)
+    result[duration_column] = (next_time - result[time_column]).dt.total_seconds()
+    result[event_column] = next_time.notna()
+
+    if observation_end is not None:
+        end = pd.to_datetime(observation_end, utc=True)
+        censored = ~result[event_column]
+        censor_durations = (end - result.loc[censored, time_column]).dt.total_seconds()
+        if (censor_durations < 0).any():
+            raise ValueError("observation_end precedes one or more request times")
+        result.loc[censored, duration_column] = censor_durations
+
+    return result
+
+
+class KVTTLTimePredictor(BaseEstimator):
+    """Discrete-time logistic-hazard model for the next request time.
+
+    One logistic-regression example is created for each request/bucket for
+    which the cache was still at risk. The predicted conditional hazards are
+    converted into a proper distribution whose probabilities sum to one.
+
+    User identity is handled by a shared model with one-hot user effects. This
+    is generally more stable than fitting a separate model for each user, while
+    still allowing personalized predictions.
+    """
+
+    _ENGINEERED_NUMERIC = (
+        "request_hour_sin",
+        "request_hour_cos",
+        "request_weekday_sin",
+        "request_weekday_cos",
+        "previous_gap_seconds",
+        "rolling_gap_median_seconds",
+        "ewma_gap_seconds",
+        "past_return_rate_5m",
+        "past_return_rate_15m",
+        "past_return_rate_60m",
+        "requests_in_previous_10m",
+        "requests_in_previous_60m",
+        "user_history_count",
+        "decision_hour_sin",
+        "decision_hour_cos",
+    )
+
+    def __init__(
+        self,
+        *,
+        bucket_seconds: int = 5 * 60,
+        max_ttl_seconds: int = 60 * 60,
+        user_column: str = "user_id",
+        time_column: str = "request_time",
+        duration_column: str = "time_to_next_request_seconds",
+        event_column: str = "event_observed",
+        categorical_features: Sequence[str] = ("user_id",),
+        numeric_features: Sequence[str] = (),
+        history_window: int = 20,
+        regularization_c: float = 1.0,
+        random_state: int = 0,
+    ) -> None:
+        if bucket_seconds <= 0:
+            raise ValueError("bucket_seconds must be positive")
+        if max_ttl_seconds <= 0 or max_ttl_seconds % bucket_seconds != 0:
+            raise ValueError("max_ttl_seconds must be a positive multiple of bucket_seconds")
+        if history_window <= 0:
+            raise ValueError("history_window must be positive")
+
+        self.bucket_seconds = int(bucket_seconds)
+        self.max_ttl_seconds = int(max_ttl_seconds)
+        self.user_column = user_column
+        self.time_column = time_column
+        self.duration_column = duration_column
+        self.event_column = event_column
+        self.categorical_features = tuple(categorical_features)
+        self.numeric_features = tuple(numeric_features)
+        self.history_window = int(history_window)
+        self.regularization_c = float(regularization_c)
+        self.random_state = int(random_state)
+
+    @property
+    def n_buckets(self) -> int:
+        return self.max_ttl_seconds // self.bucket_seconds
+
+    @property
+    def bucket_edges_seconds(self) -> np.ndarray:
+        return np.arange(self.n_buckets + 1, dtype=float) * self.bucket_seconds
+
+    def fit(self, requests: pd.DataFrame) -> "KVTTLTimePredictor":
+        """Fit the hazard model from chronologically observed requests."""
+
+        self._validate_request_columns(requests, training=True)
+        frame = requests.copy().reset_index(drop=True)
+        frame[self.time_column] = pd.to_datetime(frame[self.time_column], utc=True)
+        frame[self.duration_column] = pd.to_numeric(frame[self.duration_column], errors="coerce")
+
+        if self.event_column not in frame.columns:
+            frame[self.event_column] = True
+        frame[self.event_column] = frame[self.event_column].astype(bool)
+
+        known = frame[self.duration_column].notna()
+        if not known.any():
+            raise ValueError("No rows have a known event or censoring duration")
+        if (frame.loc[known, self.duration_column] < 0).any():
+            raise ValueError("Durations must be non-negative")
+
+        # Engineer history on every request, including rows whose own target is
+        # unknown: those requests are still legitimate history for later rows.
+        all_request_features = self._engineer_request_features(frame)
+        request_features = all_request_features.loc[known].reset_index(drop=True)
+        training_frame = frame.loc[known].reset_index(drop=True)
+        person_period, labels = self._expand_training_rows(
+            request_features,
+            training_frame[self.duration_column].to_numpy(dtype=float),
+            training_frame[self.event_column].to_numpy(dtype=bool),
+        )
+        if person_period.empty:
+            raise ValueError("No complete risk intervals are available for training")
+        if np.unique(labels).size < 2:
+            raise ValueError(
+                "Training data needs both a return event within the modeled horizon "
+                "and at least one survived bucket"
+            )
+
+        self.numeric_columns_ = [*self._ENGINEERED_NUMERIC, *self.numeric_features]
+        self.categorical_columns_ = [*self.categorical_features, "bucket_index"]
+        self.model_columns_ = [*self.numeric_columns_, *self.categorical_columns_]
+
+        numeric_pipeline = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="median", add_indicator=True)),
+                ("scaler", StandardScaler()),
+            ]
+        )
+        categorical_pipeline = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                ("one_hot", OneHotEncoder(handle_unknown="ignore")),
+            ]
+        )
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ("numeric", numeric_pipeline, self.numeric_columns_),
+                ("categorical", categorical_pipeline, self.categorical_columns_),
+            ]
+        )
+        classifier = LogisticRegression(
+            C=self.regularization_c,
+            max_iter=2_000,
+            random_state=self.random_state,
+        )
+        self.pipeline_ = Pipeline(
+            steps=[("preprocessor", preprocessor), ("classifier", classifier)]
+        )
+        self.pipeline_.fit(person_period[self.model_columns_], labels)
+
+        self.training_summary_ = {
+            "request_rows_used": int(len(training_frame)),
+            "person_period_rows": int(len(person_period)),
+            "events_within_horizon": int(labels.sum()),
+            "bucket_seconds": self.bucket_seconds,
+            "max_ttl_seconds": self.max_ttl_seconds,
+        }
+        return self
+
+    # ``train`` is included because it is often the most natural API name in a
+    # service. ``fit`` remains sklearn-compatible.
+    def train(self, requests: pd.DataFrame) -> "KVTTLTimePredictor":
+        return self.fit(requests)
+
+    def predict_hazards(self, requests: pd.DataFrame) -> np.ndarray:
+        """Return ``P(event in bucket k | survived to bucket k)``.
+
+        The output shape is ``(number of requests, number of buckets)``.
+        """
+
+        check_is_fitted(self, "pipeline_")
+        self._validate_request_columns(requests, training=False)
+        frame = requests.copy().reset_index(drop=True)
+        frame[self.time_column] = pd.to_datetime(frame[self.time_column], utc=True)
+        request_features = self._engineer_request_features(frame)
+        risk_rows = self._make_all_risk_rows(request_features)
+
+        hazards = self.pipeline_.predict_proba(risk_rows[self.model_columns_])[:, 1]
+        hazards = np.clip(hazards, 1e-7, 1.0 - 1e-7)
+        return hazards.reshape(len(frame), self.n_buckets)
+
+    def predict_proba(
+        self,
+        requests: pd.DataFrame,
+        *,
+        elapsed_seconds: float = 0.0,
+    ) -> np.ndarray:
+        """Return probabilities for every bucket plus the ``> horizon`` tail.
+
+        Columns 0..K-1 represent the fixed time buckets and column K represents
+        a return later than ``max_ttl_seconds``. Rows sum to one.
+
+        If the cache has already been idle, ``elapsed_seconds`` conditions on
+        survival through all fully completed buckets. With five-minute buckets,
+        an elapsed value of 12 minutes therefore conditions on ``T > 10m``.
+        TTL decisions should normally call this at bucket boundaries.
+        """
+
+        if elapsed_seconds < 0:
+            raise ValueError("elapsed_seconds must be non-negative")
+
+        hazards = self.predict_hazards(requests)
+        completed = min(int(elapsed_seconds // self.bucket_seconds), self.n_buckets)
+        probabilities = np.zeros((len(requests), self.n_buckets + 1), dtype=float)
+
+        if completed == self.n_buckets:
+            probabilities[:, -1] = 1.0
+            return probabilities
+
+        survival = np.ones(len(requests), dtype=float)
+        for bucket in range(completed, self.n_buckets):
+            probabilities[:, bucket] = survival * hazards[:, bucket]
+            survival *= 1.0 - hazards[:, bucket]
+        probabilities[:, -1] = survival
+        return probabilities
+
+    # Friendly alias for service code.
+    def inference(
+        self,
+        requests: pd.DataFrame,
+        *,
+        elapsed_seconds: float = 0.0,
+    ) -> np.ndarray:
+        return self.predict_proba(requests, elapsed_seconds=elapsed_seconds)
+
+    def predict_distribution(
+        self,
+        requests: pd.DataFrame,
+        *,
+        elapsed_seconds: float = 0.0,
+    ) -> pd.DataFrame:
+        """Return a readable long-form probability distribution."""
+
+        probabilities = self.predict_proba(requests, elapsed_seconds=elapsed_seconds)
+        records: list[dict[str, Any]] = []
+        for request_row in range(len(requests)):
+            cumulative = 0.0
+            for bucket in range(self.n_buckets):
+                start = int(bucket * self.bucket_seconds)
+                end = int((bucket + 1) * self.bucket_seconds)
+                probability = float(probabilities[request_row, bucket])
+                cumulative += probability
+                records.append(
+                    {
+                        "request_row": request_row,
+                        "bucket_index": bucket,
+                        "interval": f"({start}, {end}] seconds",
+                        "start_seconds": start,
+                        "end_seconds": end,
+                        "probability": probability,
+                        "cumulative_probability": cumulative,
+                        "is_tail": False,
+                    }
+                )
+
+            tail_probability = float(probabilities[request_row, -1])
+            records.append(
+                {
+                    "request_row": request_row,
+                    "bucket_index": self.n_buckets,
+                    "interval": f"> {self.max_ttl_seconds} seconds",
+                    "start_seconds": self.max_ttl_seconds,
+                    "end_seconds": np.inf,
+                    "probability": tail_probability,
+                    "cumulative_probability": cumulative + tail_probability,
+                    "is_tail": True,
+                }
+            )
+        return pd.DataFrame.from_records(records)
+
+    def predict_one(
+        self,
+        history: pd.DataFrame,
+        current_request: Mapping[str, Any] | pd.Series,
+        *,
+        elapsed_seconds: float = 0.0,
+    ) -> pd.DataFrame:
+        """Predict for one new request using its user's preceding history.
+
+        ``history`` may contain multiple users. The current request is appended,
+        history features are calculated without future information, and only the
+        current request's distribution is returned.
+        """
+
+        current = pd.DataFrame([dict(current_request)])
+        combined = pd.concat([history, current], ignore_index=True, sort=False)
+        distribution = self.predict_distribution(
+            combined, elapsed_seconds=elapsed_seconds
+        )
+        last_row = len(combined) - 1
+        return (
+            distribution.loc[distribution["request_row"] == last_row]
+            .drop(columns="request_row")
+            .reset_index(drop=True)
+        )
+
+    def save(self, path: str | Path) -> None:
+        """Serialize the fitted predictor with joblib."""
+
+        check_is_fitted(self, "pipeline_")
+        joblib.dump(self, Path(path))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "KVTTLTimePredictor":
+        """Load a predictor previously written by :meth:`save`."""
+
+        predictor = joblib.load(Path(path))
+        if not isinstance(predictor, cls):
+            raise TypeError(f"{path!s} does not contain a {cls.__name__}")
+        return predictor
+
+    def _validate_request_columns(self, requests: pd.DataFrame, *, training: bool) -> None:
+        required = {
+            self.user_column,
+            self.time_column,
+            *self.categorical_features,
+            *self.numeric_features,
+        }
+        if training:
+            required.add(self.duration_column)
+        missing = sorted(required.difference(requests.columns))
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+
+    def _engineer_request_features(self, requests: pd.DataFrame) -> pd.DataFrame:
+        frame = requests.copy().reset_index(drop=True)
+        frame["_original_position"] = np.arange(len(frame))
+        frame = frame.sort_values(
+            [self.user_column, self.time_column, "_original_position"],
+            kind="stable",
+        ).reset_index(drop=True)
+
+        timestamp = frame[self.time_column]
+        seconds_of_day = (
+            timestamp.dt.hour * 3600
+            + timestamp.dt.minute * 60
+            + timestamp.dt.second
+            + timestamp.dt.microsecond / 1_000_000
+        )
+        frame["request_hour_sin"] = np.sin(2 * np.pi * seconds_of_day / 86_400)
+        frame["request_hour_cos"] = np.cos(2 * np.pi * seconds_of_day / 86_400)
+        weekday = timestamp.dt.dayofweek
+        frame["request_weekday_sin"] = np.sin(2 * np.pi * weekday / 7)
+        frame["request_weekday_cos"] = np.cos(2 * np.pi * weekday / 7)
+
+        grouped = frame.groupby(self.user_column, sort=False, dropna=False)
+        frame["previous_gap_seconds"] = grouped[self.time_column].diff().dt.total_seconds()
+        previous_gap = frame["previous_gap_seconds"]
+
+        rolling_group = previous_gap.groupby(frame[self.user_column], dropna=False)
+        frame["rolling_gap_median_seconds"] = rolling_group.transform(
+            lambda values: values.rolling(self.history_window, min_periods=1).median()
+        )
+        frame["ewma_gap_seconds"] = rolling_group.transform(
+            lambda values: values.ewm(span=self.history_window, adjust=False).mean()
+        )
+        for minutes in (5, 15, 60):
+            indicator = previous_gap.le(minutes * 60).where(previous_gap.notna())
+            indicator_group = indicator.groupby(frame[self.user_column], dropna=False)
+            frame[f"past_return_rate_{minutes}m"] = indicator_group.transform(
+                lambda values: values.rolling(self.history_window, min_periods=1).mean()
+            )
+
+        frame["requests_in_previous_10m"] = self._counts_in_previous_window(
+            frame, window_seconds=10 * 60
+        )
+        frame["requests_in_previous_60m"] = self._counts_in_previous_window(
+            frame, window_seconds=60 * 60
+        )
+        frame["user_history_count"] = grouped.cumcount().astype(float)
+
+        return (
+            frame.sort_values("_original_position", kind="stable")
+            .drop(columns="_original_position")
+            .reset_index(drop=True)
+        )
+
+    def _counts_in_previous_window(
+        self, frame: pd.DataFrame, *, window_seconds: int
+    ) -> np.ndarray:
+        counts = np.zeros(len(frame), dtype=float)
+        for _, positions in frame.groupby(
+            self.user_column, sort=False, dropna=False
+        ).indices.items():
+            positions = np.asarray(positions, dtype=int)
+            nanoseconds = frame.loc[positions, self.time_column].astype("int64").to_numpy()
+            left = np.searchsorted(
+                nanoseconds,
+                nanoseconds - window_seconds * 1_000_000_000,
+                side="left",
+            )
+            counts[positions] = np.arange(len(positions)) - left
+        return counts
+
+    def _add_bucket_features(
+        self, repeated: pd.DataFrame, bucket_indices: np.ndarray
+    ) -> pd.DataFrame:
+        result = repeated.copy()
+        result["bucket_index"] = bucket_indices.astype(int)
+        decision_time = result[self.time_column] + pd.to_timedelta(
+            bucket_indices * self.bucket_seconds, unit="s"
+        )
+        decision_seconds = (
+            decision_time.dt.hour * 3600
+            + decision_time.dt.minute * 60
+            + decision_time.dt.second
+        )
+        result["decision_hour_sin"] = np.sin(2 * np.pi * decision_seconds / 86_400)
+        result["decision_hour_cos"] = np.cos(2 * np.pi * decision_seconds / 86_400)
+        return result
+
+    def _expand_training_rows(
+        self,
+        request_features: pd.DataFrame,
+        durations: np.ndarray,
+        observed: np.ndarray,
+    ) -> tuple[pd.DataFrame, np.ndarray]:
+        row_ids: list[int] = []
+        bucket_ids: list[int] = []
+        labels: list[int] = []
+        upper_edges = self.bucket_edges_seconds[1:]
+
+        for row_id, (duration, is_observed) in enumerate(zip(durations, observed)):
+            if is_observed and duration <= self.max_ttl_seconds:
+                event_bucket = int(np.searchsorted(upper_edges, duration, side="left"))
+                for bucket in range(event_bucket + 1):
+                    row_ids.append(row_id)
+                    bucket_ids.append(bucket)
+                    labels.append(int(bucket == event_bucket))
+                continue
+
+            if is_observed:
+                complete_buckets = self.n_buckets
+            else:
+                complete_buckets = min(
+                    int(duration // self.bucket_seconds), self.n_buckets
+                )
+            for bucket in range(complete_buckets):
+                row_ids.append(row_id)
+                bucket_ids.append(bucket)
+                labels.append(0)
+
+        if not row_ids:
+            return pd.DataFrame(), np.asarray([], dtype=int)
+        repeated = request_features.iloc[row_ids].reset_index(drop=True)
+        expanded = self._add_bucket_features(repeated, np.asarray(bucket_ids))
+        return expanded, np.asarray(labels, dtype=int)
+
+    def _make_all_risk_rows(self, request_features: pd.DataFrame) -> pd.DataFrame:
+        row_ids = np.repeat(np.arange(len(request_features)), self.n_buckets)
+        bucket_ids = np.tile(np.arange(self.n_buckets), len(request_features))
+        repeated = request_features.iloc[row_ids].reset_index(drop=True)
+        return self._add_bucket_features(repeated, bucket_ids)
+
+
+if __name__ == "__main__":
+    # Small executable example. In real data, define compatibility using all
+    # fields required for KV reuse, not merely user_id.
+    rng = np.random.default_rng(7)
+    rows: list[dict[str, Any]] = []
+    for user_id in range(8):
+        current_time = pd.Timestamp("2026-01-01", tz="UTC")
+        for _ in range(100):
+            hour = current_time.hour
+            scale = 4 * 60 if 8 <= hour <= 20 else 18 * 60
+            gap = float(rng.exponential(scale=scale))
+            rows.append(
+                {
+                    "user_id": f"user-{user_id}",
+                    "model": "large" if user_id % 2 else "small",
+                    "request_time": current_time,
+                    "time_to_next_request_seconds": gap,
+                    "event_observed": True,
+                }
+            )
+            current_time += pd.to_timedelta(gap, unit="s")
+
+    example = pd.DataFrame(rows)
+    model = KVTTLTimePredictor(categorical_features=("user_id", "model"))
+    model.train(example)
+
+    current = {
+        "user_id": "user-1",
+        "model": "large",
+        "request_time": (
+            example.loc[example["user_id"] == "user-1", "request_time"].max()
+            + pd.Timedelta(minutes=3)
+        ),
+    }
+    print(model.predict_one(example, current).to_string(index=False))

--- a/docs/how-to/kv-cache-ttl.md
+++ b/docs/how-to/kv-cache-ttl.md
@@ -1,0 +1,369 @@
+# Choose a cache TTL, and know what it is worth
+
+The provider sells two prompt-cache lifetimes. A five-minute entry costs `1.25x` base input
+to create; a one-hour entry costs `2.0x`. Both are read back at `0.1x`. Choosing between
+them — per request, per conversation, per account — is a policy, and until now this repo had
+no way to price one.
+
+This page is that way. It covers the cost model, the strategies, the offline predictor, and
+what the whole thing measured on this service's own traffic. The short version:
+
+- **Prompt caching itself is already earning 54%** of the bill (`no-cache` costs 115.62%
+  more than `fixed-5m`), and that is banked.
+- **The entire remaining TTL headroom is 8.74%**, and reaching it requires knowing the future.
+- **A blind keep-alive takes 2.91% of it** with no model at all.
+- **93% of the headroom is 92 decisions out of 5,722.** This is a rare-event problem, which
+  is a very different thing from a prediction problem, and it is the finding that should
+  shape any further work.
+
+## What the domain package is
+
+`kvcache` is a plain Go package: no SQL, no HTTP, no DOM. The dashboard's read layer hands it
+rows and it does the arithmetic.
+
+| type | what it is |
+|---|---|
+| `Request` | one historical request, plus its derived successor and idle time |
+| `Derive()` | fills `NextTS` / `IdleMs` per conversation, chronologically |
+| `Pricing`, `PriceList`, `Override` | per-model rates, and the hand edits an operator can lay over them |
+| `Semantics` | the provider's cache behaviour, made explicit |
+| `Action`, `Strategy`, `Observation` | a TTL decision, and everything it is allowed to see |
+| `Predictor` | the seam a learned model plugs into |
+| `Stats`, `History` | the leak-free statistics accumulator |
+| `Simulate()`, `Result`, `Compare()` | the replay, its bill, and the savings |
+| `Registry()`, `NewStrategy()` | the one list of arms the page, the API and the offline evaluator all read |
+
+### Units, stated once
+
+Every timestamp is **epoch milliseconds, UTC**. Every price is **USD per token** (the
+operator's price list is per million and is converted on load). There is no per-user timezone
+anywhere in the store, so "time of day" is UTC and every label that carries it says so —
+inventing a local timezone from a tenant id would be a fabricated measurement.
+
+### A conversation is a pair
+
+`Conversation` is `(tenant_id, session_id)`, never the session alone. A session id is
+client-supplied, so two accounts can present the same one; keyed on it alone the dataset
+splices their requests into one interleaved trajectory and derives idle gaps across the join.
+That is both a wrong measurement and a cross-account read.
+
+### The last request of a conversation has no idle time
+
+`Request.IdleMs` is a **pointer**, and it is `nil` there. Not `0` — zero reads as "it came
+back instantly", which is the opposite of what is known. On the production window 1,772 of
+14,407 requests are in that state, 12.3%, and all of them are at the long end. Any model
+trained on this data that silently treats them as instant returns is biased toward short gaps.
+
+## The cost formulas
+
+Per request, under the tier the action chose:
+
+```
+uncached_input = input_tokens    x input_rate
+cache_read     = read_tokens     x cache_read_rate
+cache_write    = written_tokens  x write_rate(tier)   # 5m: 1.25x in, 1h: 2.0x in
+output         = output_tokens   x output_rate
+request_cost   = uncached_input + cache_read + cache_write + output
+```
+
+`read_tokens` is `min(entry held, this request's prefix)` when the entry is still alive, else
+0; `written_tokens` is the rest of the prefix. With no `cache_control` at all the whole prefix
+is billed as **fresh input** instead — which is what makes "let it expire" a real arm rather
+than an absence, and it is the reason expiring is *not* free: a request that would have read
+from cache pays `1.0x` on its whole prefix instead of `0.1x`.
+
+Per keep-alive:
+
+```
+keep_alive = cached x cache_read_rate + ping_input x input_rate + ping_output x output_rate
+recreate   = cached x write_rate(tier) + ping_input x input_rate + ping_output x output_rate
+```
+
+A keep-alive is a cache **read**, and it costs the read rate whether the entry is held at five
+minutes or at an hour. **The difference between a 5m and a 1h keep-alive is not the price of
+one ping.** It is the creation tier that put the entry there, and how *often* a ping is needed
+— twelve times as often at five minutes. Charging two different per-ping rates would be
+inventing a price no provider publishes.
+
+A keep-alive that arrives *after* the entry lapsed is not a refresh at all: it **re-creates**
+the prefix at the write rate, `12.5x` a read at the five-minute tier and `20x` at the hourly
+one. `Result.PingsThatRewrote` counts those, because a schedule whose interval exceeds the
+lifetime it is protecting is paying to fix a problem it caused.
+
+`ping_output` is 1 token because Anthropic's Messages API requires `max_tokens >= 1`. A
+provider that accepts a zero-generation request sets `Semantics.ZeroGeneration` and the
+assumption disappears from the bill instead of being rounded away.
+
+### The one rate nobody publishes
+
+No gateway publishes a **one-hour** cache-creation rate. It is derived from the documented
+multiplier against base input (`2.0x`, against `1.25x` for five minutes), the multiplier is a
+field rather than a literal, and it is never allowed below the five-minute rate — a price list
+that implied otherwise would be a typo, and honouring it would make every 1h arm look free.
+
+### Total, premium, and savings
+
+```
+total_usd         = sum(request_cost) + sum(ping_cost)
+uncached_usd      = the same traffic with no prompt cache at all
+cache_premium_usd = total_usd - uncached_usd     # NEGATIVE means the cache paid for itself
+
+absolute_savings   = baseline_cost - strategy_cost
+percentage_savings = absolute_savings / baseline_cost x 100
+```
+
+`total_usd` and `cache_premium_usd` are different numbers and must never be shown as if they
+were the same one. **Savings are not clamped**: an arm that costs more than its baseline
+reports a negative saving, because that is the only way a comparison stays one.
+
+## Cache semantics, made explicit
+
+Anthropic's documented behaviour is the default, and each part is a field so a provider that
+differs can say so rather than being silently mispriced:
+
+> By default, the cache has a 5-minute lifetime. **The cache is refreshed for no additional
+> cost each time the cached content is used.**
+
+- a cache **hit** refreshes the entry for its tier's full lifetime, free
+  (`Semantics.HitRefreshesTTL`)
+- a keep-alive read does the same (`Semantics.PingRefreshesTTL`)
+- a refresh does **not upgrade** a tier: a five-minute entry refreshed is good for another
+  five minutes, not an hour
+- a recorded `cache_miss_reason` of `prefix_change` or `cold_start` **forces a miss** whatever
+  the policy chose. No TTL rescues content that moved, and none conjures an entry that never
+  existed. Those rows are the ceiling on every arm, and `Result.ForcedMisses` reports them —
+  a simulator that let a 1-hour TTL "rescue" a prefix change would promise savings no
+  configuration can reach.
+
+## The arms
+
+Render them from `kvcache.Registry()` rather than hardcoding a list; an unknown name is an
+error from `NewStrategy`, never a silent default.
+
+| arm | what it does |
+|---|---|
+| `no-cache` | never writes `cache_control`; the honest denominator |
+| `fixed-5m` | always the five-minute tier |
+| `fixed-1h` | always the hourly tier |
+| `keepalive-5m` | five-minute tier, refreshed with keep-alives while idle |
+| `keepalive-1h` | hourly tier, refreshed with keep-alives while idle |
+| `keepalive-5m-to-1h` | writes cheap, and **extends to an hour only if a keep-alive comes due** |
+| `observed-policy` | replays the tier each request actually asked for |
+| `historical-probability` | the account's own closed gaps against two thresholds |
+| `replay` | an action list decided elsewhere — the seam an offline model is scored through |
+| `optimal` | the cheapest sequence that exists. **Unreachable: it reads the future** |
+
+`keepalive-5m-to-1h` is the arm worth understanding. `keepalive-1h` pays the `2.0x` creation
+premium on *every* request; this pays `1.25x` on every request and `2.0x` only on the rare
+span that outlives five minutes. `Result.PingsThatUpgraded` counts those deliberate upgrades,
+and it is deliberately **not** the same counter as `PingsThatRewrote`: one is a policy buying
+a hold it chose, the other is a schedule repairing damage it caused, and one number for both
+would make a working arm and a broken one look identical.
+
+### `optimal` is a bound, not a result
+
+It is solved exactly, per conversation, by a Viterbi pass over the six actions — not by a
+greedy per-row rule, and the distinction is not academic. The action at turn *t* decides two
+things at once: whether *t* itself may read from cache, and whether *t+1* hits. A rule that
+looks only at the gap ahead gets the current turn wrong. The first implementation here *was*
+that greedy rule, and it scored **below a plain keep-alive** — impossible for a ceiling, and
+how the error was caught. `TestOptimalIsALowerBoundOnEveryOtherArm` replays every arm in the
+registry and fails if any comes out cheaper.
+
+Every surface that shows `optimal` must label it unreachable (`StrategySpec.Unreachable`).
+
+## No future leakage
+
+A `Strategy` sees an `Observation`, and an `Observation` is defined by what is **absent** from
+it: no next-request timestamp, no idle duration, no field derived from either. The historical
+statistics attached to it come from `History`, which is **empty** at the start of a replay and
+gains one observation per gap *as that gap closes* — when the successor arrives, not when the
+predecessor is decided. So a decision at time *T* can only see gaps that ended at or before
+*T*.
+
+The real next-request time is used exactly once: to **score** the decision after it is made.
+
+`TestStrategiesCannotSeeTheFuture` walks the `Observation`'s numeric fields by reflection and
+fails if any carries a fact about a request that had not happened yet. That check exists
+because the leak is invisible on screen — a predictor that can see the gap it is predicting
+"predicts" it perfectly, and every saving it reports is unreachable in production while the
+page looks completely fine.
+
+## The offline tools
+
+Two Python files in `deploy/harbor/`, because the predictor needs the scientific stack and an
+evaluation loop that shelled into Go for every candidate threshold would not get run.
+
+### `kv_ttl_cost_model.py` — the scorer
+
+Give it a trajectory and one action per turn and it returns the decomposed bill.
+`PriceBook.from_operator_file()` reads the real price list and resolves rates **per row from
+the trajectory's own `model` field**.
+
+It is a **faithful port** of `kvcache.Simulate`, not a second opinion. Two implementations of
+one money question is exactly the drift this project has been bitten by, so
+`kv_ttl_cost_drift_test.go` beside it replays the same trajectory through both and compares
+**22 fields**. It runs on the system `python3` — the scientific stack is imported lazily by
+the predictor bridge and the price-list reader, neither of which that path touches — so it is
+an always-on guard rather than a skipped one. **If the two disagree, Go is right and the port
+is the bug.**
+
+Four guards:
+
+| guard | what it pins |
+|---|---|
+| `TestPythonCostModelAgreesWithTheShippedSimulator` | 22 fields on a fixture reaching every shared branch |
+| `TestTheUpgradingKeepAliveAgrees` | the one keep-alive that is a write *on purpose* |
+| `TestTheTwoExactCeilingsAgree` | the two independently written dynamic programs |
+| `TestPingScheduleMatchesThePort` | the ping cadence over a 160-case table |
+
+### `kv_ttl_survival_predictor.py` — the predictor
+
+A discrete-time logistic-hazard (person-period) survival model over the time until the next
+cache-compatible request. It returns a **distribution** and deliberately does not choose a
+TTL: the probabilities are consumed by a separate cost policy, which is the only place the
+rates live. A model that picked a tier would bury the pricing assumption inside the fit.
+
+With the default bucketing the two columns a TTL decision needs are read straight off:
+
+```
+proba = predictor.predict_proba(rows)
+p_5m  = proba[:, 0]        # P(return inside the five-minute lifetime)
+p_1h  = 1.0 - proba[:, -1] # P(return inside the hourly lifetime)
+```
+
+Those are exactly the two questions `kvcache.Predictor.ReuseProbability` is asked, so a
+service that wants to use this wires it in behind that interface and nothing in the simulator
+or the dashboard changes.
+
+Its own docstring carries the full column contract, the extraction SQL, and seven numbered
+traps. The two that bite hardest:
+
+1. **`observation_end` is not optional.** Without it the last request of every compatibility
+   group gets a `NaN` duration and `fit` silently drops it — 12.3% of rows, all long-idle.
+2. **`compatibility_columns` must include the model.** A cache entry does not transfer between
+   models, and 101 of this deployment's 1,772 trajectories use more than one.
+
+### Running them
+
+```sh
+python3 -m venv .venv-kvpred
+.venv-kvpred/bin/pip install "numpy<2" pandas scikit-learn joblib pyyaml
+
+.venv-kvpred/bin/python deploy/harbor/kv_ttl_cost_model.py \
+    --db /var/lib/context-guru/cg.db \
+    --prices /etc/context-guru/prices.yaml
+```
+
+Read the store **read-only**. The predictor is fitted on the first 70% of the window and its
+thresholds tuned there; every arm is then scored on the held-out remainder, so no arm is
+reported on rows its parameters were chosen from.
+
+## What it measured
+
+The hosted deployment's own capture: 14,407 requests, 12 accounts, 1,772 trajectories,
+2026-08-17 11:48 → 08-19 20:38 UTC, at `/etc/context-guru/prices.yaml` — which matters,
+because this gateway bills `aws/claude-sonnet-5` at `$1.52/MTok` where anthropic.com bills
+`$3.00`, so the public list price would overstate every figure below by about `2x`.
+
+Over the whole set, against `fixed-5m` at **$4,540.33**:
+
+| arm | total | vs `fixed-5m` | hit % | pings | upgrades |
+|---|---:|---:|---:|---:|---:|
+| `optimal` *(ceiling)* | $4,143.46 | **−8.74%** | 78.2% | 92 | 0 |
+| **`keepalive-5m`** | **$4,408.10** | **−2.91%** | 78.3% | 2,023 | 0 |
+| `fixed-5m` | $4,540.33 | — | 77.1% | 0 | 0 |
+| `keepalive-5m-to-1h` | $5,256.81 | +15.78% | 79.3% | 1,836 | 1,076 |
+| `fixed-1h` | $6,115.49 | +34.69% | 79.0% | 0 | 0 |
+| `no-cache` | $9,789.96 | +115.62% | 0.0% | 0 | 0 |
+
+Where the money goes:
+
+| arm | fresh in | read | write | pings | output |
+|---|---:|---:|---:|---:|---:|
+| `optimal` | 269.51 | 696.63 | 2,990.83 | 11.50 | 174.99 |
+| `keepalive-5m` | 104.95 | 682.96 | 3,350.48 | 94.72 | 174.99 |
+| `fixed-5m` | 104.95 | 663.23 | 3,597.16 | 0.00 | 174.99 |
+| `keepalive-5m-to-1h` | 104.95 | 697.14 | 3,173.30 | **1,106.44** | 174.99 |
+| `fixed-1h` | 104.95 | 693.92 | **5,141.63** | 0.00 | 174.99 |
+
+### Hit rate is not the objective
+
+`fixed-1h` has the second-best hit rate on the page and is the most expensive arm on it.
+`optimal` has a *lower* hit rate than `fixed-1h` and is the cheapest. Against `fixed-5m`,
+`fixed-1h` buys 281 extra hits for **$1,575.16** — **$5.61 per extra hit**, where an avoided
+miss on the median 124,845-token prefix is worth **$0.55**. It is paying roughly `10x` what the
+thing is worth, because to rescue those few requests it pays the hourly creation premium on
+*all* of them.
+
+**A page that sorts or colours by hit rate will recommend the worst option.**
+
+### Why `keepalive-5m-to-1h` loses, and what would fix it
+
+It should be strictly smarter than `fixed-1h`, and it is — by $859. It still loses to plain
+`fixed-5m`, and the decomposition says why: **1,076 of its 1,836 pings were upgrades**, each a
+one-hour write of a whole prefix at `2.0x`. That is $1,106 of ping cost to save $424 of
+writes. It fires far too often, because 92.5% of gaps close inside five minutes and most of
+those upgrades bought an hour of hold for a conversation that came back in fifteen seconds.
+
+`optimal` does the same thing 92 times, not 1,836. The arm is not wrong; its trigger is
+unconditional.
+
+### The learned arms took nothing
+
+On the held-out half, the threshold-ladder arm scored **−0.01%** and a cost-based rule over
+the same model scored **+0.00%** — and not because the model is bad. It halves the Brier score
+of the base rate:
+
+| horizon | actual | predicted | Brier | Brier of the base rate |
+|---|---:|---:|---:|---:|
+| ≤ 5m | 0.7558 | 0.8157 | 0.0986 | 0.1846 |
+| ≤ 1h | 0.8315 | 0.8587 | 0.0695 | 0.1401 |
+
+They took nothing because **92.5% of gaps close inside five minutes**, so the five-minute tier
+is already right for almost every request and there is no decision left for a probability to
+improve. The model also runs about six points **optimistic** on this split — the training half
+had a higher return rate than the test half — so re-fit and re-check calibration before
+trusting a threshold on it.
+
+### Where the headroom actually is
+
+Replaying `optimal`'s own choices one kind at a time, against `fixed-5m` on the held-out half:
+
+| the optimum's choices, in isolation | saving |
+|---|---:|
+| only its 70 one-hour writes | **+5.04%** ($93.61) |
+| only its 22 keep-alive pings | +1.72% ($31.89) |
+| only its 1,246 expiries | +0.69% ($12.85) |
+
+**93% of the reachable headroom is 92 decisions out of 5,722.** That is what to build for: not
+a model that is well calibrated on average, but one that is precise on the tail and weighted
+by prefix size. A model scored on average calibration will look good and buy nothing — which
+is exactly what the two learned arms above did.
+
+## The honest downside
+
+- The measured window is **57 hours** and one deployment. Every figure here is that window's,
+  not a law.
+- Only **221 of 1,772 conversations** have two or more requests, so the gap distribution rests
+  on a minority of trajectories.
+- The production snapshot used for these numbers **predates the `cache_ttl` column**, so
+  `observed-policy` falls back to five minutes for every row and equals `fixed-5m` exactly
+  there. That is not a coincidence, and `Result.ObservedCoverage` (recorded vs assumed) is
+  what says so. On a current database it is a genuinely distinct arm.
+- The upgrading keep-alive's cost is priced as a **1-hour write**, which is the pessimistic
+  reading. It rests on this deployment's own capture (a request asking for `ttl:"1h"` over an
+  already-warm prefix returned 36,251 of 36,574 written tokens on the hourly creation tier).
+  If some provider bills it as a read instead, that arm is cheaper than reported here, never
+  dearer.
+- An open idle span — a conversation whose last request is inside the window — has a length
+  nobody knows. Its keep-alives are billed only to the window's end and counted apart in
+  `Result.PingsOnOpenSpans`, because they rest on an assumption the closed spans do not need.
+- A model with no rates contributes to **no** dollar figure and is counted in
+  `Result.Unpriced`. An unpriced model is not a free one.
+
+## Related
+
+- [Keep an idle prompt cache warm](cache-keepalive.md) — the shipped keep-alive mechanism
+- [Measuring savings](measure-savings.md) — how cost is attributed elsewhere in this repo
+- [Dashboard](../dashboard.md)

--- a/docs/how-to/kv-cache-ttl.md
+++ b/docs/how-to/kv-cache-ttl.md
@@ -12,7 +12,7 @@ what the whole thing measured on this service's own traffic. The short version:
   more than `fixed-5m`), and that is banked.
 - **The entire remaining TTL headroom is 8.74%**, and reaching it requires knowing the future.
 - **A blind keep-alive takes 2.91% of it** with no model at all.
-- **93% of the headroom is 92 decisions out of 5,722.** This is a rare-event problem, which
+- **93% of the headroom is 285 decisions out of 14,407.** This is a rare-event problem, which
   is a very different thing from a prediction problem, and it is the finding that should
   shape any further work.
 
@@ -311,8 +311,10 @@ unconditional.
 
 ### The learned arms took nothing
 
-On the held-out half, the threshold-ladder arm scored **−0.01%** and a cost-based rule over
-the same model scored **+0.00%** — and not because the model is bad. It halves the Brier score
+On the **held-out half** — 5,722 requests, where the ceiling is 7.50% rather than the whole
+set's 8.74%, because the two are different populations and their percentages are not
+interchangeable — the threshold-ladder arm scored **−0.01%** and a cost-based rule over the
+same model scored **+0.00%**. Not because the model is bad. It halves the Brier score
 of the base rate:
 
 | horizon | actual | predicted | Brier | Brier of the base rate |
@@ -328,18 +330,31 @@ trusting a threshold on it.
 
 ### Where the headroom actually is
 
-Replaying `optimal`'s own choices one kind at a time, against `fixed-5m` on the held-out half:
+Replaying `optimal`'s own choices one kind at a time — **on the whole set**, so these compose
+with the 8.74% above rather than with the held-out figures in the section before it:
 
-| the optimum's choices, in isolation | saving |
+| the optimum's choices, in isolation | saving vs `fixed-5m` |
 |---|---:|
-| only its 70 one-hour writes | **+5.04%** ($93.61) |
-| only its 22 keep-alive pings | +1.72% ($31.89) |
-| only its 1,246 expiries | +0.69% ($12.85) |
+| only the **218 requests** it wrote at the 1-hour tier | **+6.37%** ($289.18) |
+| only the **67 requests** it held with keep-alives | +1.77% ($80.39) |
+| only the **2,862 requests** it declined to cache | +0.47% ($21.39) |
 
-**93% of the reachable headroom is 92 decisions out of 5,722.** That is what to build for: not
-a model that is well calibrated on average, but one that is precise on the tail and weighted
-by prefix size. A model scored on average calibration will look good and buy nothing — which
-is exactly what the two learned arms above did.
+Those are counts of REQUESTS the optimum decided about, which is not the same as the columns
+in the table above: 92 there is keep-alives that actually *fired* (67 requests can attract more
+than one), and 230 is cache-creation *events* at the hourly tier, which a keep-alive can cause
+as well as a write. Two similar-looking numbers counting different things is worth one sentence
+rather than a reader's afternoon.
+
+Those three sum to **8.61%** against a combined **8.74%**, and the 0.13-point residual is not
+rounding: the choices interact. An hour-long hold on one turn changes whether the next turn
+hits, so replaying one kind of choice in isolation is not the same as its share of the total.
+The three rows are therefore *contributions*, not a partition, and they are quoted here because
+the ORDERING is the finding — not because they add up.
+
+**93% of the reachable headroom is 285 decisions out of 14,407 — 2.0% of requests.** That is
+what to build for: not a model that is well calibrated on average, but one that is precise on
+the tail and weighted by prefix size. A model scored on average calibration will look good and
+buy nothing — which is exactly what the two learned arms above did.
 
 ## The honest downside
 

--- a/docs/how-to/kv-cache-ttl.md
+++ b/docs/how-to/kv-cache-ttl.md
@@ -8,13 +8,14 @@ no way to price one.
 This page is that way. It covers the cost model, the strategies, the offline predictor, and
 what the whole thing measured on this service's own traffic. The short version:
 
-- **Prompt caching itself is already earning 54%** of the bill (`no-cache` costs 115.62%
-  more than `fixed-5m`), and that is banked.
-- **The entire remaining TTL headroom is 8.74%**, and reaching it requires knowing the future.
-- **A blind keep-alive takes 2.91% of it** with no model at all.
-- **93% of the headroom is 285 decisions out of 14,407.** This is a rare-event problem, which
-  is a very different thing from a prediction problem, and it is the finding that should
-  shape any further work.
+- **Prompt caching itself is already earning 77.4%** of the uncached bill, and that is banked.
+- **The reachable TTL headroom on top of it is 7.44%**, taken by a blind keep-alive with no model
+  at all. The exact ceiling is 21.95%, and reaching it requires knowing the future.
+- **93% of that ceiling is 526 decisions out of 14,407** — 3.7% of requests. This is a rare-event
+  problem, which is a very different thing from a prediction problem, and it is the finding that
+  should shape any further work.
+- **Hit rate is not the objective.** The arm with the second-best hit rate on the page is the most
+  expensive reachable arm, by 41%.
 
 ## What the domain package is
 
@@ -261,102 +262,138 @@ reported on rows its parameters were chosen from.
 
 ## What it measured
 
-The hosted deployment's own capture: 14,407 requests, 12 accounts, 1,772 trajectories,
-2026-08-17 11:48 → 08-19 20:38 UTC, at `/etc/context-guru/prices.yaml` — which matters,
-because this gateway bills `aws/claude-sonnet-5` at `$1.52/MTok` where anthropic.com bills
-`$3.00`, so the public list price would overstate every figure below by about `2x`.
+The hosted deployment's own capture: 14,407 requests, 12 accounts, **1,896 trajectories**,
+2026-08-17 11:48 → 08-19 20:38 UTC, at `/etc/context-guru/prices.yaml` — which matters, because
+this gateway bills `aws/claude-sonnet-5` at `$1.52/MTok` where anthropic.com bills `$3.00`, so
+the public list price would overstate every figure below.
 
-Over the whole set, against `fixed-5m` at **$4,540.33**:
+A trajectory is `(account, session, MODEL)`, which is why there are 1,896 of them and not 1,772:
+a cache entry does not transfer between models, so a session that switches model is two
+trajectories. Everything in this section is the whole window, one population throughout, at the
+default keep-alive schedule (a refresh every 280 s for a 5-minute entry, every 3,360 s for an
+hourly one, **at most 2 per idle span**). That schedule is a parameter, not a law, and a
+different ping budget is a lever these figures hold fixed.
 
-| arm | total | vs `fixed-5m` | hit % | pings | upgrades |
-|---|---:|---:|---:|---:|---:|
-| `optimal` *(ceiling)* | $4,143.46 | **−8.74%** | 78.2% | 92 | 0 |
-| **`keepalive-5m`** | **$4,408.10** | **−2.91%** | 78.3% | 2,023 | 0 |
-| `fixed-5m` | $4,540.33 | — | 77.1% | 0 | 0 |
-| `keepalive-5m-to-1h` | $5,256.81 | +15.78% | 79.3% | 1,836 | 1,076 |
-| `fixed-1h` | $6,115.49 | +34.69% | 79.0% | 0 | 0 |
-| `no-cache` | $9,789.96 | +115.62% | 0.0% | 0 | 0 |
+Against `fixed-5m` at **$2,215.28**:
+
+| arm | total | vs `fixed-5m` | hit % | pings |
+|---|---:|---:|---:|---:|
+| `optimal` *(unreachable — reads the future)* | $1,728.95 | **−21.95%** | 76.8% | 119 |
+| **`keepalive-5m`** | **$2,050.56** | **−7.44%** | 76.8% | 2,726 |
+| `keepalive-1h` | $2,086.91 | −5.79% | **78.6%** | 1,789 |
+| `fixed-1h` | $2,150.19 | −2.94% | 78.0% | 0 |
+| `fixed-5m` | $2,215.28 | — | 74.7% | 0 |
+| `observed-policy` | $2,215.28 | — | 74.7% | 0 |
+| `keepalive-5m-to-1h` | $3,124.58 | **+41.05%** | 78.5% | 2,406 |
+| `no-cache` | $9,789.96 | +341.93% | 0.0% | 0 |
 
 Where the money goes:
 
 | arm | fresh in | read | write | pings | output |
 |---|---:|---:|---:|---:|---:|
-| `optimal` | 269.51 | 696.63 | 2,990.83 | 11.50 | 174.99 |
-| `keepalive-5m` | 104.95 | 682.96 | 3,350.48 | 94.72 | 174.99 |
-| `fixed-5m` | 104.95 | 663.23 | 3,597.16 | 0.00 | 174.99 |
-| `keepalive-5m-to-1h` | 104.95 | 697.14 | 3,173.30 | **1,106.44** | 174.99 |
-| `fixed-1h` | 104.95 | 693.92 | **5,141.63** | 0.00 | 174.99 |
+| `optimal` *(unreachable)* | 161.74 | 907.83 | 475.16 | 9.22 | 174.99 |
+| `keepalive-5m` | 104.95 | 889.91 | 763.66 | 117.05 | 174.99 |
+| `fixed-1h` | 104.95 | 902.62 | 967.63 | 0.00 | 174.99 |
+| `fixed-5m` | 104.95 | 865.41 | 1,069.93 | 0.00 | 174.99 |
+| `keepalive-5m-to-1h` | 104.95 | 906.57 | 555.37 | **1,382.70** | 174.99 |
+
+### Prompt caching itself is the win, and it is already banked
+
+`no-cache` costs 4.4x the shipped policy: caching is taking **77.4%** off the uncached bill
+today. Everything else on this page is a fight over the remaining quarter.
 
 ### Hit rate is not the objective
 
-`fixed-1h` has the second-best hit rate on the page and is the most expensive arm on it.
-`optimal` has a *lower* hit rate than `fixed-1h` and is the cheapest. Against `fixed-5m`,
-`fixed-1h` buys 281 extra hits for **$1,575.16** — **$5.61 per extra hit**, where an avoided
-miss on the median 124,845-token prefix is worth **$0.55**. It is paying roughly `10x` what the
-thing is worth, because to rescue those few requests it pays the hourly creation premium on
-*all* of them.
+This is the most useful thing on the page, and the corrected data makes it sharper rather than
+weaker:
 
-**A page that sorts or colours by hit rate will recommend the worst option.**
+- `keepalive-1h` has the **best hit rate on the page** (78.6%) and is not the cheapest arm.
+- `keepalive-5m-to-1h` has the **second-best hit rate** (78.5%) and is **the most expensive
+  reachable arm by a wide margin** (+41.05%).
+- `optimal` has a **lower** hit rate than three arms it beats on cost, and is the cheapest thing
+  that exists.
+- The cheapest reachable arm, `keepalive-5m`, hits **less often** than `keepalive-1h`,
+  `keepalive-5m-to-1h` and `fixed-1h`.
 
-### Why `keepalive-5m-to-1h` loses, and what would fix it
+**A view that sorts or colours by hit rate will recommend the worst option.** `keepalive-5m-to-1h`
+is the demonstration: 1,486 of its 2,406 keep-alives were tier upgrades, each a one-hour write of
+a whole prefix at 2.0x input, and that is $1,382.70 of ping cost buying $515 of avoided writes. It
+fires on almost every idle span because 92.5% of gaps close inside five minutes, so most upgrades
+bought an hour of hold for a conversation that returned in seconds. The arm is not wrong; its
+trigger is unconditional.
 
-It should be strictly smarter than `fixed-1h`, and it is — by $859. It still loses to plain
-`fixed-5m`, and the decomposition says why: **1,076 of its 1,836 pings were upgrades**, each a
-one-hour write of a whole prefix at `2.0x`. That is $1,106 of ping cost to save $424 of
-writes. It fires far too often, because 92.5% of gaps close inside five minutes and most of
-those upgrades bought an hour of hold for a conversation that came back in fifteen seconds.
+### Where the headroom is
 
-`optimal` does the same thing 92 times, not 1,836. The arm is not wrong; its trigger is
-unconditional.
-
-### The learned arms took nothing
-
-On the **held-out half** — 5,722 requests, where the ceiling is 7.50% rather than the whole
-set's 8.74%, because the two are different populations and their percentages are not
-interchangeable — the threshold-ladder arm scored **−0.01%** and a cost-based rule over the
-same model scored **+0.00%**. Not because the model is bad. It halves the Brier score
-of the base rate:
-
-| horizon | actual | predicted | Brier | Brier of the base rate |
-|---|---:|---:|---:|---:|
-| ≤ 5m | 0.7558 | 0.8157 | 0.0986 | 0.1846 |
-| ≤ 1h | 0.8315 | 0.8587 | 0.0695 | 0.1401 |
-
-They took nothing because **92.5% of gaps close inside five minutes**, so the five-minute tier
-is already right for almost every request and there is no decision left for a probability to
-improve. The model also runs about six points **optimistic** on this split — the training half
-had a higher return rate than the test half — so re-fit and re-check calibration before
-trusting a threshold on it.
-
-### Where the headroom actually is
-
-Replaying `optimal`'s own choices one kind at a time — **on the whole set**, so these compose
-with the 8.74% above rather than with the held-out figures in the section before it:
+Replaying `optimal`'s own choices one kind at a time — each against the same `fixed-5m` baseline,
+with every other request falling back to `fixed-5m`. These are **ablations, not a partition**: an
+hour-long hold on one turn changes whether the next turn hits, so they interact and do not sum to
+21.95%.
 
 | the optimum's choices, in isolation | saving vs `fixed-5m` |
 |---|---:|
-| only the **218 requests** it wrote at the 1-hour tier | **+6.37%** ($289.18) |
-| only the **67 requests** it held with keep-alives | +1.77% ($80.39) |
-| only the **2,862 requests** it declined to cache | +0.47% ($21.39) |
+| only the **435 requests** it wrote at the 1-hour tier | **+17.93%** ($397.22) |
+| only the **91 requests** it held with keep-alives | +3.09% ($68.37) |
+| only the **2,801 requests** it declined to cache | +0.62% ($13.68) |
 
-Those are counts of REQUESTS the optimum decided about, which is not the same as the columns
-in the table above: 92 there is keep-alives that actually *fired* (67 requests can attract more
-than one), and 230 is cache-creation *events* at the hourly tier, which a keep-alive can cause
-as well as a write. Two similar-looking numbers counting different things is worth one sentence
-rather than a reader's afternoon.
+So **526 decisions out of 14,407 — 3.7% of requests — carry almost all of the headroom.** That is
+a rare-event problem, which is a different thing from a prediction problem, and it is the finding
+that should shape any further work: not a model that is well calibrated on average, but one that
+is precise on the tail and weighted by prefix size.
 
-Those three sum to **8.61%** against a combined **8.74%**, and the 0.13-point residual is not
-rounding: the choices interact. An hour-long hold on one turn changes whether the next turn
-hits, so replaying one kind of choice in isolation is not the same as its share of the total.
-The three rows are therefore *contributions*, not a partition, and they are quoted here because
-the ORDERING is the finding — not because they add up.
+### The learned arms
 
-**93% of the reachable headroom is 285 decisions out of 14,407 — 2.0% of requests.** That is
-what to build for: not a model that is well calibrated on average, but one that is precise on
-the tail and weighted by prefix size. A model scored on average calibration will look good and
-buy nothing — which is exactly what the two learned arms above did.
+On a held-out remainder (the predictor is fitted on the first 70% of the window by time and its
+thresholds tuned there), both machine-learned arms scored within a rounding error of `fixed-5m`.
+The cost-based rule is not merely unprofitable but **degenerate**: it chose `write_5m` on every
+row, so it never deviated from the baseline at all.
+
+That is not because the model is bad. It halves the Brier score of the base rate — see
+`kv_ttl_survival_predictor.py`, which reports that on its own chronological split, a **different**
+split from the one the arms were scored on. It buys nothing because 92.5% of gaps close inside
+five minutes, so the five-minute tier is already right for almost every request and there is no
+decision left for a probability to improve. The 3.7% above is where a model would have to earn
+its keep.
+
+### These figures were recomputed after three correctness fixes
+
+An earlier version of this page published numbers from code with three defects, all of which moved
+figures in the flattering direction, and one of which **inverted a recommendation**: `fixed-1h`
+was reported at +34.69% (the worst reachable arm) when it is in fact −2.94% (an improvement). The
+defects were a cache entry being handed between models, the ceiling not being a bound on any
+trajectory that switched model, and an `expire` turn being counted as a cache hit. They are fixed,
+pinned by tests, and verified by exhaustive search over every action sequence on multi-model
+fixtures plus 450 randomised trajectories. The figures above are from the fixed code.
 
 ## The honest downside
+
+- **The 1-hour creation rate is DERIVED, and it is the single biggest lever on these results.**
+  No gateway publishes one, so it is the documented 2.0x multiple of base input. `fixed-1h`'s
+  −2.94%, `keepalive-1h`'s −5.79% and the whole of `keepalive-5m-to-1h`'s +41.05% move directly
+  with that multiplier. It is a configurable field, which is a design virtue and *not* a reason to
+  treat the number as measured. Worse, the code knows the sharper risk: a requested `ttl:"1h"` is
+  not always honoured — on this gateway it depends on the model — so a 1h arm may be priced for a
+  tier the provider silently declined to give.
+- **The keep-alive schedule is held fixed at 2 refreshes per idle span.** Every ping figure and
+  the ceiling itself are optimal *under that budget*. A 5-minute entry can be held at most
+  2x280+300 = 860 s, so the band between 14 minutes and an hour is unexplored, and a larger budget
+  buys it at the 0.1x read rate against a rescue worth ~1.15x. The ceiling is therefore a ceiling
+  over six actions at one schedule, not over all policies.
+- **An `expire` turn is modelled as LAPSING the cache entry, and the provider appears not to do
+  that.** Anthropic's cache is content-addressed with no delete verb, so a request omitting
+  `cache_control` should neither read, refresh nor remove the entry. Tested against this window:
+  in 132 cases where a caching request followed a non-caching one inside the earlier entry's TTL,
+  **128 (97%) still read from cache**. The simulator charges those turns for a re-creation they
+  would not pay, so every arm that uses `expire` — including the ceiling — is charged **too much**,
+  and the ceiling is understated rather than overstated. Not corrected here because fixing it makes
+  the dynamic program's state no longer a function of the previous action alone, which is the same
+  structural break as `HitRefreshesTTL=false`; the two are one change and it needs its own PR.
+- **`NewOptimal` is unsound under `Semantics{HitRefreshesTTL: false}`** — measured 18% overstated —
+  because the entry's deadline then carries across an unbounded run of hits. That setting is a
+  configuration flip, so the arm must refuse it rather than answer.
+- **Token counts and miss reasons are observed under ONE policy and held fixed across every
+  counterfactual arm.** `cached_context` is what the 5-minute policy that actually ran was billed,
+  and a recorded `cold_start` forces a miss on every arm. Defensible, and the foundation of the
+  whole replay.
 
 - The measured window is **57 hours** and one deployment. Every figure here is that window's,
   not a law.

--- a/kvcache/kvcache.go
+++ b/kvcache/kvcache.go
@@ -1,0 +1,307 @@
+// Package kvcache is the KV-cache TTL domain: the per-request analysis dataset the
+// dashboard's KV-cache page reads, the pricing model for the five things a prompt-cache
+// policy can spend money on, the Strategy interface a TTL policy (or a future learned
+// predictor) implements, and the historical replay simulator that scores one strategy
+// against another.
+//
+// It is a PLAIN domain package, importable from anywhere, and it is deliberately not
+// inside `dash`:
+//
+//   - A strategy is a decision the PROXY will eventually have to make on the request
+//     path, not a thing the dashboard owns. Defining it inside the observability layer
+//     would mean the request path had to import the dashboard to ask what to do.
+//   - Nothing here touches SQL, HTTP or the DOM. `dash` reads the rows and hands them
+//     over; this package does the arithmetic. That is the same split the rest of this
+//     repo keeps — see the "NO ARITHMETIC HERE" rule at the top of the keep-alive tab's
+//     renderer, which this package is the server-side other half of.
+//
+// # Units, and they are stated once
+//
+// Every timestamp is epoch MILLISECONDS and every instant is UTC. Every duration in a
+// struct field is milliseconds and says so in its name; every duration in an argument is
+// a time.Duration. Every price is USD PER TOKEN (the operator's price list is per million
+// tokens and is converted before it reaches here — see internal/modelinfo.Table).
+//
+// There is no per-user timezone anywhere in the store, so "time of day" is UTC and every
+// label that carries it says UTC. Inventing a local timezone from a tenant id would be a
+// fabricated measurement, which is the failure this repo has hit repeatedly.
+//
+// # The one rule the simulator exists to hold shut
+//
+// A strategy sees an Observation, and an Observation carries NO future information. The
+// next request's timestamp is not on it, its idle duration is not on it, and the
+// historical statistics attached to it are accumulated from gaps that had ALREADY CLOSED
+// at the decision instant. The real next-request time is used exactly once — to SCORE the
+// decision after it has been made. TestStrategiesCannotSeeTheFuture is the assertion.
+package kvcache
+
+import (
+	"sort"
+	"time"
+)
+
+// TTL is a prompt-cache lifetime tier, spelled the way the provider's usage block spells
+// it — the same vocabulary as the `cache_ttl` column, so a row's configured tier and a
+// strategy's chosen tier are the same type and cannot be compared by accident.
+type TTL string
+
+// The three tiers, and ” is a THIRD answer rather than a synonym for 5 minutes: a request
+// carrying no cache_control at all is not a 5-minute request, and folding the two together
+// is how a page comes to report that everything is cached.
+const (
+	TTLNone TTL = ""
+	TTL5m   TTL = "ephemeral_5m"
+	TTL1h   TTL = "ephemeral_1h"
+)
+
+// Lifetime is how long an entry at this tier survives without being touched.
+func (t TTL) Lifetime() time.Duration {
+	switch t {
+	case TTL5m:
+		return 5 * time.Minute
+	case TTL1h:
+		return time.Hour
+	}
+	return 0
+}
+
+// Label is the tier in the words a person reads.
+func (t TTL) Label() string {
+	switch t {
+	case TTL5m:
+		return "5m"
+	case TTL1h:
+		return "1h"
+	}
+	return "none"
+}
+
+// Valid reports whether this is a tier this package knows. An unrecognised value from the
+// store is carried through as-is by the dataset and treated as TTLNone by the simulator,
+// which is the fail-open direction: an unknown tier must not be silently priced as 1h.
+func (t TTL) Valid() bool { return t == TTLNone || t == TTL5m || t == TTL1h }
+
+// The two horizons the whole page is about: the provider's default lifetime, and the long
+// tier. Named constants because they appear in a histogram edge, a summary card, a
+// strategy threshold and a cost formula, and four literals would eventually disagree.
+const (
+	Horizon5m = 5 * time.Minute
+	Horizon1h = time.Hour
+)
+
+// Bucket is a coarse time-of-day label, in UTC.
+type Bucket string
+
+// The four buckets. Six-hour bands rather than 24 hours: the per-user statistics a
+// strategy leans on need enough requests per cell to mean anything, and on the production
+// corpus 24 cells per user leaves most of them empty. The hour itself is still on every
+// row (Request.HourUTC) for anyone who wants the finer view.
+const (
+	BucketNight     Bucket = "night"     // 00:00–05:59 UTC
+	BucketMorning   Bucket = "morning"   // 06:00–11:59 UTC
+	BucketAfternoon Bucket = "afternoon" // 12:00–17:59 UTC
+	BucketEvening   Bucket = "evening"   // 18:00–23:59 UTC
+)
+
+// Buckets is every bucket in clock order, for a filter control or a group-by.
+var Buckets = []Bucket{BucketNight, BucketMorning, BucketAfternoon, BucketEvening}
+
+// BucketOf places one UTC hour in its bucket. An hour OUTSIDE 0..23 lands in night rather
+// than in whichever band its arithmetic happens to fall into: the input comes from strftime
+// and from a JSON query parameter, so an out-of-range value is a caller error, and quietly
+// filing hour 99 under "afternoon" would be a fabricated label.
+func BucketOf(hourUTC int) Bucket {
+	if hourUTC < 0 || hourUTC > 23 {
+		return BucketNight
+	}
+	switch {
+	case hourUTC >= 18:
+		return BucketEvening
+	case hourUTC >= 12:
+		return BucketAfternoon
+	case hourUTC >= 6:
+		return BucketMorning
+	}
+	return BucketNight
+}
+
+// BucketAt places an instant in its bucket, in UTC.
+func BucketAt(tsMs int64) Bucket {
+	return BucketOf(time.UnixMilli(tsMs).UTC().Hour())
+}
+
+// Conversation identifies one trajectory, and it is a PAIR.
+//
+// A session id is client-supplied, so two accounts can present the same one — by accident
+// or on purpose. Keying a conversation on the session id alone would splice two accounts'
+// requests into one interleaved trajectory and derive idle gaps across the join, which is
+// both a wrong measurement and a cross-account read. The store's own indexes and its
+// tool-inventory GC trigger are tenant-leading for exactly this reason.
+type Conversation struct {
+	User         string
+	Conversation string
+}
+
+// Request is one historical request as the analysis dataset sees it: what was billed, what
+// tier it asked for, and — derived, never stored — when the same conversation came back.
+//
+// The JSON names are the wire contract of /api/kvcache/rows. Idle is a POINTER: a request
+// with no successor has no idle time, and 0 would read as "it came back instantly", which
+// is the single most misleading value this dataset could carry. `null` is the only honest
+// encoding, and HasNext is the flag a filter uses so nobody has to test a pointer.
+type Request struct {
+	// Identity. User is the owning tenant and ConversationID the session/trajectory.
+	ID             int64  `json:"id"`
+	User           string `json:"user"`
+	ConversationID string `json:"conversation_id"`
+	TS             int64  `json:"ts"` // epoch ms, UTC
+	HourUTC        int    `json:"hour_utc"`
+	Bucket         Bucket `json:"bucket"`
+	Model          string `json:"model"`
+	Provider       string `json:"provider"`
+	Agent          string `json:"agent"`
+
+	// The billed token tiers, exactly as the provider reported them.
+	InputTokens  int64 `json:"input_tokens"` // fresh, uncached input
+	OutputTokens int64 `json:"output_tokens"`
+	CacheRead    int64 `json:"cache_read_tokens"`
+	CacheWrite   int64 `json:"cache_write_tokens"`
+	// CacheWrite1h is the part of CacheWrite the provider billed at the one-hour tier. It
+	// is the ONLY evidence that a requested 1h was honoured rather than silently
+	// downgraded, which on this gateway depends on the model.
+	CacheWrite1h int64 `json:"cache_write_1h_tokens"`
+	// CachedContext is the billed prefix: read + write. The size of the entry that exists
+	// after this request, and the number every ping and every re-creation is priced on.
+	// NOT tokens_before, which is message text only and runs a median 3.4x low.
+	CachedContext int64 `json:"cached_context_tokens"`
+
+	// TTL is the tier this request asked for, and TTLSource says how that was known:
+	// "configured" when the row recorded its own cache_ttl, "observed" when the tier was
+	// reconstructed from the provider's 1h write counter on a row written before that
+	// column existed, "unknown" when neither could answer. A page that cannot tell those
+	// apart reports "everything is 5m" over history that recorded no tier at all.
+	TTL       TTL    `json:"ttl"`
+	TTLSource string `json:"ttl_source"`
+
+	// Hit is whether the provider served this request's prefix from cache, and MissReason
+	// its own classification (cold_start|ttl_expiry|prefix_change|unknown|hit).
+	Hit        bool   `json:"hit"`
+	MissReason string `json:"miss_reason"`
+
+	// The derived half. NextTS is the next request IN THE SAME CONVERSATION, chronologically;
+	// HasNext is false on the last request of a conversation and IdleMs is then nil.
+	NextTS   int64  `json:"next_ts,omitempty"`
+	NextID   int64  `json:"next_id,omitempty"`
+	HasNext  bool   `json:"has_next"`
+	IdleMs   *int64 `json:"idle_ms"`
+	Within5m bool   `json:"within_5m"`
+	Within1h bool   `json:"within_1h"`
+
+	// UpstreamMs is how long the provider took, in milliseconds. 0 means NOT RECORDED, and
+	// the latency differential below skips such rows rather than averaging a zero in. It is
+	// the only field here that is used for anything but money: a cache miss re-reads a whole
+	// prefix, and the window's own hit/miss means are what turns an avoided miss into an
+	// avoided delay.
+	UpstreamMs float64 `json:"upstream_ms"`
+
+	// CostUSD is what this request was billed, priced at write time from the rates that
+	// were in force. CostKnown is false where the row's token accounting was incomplete —
+	// then the cost is UNKNOWN, never zero.
+	CostUSD   float64 `json:"cost_usd"`
+	CostKnown bool    `json:"cost_known"`
+
+	// KeepAlive marks a row that IS a ping context-guru sent on its own initiative. Such
+	// rows are excluded from the dataset by default (they are not the user's traffic and
+	// they would break every idle gap they sit inside); the field is here so a caller that
+	// asks for them can see which ones they are.
+	KeepAlive bool `json:"keepalive,omitempty"`
+}
+
+// TTLSource values.
+const (
+	TTLSourceConfigured = "configured"
+	TTLSourceObserved   = "observed"
+	TTLSourceUnknown    = "unknown"
+)
+
+// Key is this request's conversation.
+func (r *Request) Key() Conversation {
+	return Conversation{User: r.User, Conversation: r.ConversationID}
+}
+
+// Idle is the idle duration and whether there is one at all. The only way to read it: a
+// caller that dereferences IdleMs without checking HasNext is the bug this returns two
+// values to prevent.
+func (r *Request) Idle() (time.Duration, bool) {
+	if !r.HasNext || r.IdleMs == nil {
+		return 0, false
+	}
+	return time.Duration(*r.IdleMs) * time.Millisecond, true
+}
+
+// Derive fills the chronological half of the dataset in place: NextTS, NextID, HasNext,
+// IdleMs, Within5m and Within1h.
+//
+// Three properties, each of which is a way this has been got wrong before:
+//
+//   - Grouped by CONVERSATION, which is (user, session). A later request from another
+//     conversation is never the successor of this one, whatever its timestamp, because the
+//     provider's entry it would reuse is a different entry. The one exception the data
+//     model would allow — a shared, byte-identical prefix across sessions — is not
+//     recorded anywhere in the store, so it is not assumed here.
+//   - Sorted by (ts, id). Timestamps tie: on the production corpus 9 of 12,635 consecutive
+//     pairs share a millisecond. The id breaks the tie deterministically, so the same
+//     window derives the same dataset twice, and a zero-length gap stays zero rather than
+//     becoming negative.
+//   - The LAST request of a conversation gets HasNext=false and a nil IdleMs. It is not a
+//     request with an idle time of zero, and it is not a request that was never followed —
+//     it is a request whose successor is outside the window (or has not happened yet), and
+//     every aggregate below counts it in its own bucket.
+//
+// Requests is sorted in place.
+func Derive(reqs []*Request) {
+	sort.SliceStable(reqs, func(i, j int) bool {
+		a, b := reqs[i], reqs[j]
+		if a.User != b.User {
+			return a.User < b.User
+		}
+		if a.ConversationID != b.ConversationID {
+			return a.ConversationID < b.ConversationID
+		}
+		if a.TS != b.TS {
+			return a.TS < b.TS
+		}
+		return a.ID < b.ID
+	})
+	for i, r := range reqs {
+		r.HasNext, r.IdleMs, r.NextTS, r.NextID = false, nil, 0, 0
+		r.Within5m, r.Within1h = false, false
+		if i+1 >= len(reqs) {
+			continue
+		}
+		n := reqs[i+1]
+		if n.Key() != r.Key() {
+			continue
+		}
+		idle := n.TS - r.TS
+		if idle < 0 {
+			idle = 0 // cannot happen after the sort above; clamped rather than trusted
+		}
+		r.HasNext, r.NextTS, r.NextID = true, n.TS, n.ID
+		v := idle
+		r.IdleMs = &v
+		r.Within5m = time.Duration(idle)*time.Millisecond <= Horizon5m
+		r.Within1h = time.Duration(idle)*time.Millisecond <= Horizon1h
+	}
+	// Restore chronological order across the whole set: the simulator replays in wall-clock
+	// order, and leaving the slice grouped by conversation would replay one conversation to
+	// its end before starting the next — which is exactly the leak the Observation is
+	// designed to prevent, since the statistics would then carry one user's whole future.
+	sort.SliceStable(reqs, func(i, j int) bool {
+		a, b := reqs[i], reqs[j]
+		if a.TS != b.TS {
+			return a.TS < b.TS
+		}
+		return a.ID < b.ID
+	})
+}

--- a/kvcache/kvcache.go
+++ b/kvcache/kvcache.go
@@ -1,5 +1,5 @@
 // Package kvcache is the KV-cache TTL domain: the per-request analysis dataset the
-// dashboard's KV-cache page reads, the pricing model for the five things a prompt-cache
+// dashboard's KV-cache page reads, the pricing model for the six things a prompt-cache
 // policy can spend money on, the Strategy interface a TTL policy (or a future learned
 // predictor) implements, and the historical replay simulator that scores one strategy
 // against another.

--- a/kvcache/kvcache.go
+++ b/kvcache/kvcache.go
@@ -140,6 +140,19 @@ func BucketAt(tsMs int64) Bucket {
 type Conversation struct {
 	User         string
 	Conversation string
+	// Model is part of the key, and leaving it out was a bug rather than a simplification. A
+	// cache entry does not transfer between models, so an opus request cannot read a sonnet
+	// request's entry. Without the model here, Derive links the two as successor and the replay
+	// grants the second a hit at 0.1x on an entry it could never have matched — measured at 46%
+	// understatement on a two-request trajectory, and the bias is one-directional: every arm
+	// looks cheaper and hits more often than it can.
+	//
+	// It reaches 5.7% of this deployment's corpus (101 of 1,772 trajectories use more than one
+	// model), and this repo's own predictor said so before the simulator did: the
+	// compatibility-columns note in deploy/harbor/kv_ttl_survival_predictor.py keys on the model
+	// for exactly this reason and spells out the consequence of not doing it. The Python was
+	// right and the Go was wrong.
+	Model string
 }
 
 // Request is one historical request as the analysis dataset sees it: what was billed, what
@@ -226,7 +239,7 @@ const (
 
 // Key is this request's conversation.
 func (r *Request) Key() Conversation {
-	return Conversation{User: r.User, Conversation: r.ConversationID}
+	return Conversation{User: r.User, Conversation: r.ConversationID, Model: r.Model}
 }
 
 // Idle is the idle duration and whether there is one at all. The only way to read it: a
@@ -267,6 +280,9 @@ func Derive(reqs []*Request) {
 		}
 		if a.ConversationID != b.ConversationID {
 			return a.ConversationID < b.ConversationID
+		}
+		if a.Model != b.Model {
+			return a.Model < b.Model
 		}
 		if a.TS != b.TS {
 			return a.TS < b.TS

--- a/kvcache/kvcache_test.go
+++ b/kvcache/kvcache_test.go
@@ -1,0 +1,333 @@
+package kvcache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// req is a terse builder for one row of the dataset.
+func req(id int64, user, conv string, tsMs int64, model string) *Request {
+	return &Request{ID: id, User: user, ConversationID: conv, TS: tsMs, Model: model,
+		HourUTC: time.UnixMilli(tsMs).UTC().Hour(), Bucket: BucketAt(tsMs),
+		CachedContext: 100_000, InputTokens: 100, OutputTokens: 50, TTL: TTL5m,
+		TTLSource: TTLSourceConfigured, MissReason: "hit", Hit: true}
+}
+
+const base = int64(1_786_967_311_185) // a real production timestamp: 2026-08-17T11:48:31Z
+
+// The successor of a request is the next request in the SAME conversation, and a conversation
+// is (user, session) — never the session alone.
+//
+// Two accounts presenting the same session id is not hypothetical: the session id is
+// client-supplied and the store's own indexes are tenant-leading for exactly this reason.
+// Keyed on the session alone, this dataset derives a 1-second gap where the truth is that
+// neither account came back at all.
+func TestDeriveNeverCrossesAConversationBoundary(t *testing.T) {
+	shared := "same-session-id"
+	a := req(1, "tenant-a", shared, base, "m")
+	b := req(2, "tenant-b", shared, base+1000, "m")
+	c := req(3, "tenant-a", shared, base+60_000, "m")
+	other := req(4, "tenant-a", "another", base+2000, "m")
+	rows := []*Request{a, b, c, other}
+	Derive(rows)
+
+	if !a.HasNext || a.NextID != c.ID {
+		t.Errorf("tenant-a's first request should be followed by its OWN next request (%d), got %d (has_next=%v)",
+			c.ID, a.NextID, a.HasNext)
+	}
+	if got, _ := a.Idle(); got != 60*time.Second {
+		t.Errorf("idle = %v, want 60s — tenant-b's request must not shorten it", got)
+	}
+	if b.HasNext {
+		t.Errorf("tenant-b has one request; it must have no successor, got next=%d", b.NextID)
+	}
+	if other.HasNext {
+		t.Error("a different conversation of the same user must not be spliced in")
+	}
+}
+
+// The last request of a conversation has NO idle time. Not zero — zero reads as "it came
+// back instantly", which is the opposite of what is known.
+func TestFinalRequestHasNoIdleTimeRatherThanZero(t *testing.T) {
+	a, b := req(1, "u", "s", base, "m"), req(2, "u", "s", base+30_000, "m")
+	Derive([]*Request{a, b})
+	if b.HasNext || b.IdleMs != nil {
+		t.Errorf("final request carries has_next=%v idle=%v; want false/nil", b.HasNext, b.IdleMs)
+	}
+	if _, ok := b.Idle(); ok {
+		t.Error("Idle() reported an idle time for a request with no successor")
+	}
+	if b.Within5m || b.Within1h {
+		t.Error("a request with no successor was followed by nothing within any horizon")
+	}
+	if !a.HasNext || a.IdleMs == nil || *a.IdleMs != 30_000 {
+		t.Errorf("the first request's idle = %v, want 30000 ms", a.IdleMs)
+	}
+}
+
+// The two horizons are INCLUSIVE at their edge, and one millisecond past it is outside.
+// Every percentage on the page rests on this comparison.
+func TestFiveMinuteAndOneHourBoundariesAreExact(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		gapMs    int64
+		w5m, w1h bool
+	}{
+		{"one ms under five minutes", 299_999, true, true},
+		{"exactly five minutes", 300_000, true, true},
+		{"one ms over five minutes", 300_001, false, true},
+		{"one ms under an hour", 3_599_999, false, true},
+		{"exactly one hour", 3_600_000, false, true},
+		{"one ms over an hour", 3_600_001, false, false},
+		{"a zero-length gap", 0, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, b := req(1, "u", "s", base, "m"), req(2, "u", "s", base+tc.gapMs, "m")
+			Derive([]*Request{a, b})
+			if a.Within5m != tc.w5m || a.Within1h != tc.w1h {
+				t.Errorf("gap %d ms -> within_5m=%v within_1h=%v; want %v/%v",
+					tc.gapMs, a.Within5m, a.Within1h, tc.w5m, tc.w1h)
+			}
+		})
+	}
+}
+
+// Timestamps tie: 9 of 12,635 consecutive pairs in the production corpus share a
+// millisecond. The id breaks the tie, so the derivation is deterministic and a zero-length
+// gap stays zero instead of becoming negative.
+func TestTiedTimestampsAreOrderedByIDAndGiveAZeroGap(t *testing.T) {
+	a, b := req(7, "u", "s", base, "m"), req(3, "u", "s", base, "m")
+	rows := []*Request{a, b}
+	Derive(rows)
+	if !b.HasNext || b.NextID != 7 {
+		t.Errorf("the lower id must come first: id 3 next = %d (has_next=%v)", b.NextID, b.HasNext)
+	}
+	if got, ok := b.Idle(); !ok || got != 0 {
+		t.Errorf("tied timestamps give a zero gap, got %v (ok=%v)", got, ok)
+	}
+	if a.HasNext {
+		t.Error("the higher id is last and has no successor")
+	}
+}
+
+// Derive leaves the slice in WALL-CLOCK order, not grouped by conversation. The simulator
+// replays it as given, and replaying one conversation to its end before starting the next
+// would carry that conversation's whole future into the statistics every other decision sees.
+func TestDeriveLeavesTheSetInChronologicalOrder(t *testing.T) {
+	rows := []*Request{
+		req(1, "u", "b", base+3000, "m"),
+		req(2, "u", "a", base+1000, "m"),
+		req(3, "u", "b", base+4000, "m"),
+		req(4, "u", "a", base+2000, "m"),
+	}
+	Derive(rows)
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].TS > rows[i].TS {
+			t.Fatalf("not chronological at %d: %d then %d", i, rows[i-1].TS, rows[i].TS)
+		}
+	}
+}
+
+func TestBucketsAreUTCSixHourBands(t *testing.T) {
+	for hour, want := range map[int]Bucket{
+		0: BucketNight, 5: BucketNight, 6: BucketMorning, 11: BucketMorning,
+		12: BucketAfternoon, 17: BucketAfternoon, 18: BucketEvening, 23: BucketEvening,
+		-1: BucketNight, 99: BucketNight,
+	} {
+		if got := BucketOf(hour); got != want {
+			t.Errorf("BucketOf(%d) = %q, want %q", hour, got, want)
+		}
+	}
+	// And the instant form agrees with the hour form, in UTC.
+	ts := time.Date(2026, 8, 17, 20, 30, 0, 0, time.UTC).UnixMilli()
+	if got := BucketAt(ts); got != BucketEvening {
+		t.Errorf("BucketAt(20:30 UTC) = %q, want evening", got)
+	}
+}
+
+func TestTTLLifetimes(t *testing.T) {
+	if TTL5m.Lifetime() != 5*time.Minute || TTL1h.Lifetime() != time.Hour || TTLNone.Lifetime() != 0 {
+		t.Fatal("a tier's lifetime is wrong")
+	}
+	if TTL("ephemeral_10m").Valid() {
+		t.Error("an unrecognised tier must not read as valid; the simulator treats it as no cache")
+	}
+}
+
+// The Observation is defined by what is ABSENT from it. This walks its numeric fields by
+// reflection and asserts that no decision carries a fact about a request that had not
+// happened yet.
+//
+// A field-by-field check rather than a comment, because the leak it prevents is invisible on
+// screen: a predictor that can see the gap it is predicting reports savings nobody can reach
+// in production, and the page would look completely fine.
+func TestStrategiesCannotSeeTheFuture(t *testing.T) {
+	// Distinctive gaps, so an accidental copy is unmistakable rather than a coincidence.
+	rows := []*Request{
+		req(11, "u", "s", base, "m"),
+		req(12, "u", "s", base+1_234_567, "m"),
+		req(13, "u", "s", base+1_234_567+7_654_321, "m"),
+	}
+	Derive(rows)
+
+	spy := &recorder{}
+	Simulate(rows, spy, Config{Prices: testPrices()})
+	if len(spy.seen) != len(rows) {
+		t.Fatalf("the strategy was consulted %d times, want %d", len(spy.seen), len(rows))
+	}
+	for i, snap := range spy.seen {
+		// Everything about a request LATER than the one being served is the future.
+		future := map[int64]string{}
+		for _, later := range rows[i+1:] {
+			future[later.TS] = "a later request's timestamp"
+			future[later.ID] = "a later request's id"
+			if later.IdleMs != nil {
+				future[*later.IdleMs] = "a later request's idle duration"
+			}
+		}
+		if r := rows[i]; r.IdleMs != nil {
+			future[*r.IdleMs] = "THIS request's own idle duration, which is its future"
+		}
+		// Facts that are legitimately present-tense must not be flagged by a value collision.
+		for _, ok := range []int64{rows[i].TS, rows[i].ID, int64(rows[i].HourUTC),
+			rows[i].CachedContext} {
+			delete(future, ok)
+		}
+		v := reflect.ValueOf(snap.o)
+		for f := 0; f < v.NumField(); f++ {
+			fv := v.Field(f)
+			if fv.Kind() != reflect.Int64 && fv.Kind() != reflect.Int {
+				continue
+			}
+			if what, bad := future[fv.Int()]; bad {
+				t.Errorf("decision %d field %s = %d, which is %s", i,
+					v.Type().Field(f).Name, fv.Int(), what)
+			}
+		}
+		// SinceLastMs is the gap that has ALREADY closed, and nothing else.
+		want := int64(0)
+		if i > 0 && rows[i-1].Key() == rows[i].Key() {
+			want = rows[i].TS - rows[i-1].TS
+		}
+		if snap.o.SinceLastMs != want {
+			t.Errorf("decision %d SinceLastMs = %d, want %d (the gap that had already closed)",
+				i, snap.o.SinceLastMs, want)
+		}
+	}
+	// And the statistics AS THEY WERE at each decision: the first decision has nothing to
+	// know, because no gap has closed yet. A precomputed table over the window would already
+	// hold both gaps here.
+	if spy.seen[0].n5 != 0 || spy.seen[0].level != LevelNone {
+		t.Errorf("the first decision already saw %d closed gaps at level %s; the window's "+
+			"future has leaked into its own history", spy.seen[0].n5, spy.seen[0].level)
+	}
+	if spy.seen[1].n5 != 1 {
+		t.Errorf("the second decision saw %d closed gaps, want exactly the one behind it",
+			spy.seen[1].n5)
+	}
+}
+
+// snapshot is what the strategy could see AT the decision, captured then rather than read
+// back afterwards — History is a live accumulator, so a pointer held from decision 1 and
+// read at the end of the replay reports the end state and proves nothing.
+type snapshot struct {
+	o     Observation
+	n5    int
+	p5    float64
+	level string
+}
+
+// recorder is a strategy that records what it was shown and always caches at five minutes.
+type recorder struct{ seen []snapshot }
+
+func (r *recorder) Name() string { return "recorder" }
+func (r *recorder) Decide(o Observation) Action {
+	s := snapshot{o: o, level: LevelNone}
+	if o.Stats != nil {
+		s.p5, s.n5, s.level = o.Stats.ReuseWithin(o.User, o.Model, o.Bucket, Horizon5m)
+	}
+	r.seen = append(r.seen, s)
+	return ActionWrite5m
+}
+
+// A gap becomes history only when it CLOSES. The decision before a long gap still sees the
+// short gaps that preceded it, and does not see the long one.
+func TestHistoryOnlyCarriesGapsThatHaveAlreadyClosed(t *testing.T) {
+	// Seven 10-second gaps, then a two-hour one.
+	var rows []*Request
+	ts := base
+	for i := int64(1); i <= 8; i++ {
+		rows = append(rows, req(i, "u", "s", ts, "m"))
+		ts += 10_000
+	}
+	rows = append(rows, req(9, "u", "s", ts+2*3_600_000, "m"))
+	Derive(rows)
+
+	spy := &recorder{}
+	Simulate(rows, spy, Config{Prices: testPrices()})
+	// The decision taken ON request 8 — the one whose span is the two-hour gap — sees the
+	// seven short gaps and nothing else.
+	got := spy.seen[7]
+	if got.n5 != 7 {
+		t.Fatalf("decision 8 saw %d closed gaps, want 7", got.n5)
+	}
+	if got.p5 != 1 {
+		t.Errorf("all seven closed gaps were 10 s, so P(within 5m) = 1, got %.3f", got.p5)
+	}
+	if got.level != LevelUserBucket {
+		t.Errorf("seven gaps in one cell should answer at %s, got %s", LevelUserBucket, got.level)
+	}
+	// The LAST decision sees eight, because by then the long gap has closed too — and its
+	// probability has dropped, which is the whole point of accumulating rather than precomputing.
+	last := spy.seen[len(spy.seen)-1]
+	if last.n5 != 8 {
+		t.Errorf("the final decision saw %d gaps, want 8 (the long one has now closed)", last.n5)
+	}
+	if last.p5 >= 1 {
+		t.Errorf("the two-hour gap did not move P(within 5m): still %.3f", last.p5)
+	}
+}
+
+// The fallback chain: a user with too little history of their own is decided on their
+// model's statistics, then on the service's, and the level says which.
+func TestStatsFallBackFromUserToModelToGlobal(t *testing.T) {
+	h := NewHistory()
+	// Six gaps for one user/model/bucket clears the floor for that cell.
+	for i := 0; i < minCell; i++ {
+		h.Observe("busy", "m1", BucketMorning, 30*time.Second)
+	}
+	if _, n, level := h.ReuseWithin("busy", "m1", BucketMorning, Horizon5m); level != LevelUserBucket || n != minCell {
+		t.Errorf("a full cell must answer at its own level, got %s n=%d", level, n)
+	}
+	// A different bucket for the same user/model still has the user+model cell behind it.
+	if _, _, level := h.ReuseWithin("busy", "m1", BucketEvening, Horizon5m); level != LevelUserModel {
+		t.Errorf("an empty bucket must fall back to user+model, got %s", level)
+	}
+	// A brand-new user on a known model falls back to the model.
+	if _, _, level := h.ReuseWithin("new", "m1", BucketNight, Horizon5m); level != LevelModel {
+		t.Errorf("a new user on a known model must fall back to the model, got %s", level)
+	}
+	// A brand-new user on a brand-new model falls back to the service.
+	if _, _, level := h.ReuseWithin("new", "unseen", BucketNight, Horizon5m); level != LevelGlobal {
+		t.Errorf("a new user on an unseen model must fall back to global, got %s", level)
+	}
+	// And nothing at all is LevelNone, never a zero probability.
+	empty := NewHistory()
+	if p, n, level := empty.ReuseWithin("u", "m", BucketNight, Horizon5m); level != LevelNone || n != 0 || p != 0 {
+		t.Errorf("an empty history must answer %s with n=0, got %s n=%d p=%v",
+			LevelNone, level, n, p)
+	}
+	// A cell under the floor does not get to speak for itself.
+	thin := NewHistory()
+	for i := 0; i < minCell-1; i++ {
+		thin.Observe("u", "m", BucketNight, time.Second)
+	}
+	if _, _, level := thin.ReuseWithin("u", "m", BucketNight, Horizon5m); level == LevelUserBucket {
+		t.Errorf("a cell with %d observations answered at its own level; the floor is %d",
+			minCell-1, minCell)
+	}
+	if got, _, _ := h.MedianIdle("busy", "m1", BucketMorning); got != 30*time.Second {
+		t.Errorf("median idle = %v, want 30s", got)
+	}
+}

--- a/kvcache/optimal_test.go
+++ b/kvcache/optimal_test.go
@@ -1,0 +1,449 @@
+package kvcache
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The tests that would have caught the three defects an independent review found in this
+// package, plus the determinism rule its own comments promise.
+//
+// The finding underneath those defects is what this file is really for: all three were fixable
+// without a single existing test changing colour. Every one of them lived at a seam where two
+// things are meant to be the same thing — the simulator against the dynamic program's transition
+// weight, the Go against the Python port, the cost model against the hit accounting — and a
+// fixture that exercises only one side of a seam cannot see across it. So each test below is
+// built to fail on the specific mistake, and the fixtures deliberately carry the property the
+// old ones lacked: more than one model.
+
+// ── the exhaustive check: is the "exact ceiling" actually exact ────────────
+
+// bruteForce scores EVERY action sequence through Simulate itself and returns the cheapest.
+//
+// Through Simulate, never through a reimplementation: a brute force that priced plans its own way
+// would prove the two agree with each other and nothing about what the product bills. That is
+// exactly how the model-switch defect stayed invisible — the DP and the simulator each priced a
+// keep-alive at a different model, and no check compared either against a third opinion.
+func bruteForce(t *testing.T, reqs []*Request, cfg Config) (float64, string) {
+	t.Helper()
+	ids := make([]int64, len(reqs))
+	for i, r := range reqs {
+		ids[i] = r.ID
+	}
+	total := 1
+	for range reqs {
+		total *= len(Actions)
+	}
+	plan := make(map[int64]Action, len(reqs))
+	cheapest, at := math.Inf(1), 0
+	for code := 0; code < total; code++ {
+		n := code
+		for i := range ids {
+			plan[ids[i]] = Actions[n%len(Actions)]
+			n /= len(Actions)
+		}
+		if got := Simulate(reqs, NewReplay("brute", plan, ActionExpire), cfg); got.TotalUSD < cheapest {
+			cheapest, at = got.TotalUSD, code
+		}
+	}
+	var winner []string
+	n := at
+	for range ids {
+		winner = append(winner, string(Actions[n%len(Actions)]))
+		n /= len(Actions)
+	}
+	return cheapest, strings.Join(winner, ";")
+}
+
+// NewOptimal must be the cheapest sequence that exists — checked by enumerating all of them.
+//
+// Every other assertion about it is comparative: TestOptimalIsALowerBoundOnEveryOtherArm checks
+// it against the arms that happen to exist, which is ten sequences out of 6^n. The doc comment
+// claims something stronger, and until this test that claim rested on the argument for the
+// dynamic program rather than on evidence.
+//
+// THE MULTI-MODEL CASES ARE THE POINT. A single-model fixture passes this test with the
+// model-switch defect fully present — the review said so before I wrote it, and it was right.
+func TestOptimalIsExhaustivelyOptimal(t *testing.T) {
+	const min5, hour = int64(300_000), int64(3_600_000)
+	for _, tc := range []struct {
+		name   string
+		gaps   []int64
+		models []string
+	}{
+		{"all short", []int64{20_000, 20_000, 20_000}, nil},
+		{"all past an hour", []int64{hour + 1, hour + 1, hour + 1}, nil},
+		{"straddling five minutes", []int64{min5 - 1, min5 + 1, 30_000}, nil},
+		{"inside a keep-alive's reach, then past an hour", []int64{600_000, hour + 1, 40_000}, nil},
+		{"one long gap between two short ones", []int64{15_000, 40 * 60_000, 15_000}, nil},
+		// The four the old code failed. A conversation that switches model is 5.7% of this
+		// deployment's corpus, and on it the ceiling was measured 65% above a plan the same
+		// simulator priced lower.
+		{"cheap then dear", []int64{600_000}, []string{"cheap", "dear"}},
+		{"dear then cheap", []int64{600_000}, []string{"dear", "cheap"}},
+		{"dear, cheap, dear", []int64{600_000, 600_000}, []string{"dear", "cheap", "dear"}},
+		{"switching across an hour", []int64{hour + 1, 60_000}, []string{"cheap", "dear", "cheap"}},
+		// A SHRINKING prefix, which is what a compaction produces — i.e. this repo's own
+		// subject. The reusable = min(entry, prefix) clamp never fired on the old fixtures,
+		// whose prefixes only ever grew, so deleting it changed nothing that was tested.
+		{"a shrinking prefix", []int64{30_000, 30_000}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shrink := tc.name == "a shrinking prefix"
+			reqs, cfg := trajectory(t, tc.gaps, tc.models, shrink)
+			best := Simulate(reqs, NewOptimal(reqs, cfg), cfg)
+			cheapest, winner := bruteForce(t, reqs, cfg)
+			if best.TotalUSD > cheapest+1e-9 {
+				t.Errorf("NewOptimal chose $%.9f; exhaustive search over every plan found $%.9f "+
+					"via %s.\nIt is not the cheapest sequence that exists, so every figure quoted "+
+					"against this ceiling is wrong by at least the difference.",
+					best.TotalUSD, cheapest, winner)
+			}
+			if best.TotalUSD < cheapest-1e-9 {
+				t.Errorf("NewOptimal reports $%.9f, BELOW the exhaustive minimum $%.9f — the DP "+
+					"and Simulate disagree about what a plan costs, so neither figure means "+
+					"anything", best.TotalUSD, cheapest)
+			}
+		})
+	}
+}
+
+// ── the hit that was not a hit ─────────────────────────────────────────────
+
+// A request that writes no cache_control is NOT a hit, however warm the entry was.
+//
+// `hit` used to be computed from aliveness alone, before the action was known, so an expire turn
+// landed in Hits, HitRate and AvoidedRecomputations while paying for a fully uncached prompt.
+// The tell was two fields of one Result contradicting each other: AvoidedRecomputations of 1
+// beside AvoidedTokens of 0. It also fed Compare.HitDelta, and so credited an avoided DELAY to a
+// request that had taken the miss latency.
+//
+// The dollar total is unchanged by this — the money was always right — which is why nothing that
+// checked costs could see it.
+func TestExpireOverALiveEntryIsNotAHit(t *testing.T) {
+	reqs, cfg := trajectory(t, []int64{60_000}, nil, false)
+	plan := map[int64]Action{reqs[0].ID: ActionWrite5m, reqs[1].ID: ActionExpire}
+	got := Simulate(reqs, NewReplay("write-then-expire", plan, ActionExpire), cfg)
+
+	if got.Hits != 0 {
+		t.Errorf("hits = %d; the second request wrote no cache_control, so the provider read "+
+			"nothing from cache and billed its whole prefix as fresh input", got.Hits)
+	}
+	if got.Misses != 2 {
+		t.Errorf("misses = %d, want 2", got.Misses)
+	}
+	if got.AvoidedRecomputations != 0 || got.AvoidedTokens != 0 {
+		t.Errorf("avoided %d recomputations over %d tokens; a request that re-sent its whole "+
+			"prefix as fresh input avoided nothing", got.AvoidedRecomputations, got.AvoidedTokens)
+	}
+	// The two fields must never contradict each other again, whatever the arm.
+	if (got.AvoidedRecomputations == 0) != (got.AvoidedTokens == 0) {
+		t.Errorf("AvoidedRecomputations=%d and AvoidedTokens=%d disagree about whether anything "+
+			"was avoided", got.AvoidedRecomputations, got.AvoidedTokens)
+	}
+	// And the money is the same either way, which is the fact that kept this hidden.
+	price := cfg.Prices.For(reqs[0].Model)
+	want := price.RequestCost(reqs[0].InputTokens, 0, reqs[0].CachedContext, reqs[0].OutputTokens, TTL5m) +
+		price.UncachedCost(reqs[1].InputTokens, reqs[1].CachedContext, reqs[1].OutputTokens)
+	if math.Abs(got.TotalUSD-want) > 1e-9 {
+		t.Errorf("total $%.9f, want $%.9f (one 5m write plus one fully uncached prompt)",
+			got.TotalUSD, want)
+	}
+}
+
+// ── determinism ───────────────────────────────────────────────────────────
+
+// The optimum's PLAN, not just its cost, must be the same on every run.
+//
+// NewOptimal keeps the FIRST best on a tie (strict `<`), and its comment names that as the
+// determinism guarantee. Nothing pinned it: switching to `<=` — keep the LAST best — survives
+// the whole suite including the drift guard, because TotalUSD is identical either way and only
+// Result.Decisions moves. A figure that flaps between runs while the total does not is the kind
+// nobody can reproduce and nobody notices.
+//
+// The fixture gives every action exactly the same cost, so every transition is a perfect tie and
+// the recorded pointer is the only thing that can keep two runs agreeing. With no prefix there is
+// nothing to read, write or refresh, so all six actions cost input+output at every turn.
+func TestTheOptimalPlanIsDeterministicUnderPerfectTies(t *testing.T) {
+	reqs, cfg := trajectory(t, []int64{30_000, 30_000, 30_000}, nil, false)
+	for _, r := range reqs {
+		r.CachedContext = 0
+	}
+	planOf := func() string {
+		o := NewOptimal(reqs, cfg)
+		var parts []string
+		for _, r := range reqs {
+			parts = append(parts, string(o.Decide(Observation{RequestID: r.ID})))
+		}
+		return strings.Join(parts, ";")
+	}
+	first := planOf()
+	for i := 0; i < 50; i++ {
+		if got := planOf(); got != first {
+			t.Fatalf("solve %d produced %q, the first produced %q — the plan is not "+
+				"deterministic, so Result.Decisions flaps between runs", i, got, first)
+		}
+	}
+	// Keeping the FIRST best means Actions[0] wins every tie, and Actions[0] is ActionExpire.
+	want := strings.TrimSuffix(strings.Repeat(string(ActionExpire)+";", len(reqs)), ";")
+	if first != want {
+		t.Errorf("under a perfect tie the plan is %q, want %q — the first-best rule the "+
+			"determinism guarantee rests on is not being applied", first, want)
+	}
+}
+
+// ── the fixture ───────────────────────────────────────────────────────────
+
+// trajectory builds one conversation. models gives a model per turn (nil = one model
+// throughout); shrink makes the prefix SHRINK rather than grow, which is what a compaction does.
+func trajectory(t *testing.T, gaps []int64, models []string, shrink bool) ([]*Request, Config) {
+	t.Helper()
+	const start = int64(1_786_967_311_185)
+	ts := start
+	reqs := make([]*Request, 0, len(gaps)+1)
+	for i := 0; i <= len(gaps); i++ {
+		reason := "hit"
+		if i == 0 {
+			reason = "cold_start"
+		}
+		prefix := int64(100_000 + i*25_000)
+		if shrink {
+			prefix = int64(250_000 - i*80_000)
+		}
+		reqs = append(reqs, &Request{
+			ID: int64(i + 1), User: "acct", ConversationID: "conv", TS: ts,
+			HourUTC: time.UnixMilli(ts).UTC().Hour(), Bucket: BucketAt(ts),
+			Model: modelAt(models, i), InputTokens: 110, OutputTokens: 44,
+			CachedContext: prefix, MissReason: reason,
+			TTL: TTL5m, TTLSource: TTLSourceConfigured,
+		})
+		if i < len(gaps) {
+			ts += gaps[i]
+		}
+	}
+	Derive(reqs)
+	// Rates an order of magnitude apart, so pricing a span at the wrong model is a visible
+	// dollar difference rather than a rounding artefact.
+	pin, pout := int64(1), int64(1)
+	rate := func(in float64) Override {
+		i, out, cr, w5, w1 := in, in*5, in*0.1, in*1.25, in*2.0
+		return Override{Input: &i, Output: &out, CacheRead: &cr, Write5m: &w5, Write1h: &w1,
+			PingInputTokens: &pin, PingOutputTokens: &pout}
+	}
+	prices := NewPriceList(context.Background(), []string{"m", "cheap", "dear"}, nil,
+		Multipliers{}, map[string]Override{
+			"m": rate(3.8e-6), "cheap": rate(0.4e-6), "dear": rate(4.0e-6)})
+	return reqs, Config{Prices: prices, WindowEnd: ts}
+}
+
+func modelAt(models []string, i int) string {
+	if i < len(models) {
+		return models[i]
+	}
+	if len(models) > 0 {
+		return models[len(models)-1]
+	}
+	return "m"
+}
+
+// A conversation is (user, session, MODEL). A cache entry does not transfer between models, so
+// two requests differing only in model are two trajectories and neither is the other's successor.
+//
+// This deployment's own predictor stated that rule before the simulator implemented it, and
+// without it Derive linked an opus request to a sonnet one and the replay granted a hit at 0.1x
+// on an entry it could never have matched.
+func TestTheModelIsPartOfTheConversationKey(t *testing.T) {
+	base := int64(1_786_967_311_185)
+	mk := func(id int64, model string, ts int64) *Request {
+		return &Request{ID: id, User: "acct", ConversationID: "same-session", TS: ts,
+			Model: model, CachedContext: 100_000, MissReason: "hit"}
+	}
+	opus, sonnet := mk(1, "dear", base), mk(2, "cheap", base+60_000)
+	later := mk(3, "dear", base+120_000)
+	rows := []*Request{opus, sonnet, later}
+	Derive(rows)
+
+	if opus.HasNext && opus.NextID == sonnet.ID {
+		t.Error("an opus request was linked to a sonnet request as its successor; a cache entry " +
+			"does not transfer between models, so the gap between them is not a reuse interval")
+	}
+	if !opus.HasNext || opus.NextID != later.ID {
+		t.Errorf("the opus request's successor is %d (has_next=%v); it should be the next "+
+			"request OF THE SAME MODEL, id %d", opus.NextID, opus.HasNext, later.ID)
+	}
+	if sonnet.HasNext {
+		t.Errorf("the lone sonnet request has successor %d; it has none", sonnet.NextID)
+	}
+	if opus.Key() == sonnet.Key() {
+		t.Errorf("two models share a conversation key: %+v", opus.Key())
+	}
+	// And the replay must not grant the sonnet request a hit on the opus entry.
+	_, cfg := trajectory(t, []int64{1}, nil, false)
+	got := Simulate(rows, Fixed5m(), cfg)
+	if got.Conversations != 2 {
+		t.Errorf("conversations = %d, want 2 (one per model)", got.Conversations)
+	}
+	if got.Hits != 1 {
+		t.Errorf("hits = %d; only the second opus request can hit, and the sonnet request "+
+			"cannot read what opus wrote", got.Hits)
+	}
+}
+
+// A session that ALTERNATES models must still link each model's requests to each other.
+//
+// This guards the second half of putting Model in the key, and it is load-bearing rather than
+// belt-and-braces. Derive sorts before it walks, so if the grouping sort does not order by model
+// as well, an alternating session interleaves — opus, sonnet, opus, sonnet — and two requests of
+// the same model are never ADJACENT in the slice. The walk only ever compares neighbours, so
+// their successors are silently lost: HasNext goes false on requests that do have one.
+//
+// That is under-linking, the opposite direction from the cross-model hit it was fixing, and
+// equally wrong: it suppresses idle gaps from History, suppresses hits, and inflates cost. Found
+// by mutating the tiebreak away, which no existing test noticed.
+func TestAlternatingModelsStillLinkWithinEachModel(t *testing.T) {
+	base := int64(1_786_967_311_185)
+	mk := func(id int64, model string, ts int64) *Request {
+		return &Request{ID: id, User: "acct", ConversationID: "one-session", TS: ts,
+			Model: model, CachedContext: 100_000, MissReason: "hit"}
+	}
+	// Interleaved in time, which is how the sort can scramble them.
+	rows := []*Request{
+		mk(1, "dear", base),
+		mk(2, "cheap", base+10_000),
+		mk(3, "dear", base+20_000),
+		mk(4, "cheap", base+30_000),
+	}
+	Derive(rows)
+	byID := map[int64]*Request{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+	for _, want := range []struct{ from, to int64 }{{1, 3}, {2, 4}} {
+		r := byID[want.from]
+		if !r.HasNext || r.NextID != want.to {
+			t.Errorf("request %d (model %q) has successor %d (has_next=%v), want %d — the same "+
+				"model's next request was not adjacent after the grouping sort, so its successor "+
+				"was lost", want.from, r.Model, r.NextID, r.HasNext, want.to)
+		}
+	}
+	for _, id := range []int64{3, 4} {
+		if byID[id].HasNext {
+			t.Errorf("request %d is the last of its model and has successor %d", id, byID[id].NextID)
+		}
+	}
+	// And no cross-links: 1 must never point at 2, nor 2 at 3.
+	if byID[1].NextID == 2 || byID[2].NextID == 3 {
+		t.Error("a request was linked across models despite the model being in the key")
+	}
+}
+
+// The invariant that makes the closed-span pricing fix unobservable, asserted directly.
+//
+// With Model in the conversation key, the previous request of a trajectory always has the SAME
+// model as the current one — so pricing a closed idle span at either is identical, and no test
+// can distinguish the two. That is a good position to be in and a bad one to leave unguarded: it
+// means the pricing fix is correct-by-subsumption, and anyone who later removes Model from the
+// key silently reintroduces the defect it was written for. So the invariant is checked here
+// rather than trusted.
+func TestAConversationNeverChangesModelMidStream(t *testing.T) {
+	base := int64(1_786_967_311_185)
+	var rows []*Request
+	id := int64(0)
+	for _, model := range []string{"dear", "cheap", "m"} {
+		for turn := 0; turn < 3; turn++ {
+			id++
+			ts := base + int64(turn)*30_000
+			rows = append(rows, &Request{ID: id, User: "acct", ConversationID: "shared",
+				TS: ts, Model: model, CachedContext: 120_000, MissReason: "hit"})
+		}
+	}
+	Derive(rows)
+	// Walk each trajectory the way Simulate does and assert the model never moves inside one.
+	seen := map[Conversation]string{}
+	for _, r := range rows {
+		k := r.Key()
+		if prev, ok := seen[k]; ok && prev != r.Model {
+			t.Errorf("conversation %+v contains both model %q and %q; a closed idle span would "+
+				"then have two candidate rates and the ceiling and the simulator could price it "+
+				"differently", k, prev, r.Model)
+		}
+		seen[k] = r.Model
+		if k.Model != r.Model {
+			t.Errorf("Key().Model = %q but the request's model is %q", k.Model, r.Model)
+		}
+	}
+	if len(seen) != 3 {
+		t.Errorf("one session with three models produced %d trajectories, want 3", len(seen))
+	}
+}
+
+// Group.Valued must mean "any request here could be priced", not "all of them could".
+func TestGroupValuedOnAMixedGroup(t *testing.T) {
+	base := int64(1_786_967_311_185)
+	rows := []*Request{
+		{ID: 1, User: "acct", ConversationID: "c", TS: base, Model: "m",
+			CachedContext: 100_000, MissReason: "cold_start"},
+		{ID: 2, User: "acct", ConversationID: "c2", TS: base + 1000, Model: "no-rates",
+			CachedContext: 100_000, MissReason: "cold_start"},
+	}
+	Derive(rows)
+	_, cfg := trajectory(t, []int64{1}, nil, false)
+	got := Simulate(rows, Fixed5m(), cfg)
+	var user *Group
+	for i := range got.ByUser {
+		if got.ByUser[i].Key == "acct" {
+			user = &got.ByUser[i]
+		}
+	}
+	if user == nil {
+		t.Fatal("no group for the only account in the window")
+	}
+	if user.Unpriced != 1 || user.Requests != 2 {
+		t.Fatalf("group has %d unpriced of %d requests; want 1 of 2", user.Unpriced, user.Requests)
+	}
+	if !user.Valued {
+		t.Error("a group with one priced request of two reports Valued=false; its dollar figure " +
+			"is real for the half that could be priced, and Unpriced says how much is missing")
+	}
+}
+
+// The n floor the Stats fallback rests on. minCell exists so a cell cannot speak for itself on
+// too few observations — "a strategy switching tier on that is choosing by noise" — and nothing
+// pinned the number.
+func TestTheMinCellFloorHolds(t *testing.T) {
+	h := NewHistory()
+	for i := 0; i < minCell-1; i++ {
+		h.Observe("u", "m", BucketNight, 30*time.Second)
+	}
+	if _, n, level := h.ReuseWithin("u", "m", BucketNight, Horizon5m); level == LevelUserBucket {
+		t.Errorf("a cell with %d observations answered at its own level (n=%d); the floor is %d",
+			minCell-1, n, minCell)
+	}
+	h.Observe("u", "m", BucketNight, 30*time.Second)
+	if _, n, level := h.ReuseWithin("u", "m", BucketNight, Horizon5m); level != LevelUserBucket {
+		t.Errorf("a cell with exactly %d observations answered at %s (n=%d); the floor is "+
+			"inclusive", minCell, level, n)
+	}
+}
+
+// MedianIdle must be the median, not an extreme. It is on the Stats interface and no shipped
+// strategy calls it, so nothing else would notice it returning the maximum.
+func TestMedianIdleIsTheMedian(t *testing.T) {
+	h := NewHistory()
+	for _, d := range []time.Duration{time.Second, 2 * time.Second, 3 * time.Second,
+		4 * time.Second, 5 * time.Second, 100 * time.Second} {
+		h.Observe("u", "m", BucketNight, d)
+	}
+	got, n, _ := h.MedianIdle("u", "m", BucketNight)
+	if n != 6 {
+		t.Fatalf("n = %d, want 6", n)
+	}
+	// Nearest-rank on an even count takes the lower of the two middles: 3s, not 3.5s and
+	// certainly not the 100s maximum.
+	if got != 3*time.Second {
+		t.Errorf("median = %v, want 3s (the lower of the two middles of 1,2,3,4,5,100)", got)
+	}
+}

--- a/kvcache/pricing.go
+++ b/kvcache/pricing.go
@@ -1,0 +1,384 @@
+package kvcache
+
+import (
+	"context"
+	"sort"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// Pricing is one model's rates for the SIX things a prompt-cache policy can spend money
+// on, plus the two assumptions a keep-alive ping forces anyone to state out loud.
+//
+// # Why this is not modelinfo.Price
+//
+// modelinfo.Price is what the operator's price list and the public map publish: four tiers
+// (input, output, cache read, cache creation). A TTL strategy needs two creation rates,
+// because a 1-hour write is 2.0x base input where a 5-minute write is 1.25x, and pricing
+// one as the other understates a 1h request by 0.75x of its whole written prefix. No
+// gateway publishes a second creation rate, so Write1h is DERIVED from the documented
+// multiplier — and the multiplier is a field, not a literal, so an operator whose provider
+// charges differently can say so.
+//
+// # Nothing here is hardcoded in a UI component
+//
+// Every rate on this struct is served to the page and editable in it, and every edit comes
+// back as an override that lands here. The page renders what it was given; it never carries
+// a rate of its own. That is the same rule the keep-alive tab keeps, for the same reason:
+// the browser has twice duplicated a table the server owns and drifted from it.
+type Pricing struct {
+	Model string `json:"model"`
+	// Input is fresh, uncached input. Output is completion. CacheRead is a cache hit.
+	Input     float64 `json:"input"`
+	Output    float64 `json:"output"`
+	CacheRead float64 `json:"cache_read"`
+	// Write5m and Write1h are the two cache-CREATION rates.
+	Write5m float64 `json:"write_5m"`
+	Write1h float64 `json:"write_1h"`
+
+	// PingInputTokens and PingOutputTokens are the request overhead a keep-alive ping
+	// cannot avoid: the fresh input it must carry past the cached prefix, and the smallest
+	// generation the provider will accept.
+	//
+	// A ping's job is to touch the cached prefix and generate nothing. Where a provider
+	// accepts a zero-generation request that is free; where it does not — Anthropic's
+	// Messages API requires max_tokens >= 1 — the smallest supported request still bills
+	// one output token, and the assumption is EXPOSED rather than rounded to zero. See
+	// Semantics.ZeroGeneration.
+	PingInputTokens  int64 `json:"ping_input_tokens"`
+	PingOutputTokens int64 `json:"ping_output_tokens"`
+
+	// Source names where these rates came from, so nobody reads a typed number as a
+	// configured one: SourcePriceList (the deployment's own price list answered),
+	// "override" (edited in the page), or "" when the model has no rates at all.
+	Source string `json:"source"`
+	// Known is false when the model has NO rates. Then every dollar figure derived from it
+	// is absent rather than zero — an unpriced model is not a free one, and this project has
+	// shipped that particular lie five times.
+	Known bool `json:"known"`
+}
+
+// The documented Anthropic-family multiples, as named defaults rather than literals spread
+// across a cost function. Overridable per deployment through Multipliers.
+const (
+	// DefaultCacheReadMultiple is a cache hit's rate as a multiple of base input.
+	DefaultCacheReadMultiple = 0.1
+	// DefaultWrite5mMultiple is a 5-minute cache write as a multiple of base input.
+	DefaultWrite5mMultiple = 1.25
+	// DefaultWrite1hMultiple is a 1-hour cache write as a multiple of base input.
+	DefaultWrite1hMultiple = 2.0
+	// DefaultPingOutputTokens is the smallest generation Anthropic's Messages API accepts.
+	DefaultPingOutputTokens = 1
+	// DefaultPingInputTokens is the fresh input a ping carries beyond the cached prefix —
+	// the one-token user turn that makes it a legal request.
+	DefaultPingInputTokens = 1
+)
+
+// Multipliers are the deployment-wide fractions used to fill in a rate a price list does
+// not state. Zero means "use the default", so a partially filled struct is safe.
+type Multipliers struct {
+	CacheRead float64 `json:"cache_read"`
+	Write5m   float64 `json:"write_5m"`
+	Write1h   float64 `json:"write_1h"`
+}
+
+// WithDefaults returns the multipliers with every zero replaced by its default. Exported
+// because the dashboard reports the multiples a simulation actually used, and reporting the
+// caller's partially filled struct would show zeros where the defaults were applied.
+func (m Multipliers) WithDefaults() Multipliers {
+	if m.CacheRead <= 0 {
+		m.CacheRead = DefaultCacheReadMultiple
+	}
+	if m.Write5m <= 0 {
+		m.Write5m = DefaultWrite5mMultiple
+	}
+	if m.Write1h <= 0 {
+		m.Write1h = DefaultWrite1hMultiple
+	}
+	return m
+}
+
+// DefaultMultipliers is the shipped set.
+func DefaultMultipliers() Multipliers { return Multipliers{}.WithDefaults() }
+
+// FromPrice derives a model's six rates from whatever the deployment's Pricer published.
+//
+// Only Write1h is ever invented, and only from the multiplier: it is the one rate no
+// gateway publishes. The rest are passed through untouched, so an operator price list that
+// disagrees with the public map wins — which is the whole reason internal/modelinfo.Table
+// exists.
+//
+// A Price with no rates at all yields Known=false, and every dollar figure downstream is
+// then omitted rather than computed as zero.
+func FromPrice(model string, p modelinfo.Price, m Multipliers, source string) Pricing {
+	m = m.WithDefaults()
+	out := Pricing{
+		Model: model, Input: p.Input, Output: p.Output, CacheRead: p.CacheRead,
+		Write5m: p.CacheWrite, Source: source,
+		PingInputTokens: DefaultPingInputTokens, PingOutputTokens: DefaultPingOutputTokens,
+	}
+	if p.Zero() {
+		out.Source = ""
+		return out
+	}
+	out.Known = true
+	// A price list that omitted a cache tier: fill from the multiplier rather than leave a
+	// cached request priced as free.
+	if out.CacheRead == 0 {
+		out.CacheRead = out.Input * m.CacheRead
+	}
+	if out.Write5m == 0 {
+		out.Write5m = out.Input * m.Write5m
+	}
+	// The 1-hour rate. Derived from base input where that is known — the multiplier is
+	// against INPUT, not against the 5m rate, because that is how the provider documents it.
+	// Where input is unknown but a 5m rate is not, scale the 5m rate by the ratio of the two
+	// multipliers, which is the same number by a longer route.
+	switch {
+	case out.Input > 0:
+		out.Write1h = out.Input * m.Write1h
+	case out.Write5m > 0 && m.Write5m > 0:
+		out.Write1h = out.Write5m * (m.Write1h / m.Write5m)
+	}
+	// A 1-hour entry can never be cheaper to create than a 5-minute one. A price list that
+	// says otherwise is a typo, and honouring it would make every 1h strategy look free.
+	if out.Write1h < out.Write5m {
+		out.Write1h = out.Write5m
+	}
+	return out
+}
+
+// Override is one model's edited rates, as the page sends them back. Every field is a
+// POINTER so that "not edited" and "edited to zero" are different facts: a rate of zero is
+// a legitimate thing to experiment with, and a sentinel could not say so.
+type Override struct {
+	Input            *float64 `json:"input,omitempty"`
+	Output           *float64 `json:"output,omitempty"`
+	CacheRead        *float64 `json:"cache_read,omitempty"`
+	Write5m          *float64 `json:"write_5m,omitempty"`
+	Write1h          *float64 `json:"write_1h,omitempty"`
+	PingInputTokens  *int64   `json:"ping_input_tokens,omitempty"`
+	PingOutputTokens *int64   `json:"ping_output_tokens,omitempty"`
+}
+
+// Apply lays an override over a derived Pricing. An override makes the row KNOWN: a model
+// the price list has never heard of is exactly the case an operator needs to be able to
+// price by hand.
+func (o Override) Apply(p Pricing) Pricing {
+	set := func(dst *float64, src *float64) {
+		if src != nil {
+			*dst = *src
+		}
+	}
+	set(&p.Input, o.Input)
+	set(&p.Output, o.Output)
+	set(&p.CacheRead, o.CacheRead)
+	set(&p.Write5m, o.Write5m)
+	set(&p.Write1h, o.Write1h)
+	if o.PingInputTokens != nil {
+		p.PingInputTokens = *o.PingInputTokens
+	}
+	if o.PingOutputTokens != nil {
+		p.PingOutputTokens = *o.PingOutputTokens
+	}
+	if o.Empty() {
+		return p
+	}
+	p.Source = "override"
+	p.Known = p.Input != 0 || p.Output != 0 || p.CacheRead != 0 || p.Write5m != 0 || p.Write1h != 0
+	return p
+}
+
+// Empty reports whether this override changes nothing.
+func (o Override) Empty() bool {
+	return o.Input == nil && o.Output == nil && o.CacheRead == nil && o.Write5m == nil &&
+		o.Write1h == nil && o.PingInputTokens == nil && o.PingOutputTokens == nil
+}
+
+// PriceList is the whole priced surface of one analysis: a row per model in the window,
+// plus the multipliers the derived rates came from. This is what the page renders in its
+// pricing panel and what it posts back edited.
+type PriceList struct {
+	Multipliers Multipliers `json:"multipliers"`
+	Models      []Pricing   `json:"models"`
+
+	byModel map[string]Pricing
+}
+
+// OverrideAll is the overrides key that applies to EVERY model before its own entry.
+//
+// It exists for the two fields that are provider facts rather than model rates — the ping's
+// minimum input and output — which a caller would otherwise have to repeat once per model in
+// the window, and would then get wrong for the thirteenth.
+const OverrideAll = "*"
+
+// NewPriceList builds the list for a set of models from a Pricer, then applies overrides.
+//
+// models is used as given (deduped and sorted) so a model with no rates still gets a ROW —
+// saying "this model has no rates" is the answer, and omitting it would leave the reader
+// unable to tell an unpriced model from one that has no traffic.
+//
+// overrides[OverrideAll] is applied to every row first, then the row's own entry, so a
+// per-model rate always wins over a blanket one.
+func NewPriceList(ctx context.Context, models []string, p modelinfo.Pricer, m Multipliers,
+	overrides map[string]Override) *PriceList {
+	m = m.WithDefaults()
+	out := &PriceList{Multipliers: m, Models: []Pricing{}, byModel: map[string]Pricing{}}
+	seen := map[string]bool{}
+	uniq := make([]string, 0, len(models))
+	for _, name := range models {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		uniq = append(uniq, name)
+	}
+	sort.Strings(uniq)
+	for _, name := range uniq {
+		var pr modelinfo.Price
+		source := ""
+		if p != nil {
+			if got, ok := p.Price(ctx, name); ok {
+				pr, source = got, SourcePriceList
+			}
+		}
+		row := FromPrice(name, pr, m, source)
+		if ov, ok := overrides[OverrideAll]; ok {
+			row = ov.Apply(row)
+		}
+		if ov, ok := overrides[name]; ok {
+			row = ov.Apply(row)
+		}
+		out.Models = append(out.Models, row)
+		out.byModel[name] = row
+	}
+	return out
+}
+
+// SourcePriceList is what a rate the deployment's own Pricer answered is labelled.
+//
+// It deliberately does not name WHICH pricer: the chain is assembled by the proxy
+// (operator price list first, then the public LiteLLM map) and this layer is handed the
+// composed Pricer, so claiming "operator_table" here would be a guess. The label says the
+// rate came from the configured price list; "override" says a person typed it.
+const SourcePriceList = "price_list"
+
+// For returns one model's rates. A model the list has never seen comes back Known=false
+// with its own name on it, so the caller can report WHICH model it could not price.
+func (l *PriceList) For(model string) Pricing {
+	if l == nil {
+		return Pricing{Model: model}
+	}
+	if p, ok := l.byModel[model]; ok {
+		return p
+	}
+	return Pricing{Model: model, PingInputTokens: DefaultPingInputTokens,
+		PingOutputTokens: DefaultPingOutputTokens}
+}
+
+// Semantics is the provider's cache behaviour, made explicit and configurable because it
+// is not the same everywhere and because getting it wrong silently changes every result.
+//
+// Anthropic's documented behaviour is the shipped default:
+//
+//   - "the cache is refreshed for no additional cost each time the cached content is
+//     used" — so a plain cache HIT resets the entry's lifetime. HitRefreshesTTL=true.
+//   - a keep-alive read is just a use, so it refreshes the entry for its OWN tier's
+//     lifetime. PingRefreshesTTL=true.
+//   - refreshing does not change the tier an entry was created at, so a refresh buys another
+//     lifetime OF THAT TIER — five minutes for a 5-minute entry, an hour for a one-hour one.
+//   - max_tokens must be >= 1, so a ping cannot generate nothing. ZeroGeneration=false.
+type Semantics struct {
+	HitRefreshesTTL  bool `json:"hit_refreshes_ttl"`
+	PingRefreshesTTL bool `json:"ping_refreshes_ttl"`
+	ZeroGeneration   bool `json:"zero_generation"`
+}
+
+// DefaultSemantics is Anthropic's documented behaviour.
+func DefaultSemantics() Semantics {
+	return Semantics{HitRefreshesTTL: true, PingRefreshesTTL: true}
+}
+
+// pingOutput is the output tokens one ping is billed for under these semantics.
+func (s Semantics) pingOutput(p Pricing) int64 {
+	if s.ZeroGeneration {
+		return 0
+	}
+	if p.PingOutputTokens < 0 {
+		return 0
+	}
+	return p.PingOutputTokens
+}
+
+// RequestCost prices one request's four billed tiers at a chosen write tier.
+//
+//	request_cost = input×input_rate + read×cache_read_rate + write×write_rate(tier) + output×output_rate
+//
+// The write rate is the tier's, never a blend: that is the whole reason Pricing carries two.
+func (p Pricing) RequestCost(input, read, write, output int64, tier TTL) float64 {
+	return float64(input)*p.Input + float64(read)*p.CacheRead +
+		float64(write)*p.writeRate(tier) + float64(output)*p.Output
+}
+
+// writeRate is the creation rate for one tier. TTLNone has no write — a request carrying no
+// cache_control creates nothing — so it returns 0 and the caller must have billed those
+// tokens as fresh input instead.
+func (p Pricing) writeRate(tier TTL) float64 {
+	switch tier {
+	case TTL5m:
+		return p.Write5m
+	case TTL1h:
+		return p.Write1h
+	}
+	return 0
+}
+
+// KeepAliveCost is what ONE keep-alive costs on a prefix of `cached` tokens.
+//
+//	keep_alive_cost = cached×cache_read_rate + ping_input×input_rate + ping_output×output_rate
+//
+// It is the same arithmetic whether the entry is held at five minutes or at an hour — a
+// refresh is a cache read at 0.1x either way — and that is worth saying out loud, because
+// the obvious guess is that a "1-hour ping" costs more. The difference between a 5-minute
+// and a 1-hour keep-alive is not the price of one ping. It is (a) the CREATION tier that had
+// to be paid to put the entry there, 1.25x against 2.0x of base input, and (b) how OFTEN a
+// ping is needed: a five-minute entry has to be touched roughly twelve times as often as a
+// one-hour one to be held for the same wall-clock span. Charging two different per-ping rates
+// would be inventing a price no provider publishes.
+func (p Pricing) KeepAliveCost(cached int64, s Semantics) float64 {
+	return float64(cached)*p.CacheRead + float64(p.PingInputTokens)*p.Input +
+		float64(s.pingOutput(p))*p.Output
+}
+
+// RecreateCost is what a keep-alive costs when it arrives TOO LATE: the entry has already
+// lapsed, so the "refresh" is a cache write, at 12.5x a read for the 5-minute tier and 20x
+// for the one-hour tier.
+//
+//	recreate_cost = cached×write_rate(tier) + ping_input×input_rate + ping_output×output_rate
+//
+// This is the pathology of a schedule whose interval exceeds the lifetime it is protecting,
+// and pricing it as a read is the arithmetic error that would hide it completely.
+func (p Pricing) RecreateCost(cached int64, tier TTL, s Semantics) float64 {
+	return float64(cached)*p.writeRate(tier) + float64(p.PingInputTokens)*p.Input +
+		float64(s.pingOutput(p))*p.Output
+}
+
+// HoldCost is what it costs to hold a prefix of `cached` tokens at `tier` from nothing: the
+// creation of the entry, plus `pings` keep-alives to carry it further.
+//
+// This is the figure the pricing panel shows beside each configured rate — "what would
+// another five minutes of this cost me, and what would another hour" — so the reader sees a
+// dollar amount on their own median prefix rather than a per-token rate to multiply in their
+// head. pings=0 is the plain write.
+func (p Pricing) HoldCost(cached int64, tier TTL, pings int, s Semantics) float64 {
+	return float64(cached)*p.writeRate(tier) + float64(pings)*p.KeepAliveCost(cached, s)
+}
+
+// UncachedCost is the same prompt with no prompt cache at all: every prefix token billed
+// as fresh input. The denominator of the "incremental cache premium", and the No-cache
+// baseline's own arithmetic.
+//
+//	uncached_cost = (input + prefix)×input_rate + output×output_rate
+func (p Pricing) UncachedCost(input, prefix, output int64) float64 {
+	return float64(input+prefix)*p.Input + float64(output)*p.Output
+}

--- a/kvcache/pricing_test.go
+++ b/kvcache/pricing_test.go
@@ -1,0 +1,198 @@
+package kvcache
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// stubPricer is an operator price list, in per-TOKEN units (the unit this package works in;
+// the real Table converts from per-million on load).
+type stubPricer map[string]modelinfo.Price
+
+func (s stubPricer) Price(_ context.Context, model string) (modelinfo.Price, bool) {
+	p, ok := s[model]
+	return p, ok
+}
+
+// testRates are the IBM gateway's own claude-sonnet-5 rates, which are roughly half
+// anthropic.com's list price — the exact reason internal/modelinfo.Table exists.
+var testRates = modelinfo.Price{
+	Input: 3e-6, Output: 15e-6, CacheRead: 0.3e-6, CacheWrite: 3.75e-6,
+}
+
+// testPrices is the price list every simulator test replays against: one priced model ("m")
+// and one the list has never heard of ("unpriced").
+func testPrices() *PriceList {
+	return NewPriceList(context.Background(), []string{"m", "unpriced"},
+		stubPricer{"m": testRates}, Multipliers{}, nil)
+}
+
+func near(t *testing.T, what string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s = %.12f, want %.12f", what, got, want)
+	}
+}
+
+// The 1-hour creation rate is DERIVED, because no gateway publishes one, and it is derived
+// from the multiplier against base INPUT rather than from the 5-minute rate.
+func TestOneHourWriteIsDerivedFromTheMultiplierAgainstInput(t *testing.T) {
+	p := FromPrice("m", testRates, Multipliers{}, SourcePriceList)
+	if !p.Known {
+		t.Fatal("a fully specified price list must be Known")
+	}
+	near(t, "input", p.Input, 3e-6)
+	near(t, "write_5m", p.Write5m, 3.75e-6)    // the list's own cache_creation rate
+	near(t, "write_1h", p.Write1h, 6e-6)       // 2.0 x input
+	near(t, "cache_read", p.CacheRead, 0.3e-6) // the list's own read rate
+	if p.PingOutputTokens != DefaultPingOutputTokens || p.PingInputTokens != DefaultPingInputTokens {
+		t.Errorf("ping overhead = %d in / %d out; the assumption must be explicit, not zero",
+			p.PingInputTokens, p.PingOutputTokens)
+	}
+	// A deployment whose provider charges differently says so, and nothing is hardcoded.
+	q := FromPrice("m", testRates, Multipliers{Write1h: 3.0}, SourcePriceList)
+	near(t, "write_1h at a 3.0x multiplier", q.Write1h, 9e-6)
+}
+
+// A price list that omits a cache tier must not leave a cached request priced as free.
+func TestAMissingCacheTierIsFilledFromTheMultiplierNotLeftAtZero(t *testing.T) {
+	p := FromPrice("m", modelinfo.Price{Input: 4e-6, Output: 20e-6}, Multipliers{}, SourcePriceList)
+	near(t, "cache_read", p.CacheRead, 0.4e-6)
+	near(t, "write_5m", p.Write5m, 5e-6)
+	near(t, "write_1h", p.Write1h, 8e-6)
+}
+
+// A 1-hour entry can never be cheaper to create than a 5-minute one. A price list that says
+// otherwise is a typo, and honouring it would make every 1h arm look free.
+func TestOneHourWriteIsNeverCheaperThanFiveMinute(t *testing.T) {
+	p := FromPrice("m", modelinfo.Price{Input: 1e-6, Output: 1e-6, CacheRead: 1e-7,
+		CacheWrite: 9e-6}, Multipliers{}, SourcePriceList)
+	if p.Write1h < p.Write5m {
+		t.Errorf("write_1h %.9f < write_5m %.9f", p.Write1h, p.Write5m)
+	}
+	near(t, "write_1h clamped to write_5m", p.Write1h, 9e-6)
+}
+
+// An unpriced model gets a ROW that says so — never a zero rate, and never omission.
+func TestAnUnpricedModelIsKnownFalseAndNotZeroRated(t *testing.T) {
+	l := testPrices()
+	p := l.For("unpriced")
+	if p.Known {
+		t.Fatal("a model the price list has never heard of must not read as priced")
+	}
+	if p.Source != "" {
+		t.Errorf("source = %q; an unpriced row names no source", p.Source)
+	}
+	if l.For("never-seen").Model != "never-seen" {
+		t.Error("a model outside the list must still come back naming itself, so the page can " +
+			"report WHICH model it could not price")
+	}
+	// And it appears in the list, so the reader can tell "unpriced" from "no traffic".
+	var found bool
+	for _, m := range l.Models {
+		if m.Model == "unpriced" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the unpriced model was dropped from the list instead of reported")
+	}
+}
+
+// An override is how an operator prices a model the list has never heard of — a preview id,
+// an internal route name, a server-resolved tier. It makes the row KNOWN.
+func TestAnOverridePricesAModelTheListDoesNotKnow(t *testing.T) {
+	in, w1h := 2e-6, 5e-6
+	l := NewPriceList(context.Background(), []string{"unpriced"}, stubPricer{}, Multipliers{},
+		map[string]Override{"unpriced": {Input: &in, Write1h: &w1h}})
+	p := l.For("unpriced")
+	if !p.Known {
+		t.Fatal("an override must make the row priced")
+	}
+	if p.Source != "override" {
+		t.Errorf("source = %q, want override — nobody may read a typed number as a configured one",
+			p.Source)
+	}
+	near(t, "overridden input", p.Input, 2e-6)
+	near(t, "overridden write_1h", p.Write1h, 5e-6)
+	// A zero is a legitimate override value, and "not edited" must stay distinguishable from it.
+	zero := 0.0
+	q := Override{CacheRead: &zero}.Apply(FromPrice("m", testRates, Multipliers{}, SourcePriceList))
+	near(t, "an override to zero", q.CacheRead, 0)
+	if !q.Known {
+		t.Error("zeroing one tier does not make a model unpriced")
+	}
+	if !(Override{}).Empty() {
+		t.Error("an empty override must report itself empty")
+	}
+	if got := (Override{}).Apply(FromPrice("m", testRates, Multipliers{}, SourcePriceList)); got.Source != SourcePriceList {
+		t.Errorf("an empty override changed the source to %q", got.Source)
+	}
+}
+
+// The cost formulas, spelled out against hand arithmetic. Every dollar figure on the page
+// comes through these four functions, so they are asserted rather than trusted.
+func TestCostFormulas(t *testing.T) {
+	p := FromPrice("m", testRates, Multipliers{}, SourcePriceList)
+	sem := DefaultSemantics()
+
+	// request_cost = input×3e-6 + read×0.3e-6 + write×write_rate + output×15e-6
+	near(t, "a 5m write of 100k with 200 fresh input and 50 output",
+		p.RequestCost(200, 0, 100_000, 50, TTL5m),
+		200*3e-6+100_000*3.75e-6+50*15e-6)
+	near(t, "the same request at the 1h tier",
+		p.RequestCost(200, 0, 100_000, 50, TTL1h),
+		200*3e-6+100_000*6e-6+50*15e-6)
+	near(t, "a hit that reads 100k and writes nothing",
+		p.RequestCost(200, 100_000, 0, 50, TTL5m),
+		200*3e-6+100_000*0.3e-6+50*15e-6)
+	// No cache_control: there is no write rate at all, and the caller must have billed the
+	// prefix as fresh input instead.
+	near(t, "no tier has no write rate", p.RequestCost(0, 0, 100_000, 0, TTLNone), 0)
+
+	// keep_alive_cost = cached×0.3e-6 + 1×3e-6 + 1×15e-6
+	near(t, "one keep-alive on a 100k prefix", p.KeepAliveCost(100_000, sem),
+		100_000*0.3e-6+3e-6+15e-6)
+	// A provider that accepts a zero-generation request drops the output token.
+	near(t, "one keep-alive with zero generation",
+		p.KeepAliveCost(100_000, Semantics{ZeroGeneration: true}),
+		100_000*0.3e-6+3e-6)
+
+	// recreate_cost pays the WRITE rate, which is where the 12.5x and 20x live.
+	near(t, "a late keep-alive at the 5m tier", p.RecreateCost(100_000, TTL5m, sem),
+		100_000*3.75e-6+3e-6+15e-6)
+	near(t, "a late keep-alive at the 1h tier", p.RecreateCost(100_000, TTL1h, sem),
+		100_000*6e-6+3e-6+15e-6)
+	// The ratio the whole mechanism rests on: a refresh against a re-creation.
+	if r := (100_000 * 3.75e-6) / (100_000 * 0.3e-6); math.Abs(r-12.5) > 1e-9 {
+		t.Errorf("a 5m re-creation is %.3fx a read, want 12.5x", r)
+	}
+
+	// uncached_cost = (input+prefix)×input + output×output
+	near(t, "the same prompt with no cache at all", p.UncachedCost(200, 100_000, 50),
+		(200+100_000)*3e-6+50*15e-6)
+
+	// hold_cost = creation + pings×keep_alive
+	near(t, "holding 100k at 5m with two refreshes", p.HoldCost(100_000, TTL5m, 2, sem),
+		100_000*3.75e-6+2*(100_000*0.3e-6+3e-6+15e-6))
+	near(t, "holding 100k at 1h with no refresh", p.HoldCost(100_000, TTL1h, 0, sem),
+		100_000*6e-6)
+}
+
+// The multipliers are the deployment's, and a zero means "use the default" so a partially
+// filled struct is safe rather than free.
+func TestMultiplierDefaults(t *testing.T) {
+	m := Multipliers{Write1h: 2.5}.WithDefaults()
+	if m.CacheRead != DefaultCacheReadMultiple || m.Write5m != DefaultWrite5mMultiple {
+		t.Errorf("a partially filled Multipliers lost its defaults: %+v", m)
+	}
+	if m.Write1h != 2.5 {
+		t.Errorf("the supplied multiplier was overwritten: %v", m.Write1h)
+	}
+	if d := DefaultMultipliers(); d.CacheRead != 0.1 || d.Write5m != 1.25 || d.Write1h != 2.0 {
+		t.Errorf("the shipped multiples moved: %+v", d)
+	}
+}

--- a/kvcache/registry.go
+++ b/kvcache/registry.go
@@ -240,7 +240,8 @@ func (r *Replay) Unanswered() int64 { return r.missing }
 // turn t — its size, its tier, its deadline, the keep-alives that fired during the span — is
 // a function of the PREVIOUS action alone, given the two rows' timestamps. So the cost
 // decomposes as a sum of f(action[t-1], action[t]) along the chain and one Viterbi pass per
-// trajectory settles it: five states, five transitions, O(25n).
+// trajectory settles it: len(Actions) states, len(Actions) transitions each, so
+// O(len(Actions)^2 * n) — six actions today, and the bookkeeping is linear (see back[] below).
 //
 // Every surface that shows this must label it unreachable (see StrategySpec.Unreachable).
 type Optimal struct{ chosen map[int64]Action }
@@ -273,17 +274,29 @@ func NewOptimal(reqs []*Request, cfg Config) *Optimal {
 			}
 			return group[i].ID < group[j].ID
 		})
-		// cost[a] and path[a] are the best total, and the plan behind it, for a prefix of the
-		// trajectory whose LAST action is Actions[a].
+		// cost[a] is the best total for a prefix of the trajectory whose LAST action is
+		// Actions[a]. The plan itself is NOT carried forward beside it: back[i][a] records which
+		// previous action that best came from, and the plan is recovered by walking those
+		// pointers once at the end.
+		//
+		// That is the difference between the O(len(Actions)^2 * n) this claims and the O(n^2) an
+		// earlier version actually did. It kept a []Action per state and copied the whole winning
+		// prefix into each of them every turn, so the recurrence was linear while the bookkeeping
+		// around it was quadratic in both time and allocation — measured at 8.4 ms for a
+		// 500-request trajectory rising to 94 SECONDS at 64k, a clean 4x per doubling. Trajectory
+		// length is not bounded by anything we control: a conversation is keyed on a
+		// CLIENT-SUPPLIED session id, so one account reusing one id makes one group arbitrarily
+		// long. A comment claiming linear bookkeeping over quadratic code is how that becomes a
+		// production incident rather than a benchmark.
 		cost := make([]float64, len(Actions))
-		path := make([][]Action, len(Actions))
+		back := make([][]int, len(group))
 		for i, r := range group {
 			nextCost := make([]float64, len(Actions))
-			nextPath := make([][]Action, len(Actions))
+			back[i] = make([]int, len(Actions))
 			for bi, b := range Actions {
 				if i == 0 {
 					nextCost[bi] = stepCost(nil, ActionExpire, r, b, cfg)
-					nextPath[bi] = []Action{b}
+					back[i][bi] = -1
 					continue
 				}
 				bestCost, bestAt := 0.0, -1
@@ -294,9 +307,9 @@ func NewOptimal(reqs []*Request, cfg Config) *Optimal {
 					}
 				}
 				nextCost[bi] = bestCost
-				nextPath[bi] = append(append([]Action(nil), path[bestAt]...), b)
+				back[i][bi] = bestAt
 			}
-			cost, path = nextCost, nextPath
+			cost = nextCost
 		}
 		// The OPEN span after the last turn: an action that pings keeps spending, bounded by
 		// the window's end. Without charging for it the optimum would happily choose a
@@ -309,8 +322,14 @@ func NewOptimal(reqs []*Request, cfg Config) *Optimal {
 				bestCost, bestAt = c, ai
 			}
 		}
-		for j, r := range group {
-			out.chosen[r.ID] = path[bestAt][j]
+		// Walk the back-pointers from the last turn to the first, then assign. One pass, one
+		// int per (turn, state), no prefix ever copied.
+		at := bestAt
+		for i := len(group) - 1; i >= 0; i-- {
+			out.chosen[group[i].ID] = Actions[at]
+			if prev := back[i][at]; prev >= 0 {
+				at = prev
+			}
 		}
 	}
 	return out

--- a/kvcache/registry.go
+++ b/kvcache/registry.go
@@ -262,7 +262,10 @@ func NewOptimal(reqs []*Request, cfg Config) *Optimal {
 		if keys[i].User != keys[j].User {
 			return keys[i].User < keys[j].User
 		}
-		return keys[i].Conversation < keys[j].Conversation
+		if keys[i].Conversation != keys[j].Conversation {
+			return keys[i].Conversation < keys[j].Conversation
+		}
+		return keys[i].Model < keys[j].Model
 	})
 
 	out := &Optimal{chosen: make(map[int64]Action, len(reqs))}

--- a/kvcache/registry.go
+++ b/kvcache/registry.go
@@ -1,0 +1,386 @@
+package kvcache
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The strategy REGISTRY, the explicit-action seam, and the exact cost ceiling.
+//
+// # Why a registry lives here and not in the API layer
+//
+// A dashboard route that maps "fixed-5m" to a Strategy is a second list of the arms that
+// exist, and it drifts: an arm added here would be invisible there, and an arm renamed here
+// would 404 there. Worse, the offline ML evaluator (deploy/harbor/kv_ttl_cost_model.py) has
+// its own arm table, so a name that means one thing on the page and another in the
+// evaluation is a comparison nobody can trust. One registry, in the domain package, is what
+// the page, the API and the port all read.
+
+// StrategySpec is one arm, as the API and the page should present it.
+type StrategySpec struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// Unreachable marks an arm that reads the FUTURE. It is a bound on what any policy could
+	// achieve, never a result, and every surface that shows it must say so — a ceiling
+	// rendered beside real arms in the same style is a promise the product cannot keep.
+	Unreachable bool `json:"unreachable"`
+	// NeedsDataset marks an arm that cannot be built from a name alone because it is
+	// constructed from the whole trajectory set (it precomputes a per-request answer).
+	NeedsDataset bool `json:"needs_dataset"`
+	// Baseline marks the arm that is the honest default denominator for a savings figure.
+	Baseline bool `json:"baseline,omitempty"`
+}
+
+// The canonical arm names. Strings, because they are a wire contract: they appear in a query
+// parameter, in a JSON key, in the offline evaluator's own table and on the page.
+const (
+	StrategyNoCache     = "no-cache"
+	StrategyFixed5m     = "fixed-5m"
+	StrategyFixed1h     = "fixed-1h"
+	StrategyKeepAlive5m = "keepalive-5m"
+	StrategyKeepAlive1h = "keepalive-1h"
+	// StrategyExtend1h writes at the cheap tier and extends to an hour only when a
+	// conversation actually goes quiet.
+	StrategyExtend1h   = "keepalive-5m-to-1h"
+	StrategyObserved   = "observed-policy"
+	StrategyHistorical = "historical-probability"
+	StrategyOptimal    = "optimal"
+	StrategyReplay     = "replay"
+)
+
+// registry is the ordered arm list. The ORDER is the presentation order and it is
+// deliberate: the two baselines first, then the fixed tiers, then the keep-alive arms, then
+// the ones that decide, and the ceiling LAST — so a reader meets the reachable arms before
+// the one that cannot be reached.
+var registry = []StrategySpec{
+	{Name: StrategyNoCache, Description: NoCache{}.Describe()},
+	{Name: StrategyFixed5m, Description: Fixed5m().Describe(), Baseline: true},
+	{Name: StrategyFixed1h, Description: Fixed1h().Describe()},
+	{Name: StrategyKeepAlive5m, Description: KeepAlive5m().Describe()},
+	{Name: StrategyKeepAlive1h, Description: KeepAlive1h().Describe()},
+	{Name: StrategyExtend1h, Description: Extend1h{}.Describe()},
+	{Name: StrategyObserved, Description: "Replay the tier each request actually asked for; " +
+		"where no tier was recorded, assume the provider's default and count the row as " +
+		"uncovered.", NeedsDataset: true},
+	{Name: StrategyHistorical, Description: HistoricalProbability{}.Describe()},
+	{Name: StrategyReplay, Description: "Replay an explicit action supplied per request. The " +
+		"seam a policy decided elsewhere — an offline predictor, a hand-written experiment — " +
+		"is scored through.", NeedsDataset: true},
+	{Name: StrategyOptimal, Description: "The cheapest action sequence that exists, computed " +
+		"exactly. Reads the true next-request time.", Unreachable: true, NeedsDataset: true},
+}
+
+// Registry lists every arm, in presentation order. A copy, so a caller cannot reorder it.
+func Registry() []StrategySpec { return append([]StrategySpec(nil), registry...) }
+
+// StrategyNames is the arm names in the same order.
+func StrategyNames() []string {
+	out := make([]string, 0, len(registry))
+	for _, s := range registry {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// NewStrategy builds one arm by name.
+//
+// reqs is required by the arms whose spec says NeedsDataset (they precompute a per-request
+// answer over the whole set) and ignored by the rest. `replay` cannot be built here — it
+// needs the action list itself — so it is an error, with the constructor named.
+func NewStrategy(name string, reqs []*Request, cfg Config) (Strategy, error) {
+	switch name {
+	case StrategyNoCache:
+		return NoCache{}, nil
+	case StrategyFixed5m:
+		return Fixed5m(), nil
+	case StrategyFixed1h:
+		return Fixed1h(), nil
+	case StrategyKeepAlive5m:
+		return KeepAlive5m(), nil
+	case StrategyKeepAlive1h:
+		return KeepAlive1h(), nil
+	case StrategyExtend1h:
+		return Extend1h{}, nil
+	case StrategyObserved:
+		return NewObserved(reqs, TTL5m), nil
+	case StrategyHistorical:
+		return HistoricalProbability{Semantics: cfg.Semantics, PingIdle: cfg.PingIdle,
+			MaxPings: cfg.MaxPings}, nil
+	case StrategyOptimal:
+		return NewOptimal(reqs, cfg), nil
+	case StrategyReplay:
+		return nil, fmt.Errorf("kvcache: %q carries its own action list; build it with "+
+			"NewReplay", name)
+	}
+	return nil, fmt.Errorf("kvcache: no strategy %q; have %s", name,
+		strings.Join(StrategyNames(), ", "))
+}
+
+// ── the keep-alive arms ────────────────────────────────────────────────────
+
+// KeepAlive is a fixed arm that holds every prefix at one tier AND refreshes it with
+// keep-alives while the conversation is idle.
+//
+// Separate from Fixed because the difference is not the tier: it is whether anything is
+// spent to hold the entry past its own lifetime. On the production corpus this is the only
+// hand-written arm that beats the shipped 5-minute policy, and it does so without consulting
+// any statistics at all — which is the measurement any learned arm has to be compared with.
+type KeepAlive struct{ TTL TTL }
+
+// KeepAlive5m and KeepAlive1h are the two shipped keep-alive arms.
+func KeepAlive5m() KeepAlive { return KeepAlive{TTL: TTL5m} }
+func KeepAlive1h() KeepAlive { return KeepAlive{TTL: TTL1h} }
+
+func (k KeepAlive) Name() string { return "keepalive-" + k.TTL.Label() }
+func (k KeepAlive) Decide(Observation) Action {
+	if k.TTL == TTL1h {
+		return ActionPing1h
+	}
+	return ActionPing5m
+}
+func (k KeepAlive) Describe() string {
+	if k.TTL == TTL1h {
+		return "Hold every prefix at the 1-hour tier and refresh it with keep-alives while " +
+			"idle. Costs 2.0x input to create, and needs one twelfth as many refreshes as the " +
+			"5-minute arm to hold the same span."
+	}
+	return "Hold every prefix at the 5-minute tier and refresh it with keep-alives while " +
+		"idle. The cheapest tier to create, refreshed at 0.1x."
+}
+
+// Extend1h writes every prefix at the CHEAP five-minute tier and buys the long hold only if
+// the conversation actually goes quiet.
+//
+// It is the arm the other two keep-alive arms bracket, and on traffic like this deployment's
+// it is the one worth having: 92.5% of gaps close inside five minutes, so KeepAlive1h pays the
+// 2.0x creation premium on nearly every request for a hold nearly none of them needs, while
+// this pays 1.25x on every request and 2.0x only on the rare span that outlives five minutes.
+// See ActionWrite5mPing1h for what the upgrading keep-alive costs and why it is priced as a
+// write.
+type Extend1h struct{}
+
+func (Extend1h) Name() string              { return StrategyExtend1h }
+func (Extend1h) Decide(Observation) Action { return ActionWrite5mPing1h }
+func (Extend1h) Describe() string {
+	return "Write every prefix at the 5-minute tier (1.25x input), and if a keep-alive comes " +
+		"due before it lapses, extend the context by an hour with a 1-hour write (2.0x) — so " +
+		"the long-hold premium is paid only on the conversations that actually go quiet."
+}
+
+// ── the explicit-action seam ───────────────────────────────────────────────
+
+// Replay scores an action list decided somewhere else.
+//
+// This is how a policy that this package cannot run gets compared on equal terms: an offline
+// learned predictor (deploy/harbor/kv_ttl_survival_predictor.py drives one), a hand-written
+// experiment, or a recorded production decision. It receives the same replay, the same
+// rates, the same baseline and the same savings arithmetic as every built-in arm, which is
+// the whole point — an evaluation whose scorer differs from the product's is not an
+// evaluation of the product.
+type Replay struct {
+	// Label is the name results are grouped under. Defaults to "replay".
+	Label string
+	// Fallback is used for a request the list does not mention. ActionExpire by default,
+	// because it is the arm that cannot flatter anything.
+	Fallback Action
+	actions  map[int64]Action
+	missing  int64
+}
+
+// NewReplay builds the arm from a per-request-id action list.
+func NewReplay(label string, actions map[int64]Action, fallback Action) *Replay {
+	r := &Replay{Label: label, Fallback: fallback, actions: map[int64]Action{}}
+	if r.Label == "" {
+		r.Label = StrategyReplay
+	}
+	if r.Fallback == "" {
+		r.Fallback = ActionExpire
+	}
+	for id, a := range actions {
+		r.actions[id] = a
+	}
+	return r
+}
+
+func (r *Replay) Name() string { return r.Label }
+func (r *Replay) Describe() string {
+	return fmt.Sprintf("An action supplied per request (%d of them), scored against the same "+
+		"baseline and the same rates as every built-in arm.", len(r.actions))
+}
+
+// Decide reads the supplied action for the request being served.
+func (r *Replay) Decide(o Observation) Action {
+	if a, ok := r.actions[o.RequestID]; ok {
+		return a
+	}
+	r.missing++
+	return r.Fallback
+}
+
+// Unanswered is how many requests the list did not mention. Reported rather than silently
+// defaulted: an action list that covers half the window is not a policy, and a total that
+// hid the fact would be the flattering half of one.
+func (r *Replay) Unanswered() int64 { return r.missing }
+
+// ── the exact ceiling ──────────────────────────────────────────────────────
+
+// Optimal is the cheapest action sequence that exists, and it is a BOUND, not a policy.
+//
+// # Why a dynamic program and not a greedy rule
+//
+// The action chosen at turn t decides two things at once: whether turn t itself may READ
+// from cache (ActionExpire writes no cache_control, so the whole prefix is billed as fresh
+// input however warm the entry was) and whether turn t+1 hits. A rule that looks only at the
+// gap ahead therefore gets the current turn wrong. The first version of this in the offline
+// evaluator was exactly that greedy rule, and it scored BELOW a plain keep-alive — which is
+// impossible for a ceiling, and is how the error was caught.
+//
+// The exact optimum is cheap because the state is small. Everything about the entry entering
+// turn t — its size, its tier, its deadline, the keep-alives that fired during the span — is
+// a function of the PREVIOUS action alone, given the two rows' timestamps. So the cost
+// decomposes as a sum of f(action[t-1], action[t]) along the chain and one Viterbi pass per
+// trajectory settles it: five states, five transitions, O(25n).
+//
+// Every surface that shows this must label it unreachable (see StrategySpec.Unreachable).
+type Optimal struct{ chosen map[int64]Action }
+
+// NewOptimal solves each trajectory. Deterministic: the action order is the `Actions` slice,
+// never a map range, so the same dataset yields the same plan twice.
+func NewOptimal(reqs []*Request, cfg Config) *Optimal {
+	cfg = cfg.withDefaults(reqs)
+	byConv := map[Conversation][]*Request{}
+	for _, r := range reqs {
+		byConv[r.Key()] = append(byConv[r.Key()], r)
+	}
+	keys := make([]Conversation, 0, len(byConv))
+	for k := range byConv {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].User != keys[j].User {
+			return keys[i].User < keys[j].User
+		}
+		return keys[i].Conversation < keys[j].Conversation
+	})
+
+	out := &Optimal{chosen: make(map[int64]Action, len(reqs))}
+	for _, k := range keys {
+		group := byConv[k]
+		sort.SliceStable(group, func(i, j int) bool {
+			if group[i].TS != group[j].TS {
+				return group[i].TS < group[j].TS
+			}
+			return group[i].ID < group[j].ID
+		})
+		// cost[a] and path[a] are the best total, and the plan behind it, for a prefix of the
+		// trajectory whose LAST action is Actions[a].
+		cost := make([]float64, len(Actions))
+		path := make([][]Action, len(Actions))
+		for i, r := range group {
+			nextCost := make([]float64, len(Actions))
+			nextPath := make([][]Action, len(Actions))
+			for bi, b := range Actions {
+				if i == 0 {
+					nextCost[bi] = stepCost(nil, ActionExpire, r, b, cfg)
+					nextPath[bi] = []Action{b}
+					continue
+				}
+				bestCost, bestAt := 0.0, -1
+				for ai, a := range Actions {
+					c := cost[ai] + stepCost(group[i-1], a, r, b, cfg)
+					if bestAt < 0 || c < bestCost {
+						bestCost, bestAt = c, ai
+					}
+				}
+				nextCost[bi] = bestCost
+				nextPath[bi] = append(append([]Action(nil), path[bestAt]...), b)
+			}
+			cost, path = nextCost, nextPath
+		}
+		// The OPEN span after the last turn: an action that pings keeps spending, bounded by
+		// the window's end. Without charging for it the optimum would happily choose a
+		// keep-alive it never settles up on.
+		last := group[len(group)-1]
+		bestCost, bestAt := 0.0, -1
+		for ai, a := range Actions {
+			c := cost[ai] + openSpanCost(last, a, cfg)
+			if bestAt < 0 || c < bestCost {
+				bestCost, bestAt = c, ai
+			}
+		}
+		for j, r := range group {
+			out.chosen[r.ID] = path[bestAt][j]
+		}
+	}
+	return out
+}
+
+func (o *Optimal) Name() string { return StrategyOptimal }
+func (o *Optimal) Describe() string {
+	return "The cheapest action sequence that exists, solved exactly per trajectory. It reads " +
+		"the true next-request time, so it is the CEILING no policy can reach — never a result."
+}
+func (o *Optimal) Decide(ob Observation) Action { return o.chosen[ob.RequestID] }
+
+// entryAfter is the (tokens, tier, expires) a turn leaves behind. A hit refreshes and a
+// write starts, and both land on the same expression, which is why this needs no hit flag.
+func entryAfter(row *Request, action Action) (int64, TTL, int64) {
+	tier := action.Tier()
+	if tier == TTLNone {
+		return 0, TTLNone, 0
+	}
+	return row.CachedContext, tier, row.TS + int64(tier.Lifetime()/timeMillisecond)
+}
+
+// stepCost is the DP's transition weight: what the pair (prevAction, action) adds — the
+// span's keep-alives plus this request's own bill. It reads the SAME cost functions and the
+// same ping core Simulate does, so the ceiling cannot be computed against different rules
+// than the arms it bounds.
+func stepCost(prev *Request, prevAction Action, row *Request, action Action, cfg Config) float64 {
+	var tokens, expires int64
+	tier := TTLNone
+	var pingCost float64
+	if prev != nil {
+		tokens, tier, expires = entryAfter(prev, prevAction)
+		span := pingSpan(tokens, tier, expires, prev.TS, prevAction, row.TS,
+			cfg.Prices.For(prev.Model), cfg.Semantics, cfg)
+		pingCost, expires = span.cost, span.expires
+	}
+	alive := tokens > 0 && row.TS < expires
+	hit := alive && row.MissReason != "prefix_change" && row.MissReason != "cold_start"
+	var reusable int64
+	if hit {
+		reusable = tokens
+		if reusable > row.CachedContext {
+			reusable = row.CachedContext
+		}
+	}
+	t := action.Tier()
+	fresh, read, write := row.InputTokens, reusable, int64(0)
+	if t == TTLNone {
+		fresh += row.CachedContext
+		read = 0
+	} else {
+		write = row.CachedContext - reusable
+		if write < 0 {
+			write = 0
+		}
+	}
+	price := cfg.Prices.For(row.Model)
+	if !price.Known {
+		return pingCost
+	}
+	return pingCost + price.RequestCost(fresh, read, write, row.OutputTokens, t)
+}
+
+// openSpanCost is what a pinging action keeps spending after a trajectory's last request.
+func openSpanCost(last *Request, action Action, cfg Config) float64 {
+	tokens, tier, expires := entryAfter(last, action)
+	return pingSpan(tokens, tier, expires, last.TS, action, cfg.WindowEnd,
+		cfg.Prices.For(last.Model), cfg.Semantics, cfg).cost
+}
+
+// timeMillisecond is time.Millisecond as an int64, so the conversions above read as
+// arithmetic rather than as a cast chain.
+const timeMillisecond = 1e6 // nanoseconds per millisecond

--- a/kvcache/registry_test.go
+++ b/kvcache/registry_test.go
@@ -1,0 +1,241 @@
+package kvcache
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+// dataset builds a trajectory set with gaps spread across both horizons, so that different
+// arms genuinely win on different rows: short gaps where a 5-minute write is enough, gaps in
+// the band only a keep-alive or a 1-hour tier reaches, gaps past an hour that nothing
+// rescues, and trajectories that simply stop.
+func dataset(t *testing.T) ([]*Request, Config) {
+	t.Helper()
+	const start = int64(1_786_967_311_185)
+	gaps := []int64{5_000, 45_000, 299_999, 300_001, 600_000, 900_000, 2_400_000,
+		3_599_999, 3_600_001, 20_000_000}
+	var reqs []*Request
+	var id int64
+	for c, gap := range gaps {
+		conv := "conv-" + string(rune('a'+c))
+		ts := start + int64(c)*1_000
+		// Prefixes big enough that the write premium is the dominant term, which is the regime
+		// the production corpus is in (median billed prefix 124,845 tokens).
+		for turn := 0; turn < 4; turn++ {
+			id++
+			reason := "hit"
+			if turn == 0 {
+				reason = "cold_start"
+			}
+			reqs = append(reqs, &Request{
+				ID: id, User: "acct-1", ConversationID: conv, TS: ts,
+				HourUTC: time.UnixMilli(ts).UTC().Hour(), Bucket: BucketAt(ts),
+				Model: "m", InputTokens: 120, OutputTokens: 45,
+				CachedContext: 120_000 + int64(turn)*20_000, MissReason: reason,
+				TTL: TTL5m, TTLSource: TTLSourceConfigured,
+			})
+			ts += gap
+		}
+	}
+	Derive(reqs)
+	var end int64
+	for _, r := range reqs {
+		if r.TS > end {
+			end = r.TS
+		}
+	}
+	in, out, cr, w5, w1 := 3.8e-6, 19e-6, 0.38e-6, 4.75e-6, 7.6e-6
+	pin, pout := int64(1), int64(1)
+	prices := NewPriceList(context.Background(), []string{"m"}, nil, Multipliers{},
+		map[string]Override{"m": {Input: &in, Output: &out, CacheRead: &cr, Write5m: &w5,
+			Write1h: &w1, PingInputTokens: &pin, PingOutputTokens: &pout}})
+	return reqs, Config{Prices: prices, WindowEnd: end}
+}
+
+// The ceiling has to BE a ceiling. Every arm in the registry is replayed and none of them may
+// come out cheaper than the exact optimum.
+//
+// This is the assertion that caught the original implementation, which was a greedy per-row
+// rule and scored BELOW a plain keep-alive — impossible for a bound, and invisible in any
+// single number. It is a property, not an example: a future arm added to the registry is
+// covered the day it lands.
+func TestOptimalIsALowerBoundOnEveryOtherArm(t *testing.T) {
+	reqs, cfg := dataset(t)
+	best := Simulate(reqs, NewOptimal(reqs, cfg), cfg)
+	if best.TotalUSD <= 0 {
+		t.Fatalf("the optimum priced this dataset at %.6f; the fixture is not exercising cost",
+			best.TotalUSD)
+	}
+	var cheaper int
+	for _, spec := range Registry() {
+		if spec.Name == StrategyOptimal || spec.Name == StrategyReplay {
+			continue
+		}
+		s, err := NewStrategy(spec.Name, reqs, cfg)
+		if err != nil {
+			t.Fatalf("%s: %v", spec.Name, err)
+		}
+		got := Simulate(reqs, s, cfg)
+		// A cent of slack for float summation order, not a licence to be beaten.
+		if got.TotalUSD < best.TotalUSD-0.01 {
+			t.Errorf("%s costs $%.6f, BELOW the exact optimum's $%.6f. The ceiling is not a "+
+				"ceiling, so every saving quoted against it is wrong.",
+				spec.Name, got.TotalUSD, best.TotalUSD)
+		}
+		if got.TotalUSD > best.TotalUSD+0.01 {
+			cheaper++
+		}
+		// And the comparison must be signed, never clamped: an arm dearer than the bound has a
+		// negative saving against it.
+		if sv := Compare(got, best); sv.AbsoluteUSD < 0 {
+			t.Errorf("%s: the optimum reports a NEGATIVE saving (%.6f) against a dearer arm",
+				spec.Name, sv.AbsoluteUSD)
+		}
+	}
+	if cheaper == 0 {
+		t.Error("no arm was dearer than the optimum, so this dataset cannot tell a real bound " +
+			"from a coincidence")
+	}
+	// A random plan must not beat it either — the DP is over the same five actions, so a
+	// hand-picked sequence is a direct challenge to its optimality.
+	plans := map[int64]Action{}
+	for i, r := range reqs {
+		plans[r.ID] = Actions[i%len(Actions)]
+	}
+	if got := Simulate(reqs, NewReplay("rr", plans, ActionExpire), cfg); got.TotalUSD < best.TotalUSD-0.01 {
+		t.Errorf("a round-robin plan costs $%.6f, below the optimum's $%.6f",
+			got.TotalUSD, best.TotalUSD)
+	}
+}
+
+// The registry is a wire contract: the names are in a query parameter, a JSON key and the
+// offline evaluator's own arm table.
+func TestRegistryIsBuildableAndUnique(t *testing.T) {
+	reqs, cfg := dataset(t)
+	seen := map[string]bool{}
+	var baselines, unreachable int
+	for _, spec := range Registry() {
+		if seen[spec.Name] {
+			t.Errorf("duplicate arm name %q", spec.Name)
+		}
+		seen[spec.Name] = true
+		if spec.Description == "" {
+			t.Errorf("%s has no description; the page renders it beside the number", spec.Name)
+		}
+		if spec.Baseline {
+			baselines++
+		}
+		if spec.Unreachable {
+			unreachable++
+		}
+		s, err := NewStrategy(spec.Name, reqs, cfg)
+		if spec.Name == StrategyReplay {
+			if err == nil {
+				t.Error("replay must refuse to be built without its action list")
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: %v", spec.Name, err)
+		}
+		if s.Name() != spec.Name {
+			t.Errorf("registry calls it %q, the strategy calls itself %q", spec.Name, s.Name())
+		}
+	}
+	if baselines != 1 {
+		t.Errorf("%d arms are marked Baseline; exactly one is the honest denominator", baselines)
+	}
+	if unreachable != 1 {
+		t.Errorf("%d arms are marked Unreachable; only the exact optimum reads the future",
+			unreachable)
+	}
+	if _, err := NewStrategy("no-such-arm", reqs, cfg); err == nil {
+		t.Error("an unknown arm name must be an error, not a silent default")
+	}
+	if len(StrategyNames()) != len(registry) {
+		t.Error("StrategyNames disagrees with the registry")
+	}
+}
+
+// Replay is the seam an offline predictor is scored through, so it must score exactly what it
+// was handed and REPORT what it was not.
+func TestReplayScoresWhatItWasGivenAndCountsWhatItWasNot(t *testing.T) {
+	reqs, cfg := dataset(t)
+	// Half the rows named, the rest left out.
+	plan := map[int64]Action{}
+	for i, r := range reqs {
+		if i%2 == 0 {
+			plan[r.ID] = ActionWrite1h
+		}
+	}
+	r := NewReplay("offline-model", plan, ActionWrite5m)
+	got := Simulate(reqs, r, cfg)
+	if got.Strategy != "offline-model" {
+		t.Errorf("results grouped under %q, want the supplied label", got.Strategy)
+	}
+	if want := int64(len(reqs) - len(plan)); r.Unanswered() != want {
+		t.Errorf("Unanswered = %d, want %d — a list that covers half the window must say so",
+			r.Unanswered(), want)
+	}
+	if got.Decisions[ActionWrite1h] != int64(len(plan)) {
+		t.Errorf("the plan named %d 1-hour writes, the replay made %d",
+			len(plan), got.Decisions[ActionWrite1h])
+	}
+	if got.Decisions[ActionWrite5m] != int64(len(reqs)-len(plan)) {
+		t.Errorf("the fallback was not applied to the rows the plan omitted: %v", got.Decisions)
+	}
+	// A full plan must reproduce the arm it was copied from, exactly. This is what makes the
+	// seam trustworthy: scoring a policy through Replay is the same as running it.
+	fixed := Simulate(reqs, Fixed1h(), cfg)
+	all := map[int64]Action{}
+	for _, q := range reqs {
+		all[q.ID] = ActionWrite1h
+	}
+	via := Simulate(reqs, NewReplay("as-fixed-1h", all, ActionExpire), cfg)
+	if math.Abs(via.TotalUSD-fixed.TotalUSD) > 1e-9 {
+		t.Errorf("replaying fixed-1h's own actions cost $%.9f, the arm itself $%.9f",
+			via.TotalUSD, fixed.TotalUSD)
+	}
+	if via.Hits != fixed.Hits || via.Pings != fixed.Pings || via.Writes1h != fixed.Writes1h {
+		t.Errorf("the replay diverged on counts: %d/%d hits, %d/%d pings, %d/%d 1h writes",
+			via.Hits, fixed.Hits, via.Pings, fixed.Pings, via.Writes1h, fixed.Writes1h)
+	}
+}
+
+// The keep-alive arms must actually send keep-alives, and the 1-hour one must need far fewer
+// of them for the same traffic — the ping-count half of the 5m-versus-1h trade.
+func TestKeepAliveArmsPingAndTheHourlyOnePingsLess(t *testing.T) {
+	reqs, cfg := dataset(t)
+	five := Simulate(reqs, KeepAlive5m(), cfg)
+	hour := Simulate(reqs, KeepAlive1h(), cfg)
+	if five.Pings == 0 || hour.Pings == 0 {
+		t.Fatalf("a keep-alive arm sent no pings (5m=%d, 1h=%d)", five.Pings, hour.Pings)
+	}
+	if hour.Pings >= five.Pings {
+		t.Errorf("the 1-hour arm sent %d pings and the 5-minute arm %d; an hourly entry needs "+
+			"refreshing far less often", hour.Pings, five.Pings)
+	}
+	// The hourly arm's coverage CONTAINS the five-minute arm's, so it cannot hit less often.
+	if hour.HitRate < five.HitRate-1e-9 {
+		t.Errorf("the 1-hour arm hit %.2f%% against the 5-minute arm's %.2f%%; an hour of "+
+			"coverage contains five minutes of it", hour.HitRate, five.HitRate)
+	}
+	// The other half of the trade is the RATE, per written token — deliberately not asserted
+	// through CacheWriteUSD, which is rate x volume: the hourly arm misses less, so it writes
+	// FEWER tokens, and its total write bill can legitimately come out lower. Asserting on the
+	// total was this test's own first bug, and it is the same confusion as reading a hit rate
+	// as a cost.
+	p := cfg.Prices.For("m")
+	if p.Write1h <= p.Write5m {
+		t.Errorf("write_1h %.9f is not dearer per token than write_5m %.9f", p.Write1h, p.Write5m)
+	}
+	t.Logf("the trade on this dataset: 5m $%.2f (%d pings, %.1f%% hit) against "+
+		"1h $%.2f (%d pings, %.1f%% hit)", five.TotalUSD, five.Pings, five.HitRate,
+		hour.TotalUSD, hour.Pings, hour.HitRate)
+	if five.Writes5m == 0 || hour.Writes1h == 0 {
+		t.Errorf("the arms did not write at their own tiers (5m=%d, 1h=%d)",
+			five.Writes5m, hour.Writes1h)
+	}
+}

--- a/kvcache/registry_test.go
+++ b/kvcache/registry_test.go
@@ -98,7 +98,7 @@ func TestOptimalIsALowerBoundOnEveryOtherArm(t *testing.T) {
 		t.Error("no arm was dearer than the optimum, so this dataset cannot tell a real bound " +
 			"from a coincidence")
 	}
-	// A random plan must not beat it either — the DP is over the same five actions, so a
+	// A random plan must not beat it either — the DP is over the same actions, so a
 	// hand-picked sequence is a direct challenge to its optimality.
 	plans := map[int64]Action{}
 	for i, r := range reqs {

--- a/kvcache/registry_test.go
+++ b/kvcache/registry_test.go
@@ -239,3 +239,71 @@ func TestKeepAliveArmsPingAndTheHourlyOnePingsLess(t *testing.T) {
 			five.Writes5m, hour.Writes1h)
 	}
 }
+
+// An UNPRICED window must not be able to pass as a measurement, and least of all as a ceiling.
+//
+// The hazard is real and was hit in the browser rather than in a test: the price map is fetched
+// in the background, so the first load after a restart has no rates for a few seconds. In that
+// window every arm sums to $0.00, and the exact optimum — whose dynamic program is comparing
+// zeroes — settles on the first action in the table and reports "never cache anything, 0% hit
+// rate" in the style reserved for the cheapest plan that exists. $0.00 is indistinguishable
+// from free, and a ceiling of "cache nothing" is a fabricated recommendation.
+//
+// This does not assert that anything REFUSES. Refusing would trade a misleading answer for a
+// missing panel, and the caller is better placed to choose. It asserts that the condition is
+// impossible to MISS: Result.Valued is false on every arm, so anything rendering a cost, a
+// saving or a ceiling has one field to check.
+func TestAnUnpricedWindowIsNotValuedAndCannotPassAsACeiling(t *testing.T) {
+	reqs, cfg := dataset(t)
+	// The same trajectories against a price list that knows nothing — a cold start, exactly.
+	cfg.Prices = NewPriceList(context.Background(), []string{"m"}, nil, Multipliers{}, nil)
+	if cfg.Prices.For("m").Known {
+		t.Fatal("the fixture priced a model it was given no rates for")
+	}
+
+	best := Simulate(reqs, NewOptimal(reqs, cfg), cfg)
+	if best.Valued {
+		t.Error("an all-unpriced replay reports Valued=true; every dollar on it is zero for " +
+			"want of rates, and a caller that trusts it will render $0.00 as free")
+	}
+	if best.Unpriced != best.Requests {
+		t.Errorf("Unpriced %d of %d requests; the fixture is partly priced and is not testing "+
+			"the cold-start window", best.Unpriced, best.Requests)
+	}
+	if best.TotalUSD != 0 {
+		t.Errorf("an unpriced replay totalled $%.6f; it must contribute nothing rather than "+
+			"guess", best.TotalUSD)
+	}
+
+	// Every arm, and the point is that they are INDISTINGUISHABLE. The ceiling has no claim to
+	// being cheapest here, so nothing may be concluded from the ordering — which is precisely
+	// why Valued has to gate the display rather than the comparison being trusted.
+	for _, spec := range Registry() {
+		if spec.Name == StrategyReplay {
+			continue
+		}
+		s, err := NewStrategy(spec.Name, reqs, cfg)
+		if err != nil {
+			t.Fatalf("%s: %v", spec.Name, err)
+		}
+		got := Simulate(reqs, s, cfg)
+		if got.Valued {
+			t.Errorf("%s reports Valued=true on an unpriced window", spec.Name)
+		}
+		if got.TotalUSD != 0 {
+			t.Errorf("%s totalled $%.6f with no rates", spec.Name, got.TotalUSD)
+		}
+		// And a saving computed from two unpriced arms is undefined, not 0%.
+		if sv := Compare(best, got); sv.Known {
+			t.Errorf("%s: a percentage saving was reported against a zero baseline", spec.Name)
+		}
+	}
+
+	// The same dataset WITH rates is valued, so this test cannot pass by the fixture being
+	// empty — the failure mode that makes a negative assertion worthless.
+	_, priced := dataset(t)
+	if v := Simulate(reqs, Fixed5m(), priced); !v.Valued || v.TotalUSD <= 0 {
+		t.Errorf("the priced control is not valued (Valued=%v, total=%.6f); this test proves "+
+			"nothing", v.Valued, v.TotalUSD)
+	}
+}

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -43,9 +43,20 @@ import (
 // last, and `max` caps the count. A span no longer than `idle` attracts none.
 //
 // This is the same arithmetic as dash.PingsPerSpan, which serves the keep-alive tab's own
-// calculator. It is restated here because the dependency runs the other way — dash imports
-// this package — and TestPingScheduleMatchesTheKeepAliveTab in package dash asserts the two
-// agree over a table of inputs, so they cannot drift.
+// calculator. It is restated here because the dependency runs the other way: dash imports this
+// package, so this one cannot import dash to reuse it.
+//
+// THE TWO ARE NOT PINNED AGAINST EACH OTHER, and that is a gap rather than a decision. An
+// earlier version of this comment claimed a test in package dash asserted they agree. No such
+// test exists, and a comment that promises a guard is worse than no comment at all, because it
+// tells the next reader to stop worrying. The Python port IS pinned, by four guards in
+// deploy/harbor/kv_ttl_cost_drift_test.go — so the one duplication left unguarded is the Go/Go
+// pair, which would be the easiest of the three to guard.
+//
+// The formulas agree today. They are not the same function at the boundaries: dash's takes
+// float64 SECONDS and floor-divides those, this takes a time.Duration and floor-divides integer
+// nanoseconds. The test belongs in package dash — only it can import both — and is about twenty
+// lines mirroring TestPingScheduleMatchesThePort.
 func PingsPerSpan(gap, idle time.Duration, max int) int {
 	if idle <= 0 || max <= 0 || gap <= idle {
 		return 0

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -432,7 +432,22 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 				gap = 0
 			}
 			hist.Observe(r.User, r.Model, BucketAt(st.lastTS), gap)
-			simulatePings(out, ug, mg, st, price, sem, cfg, r.TS, false)
+			// Priced and attributed at the PREVIOUS request's model, not this one's. The entry
+			// these keep-alives refresh was created by that request, so its rates are the ones
+			// the provider would bill and its group is the one the spend belongs to — which is
+			// exactly what convState.model is carried for, and what the open-span pass below
+			// already does.
+			//
+			// This used to pass the CURRENT request's price and groups, which is invisible on
+			// single-model traffic and wrong the moment a conversation switches: 101 of this
+			// deployment's 1,772 trajectories use more than one model. It was not only a
+			// misattribution. stepCost prices the same span at the previous model
+			// (registry.go), so the exact optimum was minimising a different objective than
+			// Simulate was billing, and NewOptimal stopped being a bound at all — measured at
+			// 65% above a plan the same simulator prices lower.
+			prevPrice := cfg.Prices.For(st.model)
+			simulatePings(out, acc(byUser, st.user), acc(byModel, st.model), st, prevPrice,
+				sem, cfg, r.TS, false)
 		}
 
 		// ── 2. hit or miss, under THIS strategy's own history ───────────────
@@ -440,14 +455,6 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		forced := r.MissReason == "prefix_change" || r.MissReason == "cold_start"
 		if forced {
 			out.ForcedMisses++
-		}
-		hit := alive && !forced
-		reusable := int64(0)
-		if hit {
-			reusable = st.tokens
-			if reusable > r.CachedContext {
-				reusable = r.CachedContext
-			}
 		}
 
 		// ── 3. decide, with nothing but the past ────────────────────────────
@@ -467,6 +474,28 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		out.StatsLevels[level]++
 		action := s.Decide(o)
 		out.Decisions[action]++
+		// HIT IS DECIDED HERE, after the action, and it needs the action to be decided at all.
+		//
+		// A request whose action is ActionExpire writes no cache_control, so the provider reads
+		// nothing from cache and bills the whole prefix as fresh input — however warm the entry
+		// was a microsecond earlier. Computing `hit` from aliveness alone, before the action was
+		// known, therefore counted such a turn as a hit: it landed in Hits, in HitRate and in
+		// AvoidedRecomputations while paying for a fully uncached prompt. The tell was in the same
+		// Result: AvoidedRecomputations of 1 beside AvoidedTokens of 0, two fields contradicting
+		// each other. It also fed Compare.HitDelta and so credited an avoided DELAY to a request
+		// that took the miss latency.
+		//
+		// Nothing above depends on the order: the Observation carries no hit flag, deliberately,
+		// so a strategy cannot see this and the decision cannot be circular.
+		tier := action.Tier()
+		hit := alive && !forced && tier != TTLNone
+		reusable := int64(0)
+		if hit {
+			reusable = st.tokens
+			if reusable > r.CachedContext {
+				reusable = r.CachedContext
+			}
+		}
 		if isObserved {
 			if obs.Covered(r.ID) {
 				out.ObservedCoverage.Recorded++
@@ -476,7 +505,6 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		}
 
 		// ── 4. bill this request under the chosen tier ──────────────────────
-		tier := action.Tier()
 		fresh, read, write := r.InputTokens, reusable, int64(0)
 		switch {
 		case tier == TTLNone:
@@ -730,7 +758,10 @@ func statesInOrder(m map[Conversation]*convState) []*convState {
 		if keys[i].User != keys[j].User {
 			return keys[i].User < keys[j].User
 		}
-		return keys[i].Conversation < keys[j].Conversation
+		if keys[i].Conversation != keys[j].Conversation {
+			return keys[i].Conversation < keys[j].Conversation
+		}
+		return keys[i].Model < keys[j].Model
 	})
 	out := make([]*convState, 0, len(keys))
 	for _, k := range keys {

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -134,6 +134,12 @@ type Group struct {
 	Writes5m int64   `json:"writes_5m"`
 	Writes1h int64   `json:"writes_1h"`
 	Unpriced int64   `json:"unpriced"`
+	// Valued is whether ANY request in this group could be priced, exactly as Result.Valued is
+	// for the whole replay — and it is here because omitting it forced the consumer to spell the
+	// predicate a second time as `unpriced < requests` on every per-user and per-model row. Two
+	// spellings of one predicate is how they come to disagree the day one of them gains a caveat,
+	// which is the argument for Result.Valued and applies unchanged one level down.
+	Valued bool `json:"valued"`
 }
 
 // Latency is the window's own measured cost of a cache miss, in milliseconds, and the two
@@ -730,6 +736,7 @@ func finishGroups(m map[string]*groupAcc) []Group {
 		if d := g.Hits + g.Misses; d > 0 {
 			g.HitRate = 100 * float64(g.Hits) / float64(d)
 		}
+		g.Valued = g.Requests > 0 && g.Unpriced < g.Requests
 		out = append(out, g)
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -247,6 +247,22 @@ type Result struct {
 	// not a free one.
 	Unpriced int64 `json:"unpriced"`
 
+	// Valued is whether ANY of these requests could be priced at all.
+	//
+	// False means every dollar figure on this Result is zero because nothing had RATES — not
+	// because nothing was spent. Derivable from Unpriced == Requests, and stated anyway,
+	// because a consumer that has to derive it is a consumer that will forget to: the price
+	// map is fetched in the background, so the first load after a restart genuinely has no
+	// rates for a few seconds, and in that window every arm costs 0.00 and the exact ceiling
+	// degenerates to "never cache anything, 0%% hit rate" — a fabricated recommendation
+	// rendered in the style reserved for the cheapest plan that exists.
+	//
+	// Nothing here refuses to produce a plan when it cannot price one; refusing would trade a
+	// misleading answer for a missing panel, and the caller is better placed to choose. What
+	// this guarantees is that the caller cannot MISS the condition. Anything that renders a
+	// cost, a saving or a ceiling must check it first.
+	Valued bool `json:"valued"`
+
 	// Decisions counts each action the strategy chose.
 	Decisions map[Action]int64 `json:"decisions"`
 	// StatsLevels counts which fallback level the account's own statistics could answer at,
@@ -539,6 +555,9 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		out.HitRate = 100 * float64(out.Hits) / float64(d)
 		out.MissRate = 100 * float64(out.Misses) / float64(d)
 	}
+	// Set BEFORE the totals are read by anything: an all-unpriced replay sums to 0.00, which
+	// is indistinguishable from free.
+	out.Valued = out.Requests > 0 && out.Unpriced < out.Requests
 	out.TotalUSD = out.FreshInputUSD + out.CacheReadUSD + out.CacheWriteUSD + out.OutputUSD +
 		out.PingUSD
 	out.CachePremium = out.TotalUSD - out.UncachedUSD

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -1,0 +1,723 @@
+package kvcache
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// The historical replay simulator: walk the selected trajectories in wall-clock order,
+// ask the strategy what to do using only what was knowable at each instant, then use the
+// real next-request time ONLY to score the decision.
+//
+// # What a strategy can and cannot change
+//
+// A TTL policy can convert a `ttl_expiry` miss into a hit, and it can turn a hit into a
+// miss by letting an entry lapse. It CANNOT fix a `prefix_change` — the content moved, so
+// there was nothing to match at any lifetime — and it cannot fix a `cold_start`, which is
+// the absence of an entry rather than the expiry of one. Those two reasons therefore force
+// a miss whatever the strategy chose, and the count is reported as ForcedMisses so the
+// ceiling on any arm is visible rather than implied. A simulator that let a 1-hour TTL
+// "rescue" a prefix change would report savings that no configuration can reach.
+//
+// # What a ping actually does
+//
+// A keep-alive fires one INTERVAL after the last activity and every interval after that, up
+// to MaxPings, and only while the idle span is still open. At the instant it fires:
+//
+//   - the entry is still alive: the ping is a cache READ, priced at the read rate, and it
+//     refreshes the entry for its own tier's lifetime (Semantics.PingRefreshesTTL).
+//   - the entry has already lapsed: the ping is a cache WRITE. It re-creates the prefix at
+//     the creation rate — 12.5x what a refresh costs at the 5-minute tier, 20x at the
+//     one-hour tier — which is the pathology of a schedule whose interval exceeds the
+//     lifetime it is protecting. Counted as PingsThatRewrote, and never priced as a read.
+//
+// The INTERVAL depends on the tier, and that is the whole cost difference between a
+// five-minute and a one-hour keep-alive: one ping costs the same either way (a read), but a
+// five-minute entry must be touched roughly twelve times as often to be held for the same
+// span. Config.PingIdle is the 5-minute interval and Config.PingIdle1h the one-hour one.
+
+// PingsPerSpan is how many keep-alives one idle span of `gap` attracts under (idle, max).
+//
+// The first fires at `idle` after the last activity, each subsequent one `idle` after the
+// last, and `max` caps the count. A span no longer than `idle` attracts none.
+//
+// This is the same arithmetic as dash.PingsPerSpan, which serves the keep-alive tab's own
+// calculator. It is restated here because the dependency runs the other way — dash imports
+// this package — and TestPingScheduleMatchesTheKeepAliveTab in package dash asserts the two
+// agree over a table of inputs, so they cannot drift.
+func PingsPerSpan(gap, idle time.Duration, max int) int {
+	if idle <= 0 || max <= 0 || gap <= idle {
+		return 0
+	}
+	n := int(math.Floor(float64(gap-idle)/float64(idle))) + 1
+	if n > max {
+		n = max
+	}
+	return n
+}
+
+// Config is everything the replay needs beyond the strategy itself.
+type Config struct {
+	// Prices is the rate table. A model with no rates leaves its requests UNPRICED — counted,
+	// never valued.
+	Prices *PriceList
+	// Semantics is the provider's cache behaviour. Zero value means DefaultSemantics().
+	Semantics Semantics
+	// PingIdle is the keep-alive interval for a FIVE-MINUTE entry and PingIdle1h the interval
+	// for a ONE-HOUR one; MaxPings caps either. Both default a little inside the lifetime they
+	// protect, so a refresh lands before the deadline rather than on it. Zero values mean the
+	// shipped defaults.
+	PingIdle   time.Duration
+	PingIdle1h time.Duration
+	MaxPings   int
+	// WindowEnd bounds the OPEN idle span at the end of a conversation, in epoch ms.
+	//
+	// A conversation whose last request is inside the window has an idle span whose length
+	// nobody knows — its successor may be outside the window, or may never come. Its pings and
+	// its retention are therefore billed only up to here, and that is not a rounding-down: a
+	// keep-alive policy cannot know a conversation is over either, so it really does spend up
+	// to MaxPings on the last request of every dead session, and charging that is what stops
+	// the ping arms looking cheaper than they are. What the bound does is stop the charge
+	// running past the data.
+	//
+	// The pings it produces are counted apart (Result.PingsOnOpenSpans) because their NUMBER
+	// depends on where the window happens to end whenever the remaining span is shorter than
+	// MaxPings intervals, which is an assumption the closed spans do not need.
+	//
+	// 0 means the last timestamp in the dataset. Never time.Now(): the same historical window
+	// has to replay to the same answer twice.
+	WindowEnd int64
+}
+
+func (c Config) withDefaults(reqs []*Request) Config {
+	if c.Semantics == (Semantics{}) {
+		c.Semantics = DefaultSemantics()
+	}
+	if c.PingIdle <= 0 {
+		c.PingIdle = DefaultPingIdle
+	}
+	if c.PingIdle1h <= 0 {
+		c.PingIdle1h = DefaultPingIdle1h
+	}
+	if c.MaxPings <= 0 {
+		c.MaxPings = DefaultMaxPings
+	}
+	if c.WindowEnd <= 0 {
+		for _, r := range reqs {
+			if r.TS > c.WindowEnd {
+				c.WindowEnd = r.TS
+			}
+		}
+	}
+	return c
+}
+
+// pingInterval is the keep-alive interval for one tier.
+func (c Config) pingInterval(tier TTL) time.Duration {
+	if tier == TTL1h {
+		return c.PingIdle1h
+	}
+	return c.PingIdle
+}
+
+// Group is one strategy's result restricted to one user or one model.
+type Group struct {
+	Key      string  `json:"key"`
+	Requests int64   `json:"requests"`
+	TotalUSD float64 `json:"total_usd"`
+	Hits     int64   `json:"hits"`
+	Misses   int64   `json:"misses"`
+	HitRate  float64 `json:"hit_rate_pct"`
+	Pings    int64   `json:"pings"`
+	PingUSD  float64 `json:"ping_usd"`
+	Writes5m int64   `json:"writes_5m"`
+	Writes1h int64   `json:"writes_1h"`
+	Unpriced int64   `json:"unpriced"`
+}
+
+// Latency is the window's own measured cost of a cache miss, in milliseconds, and the two
+// populations it was measured over.
+//
+// Derived from the selected rows and nothing else: the mean upstream time of the requests
+// that really hit, against the mean of the ones that really missed. Known=false where either
+// population is too small to mean anything, and then no latency figure is reported at all
+// rather than a difference of two noisy means.
+type Latency struct {
+	PerMissMs float64 `json:"per_miss_ms"`
+	HitN      int64   `json:"hit_n"`
+	MissN     int64   `json:"miss_n"`
+	HitMeanMs float64 `json:"hit_mean_ms"`
+	MissMean  float64 `json:"miss_mean_ms"`
+	Known     bool    `json:"known"`
+}
+
+// latencyMinN is how many of each population the differential needs. 20 is small, and it is
+// stated rather than assumed: below it the difference of two means is not a measurement.
+const latencyMinN = 20
+
+// MeasureLatency computes the window's own hit/miss latency differential from the rows.
+func MeasureLatency(reqs []*Request) Latency {
+	var l Latency
+	var hitSum, missSum float64
+	for _, r := range reqs {
+		if r.UpstreamMs <= 0 {
+			continue // not recorded: absent, not zero
+		}
+		if r.Hit {
+			l.HitN++
+			hitSum += r.UpstreamMs
+			continue
+		}
+		l.MissN++
+		missSum += r.UpstreamMs
+	}
+	if l.HitN < latencyMinN || l.MissN < latencyMinN {
+		return l
+	}
+	l.HitMeanMs = hitSum / float64(l.HitN)
+	l.MissMean = missSum / float64(l.MissN)
+	l.PerMissMs = l.MissMean - l.HitMeanMs
+	l.Known = true
+	return l
+}
+
+// Result is one strategy's whole replay.
+type Result struct {
+	Strategy    string `json:"strategy"`
+	Description string `json:"description,omitempty"`
+
+	Requests      int64 `json:"requests"`
+	Conversations int64 `json:"conversations"`
+
+	// The cost decomposition. TotalUSD is their sum and is the figure a comparison uses.
+	TotalUSD      float64 `json:"total_usd"`
+	FreshInputUSD float64 `json:"fresh_input_usd"`
+	CacheReadUSD  float64 `json:"cache_read_usd"`
+	CacheWriteUSD float64 `json:"cache_write_usd"`
+	OutputUSD     float64 `json:"output_usd"`
+	PingUSD       float64 `json:"ping_usd"`
+
+	// UncachedUSD is the same traffic with no prompt cache at all. TotalUSD − UncachedUSD is
+	// the INCREMENTAL CACHE PREMIUM: what the caching machinery itself cost or earned,
+	// separate from the bill it sits inside. Negative means the cache paid for itself.
+	UncachedUSD  float64 `json:"uncached_usd"`
+	CachePremium float64 `json:"cache_premium_usd"`
+
+	Hits    int64   `json:"hits"`
+	Misses  int64   `json:"misses"`
+	HitRate float64 `json:"hit_rate_pct"`
+	// MissRate is reported as well as HitRate rather than left to the reader's subtraction,
+	// because Unpriced rows are in neither and the two would not sum to 100 for a reader who
+	// assumed they did.
+	MissRate float64 `json:"miss_rate_pct"`
+	// ForcedMisses are the rows whose own recorded reason (prefix_change, cold_start) no TTL
+	// policy could have rescued. The ceiling on every arm, reported so it is not implied.
+	ForcedMisses int64 `json:"forced_misses"`
+
+	Pings            int64 `json:"pings"`
+	PingsThatRewrote int64 `json:"pings_that_rewrote"`
+	// PingsThatUpgraded are keep-alives that DELIBERATELY paid a longer tier's creation
+	// rate to extend a LIVE entry — ActionWrite5mPing1h's whole mechanism. Counted apart from
+	// PingsThatRewrote because the two mean opposite things: one is a policy buying a hold it
+	// chose, the other is a schedule repairing damage it caused. One counter for both would
+	// make a working arm and a broken one look identical.
+	PingsThatUpgraded int64 `json:"pings_that_upgraded"`
+	// PingsOnOpenSpans are pings billed into an idle span whose end is unknown, bounded by
+	// Config.WindowEnd. Counted apart because they rest on an assumption the closed spans
+	// do not need.
+	PingsOnOpenSpans int64 `json:"pings_on_open_spans"`
+
+	Writes5m int64 `json:"writes_5m"`
+	Writes1h int64 `json:"writes_1h"`
+	Expires  int64 `json:"expires"`
+
+	// AvoidedRecomputations is the simulated hits, and AvoidedTokens the prefix tokens they
+	// served from cache instead of re-creating.
+	AvoidedRecomputations int64 `json:"avoided_recomputations"`
+	AvoidedTokens         int64 `json:"avoided_tokens"`
+
+	// RetainedMs is the UNION of the intervals during which this strategy held a live cache
+	// entry, summed over conversations and clipped to the window. A union rather than a sum
+	// of lifetimes: overlapping refreshes would otherwise count the same second twice.
+	RetainedMs int64 `json:"retained_ms"`
+
+	// Unpriced is requests whose model has no rates. They are counted in Requests and in the
+	// hit/miss split, and contribute NOTHING to any dollar figure — an unpriced request is
+	// not a free one.
+	Unpriced int64 `json:"unpriced"`
+
+	// Decisions counts each action the strategy chose.
+	Decisions map[Action]int64 `json:"decisions"`
+	// StatsLevels counts which fallback level the account's own statistics could answer at,
+	// at each decision instant. How much of an arm was actually personalised, rather than
+	// decided on the service-wide average.
+	StatsLevels map[string]int64 `json:"stats_levels"`
+	// ObservedCoverage is how many decisions the observed-policy arm could base on a
+	// RECORDED tier. Absent (nil) for every other arm.
+	ObservedCoverage *Coverage `json:"observed_coverage,omitempty"`
+
+	ByUser  []Group `json:"by_user"`
+	ByModel []Group `json:"by_model"`
+
+	Latency Latency `json:"latency"`
+}
+
+// Coverage is "how much of this arm is a measurement": decisions that rested on a recorded
+// fact against decisions that rested on an assumed default.
+type Coverage struct {
+	Recorded int64 `json:"recorded"`
+	Assumed  int64 `json:"assumed"`
+}
+
+// Savings is one strategy against one baseline. Nothing here is clamped.
+type Savings struct {
+	Strategy string `json:"strategy"`
+	Baseline string `json:"baseline"`
+	// BaselineUSD and StrategyUSD are the two totals.
+	BaselineUSD float64 `json:"baseline_usd"`
+	StrategyUSD float64 `json:"strategy_usd"`
+	// AbsoluteUSD = baseline − strategy. NEGATIVE where the strategy costs more, and it is
+	// reported that way: clamping it to zero is how a comparison stops being one.
+	AbsoluteUSD float64 `json:"absolute_usd"`
+	// PercentUSD = absolute / baseline × 100, and Known is false when the baseline is zero —
+	// a percentage of nothing is not 0%, it is undefined.
+	PercentUSD float64 `json:"percent_usd"`
+	Known      bool    `json:"percent_known"`
+	// HitDelta is simulated hits gained (or lost) against the baseline.
+	HitDelta int64 `json:"hit_delta"`
+	// LatencyAvoidedMs is HitDelta × the window's own measured per-miss latency cost. Absent
+	// where that differential could not be measured.
+	LatencyAvoidedMs float64 `json:"latency_avoided_ms"`
+	LatencyKnown     bool    `json:"latency_known"`
+}
+
+// Compare scores a strategy against a baseline.
+//
+//	absolute_savings   = baseline_cost − strategy_cost
+//	percentage_savings = absolute_savings / baseline_cost × 100
+func Compare(baseline, s *Result) Savings {
+	out := Savings{Strategy: s.Strategy, Baseline: baseline.Strategy,
+		BaselineUSD: baseline.TotalUSD, StrategyUSD: s.TotalUSD,
+		AbsoluteUSD: baseline.TotalUSD - s.TotalUSD,
+		HitDelta:    s.Hits - baseline.Hits}
+	if baseline.TotalUSD != 0 {
+		out.PercentUSD = out.AbsoluteUSD / baseline.TotalUSD * 100
+		out.Known = true
+	}
+	if s.Latency.Known {
+		out.LatencyAvoidedMs = float64(out.HitDelta) * s.Latency.PerMissMs
+		out.LatencyKnown = true
+	}
+	return out
+}
+
+// convState is one conversation's simulated cache entry plus the decision governing its
+// currently-open idle span.
+type convState struct {
+	tokens  int64
+	tier    TTL
+	expires int64
+	lastTS  int64
+	turn    int
+	// pending is the action chosen at lastTS. It governs the span from lastTS to whatever
+	// closes it, which is why it is held rather than applied immediately: a ping's cost
+	// depends on how long the span turned out to be, and that is scoring, not deciding.
+	pending Action
+	// coveredUntil is the far end of the union of alive intervals so far, for RetainedMs.
+	coveredUntil int64
+	// user and model are the last request's, so the OPEN-span pass can price its pings at the
+	// same rates and attribute them to the same groups the closed spans used.
+	user  string
+	model string
+}
+
+// group accumulates one Group.
+type groupAcc struct{ g Group }
+
+// Simulate replays the dataset under one strategy.
+//
+// reqs must be the DERIVED dataset (see Derive): sorted chronologically and carrying each
+// request's own successor. It is not mutated.
+func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
+	cfg = cfg.withDefaults(reqs)
+	sem := cfg.Semantics
+	out := &Result{Strategy: s.Name(), Decisions: map[Action]int64{},
+		StatsLevels: map[string]int64{}, ByUser: []Group{}, ByModel: []Group{},
+		Latency: MeasureLatency(reqs)}
+	if d, ok := s.(Describer); ok {
+		out.Description = d.Describe()
+	}
+	obs, isObserved := s.(*Observed)
+	if isObserved {
+		out.ObservedCoverage = &Coverage{}
+	}
+
+	hist := NewHistory()
+	states := map[Conversation]*convState{}
+	byUser := map[string]*groupAcc{}
+	byModel := map[string]*groupAcc{}
+	acc := func(m map[string]*groupAcc, k string) *groupAcc {
+		if g := m[k]; g != nil {
+			return g
+		}
+		g := &groupAcc{g: Group{Key: k}}
+		m[k] = g
+		return g
+	}
+
+	// order is the chronological walk. Sorted here rather than trusted: Simulate is exported
+	// and a caller that filtered the dataset after Derive would otherwise replay out of order,
+	// which is a silent correctness failure rather than a loud one.
+	order := make([]*Request, len(reqs))
+	copy(order, reqs)
+	sort.SliceStable(order, func(i, j int) bool {
+		if order[i].TS != order[j].TS {
+			return order[i].TS < order[j].TS
+		}
+		return order[i].ID < order[j].ID
+	})
+
+	for _, r := range order {
+		key := r.Key()
+		st := states[key]
+		if st == nil {
+			st = &convState{}
+			states[key] = st
+			out.Conversations++
+		}
+		price := cfg.Prices.For(r.Model)
+		ug, mg := acc(byUser, r.User), acc(byModel, r.Model)
+
+		// ── 1. close the previous span ──────────────────────────────────────
+		// The gap that has just ended becomes HISTORY here, and only here. Every decision
+		// below therefore sees gaps that closed at or before this instant, which is the
+		// no-leakage invariant in one line.
+		if st.turn > 0 {
+			gap := time.Duration(r.TS-st.lastTS) * time.Millisecond
+			if gap < 0 {
+				gap = 0
+			}
+			hist.Observe(r.User, r.Model, BucketAt(st.lastTS), gap)
+			simulatePings(out, ug, mg, st, price, sem, cfg, r.TS, false)
+		}
+
+		// ── 2. hit or miss, under THIS strategy's own history ───────────────
+		alive := st.tokens > 0 && r.TS < st.expires
+		forced := r.MissReason == "prefix_change" || r.MissReason == "cold_start"
+		if forced {
+			out.ForcedMisses++
+		}
+		hit := alive && !forced
+		reusable := int64(0)
+		if hit {
+			reusable = st.tokens
+			if reusable > r.CachedContext {
+				reusable = r.CachedContext
+			}
+		}
+
+		// ── 3. decide, with nothing but the past ────────────────────────────
+		o := Observation{
+			User: r.User, Conversation: r.ConversationID, Model: r.Model, RequestID: r.ID,
+			Now: r.TS, HourUTC: r.HourUTC, Bucket: r.Bucket,
+			CachedTokens: r.CachedContext, TTL: st.tier, ExpiresAt: st.expires,
+			Turn: st.turn + 1, Stats: hist, Pricing: price,
+		}
+		if st.turn > 0 {
+			o.SinceLastMs = r.TS - st.lastTS
+		}
+		_, n, level := hist.ReuseWithin(r.User, r.Model, r.Bucket, Horizon5m)
+		if n == 0 {
+			level = LevelNone
+		}
+		out.StatsLevels[level]++
+		action := s.Decide(o)
+		out.Decisions[action]++
+		if isObserved {
+			if obs.Covered(r.ID) {
+				out.ObservedCoverage.Recorded++
+			} else {
+				out.ObservedCoverage.Assumed++
+			}
+		}
+
+		// ── 4. bill this request under the chosen tier ──────────────────────
+		tier := action.Tier()
+		fresh, read, write := r.InputTokens, reusable, int64(0)
+		switch {
+		case tier == TTLNone:
+			// No cache_control at all: the whole prompt is fresh input, and anything the
+			// entry might have held is irrelevant because nothing was marked cacheable.
+			fresh += r.CachedContext
+			read = 0
+		default:
+			write = r.CachedContext - reusable
+			if write < 0 {
+				write = 0
+			}
+		}
+		out.Requests++
+		ug.g.Requests++
+		mg.g.Requests++
+		if !price.Known {
+			out.Unpriced++
+			ug.g.Unpriced++
+			mg.g.Unpriced++
+		} else {
+			out.FreshInputUSD += float64(fresh) * price.Input
+			out.CacheReadUSD += float64(read) * price.CacheRead
+			out.CacheWriteUSD += float64(write) * price.writeRate(tier)
+			out.OutputUSD += float64(r.OutputTokens) * price.Output
+			out.UncachedUSD += price.UncachedCost(r.InputTokens, r.CachedContext, r.OutputTokens)
+			cost := price.RequestCost(fresh, read, write, r.OutputTokens, tier)
+			ug.g.TotalUSD += cost
+			mg.g.TotalUSD += cost
+		}
+		if hit {
+			out.Hits++
+			ug.g.Hits++
+			mg.g.Hits++
+			out.AvoidedRecomputations++
+			out.AvoidedTokens += read
+		} else {
+			out.Misses++
+			ug.g.Misses++
+			mg.g.Misses++
+		}
+		// A WRITE is a cache-creation event, not a decision: a request that hit and re-marked
+		// the same prefix wrote nothing and is not a write. The decision counts live in
+		// Result.Decisions, which is where "how often did the arm choose 1h" is answered.
+		switch {
+		case tier == TTLNone:
+			out.Expires++
+		case write > 0 && tier == TTL5m:
+			out.Writes5m++
+			ug.g.Writes5m++
+			mg.g.Writes5m++
+		case write > 0 && tier == TTL1h:
+			out.Writes1h++
+			ug.g.Writes1h++
+			mg.g.Writes1h++
+		}
+
+		// ── 5. the entry this request leaves behind ─────────────────────────
+		if tier == TTLNone {
+			st.tokens, st.tier, st.expires = 0, TTLNone, 0
+		} else {
+			st.tokens, st.tier = r.CachedContext, tier
+			// A hit refreshes the lifetime; a write starts it. Both land on the same
+			// expression here, and Semantics.HitRefreshesTTL is what makes the difference
+			// visible for a provider where it is not true: there, a hit keeps the entry's
+			// ORIGINAL deadline.
+			if hit && !sem.HitRefreshesTTL {
+				if st.expires < r.TS {
+					st.expires = r.TS + int64(tier.Lifetime()/time.Millisecond)
+				}
+			} else {
+				st.expires = r.TS + int64(tier.Lifetime()/time.Millisecond)
+			}
+			retain(out, st, r.TS, st.expires, cfg.WindowEnd)
+		}
+		st.lastTS, st.pending, st.turn = r.TS, action, st.turn+1
+		st.user, st.model = r.User, r.Model
+	}
+
+	// The OPEN spans: a conversation whose last request is inside the window has an idle span
+	// nobody knows the length of. Its pings are billed only to WindowEnd, priced at the last
+	// request's own model, and counted apart in PingsOnOpenSpans — because their number rests
+	// on where the window happens to end rather than on an observed next request.
+	for _, st := range statesInOrder(states) {
+		if st.turn == 0 || !st.pending.Pings() {
+			continue
+		}
+		simulatePings(out, acc(byUser, st.user), acc(byModel, st.model),
+			st, cfg.Prices.For(st.model), sem, cfg, cfg.WindowEnd, true)
+	}
+
+	if d := out.Hits + out.Misses; d > 0 {
+		out.HitRate = 100 * float64(out.Hits) / float64(d)
+		out.MissRate = 100 * float64(out.Misses) / float64(d)
+	}
+	out.TotalUSD = out.FreshInputUSD + out.CacheReadUSD + out.CacheWriteUSD + out.OutputUSD +
+		out.PingUSD
+	out.CachePremium = out.TotalUSD - out.UncachedUSD
+	out.ByUser = finishGroups(byUser)
+	out.ByModel = finishGroups(byModel)
+	return out
+}
+
+// retain adds one alive interval to the UNION already recorded, clipped to the window.
+func retain(out *Result, st *convState, from, until, windowEnd int64) {
+	if windowEnd > 0 && until > windowEnd {
+		until = windowEnd
+	}
+	if st.coveredUntil > from {
+		from = st.coveredUntil
+	}
+	if until > from {
+		out.RetainedMs += until - from
+	}
+	if until > st.coveredUntil {
+		st.coveredUntil = until
+	}
+}
+
+// pingOutcome is what one idle span's keep-alives cost and the entry they leave behind.
+//
+// Pure: pingSpan mutates nothing. Both the accounting path (simulatePings) and the exact
+// ceiling's dynamic program (NewOptimal) read this ONE implementation, so a second copy of
+// the ping arithmetic cannot drift away from the first — the same reason the Python port in
+// deploy/harbor/kv_ttl_cost_model.py has exactly this shape.
+type pingOutcome struct {
+	cost     float64
+	fired    int64
+	rewrote  int64
+	upgraded int64
+	tier     TTL
+	expires  int64
+	// refreshes is (firedAt, newExpires) per ping, for the retention union.
+	refreshes [][2]int64
+}
+
+// pingSpan is the keep-alives that fire in (lastTS, spanEnd) under `pending`.
+//
+// The interval follows the entry's CURRENT tier, recomputed each time round, rather than the
+// action's target tier fixed once. That matters only for ActionWrite5mPing1h, whose entry
+// starts at five minutes and becomes hourly partway through — so its first keep-alive has to
+// land inside five minutes and the rest need only land inside an hour. For every other action
+// the tier never moves and this is the same fixed cadence as before, which is what the ping
+// schedule table in deploy/harbor/kv_ttl_cost_drift_test.go pins.
+func pingSpan(tokens int64, tier TTL, expires, lastTS int64, pending Action, spanEnd int64,
+	price Pricing, sem Semantics, cfg Config) pingOutcome {
+	out := pingOutcome{tier: tier, expires: expires}
+	if !pending.Pings() || spanEnd <= lastTS || tokens <= 0 {
+		return out
+	}
+	want := pending.PingTier()
+	at := lastTS
+	for i := 0; i < cfg.MaxPings; i++ {
+		step := int64(cfg.pingInterval(out.tier) / time.Millisecond)
+		if step <= 0 {
+			break
+		}
+		at += step
+		if at >= spanEnd {
+			break
+		}
+		alive := at < out.expires
+		var cost float64
+		switch {
+		case !alive:
+			// The entry lapsed before this ping fired, so the "refresh" re-creates it at the
+			// tier the action was aiming for. Priced as a write, and counted, because a
+			// schedule that does this is paying 12.5x to fix a problem it caused.
+			out.tier = want
+			cost = price.RecreateCost(tokens, out.tier, sem)
+			out.rewrote++
+		case want == TTL1h && out.tier != TTL1h:
+			// A deliberate UPGRADE of a live entry: pay the 1-hour creation rate now to hold it
+			// for an hour instead of five minutes. This is ActionWrite5mPing1h's mechanism, and
+			// it is the one case where a keep-alive is a write on purpose rather than by
+			// accident.
+			out.tier = TTL1h
+			cost = price.RecreateCost(tokens, TTL1h, sem)
+			out.upgraded++
+		default:
+			cost = price.KeepAliveCost(tokens, sem)
+		}
+		out.fired++
+		if price.Known {
+			out.cost += cost
+		}
+		if sem.PingRefreshesTTL || !alive {
+			if life := int64(out.tier.Lifetime() / time.Millisecond); life > 0 {
+				out.expires = at + life
+				out.refreshes = append(out.refreshes, [2]int64{at, out.expires})
+			}
+		}
+	}
+	return out
+}
+
+// simulatePings bills the keep-alives that fire between st.lastTS and spanEnd.
+//
+// `open` marks a span with no successor: its pings are counted separately, because their
+// number rests on where the window ends rather than on an observed next request.
+func simulatePings(out *Result, ug, mg *groupAcc, st *convState, price Pricing, sem Semantics,
+	cfg Config, spanEnd int64, open bool) {
+	// Whatever happens below, this span is now settled: clearing the pending action is what
+	// stops a conversation being charged twice if the open-span pass visits it as well.
+	pending := st.pending
+	st.pending = ActionExpire
+	r := pingSpan(st.tokens, st.tier, st.expires, st.lastTS, pending, spanEnd, price, sem, cfg)
+	if r.fired == 0 {
+		return
+	}
+	st.tier, st.expires = r.tier, r.expires
+	out.Pings += r.fired
+	out.PingsThatRewrote += r.rewrote
+	out.PingsThatUpgraded += r.upgraded
+	if open {
+		out.PingsOnOpenSpans += r.fired
+	}
+	if ug != nil {
+		ug.g.Pings += r.fired
+	}
+	if mg != nil {
+		mg.g.Pings += r.fired
+	}
+	if price.Known {
+		out.PingUSD += r.cost
+		if ug != nil {
+			ug.g.PingUSD += r.cost
+			ug.g.TotalUSD += r.cost
+		}
+		if mg != nil {
+			mg.g.PingUSD += r.cost
+			mg.g.TotalUSD += r.cost
+		}
+	}
+	for _, ref := range r.refreshes {
+		retain(out, st, ref[0], ref[1], cfg.WindowEnd)
+	}
+}
+
+// statesInOrder is the conversation states in a deterministic order, so an open-span pass
+// produces the same figures twice.
+func statesInOrder(m map[Conversation]*convState) []*convState {
+	keys := make([]Conversation, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].User != keys[j].User {
+			return keys[i].User < keys[j].User
+		}
+		return keys[i].Conversation < keys[j].Conversation
+	})
+	out := make([]*convState, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, m[k])
+	}
+	return out
+}
+
+// finishGroups turns the accumulators into a sorted slice with rates filled in.
+func finishGroups(m map[string]*groupAcc) []Group {
+	out := make([]Group, 0, len(m))
+	for _, a := range m {
+		g := a.g
+		if d := g.Hits + g.Misses; d > 0 {
+			g.HitRate = 100 * float64(g.Hits) / float64(d)
+		}
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TotalUSD != out[j].TotalUSD {
+			return out[i].TotalUSD > out[j].TotalUSD
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}

--- a/kvcache/simulate_test.go
+++ b/kvcache/simulate_test.go
@@ -1,0 +1,639 @@
+package kvcache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// chain builds one conversation from a list of gaps, in milliseconds.
+func chain(user, conv, model string, startTS int64, gapsMs ...int64) []*Request {
+	rows := []*Request{req(1, user, conv, startTS, model)}
+	ts := startTS
+	for i, g := range gapsMs {
+		ts += g
+		rows = append(rows, req(int64(i+2), user, conv, ts, model))
+	}
+	Derive(rows)
+	return rows
+}
+
+// alwaysDo is a strategy fixed to one action: the way to exercise one branch of the
+// simulator without a real policy's thresholds getting in the way.
+type alwaysDo struct{ a Action }
+
+func (s alwaysDo) Name() string              { return "always-" + string(s.a) }
+func (s alwaysDo) Decide(Observation) Action { return s.a }
+
+// Every unit price in these tests, so an expected total can be read as arithmetic rather
+// than as a magic constant.
+const (
+	pIn        = 3e-6
+	pOut       = 15e-6
+	pRead      = 0.3e-6
+	pWrite5m   = 3.75e-6
+	pWrite1h   = 6e-6
+	prefix     = 100_000 // req()'s CachedContext
+	freshTok   = 100     // req()'s InputTokens
+	outTok     = 50      // req()'s OutputTokens
+	overhead   = 1*pIn + 1*pOut
+	costMiss   = freshTok*pIn + prefix*pWrite5m + outTok*pOut
+	costMiss1h = freshTok*pIn + prefix*pWrite1h + outTok*pOut
+	costHit    = freshTok*pIn + prefix*pRead + outTok*pOut
+	costNone   = (freshTok+prefix)*pIn + outTok*pOut
+	costPing   = prefix*pRead + overhead
+	costLate   = prefix*pWrite5m + overhead
+)
+
+// The no-cache baseline is EXACTLY the uncached cost, which is what makes it a usable
+// denominator: every prompt token billed once, at the fresh rate, and no cache premium at all.
+func TestNoCacheBaselineIsExactlyTheUncachedCost(t *testing.T) {
+	rows := chain("u", "s", "m", base, 60_000)
+	r := Simulate(rows, NoCache{}, Config{Prices: testPrices()})
+
+	near(t, "total", r.TotalUSD, 2*costNone)
+	near(t, "uncached", r.UncachedUSD, 2*costNone)
+	near(t, "cache premium", r.CachePremium, 0)
+	if r.Hits != 0 || r.Misses != 2 {
+		t.Errorf("hits/misses = %d/%d; nothing is ever cached, so nothing can hit", r.Hits, r.Misses)
+	}
+	if r.Expires != 2 || r.Writes5m != 0 || r.Writes1h != 0 || r.Pings != 0 {
+		t.Errorf("no-cache wrote something: expires=%d w5m=%d w1h=%d pings=%d",
+			r.Expires, r.Writes5m, r.Writes1h, r.Pings)
+	}
+	near(t, "cache read", r.CacheReadUSD, 0)
+	near(t, "cache write", r.CacheWriteUSD, 0)
+	if r.RetainedMs != 0 {
+		t.Errorf("no-cache held an entry for %d ms", r.RetainedMs)
+	}
+}
+
+// The core of the whole page: a five-minute entry survives a gap inside its lifetime and is
+// gone after one outside it.
+func TestFixed5mHitsInsideTheLifetimeAndMissesOutside(t *testing.T) {
+	rows := chain("u", "s", "m", base, 60_000, 400_000)
+	r := Simulate(rows, Fixed5m(), Config{Prices: testPrices()})
+
+	if r.Hits != 1 || r.Misses != 2 {
+		t.Fatalf("hits/misses = %d/%d, want 1/2: the 60 s gap holds, the 400 s gap does not",
+			r.Hits, r.Misses)
+	}
+	near(t, "hit rate", r.HitRate, 100.0/3)
+	near(t, "miss rate", r.MissRate, 200.0/3)
+	near(t, "total", r.TotalUSD, 2*costMiss+costHit)
+	if r.Writes5m != 2 {
+		t.Errorf("writes_5m = %d, want 2 — a hit that re-marks the same prefix writes nothing",
+			r.Writes5m)
+	}
+	if r.Writes1h != 0 || r.Expires != 0 {
+		t.Errorf("unexpected 1h writes (%d) or expiries (%d)", r.Writes1h, r.Expires)
+	}
+	if r.AvoidedRecomputations != 1 || r.AvoidedTokens != prefix {
+		t.Errorf("avoided %d recomputations / %d tokens, want 1 / %d",
+			r.AvoidedRecomputations, r.AvoidedTokens, prefix)
+	}
+	if r.Decisions[ActionWrite5m] != 3 {
+		t.Errorf("the arm chose write_5m %d times, want 3 (every request)",
+			r.Decisions[ActionWrite5m])
+	}
+	// The cache was held from the first request to 300 s past the second, and the window ends
+	// at the third request: 60 s + 300 s of coverage.
+	if want := int64(360_000); r.RetainedMs != want {
+		t.Errorf("retained = %d ms, want %d", r.RetainedMs, want)
+	}
+	// The cache paid for itself here, and CachePremium says so with a NEGATIVE number.
+	near(t, "cache premium", r.CachePremium, (2*costMiss+costHit)-3*costNone)
+	if r.CachePremium >= 0 {
+		t.Errorf("cache premium = %.6f; on this window caching is cheaper than not caching",
+			r.CachePremium)
+	}
+}
+
+// A one-hour tier holds through a gap that lapses at five minutes, and the comparison is
+// what the page exists to show.
+func TestOneHourTierHoldsAGapThatLapsesAtFiveMinutes(t *testing.T) {
+	rows := chain("u", "s", "m", base, 1_800_000) // 30 minutes
+	cfg := Config{Prices: testPrices()}
+	five := Simulate(rows, Fixed5m(), cfg)
+	hour := Simulate(rows, Fixed1h(), cfg)
+
+	if five.Hits != 0 {
+		t.Errorf("a 30-minute gap cannot hit a five-minute entry; got %d hits", five.Hits)
+	}
+	if hour.Hits != 1 {
+		t.Errorf("a 30-minute gap is inside an hour; got %d hits", hour.Hits)
+	}
+	near(t, "fixed-5m total", five.TotalUSD, 2*costMiss)
+	near(t, "fixed-1h total", hour.TotalUSD, costMiss1h+costHit)
+	if hour.Writes1h != 1 || hour.Writes5m != 0 {
+		t.Errorf("the 1h arm wrote %d at 1h and %d at 5m", hour.Writes1h, hour.Writes5m)
+	}
+
+	s := Compare(five, hour)
+	near(t, "absolute savings", s.AbsoluteUSD, 2*costMiss-(costMiss1h+costHit))
+	if !s.Known {
+		t.Fatal("a non-zero baseline must yield a percentage")
+	}
+	near(t, "percentage savings", s.PercentUSD, s.AbsoluteUSD/(2*costMiss)*100)
+	if s.HitDelta != 1 {
+		t.Errorf("hit delta = %d, want 1", s.HitDelta)
+	}
+}
+
+// A strategy that costs MORE reports negative savings. Not zero, not omitted.
+//
+// The 1-hour tier on a conversation that comes back in ten seconds pays 2.0x input to
+// protect something a 1.25x write would have held anyway, and a page that clamped this to
+// "0% saved" would be hiding the single most useful result the simulator produces.
+func TestAStrategyThatCostsMoreReportsNegativeSavings(t *testing.T) {
+	rows := chain("u", "s", "m", base, 10_000)
+	cfg := Config{Prices: testPrices()}
+	five := Simulate(rows, Fixed5m(), cfg)
+	hour := Simulate(rows, Fixed1h(), cfg)
+
+	s := Compare(five, hour)
+	if s.AbsoluteUSD >= 0 {
+		t.Fatalf("the 1h arm should cost MORE here; absolute savings = %.6f", s.AbsoluteUSD)
+	}
+	near(t, "absolute savings", s.AbsoluteUSD, (costMiss+costHit)-(costMiss1h+costHit))
+	if s.PercentUSD >= 0 {
+		t.Errorf("percentage savings = %.3f; a negative absolute must give a negative percentage",
+			s.PercentUSD)
+	}
+	near(t, "percentage savings", s.PercentUSD, s.AbsoluteUSD/(costMiss+costHit)*100)
+}
+
+// A percentage of nothing is UNDEFINED, not 0%.
+func TestPercentageSavingsIsUndefinedOnAZeroBaseline(t *testing.T) {
+	rows := chain("u", "s", "unpriced", base, 10_000)
+	cfg := Config{Prices: testPrices()}
+	base0 := Simulate(rows, NoCache{}, cfg)
+	if base0.TotalUSD != 0 {
+		t.Fatalf("an unpriced model must contribute no dollars; got %.9f", base0.TotalUSD)
+	}
+	s := Compare(base0, Simulate(rows, Fixed5m(), cfg))
+	if s.Known {
+		t.Error("a zero baseline yielded a percentage; a percentage of nothing is not 0%")
+	}
+	if s.PercentUSD != 0 {
+		t.Errorf("percent = %v on an undefined comparison", s.PercentUSD)
+	}
+}
+
+// An unpriced model's requests are COUNTED — in the totals, in the hit/miss split — and
+// contribute nothing to any dollar figure. An unpriced request is not a free one.
+func TestUnpricedRequestsAreCountedNotValued(t *testing.T) {
+	rows := chain("u", "s", "unpriced", base, 60_000)
+	r := Simulate(rows, Fixed5m(), Config{Prices: testPrices()})
+	if r.Requests != 2 || r.Unpriced != 2 {
+		t.Errorf("requests=%d unpriced=%d, want 2/2", r.Requests, r.Unpriced)
+	}
+	if r.Hits != 1 || r.Misses != 1 {
+		t.Errorf("hits/misses = %d/%d; an unpriced row still hits or misses", r.Hits, r.Misses)
+	}
+	if r.TotalUSD != 0 || r.CacheWriteUSD != 0 || r.UncachedUSD != 0 {
+		t.Errorf("an unpriced model produced dollars: total=%v write=%v uncached=%v",
+			r.TotalUSD, r.CacheWriteUSD, r.UncachedUSD)
+	}
+	if len(r.ByModel) != 1 || r.ByModel[0].Unpriced != 2 {
+		t.Errorf("the per-model group did not carry the unpriced count: %+v", r.ByModel)
+	}
+}
+
+// Keep-alives hold an entry across a gap that would otherwise lapse, and they cost the READ
+// rate.
+func TestKeepAlivesHoldAnEntryAcrossALongGap(t *testing.T) {
+	rows := chain("u", "s", "m", base, 600_000) // 10 minutes
+	cfg := Config{Prices: testPrices(), PingIdle: 280 * time.Second, MaxPings: 2}
+	r := Simulate(rows, alwaysDo{ActionPing5m}, cfg)
+
+	if r.Pings != 2 {
+		t.Fatalf("pings = %d, want 2 at 280 s into a 600 s gap with K=2", r.Pings)
+	}
+	if r.PingsThatRewrote != 0 {
+		t.Errorf("%d pings arrived after the entry lapsed; at 280 s inside a 300 s lifetime none should",
+			r.PingsThatRewrote)
+	}
+	if r.PingsOnOpenSpans != 0 {
+		t.Errorf("pings_on_open_spans = %d; the window ends at the last request, so its open "+
+			"span has no room for one", r.PingsOnOpenSpans)
+	}
+	if r.Hits != 1 {
+		t.Errorf("the refreshed entry did not survive to the second request: %d hits", r.Hits)
+	}
+	near(t, "ping cost", r.PingUSD, 2*costPing)
+	near(t, "total", r.TotalUSD, costMiss+2*costPing+costHit)
+
+	// And it is cheaper than letting it lapse, which is the whole claim.
+	plain := Simulate(rows, Fixed5m(), cfg)
+	s := Compare(plain, r)
+	if s.AbsoluteUSD <= 0 {
+		t.Errorf("pinging cost more than lapsing here: %.6f", s.AbsoluteUSD)
+	}
+}
+
+// A keep-alive that arrives AFTER the entry lapsed is a cache WRITE, and it is priced and
+// counted as one. Pricing it as a read is the arithmetic error that would hide a schedule
+// whose interval exceeds the lifetime it is protecting.
+func TestALateKeepAliveIsBilledAsAWriteAndCounted(t *testing.T) {
+	rows := chain("u", "s", "m", base, 900_000)
+	cfg := Config{Prices: testPrices(), PingIdle: 400 * time.Second, MaxPings: 1}
+	r := Simulate(rows, alwaysDo{ActionPing5m}, cfg)
+
+	if r.Pings != 1 || r.PingsThatRewrote != 1 {
+		t.Fatalf("pings=%d rewrote=%d, want 1/1: a 400 s interval cannot protect a 300 s lifetime",
+			r.Pings, r.PingsThatRewrote)
+	}
+	near(t, "the late ping's cost", r.PingUSD, costLate)
+	if r.PingUSD < 10*costPing {
+		t.Errorf("the late ping was priced at %.6f, near a read's %.6f — it re-created the "+
+			"prefix and must be billed at the creation rate", r.PingUSD, costPing)
+	}
+	if r.Hits != 0 {
+		t.Errorf("the re-created entry lapsed again before the 900 s mark; got %d hits", r.Hits)
+	}
+}
+
+// A one-hour hold needs far fewer keep-alives than a five-minute one to cover the same span.
+// That ping COUNT, not a different per-ping rate, is the cost difference between the two.
+func TestAOneHourHoldNeedsFarFewerKeepAlives(t *testing.T) {
+	rows := chain("u", "s", "m", base, 4*3_600_000) // four hours
+	cfg := Config{Prices: testPrices(), MaxPings: 10}
+	hour := Simulate(rows, alwaysDo{ActionPing1h}, cfg)
+	five := Simulate(rows, alwaysDo{ActionPing5m}, cfg)
+
+	if hour.Pings != 4 {
+		t.Errorf("the 1h arm sent %d pings, want 4 at a 3360 s interval across four hours",
+			hour.Pings)
+	}
+	if five.Pings != 10 {
+		t.Errorf("the 5m arm sent %d pings, want its cap of 10", five.Pings)
+	}
+	if hour.Hits != 1 {
+		t.Errorf("four refreshes of a one-hour entry should carry it four hours; %d hits", hour.Hits)
+	}
+	if five.Hits != 0 {
+		t.Errorf("ten refreshes of a five-minute entry reach ~52 minutes, not four hours; %d hits",
+			five.Hits)
+	}
+	// Per ping, the two cost the same: a refresh is a read either way.
+	near(t, "one 1h refresh", hour.PingUSD/float64(hour.Pings), costPing)
+	near(t, "one 5m refresh", five.PingUSD/float64(five.Pings), costPing)
+}
+
+// A `prefix_change` or `cold_start` miss is not something any TTL can rescue: the content
+// moved, or there was no entry. Both force a miss whatever the strategy chose, and the count
+// is reported so the ceiling on every arm is visible rather than implied.
+func TestForcedMissesCannotBeRescuedByAnyTier(t *testing.T) {
+	rows := chain("u", "s", "m", base, 10_000, 10_000)
+	rows[0].MissReason = "cold_start"
+	rows[1].MissReason = "prefix_change"
+	for _, s := range []Strategy{Fixed5m(), Fixed1h(), alwaysDo{ActionPing1h}} {
+		r := Simulate(rows, s, Config{Prices: testPrices()})
+		if r.ForcedMisses != 2 {
+			t.Errorf("%s: forced_misses = %d, want 2", s.Name(), r.ForcedMisses)
+		}
+		if r.Hits != 1 {
+			t.Errorf("%s: hits = %d; only the third request (reason 'hit') can hit", s.Name(), r.Hits)
+		}
+		// And the forced miss pays a full write, not a read.
+		if r.CacheReadUSD >= r.CacheWriteUSD {
+			t.Errorf("%s: read %.6f vs write %.6f — a prefix change re-creates the prefix",
+				s.Name(), r.CacheReadUSD, r.CacheWriteUSD)
+		}
+	}
+}
+
+// The observed-policy arm replays the tier each request actually asked for, and reports how
+// much of itself rested on a RECORDED tier rather than on an assumed default.
+func TestObservedPolicyReplaysTheRecordedTierAndReportsCoverage(t *testing.T) {
+	rows := chain("u", "s", "m", base, 10_000, 10_000)
+	rows[0].TTL, rows[0].TTLSource = TTL1h, TTLSourceConfigured
+	rows[1].TTL, rows[1].TTLSource = TTL5m, TTLSourceConfigured
+	rows[2].TTL, rows[2].TTLSource = TTLNone, TTLSourceUnknown // a row written before the column existed
+
+	obs := NewObserved(rows, TTL5m)
+	r := Simulate(rows, obs, Config{Prices: testPrices()})
+
+	if r.Decisions[ActionWrite1h] != 1 || r.Decisions[ActionWrite5m] != 2 {
+		t.Errorf("decisions = %v; want one 1h (recorded) and two 5m (one recorded, one assumed)",
+			r.Decisions)
+	}
+	if r.ObservedCoverage == nil {
+		t.Fatal("the observed arm must report its own coverage")
+	}
+	if r.ObservedCoverage.Recorded != 2 || r.ObservedCoverage.Assumed != 1 {
+		t.Errorf("coverage = %+v, want 2 recorded / 1 assumed", *r.ObservedCoverage)
+	}
+	// Every other arm reports no coverage at all rather than a fabricated 100%.
+	if Simulate(rows, Fixed5m(), Config{Prices: testPrices()}).ObservedCoverage != nil {
+		t.Error("a fixed arm reported an observed-policy coverage it cannot have")
+	}
+}
+
+// Whether a plain cache HIT refreshes the lifetime is a provider property, and changing it
+// changes the result — which is why it is a configurable field and not an assumption.
+func TestHitRefreshesTTLIsConfigurableAndChangesTheOutcome(t *testing.T) {
+	rows := chain("u", "s", "m", base, 200_000, 250_000)
+	refreshing := Simulate(rows, Fixed5m(), Config{Prices: testPrices()})
+	sem := DefaultSemantics()
+	sem.HitRefreshesTTL = false
+	frozen := Simulate(rows, Fixed5m(), Config{Prices: testPrices(), Semantics: sem})
+
+	if refreshing.Hits != 2 {
+		t.Errorf("with refreshing hits, both gaps hold: got %d hits", refreshing.Hits)
+	}
+	if frozen.Hits != 1 {
+		t.Errorf("without refreshing hits, the entry dies 300 s after the FIRST request: got %d hits",
+			frozen.Hits)
+	}
+	if frozen.TotalUSD <= refreshing.TotalUSD {
+		t.Errorf("the non-refreshing provider must cost more: %.6f vs %.6f",
+			frozen.TotalUSD, refreshing.TotalUSD)
+	}
+}
+
+// Retention is the UNION of the intervals an entry was alive, clipped to the window. A sum of
+// lifetimes would double-count every overlapping refresh.
+func TestRetainedTimeIsAUnionNotASumOfLifetimes(t *testing.T) {
+	rows := chain("u", "s", "m", base, 60_000)
+	r := Simulate(rows, Fixed5m(), Config{Prices: testPrices(), WindowEnd: base + 400_000})
+	// Two five-minute lifetimes were started, 60 s apart: their union is 360 s, their sum 600 s.
+	if want := int64(360_000); r.RetainedMs != want {
+		t.Errorf("retained = %d ms, want %d (the union); the sum of lifetimes would be 600000",
+			r.RetainedMs, want)
+	}
+}
+
+// An open idle span — a conversation whose last request is inside the window — has a length
+// nobody knows. Its pings are bounded by the window's end and counted APART, because they
+// rest on an assumption the closed spans do not need.
+func TestPingsOnAnOpenSpanAreBoundedAndCountedApart(t *testing.T) {
+	rows := chain("u", "s", "m", base, 10_000)
+	cfg := Config{Prices: testPrices(), PingIdle: 280 * time.Second, MaxPings: 2,
+		WindowEnd: base + 10_000 + 900_000}
+	r := Simulate(rows, alwaysDo{ActionPing5m}, cfg)
+	if r.Pings != 2 || r.PingsOnOpenSpans != 2 {
+		t.Errorf("pings=%d open=%d; the only span with room for a ping is the open one",
+			r.Pings, r.PingsOnOpenSpans)
+	}
+	// With no window end, an open span costs nothing — the conservative direction, and the
+	// one that cannot inflate a saving.
+	bare := Simulate(rows, alwaysDo{ActionPing5m}, Config{Prices: testPrices(),
+		PingIdle: 280 * time.Second, MaxPings: 2})
+	if bare.Pings != 0 {
+		t.Errorf("with the window ending at the last request, an open span attracts %d pings",
+			bare.Pings)
+	}
+}
+
+func TestPingsPerSpan(t *testing.T) {
+	const idle = 280 * time.Second
+	for _, tc := range []struct {
+		gap  time.Duration
+		idle time.Duration
+		max  int
+		want int
+	}{
+		{0, idle, 2, 0},
+		{idle, idle, 2, 0}, // a gap no longer than the interval attracts none
+		{idle + time.Millisecond, idle, 2, 1},
+		{2 * idle, idle, 2, 2},
+		{600 * time.Second, idle, 2, 2},
+		{10000 * time.Second, idle, 2, 2}, // the cap binds
+		{10000 * time.Second, idle, 0, 0}, // K=0 sends nothing
+		{10000 * time.Second, 0, 2, 0},    // no interval sends nothing
+		{4 * time.Hour, 3360 * time.Second, 10, 4},
+	} {
+		if got := PingsPerSpan(tc.gap, tc.idle, tc.max); got != tc.want {
+			t.Errorf("PingsPerSpan(%v, %v, %d) = %d, want %d", tc.gap, tc.idle, tc.max, got, tc.want)
+		}
+	}
+}
+
+// The historical-probability arm uses the account's OWN closed gaps, and its prefix gate
+// stops it caching something too small to repay a write.
+func TestHistoricalProbabilityActsOnItsOwnHistoryAndItsPrefixGate(t *testing.T) {
+	// Eight ten-second gaps: this user always comes back inside five minutes.
+	rows := chain("u", "s", "m", base, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000)
+	r := Simulate(rows, HistoricalProbability{}, Config{Prices: testPrices()})
+	if r.Decisions[ActionWrite5m] == 0 {
+		t.Errorf("an account that always returns in 10 s was never given a 5m write: %v", r.Decisions)
+	}
+	if r.Decisions[ActionWrite1h] != 0 || r.Decisions[ActionPing1h] != 0 {
+		t.Errorf("a 10-second working pattern does not need an hour of protection: %v", r.Decisions)
+	}
+
+	// The same traffic with a prefix under the gate is never cached at all.
+	small := chain("u", "s", "m", base, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000)
+	for _, q := range small {
+		q.CachedContext = 500
+	}
+	g := Simulate(small, HistoricalProbability{}, Config{Prices: testPrices()})
+	if g.Decisions[ActionExpire] != int64(len(small)) {
+		t.Errorf("a 500-token prefix was cached: %v", g.Decisions)
+	}
+	// Every arm reports which fallback level its statistics could answer at, so a reader can
+	// see how much of it was actually personalised.
+	if len(r.StatsLevels) == 0 {
+		t.Error("no statistics coverage was reported")
+	}
+	if r.StatsLevels[LevelNone] != 1 {
+		t.Errorf("stats levels = %v; exactly the first decision has no closed gap behind it",
+			r.StatsLevels)
+	}
+}
+
+// A long-idle account is given the LONG hold, and which form of it — a 1h write or a 5m
+// write plus refreshes — is decided by the rates rather than in advance.
+func TestHistoricalProbabilityChoosesTheCheaperLongHold(t *testing.T) {
+	// Gaps of about twenty minutes: outside five minutes, inside an hour.
+	rows := chain("u", "s", "m", base, 1_200_000, 1_200_000, 1_200_000, 1_200_000, 1_200_000,
+		1_200_000, 1_200_000)
+	r := Simulate(rows, HistoricalProbability{}, Config{Prices: testPrices()})
+	long := r.Decisions[ActionWrite1h] + r.Decisions[ActionPing5m]
+	if long == 0 {
+		t.Fatalf("a twenty-minute working pattern got no long hold: %v", r.Decisions)
+	}
+	// At these rates two refreshes (2 x $0.030018) are cheaper than the 1h premium
+	// (100k x (6e-6 - 3.75e-6) = $0.225), so the ping path wins — computed, not assumed.
+	if r.Decisions[ActionPing5m] == 0 {
+		t.Errorf("the cheaper long hold was not chosen: %v", r.Decisions)
+	}
+	// Raise the 1h multiplier's competitor by making refreshes expensive and it flips.
+	dear := NewPriceList(context.Background(), []string{"m"},
+		stubPricer{"m": {Input: 3e-6, Output: 15e-6, CacheRead: 3e-6, CacheWrite: 3.75e-6}},
+		Multipliers{}, nil)
+	q := Simulate(rows, HistoricalProbability{}, Config{Prices: dear})
+	if q.Decisions[ActionWrite1h] == 0 {
+		t.Errorf("with refreshes at the input rate the 1h write must win: %v", q.Decisions)
+	}
+}
+
+// stubPredictor is a learned model's stand-in: it answers the one question the seam asks.
+type stubPredictor struct{ p5, p1h float64 }
+
+func (s stubPredictor) ReuseProbability(_ Observation, horizon time.Duration) (float64, bool) {
+	if horizon <= Horizon5m {
+		return s.p5, true
+	}
+	return s.p1h, true
+}
+
+// A predictor plugs in without the simulator or the results changing shape. This is the
+// property that makes the interface worth having.
+func TestACustomPredictorPlugsInWithoutChangingTheSimulator(t *testing.T) {
+	rows := chain("u", "s", "m", base, 1_800_000)
+	cfg := Config{Prices: testPrices()}
+
+	confident := Simulate(rows, Custom{Label: "learned", Predictor: stubPredictor{p5: 0.95}}, cfg)
+	if confident.Strategy != "learned" {
+		t.Errorf("strategy name = %q, want the supplied label", confident.Strategy)
+	}
+	if confident.Decisions[ActionWrite5m] != 2 {
+		t.Errorf("a 95%% five-minute prediction must give a 5m write: %v", confident.Decisions)
+	}
+	// A predictor that says the conversation is over lets the entry expire.
+	done := Simulate(rows, Custom{Predictor: stubPredictor{p5: 0.01, p1h: 0.02}}, cfg)
+	if done.Decisions[ActionExpire] != 2 {
+		t.Errorf("a 1%% prediction must let the cache expire: %v", done.Decisions)
+	}
+	near(t, "an expiring arm costs the uncached price", done.TotalUSD, 2*costNone)
+
+	// A long-horizon prediction takes the long hold, and AlwaysPing forces the ping path so
+	// an operator can measure it specifically.
+	pinged := Simulate(rows, Custom{Predictor: stubPredictor{p5: 0.1, p1h: 0.9}, AlwaysPing: true},
+		Config{Prices: testPrices(), PingIdle: 280 * time.Second, MaxPings: 8})
+	if pinged.Decisions[ActionPing5m] == 0 || pinged.Pings == 0 {
+		t.Errorf("AlwaysPing did not take the ping path: %v (%d pings)",
+			pinged.Decisions, pinged.Pings)
+	}
+
+	// And the last seam: a whole decision function.
+	fn := Simulate(rows, Custom{Label: "callback",
+		Decider: func(Observation) Action { return ActionWrite1h }}, cfg)
+	if fn.Decisions[ActionWrite1h] != 2 {
+		t.Errorf("the supplied decider was not used: %v", fn.Decisions)
+	}
+}
+
+// Every arm is grouped by user and by model, and the groups reconcile with the totals.
+func TestResultsAreGroupedByUserAndModelAndReconcile(t *testing.T) {
+	var rows []*Request
+	rows = append(rows, chain("alice", "a1", "m", base, 60_000)...)
+	for _, r := range chain("bob", "b1", "m", base+5_000, 60_000) {
+		r.ID += 100
+		rows = append(rows, r)
+	}
+	Derive(rows)
+	r := Simulate(rows, Fixed5m(), Config{Prices: testPrices()})
+
+	if len(r.ByUser) != 2 {
+		t.Fatalf("by_user has %d groups, want 2", len(r.ByUser))
+	}
+	var sum float64
+	var reqs, hits int64
+	for _, g := range r.ByUser {
+		sum += g.TotalUSD
+		reqs += g.Requests
+		hits += g.Hits
+	}
+	near(t, "the per-user groups sum to the total", sum, r.TotalUSD)
+	if reqs != r.Requests || hits != r.Hits {
+		t.Errorf("groups hold %d requests / %d hits, totals say %d / %d",
+			reqs, hits, r.Requests, r.Hits)
+	}
+	if r.Conversations != 2 {
+		t.Errorf("conversations = %d, want 2", r.Conversations)
+	}
+	// Both users are on one model, so there is one model group holding everything.
+	if len(r.ByModel) != 1 || r.ByModel[0].Requests != r.Requests {
+		t.Errorf("by_model = %+v", r.ByModel)
+	}
+}
+
+// The latency differential is measured from the window's own rows, and it is ABSENT rather
+// than estimated when either population is too small to mean anything.
+func TestLatencyDifferentialNeedsBothPopulations(t *testing.T) {
+	rows := chain("u", "s", "m", base, 10_000)
+	rows[0].UpstreamMs, rows[0].Hit = 20_000, false
+	rows[1].UpstreamMs, rows[1].Hit = 1_000, true
+	if l := MeasureLatency(rows); l.Known {
+		t.Errorf("two rows produced a latency differential: %+v", l)
+	}
+
+	var many []*Request
+	for i := int64(0); i < 60; i++ {
+		r := req(i+1, "u", "s", base+i*10_000, "m")
+		r.Hit = i%2 == 0
+		r.MissReason = "hit"
+		if !r.Hit {
+			r.MissReason = "ttl_expiry"
+		}
+		r.UpstreamMs = 1_000
+		if !r.Hit {
+			r.UpstreamMs = 3_000
+		}
+		many = append(many, r)
+	}
+	Derive(many)
+	l := MeasureLatency(many)
+	if !l.Known {
+		t.Fatalf("30 of each population is enough: %+v", l)
+	}
+	near(t, "per-miss latency", l.PerMissMs, 2_000)
+	if l.HitN != 30 || l.MissN != 30 {
+		t.Errorf("populations = %d hits / %d misses", l.HitN, l.MissN)
+	}
+	// A row with no recorded upstream time is ABSENT from both means, not a zero in one.
+	many[0].UpstreamMs = 0
+	if l2 := MeasureLatency(many); l2.HitN != 29 {
+		t.Errorf("an unrecorded latency was counted: %d hits", l2.HitN)
+	}
+
+	// And the comparison carries it through only when it is known.
+	cfg := Config{Prices: testPrices()}
+	s := Compare(Simulate(many, NoCache{}, cfg), Simulate(many, Fixed1h(), cfg))
+	if !s.LatencyKnown || s.LatencyAvoidedMs <= 0 {
+		t.Errorf("a measurable differential and a positive hit delta must give an avoided "+
+			"latency: %+v", s)
+	}
+}
+
+// Simulate sorts defensively and is deterministic: the same window gives the same figures
+// twice, whatever order the caller hands the rows in.
+func TestSimulateIsDeterministicAndSortsDefensively(t *testing.T) {
+	rows := chain("u", "s", "m", base, 60_000, 400_000, 30_000)
+	shuffled := []*Request{rows[2], rows[0], rows[3], rows[1]}
+	cfg := Config{Prices: testPrices()}
+	a := Simulate(rows, Fixed5m(), cfg)
+	b := Simulate(shuffled, Fixed5m(), cfg)
+	if a.TotalUSD != b.TotalUSD || a.Hits != b.Hits || a.RetainedMs != b.RetainedMs {
+		t.Errorf("an out-of-order slice replayed differently:\n %+v\n %+v", a, b)
+	}
+	c := Simulate(rows, Fixed5m(), cfg)
+	if a.TotalUSD != c.TotalUSD || a.Pings != c.Pings {
+		t.Error("two replays of the same window disagreed")
+	}
+}
+
+// Every strategy describes itself, because the results table shows the sentence beside the
+// name and a reader cannot compare arms they cannot tell apart.
+func TestEveryShippedStrategyDescribesItself(t *testing.T) {
+	for _, s := range []Strategy{NoCache{}, Fixed5m(), Fixed1h(),
+		NewObserved(nil, TTL5m), HistoricalProbability{}, Custom{}} {
+		d, ok := s.(Describer)
+		if !ok {
+			t.Errorf("%s has no description", s.Name())
+			continue
+		}
+		if len(d.Describe()) < 20 {
+			t.Errorf("%s describes itself as %q", s.Name(), d.Describe())
+		}
+	}
+	// And the names are stable keys, so a result can be grouped by them.
+	if (NoCache{}).Name() != "no-cache" || Fixed5m().Name() != "fixed-5m" ||
+		Fixed1h().Name() != "fixed-1h" {
+		t.Error("a strategy name moved; the dashboard groups results by these keys")
+	}
+}

--- a/kvcache/strategy.go
+++ b/kvcache/strategy.go
@@ -1,0 +1,689 @@
+package kvcache
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+// Action is what a strategy decides to do about a conversation's cached context for the
+// idle span that starts now.
+//
+// Five actions and no sixth: they are the whole set of things a caller can actually buy
+// from a prompt-caching provider. "Do nothing" is ActionExpire — an entry nobody pays to
+// keep lapses on its own — and saying so explicitly is what makes a no-cache baseline a
+// strategy rather than an absence.
+type Action string
+
+const (
+	// ActionExpire writes no cache_control at all: this request's prompt is billed as fresh
+	// input and nothing is held afterwards.
+	ActionExpire Action = "expire"
+	// ActionWrite5m writes/retains the prefix at the 5-minute tier.
+	ActionWrite5m Action = "write_5m"
+	// ActionWrite1h writes/retains the prefix at the 1-hour tier.
+	ActionWrite1h Action = "write_1h"
+	// ActionPing5m writes/retains at 5 minutes AND keeps refreshing it with keep-alive
+	// reads while the conversation is idle.
+	ActionPing5m Action = "ping_5m"
+	// ActionPing1h holds the entry at the 1-hour tier and refreshes it with keep-alive
+	// reads while the conversation is idle.
+	ActionPing1h Action = "ping_1h"
+	// ActionWrite5mPing1h writes at the CHEAP tier and buys the long hold only if the
+	// conversation actually goes quiet: the request itself creates a 5-minute entry at 1.25x
+	// input, and if a keep-alive comes due before that lapses, THAT keep-alive extends the
+	// context by an hour — a 1-hour write of the prefix at 2.0x, after which the entry is
+	// hourly and needs refreshing twelve times less often.
+	//
+	// It is a distinct arm from ActionPing1h and not a variation of it. ActionPing1h pays the
+	// 2.0x creation premium on EVERY request; this pays 1.25x on every request and 2.0x only
+	// on the rare span that outlives five minutes. On traffic where 92.5% of gaps close inside
+	// five minutes that is a different bill entirely, which is the whole reason it exists.
+	//
+	// The upgrade is priced as a 1-hour WRITE rather than a read, and that is a measurement
+	// rather than a guess: the deployment's own capture shows a request asking for ttl:"1h"
+	// over an already-warm prefix returning 36,251 of 36,574 written tokens on the 1h
+	// creation tier (see the cache_write_1h column in dash/schema.go). If some provider bills
+	// it as a read instead, this arm is CHEAPER than reported here, never dearer.
+	ActionWrite5mPing1h Action = "write_5m_ping_1h"
+)
+
+// Actions is every action, in escalating cost order.
+var Actions = []Action{ActionExpire, ActionWrite5m, ActionWrite1h, ActionPing5m, ActionPing1h,
+	ActionWrite5mPing1h}
+
+// Tier is the TTL the REQUEST ITSELF writes at. Not necessarily the tier the entry ends up
+// at: ActionWrite5mPing1h writes 5 minutes and its keep-alive upgrades that to an hour, which
+// is exactly the distinction that makes it cheap in the common case.
+func (a Action) Tier() TTL {
+	switch a {
+	case ActionWrite5m, ActionPing5m, ActionWrite5mPing1h:
+		return TTL5m
+	case ActionWrite1h, ActionPing1h:
+		return TTL1h
+	}
+	return TTLNone
+}
+
+// PingTier is the tier this action's keep-alives hold the entry at, which is what a ping has
+// to pay to reach. TTLNone for an action that never pings.
+func (a Action) PingTier() TTL {
+	switch a {
+	case ActionPing5m:
+		return TTL5m
+	case ActionPing1h, ActionWrite5mPing1h:
+		return TTL1h
+	}
+	return TTLNone
+}
+
+// Pings reports whether this action sends keep-alives during the idle span.
+func (a Action) Pings() bool {
+	return a == ActionPing5m || a == ActionPing1h || a == ActionWrite5mPing1h
+}
+
+// Caches reports whether this action writes cache_control at all.
+func (a Action) Caches() bool { return a.Tier() != TTLNone }
+
+// Load is optional system-load information, for a strategy that wants to back off when the
+// deployment is busy. A POINTER on the Observation, and nil on every deployment that does
+// not measure it: a strategy that reads a zero as "idle" would behave differently on a
+// deployment that simply has no gauge, which is the failure mode a bool-plus-value pair
+// cannot express.
+type Load struct {
+	// InFlight is concurrent upstream requests at the decision instant.
+	InFlight int `json:"in_flight"`
+	// UpstreamMs is the recent mean upstream latency, in milliseconds.
+	UpstreamMs float64 `json:"upstream_ms"`
+}
+
+// Observation is everything a strategy is allowed to see, and it is defined by what is
+// ABSENT from it.
+//
+// There is no next-request timestamp on it, no idle duration, and no field derived from
+// either. That is not an oversight to be fixed by a future field — it is the invariant the
+// whole simulator exists to hold, because a predictor that can see how long the gap turned
+// out to be will "predict" it perfectly and every saving it reports will be unreachable in
+// production. TestStrategiesCannotSeeTheFuture asserts it by handing every strategy an
+// Observation whose future is a trap.
+//
+// Everything here was knowable at Now: the request that has just been served, the state of
+// the entry it leaves behind, the account's rates, and statistics accumulated from gaps
+// that had already CLOSED.
+type Observation struct {
+	// Who and what. User is the tenant, Conversation the trajectory.
+	User         string
+	Conversation string
+	Model        string
+
+	// RequestID identifies the request just served. Present-tense identity, not a
+	// prediction: it is here so an arm that replays a recorded per-request decision — and a
+	// future predictor that keys features per request — needs no side channel.
+	RequestID int64
+
+	// Now is the decision instant: epoch ms, UTC. It is the timestamp of the request just
+	// served, which is when the cache_control header has to be chosen.
+	Now     int64
+	HourUTC int
+	Bucket  Bucket
+
+	// CachedTokens is the prefix that exists after this request — the thing a TTL protects
+	// and a ping refreshes, and the number every cost below is proportional to.
+	CachedTokens int64
+
+	// SinceLastMs is how long this conversation had been idle BEFORE the request just
+	// served, i.e. the gap that has already closed. 0 on a conversation's first request.
+	// Past information, and the single most useful past fact a strategy has.
+	SinceLastMs int64
+
+	// TTL is the tier the entry is currently held at and ExpiresAt when it would lapse if
+	// nothing touched it. Both describe the state entering the decision, not its outcome.
+	TTL       TTL
+	ExpiresAt int64
+
+	// Turn is how many requests this conversation has served so far, including this one.
+	Turn int
+
+	// Stats is the historical view, or nil where a caller has none. Every number it serves
+	// is accumulated from gaps that closed strictly before Now.
+	Stats Stats
+
+	// Pricing is the model's rates, so a strategy can compare what an action costs with
+	// what it might avoid rather than acting on a token count alone.
+	Pricing Pricing
+
+	// Load is system-load information where the deployment has it, nil where it does not.
+	Load *Load
+}
+
+// Strategy is a KV-cache management policy: given only what was knowable at the decision
+// instant, choose what to do with the cached context for the span that starts now.
+//
+// Deliberately one method. A strategy that needs to learn from outcomes does so through
+// Stats, which the simulator advances as gaps close — not through a callback the simulator
+// would have to invoke with the future in hand.
+type Strategy interface {
+	// Name is the label the dashboard groups results by. Stable, because it is a key.
+	Name() string
+	// Decide chooses the action for the idle span starting at o.Now.
+	Decide(o Observation) Action
+}
+
+// Describer is an optional interface: a strategy that can explain itself in one sentence
+// gets that sentence rendered beside its results instead of just its name.
+type Describer interface {
+	Describe() string
+}
+
+// Predictor is the seam a LEARNED model plugs into.
+//
+// It answers exactly the question a TTL decision needs — will this conversation come back
+// within `horizon`? — and it receives the same Observation every strategy does, so a model
+// trained on features the Observation does not carry cannot be wired in by accident. A
+// predictor that has no opinion returns ok=false and Custom falls back to its thresholds.
+//
+// Nothing in the simulator or the dashboard needs to change to adopt one: build a
+// Custom{Predictor: yourModel} and it appears beside the hand-written strategies with the
+// same costs, the same baseline and the same savings arithmetic.
+type Predictor interface {
+	ReuseProbability(o Observation, horizon time.Duration) (p float64, ok bool)
+}
+
+// Stats is the historical view a strategy may lean on, with an explicit FALLBACK LEVEL on
+// every answer.
+//
+// The level matters as much as the number: "62% of this user's afternoon gaps closed within
+// five minutes, over 340 gaps" and "62%, over 3 gaps, actually the service-wide average
+// because this user is new" are different facts, and a strategy that cannot tell them apart
+// will act confidently on nothing. Every method therefore returns (value, n, level).
+type Stats interface {
+	// ReuseWithin is the share of this cell's already-closed gaps that were no longer than
+	// d. level is one of the Level* constants.
+	ReuseWithin(user, model string, b Bucket, d time.Duration) (p float64, n int, level string)
+	// MedianIdle is this cell's median already-closed gap.
+	MedianIdle(user, model string, b Bucket) (idle time.Duration, n int, level string)
+}
+
+// The fallback levels, most specific first. LevelNone means nothing at all was known — not
+// "zero probability".
+const (
+	LevelUserBucket = "user+model+bucket"
+	LevelUserModel  = "user+model"
+	LevelUser       = "user"
+	LevelModel      = "model"
+	LevelGlobal     = "global"
+	LevelNone       = "none"
+)
+
+// minCell is how many closed gaps a cell needs before it is trusted over its parent.
+//
+// Six because a five-minute reuse probability estimated from fewer is not a probability: at
+// n=3 the resolution is 33 percentage points, and a strategy switching tier on that is
+// choosing by noise. Below it the lookup falls through to the next level, and the level it
+// actually used is returned so the caller can say which.
+const minCell = 6
+
+// ── the accumulating statistics the simulator advances as gaps close ────────
+
+// History is the leak-free Stats implementation the simulator uses.
+//
+// It is EMPTY at the start of a replay and gains one observation per gap AS THAT GAP
+// CLOSES — that is, when the successor request arrives, not when the predecessor is
+// decided. So a decision made at time T can only ever see gaps that ended at or before T.
+// That is the whole mechanism by which the replay is honest, and it is why History is a
+// mutable accumulator rather than a precomputed table: a precomputed table over the window
+// would carry the future into every early decision.
+type History struct {
+	cells map[statKey]*cell
+}
+
+type statKey struct {
+	user, model string
+	bucket      Bucket
+}
+
+type cell struct {
+	gaps []time.Duration
+	// sorted tracks whether gaps is ordered, so the median is not re-sorted per lookup.
+	sorted bool
+	within map[time.Duration]int
+}
+
+// NewHistory builds an empty accumulator.
+func NewHistory() *History { return &History{cells: map[statKey]*cell{}} }
+
+// keys are the cells one observation lands in, from most specific to least. A gap is
+// counted in EVERY level, so a fallback is a real aggregate rather than an empty parent.
+func keysFor(user, model string, b Bucket) []statKey {
+	return []statKey{
+		{user, model, b},
+		{user, model, ""},
+		{user, "", ""},
+		{"", model, ""},
+		{"", "", ""},
+	}
+}
+
+// levels are the labels of keysFor, index for index.
+var levels = []string{LevelUserBucket, LevelUserModel, LevelUser, LevelModel, LevelGlobal}
+
+// Observe records one CLOSED gap. Callers must not call it for a gap that has not happened
+// yet — that is the leak this type exists to prevent, and the simulator calls it in exactly
+// one place, on the successor's arrival.
+func (h *History) Observe(user, model string, b Bucket, gap time.Duration) {
+	if h == nil {
+		return
+	}
+	if gap < 0 {
+		gap = 0
+	}
+	for _, k := range keysFor(user, model, b) {
+		c := h.cells[k]
+		if c == nil {
+			c = &cell{within: map[time.Duration]int{}}
+			h.cells[k] = c
+		}
+		c.gaps = append(c.gaps, gap)
+		c.sorted = false
+		if gap <= Horizon5m {
+			c.within[Horizon5m]++
+		}
+		if gap <= Horizon1h {
+			c.within[Horizon1h]++
+		}
+	}
+}
+
+// lookup finds the most specific cell with enough observations, and says which it was.
+func (h *History) lookup(user, model string, b Bucket) (*cell, string) {
+	if h == nil {
+		return nil, LevelNone
+	}
+	ks := keysFor(user, model, b)
+	for i, k := range ks {
+		if c := h.cells[k]; c != nil && len(c.gaps) >= minCell {
+			return c, levels[i]
+		}
+	}
+	// Nothing cleared the floor. The GLOBAL cell is still a better answer than none, and
+	// returning it with its own n is what lets a caller decide; it is only reported at
+	// LevelGlobal so nobody reads it as this user's own figure.
+	if c := h.cells[ks[len(ks)-1]]; c != nil && len(c.gaps) > 0 {
+		return c, LevelGlobal
+	}
+	return nil, LevelNone
+}
+
+// ReuseWithin implements Stats.
+func (h *History) ReuseWithin(user, model string, b Bucket, d time.Duration) (float64, int, string) {
+	c, level := h.lookup(user, model, b)
+	if c == nil || len(c.gaps) == 0 {
+		return 0, 0, LevelNone
+	}
+	n := len(c.gaps)
+	// The two horizons are counted incrementally; anything else is an O(n) scan, which is
+	// fine because a custom horizon is rare and correctness beats a cached wrong answer.
+	if hits, ok := c.within[d]; ok {
+		return float64(hits) / float64(n), n, level
+	}
+	hits := 0
+	for _, g := range c.gaps {
+		if g <= d {
+			hits++
+		}
+	}
+	return float64(hits) / float64(n), n, level
+}
+
+// MedianIdle implements Stats.
+func (h *History) MedianIdle(user, model string, b Bucket) (time.Duration, int, string) {
+	c, level := h.lookup(user, model, b)
+	if c == nil || len(c.gaps) == 0 {
+		return 0, 0, LevelNone
+	}
+	if !c.sorted {
+		sort.Slice(c.gaps, func(i, j int) bool { return c.gaps[i] < c.gaps[j] })
+		c.sorted = true
+	}
+	return c.gaps[(len(c.gaps)-1)/2], len(c.gaps), level
+}
+
+// ── the shipped strategies ─────────────────────────────────────────────────
+
+// NoCache is the baseline: never write cache_control, so every prompt is billed as fresh
+// input and nothing is ever held.
+//
+// It is the honest denominator for "what does caching earn", and it is also the arm that
+// makes a bad strategy visible: a policy whose total exceeds this one is charging the
+// caller for a cache that never pays for itself, and that has to be reportable rather than
+// clamped away.
+type NoCache struct{}
+
+func (NoCache) Name() string              { return "no-cache" }
+func (NoCache) Decide(Observation) Action { return ActionExpire }
+func (NoCache) Describe() string {
+	return "Never write cache_control. Every prompt is billed as fresh input; nothing is held."
+}
+
+// Fixed always chooses one tier, and never pings. The two rungs everybody compares against.
+type Fixed struct{ TTL TTL }
+
+// Fixed5m and Fixed1h are the two shipped fixed strategies.
+func Fixed5m() Fixed { return Fixed{TTL: TTL5m} }
+func Fixed1h() Fixed { return Fixed{TTL: TTL1h} }
+
+func (f Fixed) Name() string { return "fixed-" + f.TTL.Label() }
+func (f Fixed) Decide(Observation) Action {
+	if f.TTL == TTL1h {
+		return ActionWrite1h
+	}
+	return ActionWrite5m
+}
+func (f Fixed) Describe() string {
+	if f.TTL == TTL1h {
+		return "Always write the prefix at the 1-hour tier (2.0x input to create, 0.1x to read)."
+	}
+	return "Always write the prefix at the 5-minute tier (1.25x input to create, 0.1x to read)."
+}
+
+// Observed replays THE POLICY THAT ACTUALLY RAN, reconstructed from each row's own recorded
+// tier.
+//
+// It is the arm that answers "is any of this better than what we already do", and it is the
+// only strategy that reads a field of the request rather than deciding from the
+// Observation — which is legitimate precisely because it is not predicting anything: the
+// tier is a header the client already sent, i.e. a fact about the present request.
+//
+// Where the tier could not be reconstructed (TTLSourceUnknown, which is every row written
+// before the cache_ttl column existed) it falls back to Fallback and the simulator counts
+// those decisions, so the arm's coverage is reportable rather than assumed. The default
+// fallback is the provider's own default tier, because a request that reached a
+// prompt-caching provider with breakpoints in it got 5 minutes whether or not we recorded
+// the header.
+type Observed struct {
+	// tiers is the reconstructed tier per request id, supplied by the caller from the rows.
+	tiers map[int64]TTL
+	// known is the ids whose tier was actually recorded rather than assumed.
+	known map[int64]bool
+	// Fallback is the tier used where nothing was recorded.
+	Fallback TTL
+}
+
+// NewObserved builds the arm from the dataset. Reading the tiers from the rows here, once,
+// keeps Observation free of a field only one strategy could use.
+func NewObserved(reqs []*Request, fallback TTL) *Observed {
+	o := &Observed{tiers: make(map[int64]TTL, len(reqs)), known: make(map[int64]bool, len(reqs)),
+		Fallback: fallback}
+	if !fallback.Valid() {
+		o.Fallback = TTL5m
+	}
+	for _, r := range reqs {
+		if r.TTL.Valid() && r.TTLSource != TTLSourceUnknown {
+			o.tiers[r.ID] = r.TTL
+			o.known[r.ID] = true
+			continue
+		}
+		o.tiers[r.ID] = o.Fallback
+	}
+	return o
+}
+
+func (o *Observed) Name() string { return "observed-policy" }
+func (o *Observed) Describe() string {
+	return "Replay the tier each request actually asked for; where no tier was recorded, assume " +
+		o.Fallback.Label() + " and count the row as uncovered."
+}
+
+// Decide reads the tier recorded on the request being served, by its Observation.RequestID.
+func (o *Observed) Decide(ob Observation) Action {
+	t, ok := o.tiers[ob.RequestID]
+	if !ok {
+		t = o.Fallback
+	}
+	if t == TTL1h {
+		return ActionWrite1h
+	}
+	if t == TTL5m {
+		return ActionWrite5m
+	}
+	return ActionExpire
+}
+
+// Covered reports how many of the arm's decisions rested on a recorded tier.
+func (o *Observed) Covered(id int64) bool { return o != nil && o.known[id] }
+
+// HistoricalProbability is the simple learned-from-your-own-history arm: choose the cheapest
+// action whose horizon the account's own gaps say the conversation will probably come back
+// inside.
+//
+// The rule, in the order it is evaluated:
+//
+//  1. If P(next request within 5 minutes) >= P5m, a plain 5-minute write is enough: the
+//     entry survives on its own and a ping would be pure waste.
+//  2. Otherwise, if P(within 1 hour) >= P1h, hold it for an hour. Whether that is a 1h WRITE
+//     or a 5m write plus keep-alive pings is decided by which is cheaper on THIS prefix —
+//     the arithmetic is in cheaperLongHold, and it is the whole reason a strategy needs the
+//     rates rather than a token count.
+//  3. Otherwise let it expire.
+//
+// Both thresholds are fields, and the fallback chain is Stats's: a user with too little
+// history of their own is decided on their model's statistics, then on the service's, and
+// the level that was used is recorded per decision so the results can say how much of the
+// arm was actually personalised.
+type HistoricalProbability struct {
+	// P5m and P1h are the probability thresholds. Zero means the shipped default.
+	P5m float64
+	P1h float64
+	// MinPrefix is the prefix below which nothing is cached at all: a small prefix cannot
+	// repay a write, and on the production corpus the 10th percentile prefix is 0 tokens.
+	MinPrefix int64
+	// Semantics is needed for the cost comparison in step 2.
+	Semantics Semantics
+	// PingIdle and MaxPings define the keep-alive schedule the long hold would use.
+	PingIdle time.Duration
+	MaxPings int
+}
+
+// The shipped defaults for HistoricalProbability. 0.5 on both is the honest reading of a
+// probability threshold: act when the outcome is more likely than not. MinPrefix follows the
+// keep-alive tab's own shipped gate.
+const (
+	DefaultP5m       = 0.5
+	DefaultP1h       = 0.5
+	DefaultMinPrefix = 20000
+	// DefaultPingIdle and DefaultMaxPings are the shipped keep-alive schedule for a
+	// FIVE-MINUTE entry: a ping every 280 s, at most 2 per idle span. 280 rather than 300 so
+	// the refresh lands before the lifetime, not on it.
+	DefaultPingIdle = 280 * time.Second
+	DefaultMaxPings = 2
+	// DefaultPingIdle1h is the same margin against the one-hour lifetime: 56 minutes rather
+	// than 60. A one-hour entry therefore needs one twelfth as many refreshes to be held for
+	// the same wall-clock span, which is the ping-count half of the 5m-vs-1h trade.
+	DefaultPingIdle1h = 3360 * time.Second
+)
+
+func (h HistoricalProbability) withDefaults() HistoricalProbability {
+	if h.P5m <= 0 {
+		h.P5m = DefaultP5m
+	}
+	if h.P1h <= 0 {
+		h.P1h = DefaultP1h
+	}
+	if h.MinPrefix < 0 {
+		h.MinPrefix = 0
+	}
+	if h.MinPrefix == 0 {
+		h.MinPrefix = DefaultMinPrefix
+	}
+	if h.PingIdle <= 0 {
+		h.PingIdle = DefaultPingIdle
+	}
+	if h.MaxPings <= 0 {
+		h.MaxPings = DefaultMaxPings
+	}
+	if h.Semantics == (Semantics{}) {
+		h.Semantics = DefaultSemantics()
+	}
+	return h
+}
+
+func (h HistoricalProbability) Name() string { return "historical-probability" }
+func (h HistoricalProbability) Describe() string {
+	d := h.withDefaults()
+	return fmt.Sprintf("Use your own closed gaps: 5m write when P(return within 5m) >= %.0f%%, "+
+		"a 1-hour hold when P(return within 1h) >= %.0f%% (write or pings, whichever is cheaper "+
+		"on that prefix), otherwise let it expire. Prefixes under %s tokens are never cached.",
+		d.P5m*100, d.P1h*100, humanTokens(d.MinPrefix))
+}
+
+func (h HistoricalProbability) Decide(o Observation) Action {
+	d := h.withDefaults()
+	if o.CachedTokens < d.MinPrefix {
+		return ActionExpire
+	}
+	if o.Stats == nil {
+		// No history at all: the provider's own default is the least-surprising action, and
+		// it is what the traffic would have got with no strategy in play.
+		return ActionWrite5m
+	}
+	if p, n, _ := o.Stats.ReuseWithin(o.User, o.Model, o.Bucket, Horizon5m); n > 0 && p >= d.P5m {
+		return ActionWrite5m
+	}
+	if p, n, _ := o.Stats.ReuseWithin(o.User, o.Model, o.Bucket, Horizon1h); n > 0 && p >= d.P1h {
+		return d.longHold(o)
+	}
+	return ActionExpire
+}
+
+// longHold picks the cheaper of the two ways to hold an entry past five minutes.
+//
+//	write_1h = prefix × write_1h_rate                      (2.0x input, paid once, no pings)
+//	ping_5m  = prefix × write_5m_rate + K × keep_alive_cost (1.25x input plus K refreshes at 0.1x)
+//
+// Which wins is a property of the RATES and of K, not a constant: at the production corpus's
+// median prefix of 124,845 tokens the two are within a few tenths of a cent of each other,
+// and the answer flips with the ping budget. That is exactly why it is computed here rather
+// than decided in advance, and why a strategy needs the price list and not just a token count.
+func (h HistoricalProbability) longHold(o Observation) Action {
+	if !o.Pricing.Known {
+		// Unpriced: the comparison cannot be made, so choose the action that cannot be a
+		// surprise bill. A 1h write is a known one-off multiple of input; an unbounded ping
+		// schedule at an unknown rate is not.
+		return ActionWrite1h
+	}
+	write1h := float64(o.CachedTokens) * o.Pricing.Write1h
+	pingHold := float64(o.CachedTokens)*o.Pricing.Write5m +
+		float64(h.MaxPings)*o.Pricing.KeepAliveCost(o.CachedTokens, h.Semantics)
+	if pingHold < write1h {
+		return ActionPing5m
+	}
+	return ActionWrite1h
+}
+
+// Custom is the configurable arm: thresholds, or a Predictor, or both.
+//
+// It exists so a new idea can be evaluated against the same baseline without a new type and
+// without touching the simulator. With a Predictor set it asks that; with none it falls back
+// to the same historical thresholds HistoricalProbability uses, so a partially-configured
+// Custom is still a working strategy rather than a no-op.
+type Custom struct {
+	// Label is the name the dashboard groups by. Defaults to "custom".
+	Label string
+	// Predictor, when set, answers the two horizon questions instead of Stats.
+	Predictor Predictor
+	// Decider, when set, replaces the whole rule. The last resort seam: a policy that is not
+	// expressible as two thresholds plugs in here and still gets scored identically.
+	Decider func(Observation) Action
+	// Thresholds and gates, as HistoricalProbability's.
+	P5m       float64
+	P1h       float64
+	MinPrefix int64
+	Semantics Semantics
+	PingIdle  time.Duration
+	MaxPings  int
+	// AlwaysPing forces the long hold to use pings rather than the cheaper of the two, for
+	// an operator who wants to measure the ping path specifically.
+	AlwaysPing bool
+}
+
+func (c Custom) Name() string {
+	if c.Label != "" {
+		return c.Label
+	}
+	return "custom"
+}
+
+func (c Custom) Describe() string {
+	switch {
+	case c.Decider != nil:
+		return "A caller-supplied decision function, scored against the same baseline as every " +
+			"other arm."
+	case c.Predictor != nil:
+		p5, p1 := c.thresholds()
+		return fmt.Sprintf("A supplied predictor's reuse probability against thresholds "+
+			"%.0f%% (5m) and %.0f%% (1h).", p5, p1)
+	}
+	p5, p1 := c.thresholds()
+	return fmt.Sprintf("Configured thresholds over your own closed gaps: %.0f%% (5m), %.0f%% (1h).",
+		p5, p1)
+}
+
+func (c Custom) thresholds() (float64, float64) {
+	p5, p1 := c.P5m, c.P1h
+	if p5 <= 0 {
+		p5 = DefaultP5m
+	}
+	if p1 <= 0 {
+		p1 = DefaultP1h
+	}
+	return p5 * 100, p1 * 100
+}
+
+func (c Custom) Decide(o Observation) Action {
+	if c.Decider != nil {
+		return c.Decider(o)
+	}
+	base := HistoricalProbability{P5m: c.P5m, P1h: c.P1h, MinPrefix: c.MinPrefix,
+		Semantics: c.Semantics, PingIdle: c.PingIdle, MaxPings: c.MaxPings}.withDefaults()
+	if o.CachedTokens < base.MinPrefix {
+		return ActionExpire
+	}
+	if c.Predictor == nil {
+		if c.AlwaysPing {
+			// Same rule, but the long hold is forced onto the ping path.
+			if p, n, _ := o.Stats.ReuseWithin(o.User, o.Model, o.Bucket, Horizon5m); n > 0 && p >= base.P5m {
+				return ActionWrite5m
+			}
+			if o.Stats != nil {
+				if p, n, _ := o.Stats.ReuseWithin(o.User, o.Model, o.Bucket, Horizon1h); n > 0 && p >= base.P1h {
+					return ActionPing5m
+				}
+			}
+			return ActionExpire
+		}
+		return base.Decide(o)
+	}
+	if p, ok := c.Predictor.ReuseProbability(o, Horizon5m); ok && p >= base.P5m {
+		return ActionWrite5m
+	}
+	if p, ok := c.Predictor.ReuseProbability(o, Horizon1h); ok && p >= base.P1h {
+		if c.AlwaysPing {
+			return ActionPing5m
+		}
+		return base.longHold(o)
+	}
+	return ActionExpire
+}
+
+// humanTokens renders a token count the way the dashboard does, for a description string.
+func humanTokens(n int64) string {
+	if n >= 1000 {
+		v := float64(n) / 1000
+		if v == math.Trunc(v) {
+			return fmt.Sprintf("%.0fk", v)
+		}
+		return fmt.Sprintf("%.1fk", v)
+	}
+	return fmt.Sprintf("%d", n)
+}

--- a/kvcache/strategy.go
+++ b/kvcache/strategy.go
@@ -10,7 +10,7 @@ import (
 // Action is what a strategy decides to do about a conversation's cached context for the
 // idle span that starts now.
 //
-// Five actions and no sixth: they are the whole set of things a caller can actually buy
+// Six actions, and they are the whole set of things a caller can actually buy
 // from a prompt-caching provider. "Do nothing" is ActionExpire — an entry nobody pays to
 // keep lapses on its own — and saying so explicitly is what makes a no-cache baseline a
 // strategy rather than an absence.

--- a/kvcache/wire_test.go
+++ b/kvcache/wire_test.go
@@ -36,31 +36,23 @@ import (
 //     update the golden set.
 //   - ADDING a key is additive and safe. Add it to the golden set, and tell whoever owns the
 //     page, or it ships as a field nothing reads.
+//   - ADDING `omitempty` to an existing field is BREAKING even though the name is unchanged:
+//     the key then vanishes from every payload where the value is zero, and a consumer reading
+//     it sees undefined on exactly the rows where zero was the answer. The golden set therefore
+//     stores the whole tag, options and all.
 var wireKeys = map[string][]string{
-	"Request": {"id", "user", "conversation_id", "ts", "hour_utc", "bucket", "model",
-		"provider", "agent", "input_tokens", "output_tokens", "cache_read_tokens",
-		"cache_write_tokens", "cache_write_1h_tokens", "cached_context_tokens", "ttl",
-		"ttl_source", "hit", "miss_reason", "next_ts", "next_id", "has_next", "idle_ms",
-		"within_5m", "within_1h", "upstream_ms", "cost_usd", "cost_known", "keepalive"},
-	"Result": {"strategy", "description", "requests", "conversations", "total_usd",
-		"fresh_input_usd", "cache_read_usd", "cache_write_usd", "output_usd", "ping_usd",
-		"uncached_usd", "cache_premium_usd", "hits", "misses", "hit_rate_pct", "miss_rate_pct",
-		"forced_misses", "pings", "pings_that_rewrote", "pings_that_upgraded",
-		"pings_on_open_spans", "writes_5m", "writes_1h", "expires", "avoided_recomputations",
-		"avoided_tokens", "retained_ms", "unpriced", "valued", "decisions", "stats_levels",
-		"observed_coverage", "by_user", "by_model", "latency"},
-	"Savings": {"strategy", "baseline", "baseline_usd", "strategy_usd", "absolute_usd",
-		"percent_usd", "percent_known", "hit_delta", "latency_avoided_ms", "latency_known"},
-	"Group": {"key", "requests", "total_usd", "hits", "misses", "hit_rate_pct", "pings",
-		"ping_usd", "writes_5m", "writes_1h", "unpriced", "valued"},
+	"Request":      {"id", "user", "conversation_id", "ts", "hour_utc", "bucket", "model", "provider", "agent", "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "cache_write_1h_tokens", "cached_context_tokens", "ttl", "ttl_source", "hit", "miss_reason", "next_ts,omitempty", "next_id,omitempty", "has_next", "idle_ms", "within_5m", "within_1h", "upstream_ms", "cost_usd", "cost_known", "keepalive,omitempty"},
+	"Result":       {"strategy", "description,omitempty", "requests", "conversations", "total_usd", "fresh_input_usd", "cache_read_usd", "cache_write_usd", "output_usd", "ping_usd", "uncached_usd", "cache_premium_usd", "hits", "misses", "hit_rate_pct", "miss_rate_pct", "forced_misses", "pings", "pings_that_rewrote", "pings_that_upgraded", "pings_on_open_spans", "writes_5m", "writes_1h", "expires", "avoided_recomputations", "avoided_tokens", "retained_ms", "unpriced", "valued", "decisions", "stats_levels", "observed_coverage,omitempty", "by_user", "by_model", "latency"},
+	"Savings":      {"strategy", "baseline", "baseline_usd", "strategy_usd", "absolute_usd", "percent_usd", "percent_known", "hit_delta", "latency_avoided_ms", "latency_known"},
+	"Group":        {"key", "requests", "total_usd", "hits", "misses", "hit_rate_pct", "pings", "ping_usd", "writes_5m", "writes_1h", "unpriced", "valued"},
 	"Latency":      {"per_miss_ms", "hit_n", "miss_n", "hit_mean_ms", "miss_mean_ms", "known"},
 	"Coverage":     {"recorded", "assumed"},
 	"Pricing":      {"model", "input", "output", "cache_read", "write_5m", "write_1h", "ping_input_tokens", "ping_output_tokens", "source", "known"},
-	"Override":     {"input", "output", "cache_read", "write_5m", "write_1h", "ping_input_tokens", "ping_output_tokens"},
+	"Override":     {"input,omitempty", "output,omitempty", "cache_read,omitempty", "write_5m,omitempty", "write_1h,omitempty", "ping_input_tokens,omitempty", "ping_output_tokens,omitempty"},
 	"Multipliers":  {"cache_read", "write_5m", "write_1h"},
 	"Semantics":    {"hit_refreshes_ttl", "ping_refreshes_ttl", "zero_generation"},
 	"PriceList":    {"multipliers", "models"},
-	"StrategySpec": {"name", "description", "unreachable", "needs_dataset", "baseline"},
+	"StrategySpec": {"name", "description", "unreachable", "needs_dataset", "baseline,omitempty"},
 }
 
 // wireTypes is one zero value per contract type, so the reflection below cannot drift from the
@@ -98,7 +90,13 @@ func TestTheWireContractIsUnchanged(t *testing.T) {
 				}
 				continue
 			}
-			got = append(got, strings.Split(tag, ",")[0])
+			// The FULL tag, options included, not just the name before the comma. `omitempty`
+			// is part of the contract: a field that gains it stops appearing on the wire
+			// whenever its value is zero, so a consumer reading it gets undefined on exactly
+			// the rows where the zero was the interesting answer. That is how `next_ts`
+			// disappears for a conversation's last request — deliberate there, and a trap
+			// anywhere it arrives by accident. Pinning the name alone cannot see it.
+			got = append(got, tag)
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s's JSON keys changed.\n  got:  %v\n  want: %v\n\n"+
@@ -133,20 +131,22 @@ func TestTheWireContractSurvivesARoundTrip(t *testing.T) {
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatal(err)
 	}
-	// omitempty drops a zero value, so only the keys that CANNOT be empty on a real replay are
-	// required here — asserting all of them would fail on a legitimately absent field and
-	// teach whoever hits it to weaken the check.
-	for _, k := range []string{"strategy", "requests", "conversations", "total_usd",
-		"cache_write_usd", "hits", "misses", "hit_rate_pct", "valued", "decisions",
-		"stats_levels", "by_user", "by_model", "latency"} {
-		if _, ok := got[k]; !ok {
+	// Required = every field whose tag carries NO omitempty, derived from the tags rather than
+	// listed by hand. A hand-written list is the same manual step this whole test exists to
+	// remove: a field added later needs somebody to remember it, and nobody does.
+	for _, tag := range wireKeys["Result"] {
+		name, opts, _ := strings.Cut(tag, ",")
+		if strings.Contains(opts, "omitempty") {
+			continue
+		}
+		if _, ok := got[name]; !ok {
 			present := make([]string, 0, len(got))
 			for k := range got {
 				present = append(present, k)
 			}
 			sort.Strings(present)
-			t.Errorf("a real replay's JSON has no %q key; the page reads it. Present: %v",
-				k, present)
+			t.Errorf("a real replay's JSON has no %q key, and its tag carries no omitempty so "+
+				"it should always be emitted. Present: %v", name, present)
 		}
 	}
 	// Savings too: percent_known is the field that stops a zero baseline reading as 0%.

--- a/kvcache/wire_test.go
+++ b/kvcache/wire_test.go
@@ -52,7 +52,7 @@ var wireKeys = map[string][]string{
 	"Savings": {"strategy", "baseline", "baseline_usd", "strategy_usd", "absolute_usd",
 		"percent_usd", "percent_known", "hit_delta", "latency_avoided_ms", "latency_known"},
 	"Group": {"key", "requests", "total_usd", "hits", "misses", "hit_rate_pct", "pings",
-		"ping_usd", "writes_5m", "writes_1h", "unpriced"},
+		"ping_usd", "writes_5m", "writes_1h", "unpriced", "valued"},
 	"Latency":      {"per_miss_ms", "hit_n", "miss_n", "hit_mean_ms", "miss_mean_ms", "known"},
 	"Coverage":     {"recorded", "assumed"},
 	"Pricing":      {"model", "input", "output", "cache_read", "write_5m", "write_1h", "ping_input_tokens", "ping_output_tokens", "source", "known"},

--- a/kvcache/wire_test.go
+++ b/kvcache/wire_test.go
@@ -1,0 +1,162 @@
+package kvcache
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The JSON keys of this package's types are a CROSS-BOUNDARY CONTRACT, and this pins them.
+//
+// # Why a golden key set rather than trusting review
+//
+// Nothing in this package renders anything. Every type below is serialized and read by a
+// surface owned by someone else — the dashboard's KV-cache page and the offline evaluator in
+// deploy/harbor. A field renamed here does not break their build and does not fail their
+// tests: the consumer simply dereferences a key that is no longer there, gets `undefined`,
+// and renders an empty cell. That reads as a styling bug, not a contract break, and it is
+// nobody's fault in particular, which is why it survives.
+//
+// It has already happened once on this feature, one layer up: KVCacheFormula was rebuilt with
+// tags {name, expression, prose} while the page read {name, formula, note}. `name` matched by
+// luck, so eleven formula headings rendered above eleven EMPTY code boxes. Two tests passed
+// through it — one asserting the payload carried at least eight formulas, one asserting the
+// page did not hardcode them. Each was right about its own half of a contract neither checked
+// across. This is that check, for this side of the boundary.
+//
+// # What to do when this test fails
+//
+// It is not a test to "fix" by pasting the new keys in. A red line here means a consumer is
+// about to render a blank cell:
+//
+//   - Renaming or removing a key is a BREAKING change. Update the consumers in the same
+//     commit — dash's read layer and page, and deploy/harbor/kv_ttl_cost_model.py — then
+//     update the golden set.
+//   - ADDING a key is additive and safe. Add it to the golden set, and tell whoever owns the
+//     page, or it ships as a field nothing reads.
+var wireKeys = map[string][]string{
+	"Request": {"id", "user", "conversation_id", "ts", "hour_utc", "bucket", "model",
+		"provider", "agent", "input_tokens", "output_tokens", "cache_read_tokens",
+		"cache_write_tokens", "cache_write_1h_tokens", "cached_context_tokens", "ttl",
+		"ttl_source", "hit", "miss_reason", "next_ts", "next_id", "has_next", "idle_ms",
+		"within_5m", "within_1h", "upstream_ms", "cost_usd", "cost_known", "keepalive"},
+	"Result": {"strategy", "description", "requests", "conversations", "total_usd",
+		"fresh_input_usd", "cache_read_usd", "cache_write_usd", "output_usd", "ping_usd",
+		"uncached_usd", "cache_premium_usd", "hits", "misses", "hit_rate_pct", "miss_rate_pct",
+		"forced_misses", "pings", "pings_that_rewrote", "pings_that_upgraded",
+		"pings_on_open_spans", "writes_5m", "writes_1h", "expires", "avoided_recomputations",
+		"avoided_tokens", "retained_ms", "unpriced", "valued", "decisions", "stats_levels",
+		"observed_coverage", "by_user", "by_model", "latency"},
+	"Savings": {"strategy", "baseline", "baseline_usd", "strategy_usd", "absolute_usd",
+		"percent_usd", "percent_known", "hit_delta", "latency_avoided_ms", "latency_known"},
+	"Group": {"key", "requests", "total_usd", "hits", "misses", "hit_rate_pct", "pings",
+		"ping_usd", "writes_5m", "writes_1h", "unpriced"},
+	"Latency":      {"per_miss_ms", "hit_n", "miss_n", "hit_mean_ms", "miss_mean_ms", "known"},
+	"Coverage":     {"recorded", "assumed"},
+	"Pricing":      {"model", "input", "output", "cache_read", "write_5m", "write_1h", "ping_input_tokens", "ping_output_tokens", "source", "known"},
+	"Override":     {"input", "output", "cache_read", "write_5m", "write_1h", "ping_input_tokens", "ping_output_tokens"},
+	"Multipliers":  {"cache_read", "write_5m", "write_1h"},
+	"Semantics":    {"hit_refreshes_ttl", "ping_refreshes_ttl", "zero_generation"},
+	"PriceList":    {"multipliers", "models"},
+	"StrategySpec": {"name", "description", "unreachable", "needs_dataset", "baseline"},
+}
+
+// wireTypes is one zero value per contract type, so the reflection below cannot drift from the
+// golden map by a type being added and forgotten.
+func wireTypes() []any {
+	return []any{Request{}, Result{}, Savings{}, Group{}, Latency{}, Coverage{}, Pricing{},
+		Override{}, Multipliers{}, Semantics{}, PriceList{}, StrategySpec{}}
+}
+
+func TestTheWireContractIsUnchanged(t *testing.T) {
+	seen := map[string]bool{}
+	for _, v := range wireTypes() {
+		rt := reflect.TypeOf(v)
+		name := rt.Name()
+		seen[name] = true
+		want, ok := wireKeys[name]
+		if !ok {
+			t.Errorf("%s is serialized to a consumer and has no entry in wireKeys; add one, "+
+				"and tell whoever owns the page", name)
+			continue
+		}
+		var got []string
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			tag := f.Tag.Get("json")
+			if tag == "-" {
+				continue
+			}
+			if tag == "" {
+				// An exported field with NO tag is serialized under its Go name, which is a
+				// key nobody outside this package would predict.
+				if f.IsExported() {
+					t.Errorf("%s.%s is exported with no json tag, so it ships as %q — give it "+
+						"an explicit key or tag it `json:\"-\"`", name, f.Name, f.Name)
+				}
+				continue
+			}
+			got = append(got, strings.Split(tag, ",")[0])
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s's JSON keys changed.\n  got:  %v\n  want: %v\n\n"+
+				"A renamed or removed key does NOT break the consumer's build — it renders a "+
+				"blank cell, which reads as a styling bug. Update dash's read layer and page "+
+				"and deploy/harbor/kv_ttl_cost_model.py in the same commit, THEN update "+
+				"wireKeys. An added key is safe: add it here and tell whoever owns the page.",
+				name, got, want)
+		}
+	}
+	for name := range wireKeys {
+		if !seen[name] {
+			t.Errorf("wireKeys has an entry for %s, which wireTypes no longer covers", name)
+		}
+	}
+}
+
+// The keys must also survive an actual round trip through encoding/json, not merely match the
+// struct tags: a tag this test reads and a key the encoder emits are two different things once
+// embedding, `omitempty` on a struct, or a custom marshaller is involved.
+func TestTheWireContractSurvivesARoundTrip(t *testing.T) {
+	reqs, cfg := dataset(t)
+	res := Simulate(reqs, Fixed5m(), cfg)
+	if !res.Valued {
+		t.Fatal("the fixture is unpriced, so the payload below carries no cost keys to check")
+	}
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	// omitempty drops a zero value, so only the keys that CANNOT be empty on a real replay are
+	// required here — asserting all of them would fail on a legitimately absent field and
+	// teach whoever hits it to weaken the check.
+	for _, k := range []string{"strategy", "requests", "conversations", "total_usd",
+		"cache_write_usd", "hits", "misses", "hit_rate_pct", "valued", "decisions",
+		"stats_levels", "by_user", "by_model", "latency"} {
+		if _, ok := got[k]; !ok {
+			present := make([]string, 0, len(got))
+			for k := range got {
+				present = append(present, k)
+			}
+			sort.Strings(present)
+			t.Errorf("a real replay's JSON has no %q key; the page reads it. Present: %v",
+				k, present)
+		}
+	}
+	// Savings too: percent_known is the field that stops a zero baseline reading as 0%.
+	sv, err := json.Marshal(Compare(res, res))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"absolute_usd", "percent_known"} {
+		if !strings.Contains(string(sv), `"`+k+`"`) {
+			t.Errorf("Savings JSON is missing %q: %s", k, sv)
+		}
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Measuring savings: how-to/measure-savings.md
       - Stop carrying unused tools: how-to/declaration-removal.md
       - Keep an idle prompt cache warm: how-to/cache-keepalive.md
+      - Choose a cache TTL: how-to/kv-cache-ttl.md
   - Components:
       - Overview: components.md
       - Choose a preset: how-to/choose-a-preset.md


### PR DESCRIPTION
## What this is

The provider sells two prompt-cache lifetimes — **five minutes at `1.25x`** base input to create,
**an hour at `2.0x`**, both read back at `0.1x`. Choosing between them per request is a policy, and
this repo had no way to price one. This adds the domain package that does, the offline tools that
evaluate a learned predictor against it, and the measurement of what the whole thing is worth on
this deployment's own traffic.

Scope: the **calculation half only**. The dashboard page that reads it is being built separately
and is deliberately not here — this branch builds, vets and tests clean on its own.

> **This description was rewritten after an independent four-way review.** The first version quoted
> figures produced by code with three correctness defects, one of which **inverted a
> recommendation**. Those defects are fixed, pinned by tests, and every number below is remeasured.
> What the review found, and what is still known-wrong, is in **Review outcome** at the end.

## The headline

| | |
|---|---|
| Prompt caching **itself** | already taking **77.4%** off the uncached bill — banked, nothing to do |
| Reachable TTL headroom on top | **7.44%**, taken by a blind keep-alive with **no model at all** |
| The exact ceiling | **21.95%**, and reaching it requires knowing the future |
| Where the ceiling lives | **526 decisions out of 14,407** — 3.7% of requests |

That last row is the finding that should shape further work: this is a **rare-event problem**, not
a prediction problem. A model that is well calibrated on average will look good and buy nothing —
which is exactly what both machine-learned arms did.

## Measured

14,407 requests, 12 accounts, **1,896 trajectories**, 2026-08-17 11:48 → 08-19 20:38 UTC, priced at
`/etc/context-guru/prices.yaml`. A trajectory is `(account, session, MODEL)` — a cache entry does
not transfer between models, so a session that switches model is two trajectories.

One population throughout, at the default keep-alive schedule (**at most 2 refreshes per idle
span**). That schedule is a parameter, not a law, and it is a lever these figures hold fixed.

Against `fixed-5m` at **$2,215.28**:

| arm | total | vs `fixed-5m` | hit % | pings |
|---|---:|---:|---:|---:|
| `optimal` *(unreachable — reads the future)* | $1,728.95 | **−21.95%** | 76.8% | 119 |
| **`keepalive-5m`** | **$2,050.56** | **−7.44%** | 76.8% | 2,726 |
| `keepalive-1h` | $2,086.91 | −5.79% | **78.6%** | 1,789 |
| `fixed-1h` | $2,150.19 | −2.94% | 78.0% | 0 |
| `fixed-5m` / `observed-policy` | $2,215.28 | — | 74.7% | 0 |
| `keepalive-5m-to-1h` | $3,124.58 | **+41.05%** | 78.5% | 2,406 |
| `no-cache` | $9,789.96 | +341.93% | 0.0% | 0 |

### Hit rate is not the objective

- `keepalive-1h` has the **best hit rate on the page** and is not the cheapest arm.
- `keepalive-5m-to-1h` has the **second-best hit rate** and is **the most expensive reachable arm**,
  by 41%.
- `optimal` hits **less often** than three arms it beats on cost.

**A view that sorts or colours by hit rate will recommend the worst option.** The demonstration is
`keepalive-5m-to-1h`: 1,486 of its 2,406 keep-alives were tier upgrades — a one-hour write of a
whole prefix each — and 92.5% of gaps close inside five minutes, so most bought an hour of hold for
a conversation that returned in seconds. The arm is not wrong; its trigger is unconditional.

## What is in `kvcache/`

A plain domain package: no SQL, no HTTP, no DOM. A TTL decision is one the proxy will eventually
make on the request path, so defining it inside the observability layer would mean the request path
importing the dashboard to ask what to do.

| file | what |
|---|---|
| `kvcache.go` | `Request`, `Derive()`, tiers, UTC buckets, the `(user, session, model)` key |
| `pricing.go` | per-model `Pricing`, `Override`, `Semantics`, every cost formula |
| `strategy.go` | `Action`, `Strategy`, `Observation`, `Predictor`, leak-free `History` |
| `simulate.go` | chronological replay, `Result`, `Compare()` (savings unclamped) |
| `registry.go` | one arm list, plus `Replay` (the offline-model seam) and `Optimal` |

## Three properties the tests exist to hold

Each is **invisible on screen** when it breaks.

**No future leakage.** An `Observation` carries no next-request timestamp, no idle duration, and
nothing derived from either. `History` is *empty* at the start of a replay and gains a gap only as
that gap **closes**. The real next-request time is used exactly once: to *score* a decision after
it is made.

**`optimal` is a bound — now proved, not argued.** Solved per conversation by a Viterbi pass with a
back-pointer walk. `TestOptimalIsExhaustivelyOptimal` enumerates **every** action sequence
(6^4 = 1,296 per case) and scores each through `Simulate` itself, including **multi-model** cases —
which is the load-bearing half, because a single-model fixture passes with the worst defect fully
present.

**A TTL cannot rescue everything.** A recorded `prefix_change` or `cold_start` forces a miss
whatever the policy chose, and `Result.ForcedMisses` reports them.

## What is in `deploy/harbor/`

- **`kv_ttl_survival_predictor.py`** — a discrete-time logistic-hazard survival model over the time
  to the next cache-compatible request. It returns a **distribution** and deliberately does not
  choose a TTL: the probabilities are consumed by a separate cost policy, which is the only place
  the rates live.
- **`kv_ttl_cost_model.py`** — the scorer. A trajectory plus one action per turn gives the
  decomposed bill, with rates resolved **per row from the trajectory's own `model` field**.
- **`kv_ttl_cost_drift_test.go`** — why the port is trustworthy.

### The port is a port, not a second opinion

`kvcache.Simulate` is the shipped arithmetic; two implementations of one money question is exactly
the drift this project has been bitten by. Four guards pin them:

| guard | what it pins |
|---|---|
| `TestPythonCostModelAgreesWithTheShippedSimulator` | **24 fields** on a fixture reaching every shared branch |
| `TestTheUpgradingKeepAliveAgrees` | the one keep-alive that is a write *on purpose* |
| `TestTheTwoExactCeilingsAgree` | both dynamic programs |
| `TestPingScheduleMatchesThePort` | the ping cadence over 160 cases |

They run on the **system `python3`** — the scientific stack is imported lazily — so this is an
always-on guard, not a skipped one. **If the two disagree, Go is right and the port is the bug.**
The guard earned its keep during this review: after Go was fixed and before Python was, it failed
with `hits: port 5, kvcache.Simulate 4`.

## Review outcome

Four independent reviewers (security, correctness, honesty, engineering quality). The correctness
pass brute-forced every action sequence over small trajectories and ran 55 single-point mutations.

**Three critical defects, all moving figures the flattering way, all fixed:**

1. **A cache entry was handed between models** — `Conversation` lacked the model, so an opus request
   was linked to a sonnet request and the replay granted a hit at `0.1x` on an entry it could never
   have matched. *This repo already knew*: the predictor's own docstring states the rule and the
   measurement (101 of 1,772 trajectories use more than one model). The Python was right and the Go
   was wrong — the gap was not knowledge.
2. **The ceiling was not a bound** on any trajectory that switched model — 65% overstated.
3. **An `expire` turn was counted as a hit**, inflating `HitRate` and `AvoidedRecomputations` while
   paying for a fully uncached prompt. The dollar total was unchanged, which is why nothing that
   checked costs could see it.

Verified fixed by exhaustive search plus **450 randomised trajectories**, exact to 1e-12.

**Also fixed:** `NewOptimal` was O(n²) while claiming O(25n) — 94 s at 64k requests, now 285 ms;
`*.joblib` and `.venv*/` un-gitignored while the docs told operators to write a pickle **embedding
the tenant list** into a public repo; `mode=ro` defeated by `?…&` in a path (demonstrated, closed);
`--json` per-account spend at 0644, now 0600; `joblib.load` = RCE, undocumented; a comment promising
a test that does not exist; a loop that iterated zero times; "five actions" where there are six.

**Known-wrong and deliberately not fixed here:**

- **An `expire` turn is modelled as lapsing the entry, and the provider appears not to.** Tested
  against this window: in 132 cases where a caching request followed a non-caching one inside the
  earlier entry's TTL, **128 (97%) still read from cache**. Every `expire`-using arm is therefore
  charged **too much** and the ceiling is **understated**. Not corrected because it makes the DP's
  state no longer a function of the previous action alone — the same structural break as
  `HitRefreshesTTL=false` — and the two are one change that needs its own PR.
- **`NewOptimal` is unsound under `Semantics{HitRefreshesTTL: false}`** — 18% overstated.
- **`PingsPerSpan` is off by one** against the loop that bills. `dash.PingsPerSpan` has the same
  error at two call sites **with opposite sign effects**; reported separately to that owner.
- The whole-set table has no committed driver, plus four medium items.

## Verification

```
go build ./...   clean      gofmt -l .     clean
go vet ./...     clean      go test ./...  26 packages, 0 failures (also -race)
```

Zero new Go dependencies (`go.mod`/`go.sum` untouched). The Python stack is documented with a
pinned install line and imported lazily so the Go guard needs none of it.
