### PR TITLE
feat(dash): the keep-alive page — proven pings, per-session economics, and honest savings

### DIFF
--- a/config/form_test.go
+++ b/config/form_test.go
@@ -684,12 +684,30 @@ func TestTheColdCacheKeysSurviveASaveThatDoesNotMentionThem(t *testing.T) {
 	// detached map and thrown away, which is how a first-time keep-alive opt-in was lost.
 	// Nothing else may move, and no tuning field may appear — writing zeroes for those would
 	// freeze today's defaults into the document (R3).
-	for _, path := range changedPaths(t, osherDoc, out) {
-		switch path {
-		case "cache.keepalive", "cache.head_ttl_1h":
-		default:
+	// EXACTLY those two paths, and both re-parse to FALSE. `changedPaths` compares names, not
+	// values, so a switch that merely permits the two names to move accepts three wrong documents:
+	// one where neither moved (Bug 1 still present, no cache block written), one where a third
+	// path moved as well, and one where a save flipped a consent boolean ON. The first and the
+	// third both passed the permissive form.
+	moved := changedPaths(t, osherDoc, out)
+	want := map[string]bool{"cache.keepalive": true, "cache.head_ttl_1h": true}
+	for _, path := range moved {
+		if !want[path] {
 			t.Errorf("re-saving an unchanged form moved %s", path)
 		}
+		delete(want, path)
+	}
+	for path := range want {
+		t.Errorf("a re-save did not materialise %s. That is Bug 1: the two consent booleans are "+
+			"written explicitly so an absent block stops being indistinguishable from a stored "+
+			"false, and without them a first-time keep-alive opt-in is silently lost", path)
+	}
+	// And they are written as FALSE. A save that turns somebody's keep-alive ON is the one
+	// direction this document may never move by itself.
+	back := mustParse(t, out)
+	if back.Cache.KeepAlive || back.Cache.HeadTTL1h {
+		t.Errorf("a plain re-save switched a consent boolean ON: keepalive=%v head_ttl_1h=%v",
+			back.Cache.KeepAlive, back.Cache.HeadTTL1h)
 	}
 }
 

--- a/dash/cachecost_test.go
+++ b/dash/cachecost_test.go
@@ -420,6 +420,57 @@ func TestSessionRecencySurvivesARestart(t *testing.T) {
 
 // The tail comparison is per session and must survive a restart, or the first turn after one
 // reads as a snapshot change and earns a credit it did not.
+// A keep-alive PING must not re-date its session across a restart.
+//
+// SeedSessions takes each session's LATEST row, and for a pinged session that row is usually a
+// ping — 7,782 of 9,234 in the adjudicated replay were session-final. Seeding recency from one
+// would make the next real request's gap read as the time since the PING rather than since the
+// last real turn: a twenty-minute gap reading as four, no ttl_expiry recorded, and the cache
+// miss this whole mechanism is judged on made invisible. proxy/keepalive.go promises in as many
+// words that a ping never touches the session-recency map; this is the promise being kept on the
+// restart path, which is the one place the ping code cannot reach.
+func TestARestartDoesNotRecoverRecencyFromAPing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "d.db")
+	rec, err := NewRecorder(Options{DBPath: path, BatchSize: 1, FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const now = int64(1_700_000_000_000)
+	// A real turn, then a ping 19 minutes later — the shape a keep-alive leaves behind.
+	rec.Record(&Event{TS: now, TenantID: "t1", SessionID: "t1:live", Model: "m", TokensBefore: 10})
+	rec.Record(&Event{TS: now + 1_140_000, TenantID: "t1", SessionID: "t1:live", Model: "m",
+		KeepAlive: true, CacheRead: 50_000, CostUSD: 0.01})
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int64
+		_ = rec.DB().sql.QueryRow(`SELECT COUNT(*) FROM requests`).Scan(&n)
+		if n == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	rec.Close()
+
+	rec2, err := NewRecorder(Options{DBPath: path, BatchSize: 1, FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec2.Close()
+	if _, err := rec2.SeedSessions(now + 1_200_000); err != nil {
+		t.Fatal(err)
+	}
+	// The next real request arrives 20 minutes after the last REAL turn.
+	seen, _, since := rec2.Observe("t1", "t1:live", "m", now+1_200_000)
+	if !seen {
+		t.Fatal("the session was not recovered at all")
+	}
+	if since != 1_200_000 {
+		t.Errorf("recovered gap = %d ms, want 1200000 — the gap since the last real turn. %d ms "+
+			"is the gap since the PING, which would hide the very cache expiry the keep-alive "+
+			"exists to demonstrate", since, since)
+	}
+}
+
 func TestTailChangeIsPerSessionAndSurvivesARestart(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "d.db")
 	rec, err := NewRecorder(Options{DBPath: path, BatchSize: 1, FlushInterval: time.Millisecond})

--- a/dash/capture.go
+++ b/dash/capture.go
@@ -549,9 +549,17 @@ func (r *Recorder) SeedSessions(now int64) (int, error) {
 	}
 	// The tail hash of each session's LATEST request, alongside its recency: without it the
 	// first turn after a restart reads as a tail change and earns a credit it did not.
+	//
+	// `keepalive = 0` in BOTH halves. A keep-alive ping is a row in `requests`, and the row
+	// this seeds from is the session's LATEST — which for a pinged session is usually a ping.
+	// Seeding recency from one re-dates the session across a restart and makes the next real
+	// request's gap read as four minutes instead of the twenty it actually was, which is the
+	// one thing proxy/keepalive.go promises a ping never does. It would corrupt exactly the
+	// ttl_expiry attribution the keep-alive is judged on.
 	rows, err := r.db.sql.Query(`SELECT r.session_id, r.ts, r.split_tail_hash FROM requests r
-		WHERE r.ts >= ? AND r.id = (SELECT r2.id FROM requests r2
-			WHERE r2.session_id = r.session_id ORDER BY r2.ts DESC, r2.id DESC LIMIT 1)`,
+		WHERE r.ts >= ? AND r.keepalive = 0 AND r.id = (SELECT r2.id FROM requests r2
+			WHERE r2.session_id = r.session_id AND r2.keepalive = 0
+			ORDER BY r2.ts DESC, r2.id DESC LIMIT 1)`,
 		now-staleSession)
 	if err != nil {
 		return 0, err

--- a/dash/honesty_test.go
+++ b/dash/honesty_test.go
@@ -530,6 +530,15 @@ func TestInFlightSessionIsNotAVerdict(t *testing.T) {
 	}
 }
 
+// kaPingRow is a keep-alive ping: a real billed row in `requests`, marked, with no components.
+// Deliberately minimal — what matters to the caller is only that it is a row in the session
+// which is NOT an agent turn.
+func kaPingRow(ts int64, session string) *Event {
+	return &Event{TS: ts, SessionID: session, Model: "m", Provider: "anthropic",
+		KeepAlive: true, CacheRead: 50_000, CostUSD: 0.01, Meta: Meta{MaxTokens: 1},
+		TokenAccounting: AccountingComplete}
+}
+
 // TestPrefixChangeCostIsAnObservationNotADebt. The figure is bigger than every saving on
 // the dashboard, so it has to be visible; mutation is not randomly assigned, so it may not
 // be netted off. Both halves are the test.
@@ -552,6 +561,13 @@ func TestPrefixChangeCostIsAnObservationNotADebt(t *testing.T) {
 		// Mutated, but the miss was the TTL, which wins ties and is not a prefix change.
 		mk(1_000, "expired", true, CacheHit, 0.10),
 		mk(2_000, "expired", false, CacheTTLExpiry, 0.90),
+		// Same as "blamed", with a keep-alive PING between the mutating turn and the miss.
+		// A ping is not a turn: it carries no components, so if it is allowed to be "the
+		// session's previous turn" the EXISTS goes false and this row drops out of the
+		// diagnostic — under-reporting our own harm, which is the flattering direction.
+		mk(1_000, "pinged", true, CacheHit, 0.10),
+		kaPingRow(1_500, "pinged"),
+		mk(2_000, "pinged", false, CachePrefixChange, 0.30),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -559,9 +575,15 @@ func TestPrefixChangeCostIsAnObservationNotADebt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if math.Abs(o.PrefixChangeCost-0.50) > 1e-12 {
-		t.Errorf("prefix_change_cost_usd = %.4f, want 0.50 — only the turn that missed on a "+
-			"changed prefix AFTER a mutating turn belongs in it", o.PrefixChangeCost)
+	if math.Abs(o.PrefixChangeCost-0.80) > 1e-12 {
+		t.Errorf("prefix_change_cost_usd = %.4f, want 0.80 ($0.50 + the $0.30 whose mutating "+
+			"turn is separated from it by a ping) — only the turn that missed on a changed "+
+			"prefix AFTER a mutating turn belongs in it, and a ping is not a turn",
+			o.PrefixChangeCost)
+	}
+	if o.PrefixChangeRequests != 2 {
+		t.Errorf("prefix_change_requests = %d, want 2 — the cost and the count share one SQL "+
+			"definition and must agree about the ping", o.PrefixChangeRequests)
 	}
 	// It is a diagnostic. Net is baseline − cost − our spend and nothing else; subtracting an
 	// unrandomized correlation from it would book a hypothesis as money owed.

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -699,6 +699,227 @@ func (d *DB) KeepAliveSessions(f Filter, limit int) ([]*KeepAliveSessionRow, err
 	return out, nil
 }
 
+// ttlTTL1h is the provider's extended prompt-cache lifetime, for sessions whose last write
+// landed in the one-hour tier.
+const ttlTTL1h = time.Hour
+
+// write1hMultiple is the provider's published price for a ONE-HOUR cache write: 2.0x base
+// input, against 1.25x for the five-minute tier and 0.1x for a read.
+//
+// Derived from Input rather than read off the operator's price list, because the list carries
+// one `cache_write` rate per model and it is the 5-minute one — which is what the provider
+// bills for the tier this service's models actually grant. Any 1-hour figure on this page is
+// therefore explicitly a "what it would be" and is labelled as one.
+const write1hMultiple = 2.0
+
+// KeepAliveLiveRow is one session that may still hold a provider cache entry RIGHT NOW: which
+// lifetime is in force on it, how long that entry has left, and what one ping and one lapse
+// would each cost on this session's own prefix at its own model's rates.
+//
+// The economics are per SESSION and never blended, for the reason the calculator refuses to
+// average a prefix: per-ping cost is bimodal (p50 $0.0004, p99 $0.2275), so a service-wide
+// average is a number that describes no session on the list.
+type KeepAliveLiveRow struct {
+	SessionID string `json:"session_id"`
+	TenantID  string `json:"tenant_id"`
+	Model     string `json:"model"`
+	Turns     int64  `json:"turns"`
+	// LastTS is the last real request's START, which is what the provider measures the lifetime
+	// from — not the end of its response. A response that streamed for four minutes has already
+	// spent four minutes of its own entry's life.
+	LastTS int64 `json:"last_ts"`
+	// Prefix is that request's billed prefix (cache_read + cache_write): the size of the entry
+	// at risk, in the provider's own units. Never tokens_before, which is message text only and
+	// runs a median 3.38x low.
+	Prefix int64 `json:"prefix_tokens"`
+	// TTLSeconds is the lifetime IN FORCE: 3600 when this session's most recent write landed in
+	// the one-hour tier, 300 otherwise. Read off cache_write_1h rather than off configuration,
+	// because a `ttl: "1h"` request that the model does not support is granted as a 5-minute
+	// entry with a perfectly normal 200 — the tier billed is the only honest source.
+	TTLSeconds int64 `json:"ttl_seconds"`
+	// RemainingSeconds is what is left of it. Rows at or below zero are not returned: the entry
+	// is gone and the page would be stating a lifetime that has already elapsed.
+	RemainingSeconds float64 `json:"remaining_seconds"`
+	// Pings/PingUSD/SavedUSD are this session's keep-alive history in the window. Whether it is
+	// armed RIGHT NOW is not here: that lives in the proxy's control plane, which the dashboard
+	// does not read — the page joins the two, from /api/me/keepalive/sessions.
+	Pings    int64   `json:"pings"`
+	PingUSD  float64 `json:"ping_usd"`
+	SavedUSD float64 `json:"saved_usd"`
+	// Priced false means this model has no rate on the operator's list, and then EVERY dollar
+	// below is omitted rather than defaulted. A blended rate here is the defect class this
+	// project has hit five times.
+	Priced bool `json:"priced"`
+	// PingUSDEach is one ping on this prefix: the prefix at the model's cache-READ rate plus the
+	// single output token the ping asks for. MissUSD is what letting the entry lapse costs — the
+	// avoidable WRITE PREMIUM, prefix x (cache_write - cache_read), and not the whole re-read,
+	// because a resuming request pays to read its prefix either way.
+	PingUSDEach float64 `json:"ping_usd_each,omitempty"`
+	MissUSD     float64 `json:"miss_usd,omitempty"`
+	// BreakevenPings is how many pings one lapse pays for: MissUSD / PingUSDEach, floored. It is
+	// THE number that decides whether to arm, and it is nearly prefix-independent — both terms
+	// scale with the prefix, so it collapses to a ratio of the model's own rates.
+	// BreakevenMinutes is the idle time that many pings bridges at the current policy.
+	BreakevenPings   int64   `json:"breakeven_pings,omitempty"`
+	BreakevenMinutes float64 `json:"breakeven_minutes,omitempty"`
+	// The same pair for a ONE-HOUR entry, which is strictly a "what it would be" on a deployment
+	// whose models grant 5 minutes: a 1h write costs 2.0x base against 1.25x, so a lapse is
+	// dearer and pays for more pings, and each ping buys an hour instead of five minutes.
+	Breakeven1hPings   int64   `json:"breakeven_1h_pings,omitempty"`
+	Breakeven1hMinutes float64 `json:"breakeven_1h_minutes,omitempty"`
+}
+
+// KeepAliveLive is the live-session answer: the rows, and the clock they were computed against.
+type KeepAliveLive struct {
+	// Now is the server's clock at read time. On the wire so the page can count down without
+	// drifting against a browser clock that may be minutes out — a countdown computed from the
+	// client's own clock is how a "2 minutes left" reads on a session that expired ten ago.
+	Now int64 `json:"now"`
+	// IdleSeconds and MaxPings are the policy the reach figures are computed at.
+	IdleSeconds float64 `json:"idle_seconds"`
+	MaxPings    int     `json:"max_pings"`
+	// SoonSeconds is the threshold the page warns at.
+	SoonSeconds float64 `json:"soon_seconds"`
+	// Soon and SoonUSD are the expiry warning: how many rows are inside SoonSeconds of lapsing
+	// and what they would pay to re-create what they are about to lose. PotentialUSD is the same
+	// figure over every live row.
+	//
+	// Summed HERE and not in the browser. The tab's rule is that the server owns every dollar on
+	// the page (see renderKACalcControls: "nothing below multiplies a dollar by anything"), and
+	// a total assembled client-side is a figure with no test behind it — which is how a
+	// denominator came to be the twenty rows a table happened to be showing.
+	Soon         int64   `json:"soon"`
+	SoonUSD      float64 `json:"soon_usd"`
+	PotentialUSD float64 `json:"potential_usd"`
+	// SoonUnpriced counts rows inside the warning whose model has no rate, so the page can say
+	// the total excludes them rather than implying it covers everything.
+	SoonUnpriced int64              `json:"soon_unpriced"`
+	Rows         []KeepAliveLiveRow `json:"rows"`
+}
+
+// keepAliveSoon is how much of an entry's life left counts as "about to expire".
+//
+// One idle interval plus the margin a ping needs to land: below this, the next ping is the last
+// one that can still reach the entry, so it is the last moment arming can change the outcome.
+const keepAliveSoon = 330 * time.Second
+
+// KeepAliveLive lists the sessions whose provider cache entry has not yet lapsed.
+//
+// `now` is passed in rather than read, for the same reason the keeper's clock is: a function
+// that reads the wall clock cannot be tested against a fixture.
+func (d *DB) KeepAliveLive(f Filter, now int64, idleSeconds float64, maxPings int,
+	price func(string) (modelinfo.Price, bool)) (*KeepAliveLive, error) {
+	if idleSeconds <= 0 {
+		idleSeconds = recIdleSeconds
+	}
+	if maxPings <= 0 {
+		maxPings = recMaxPings
+	}
+	out := &KeepAliveLive{Now: now, IdleSeconds: idleSeconds, MaxPings: maxPings,
+		SoonSeconds: keepAliveSoon.Seconds(), Rows: []KeepAliveLiveRow{}}
+	cond, args := f.where()
+	// One pass. The partition is (tenant, session) exactly as everywhere else on this tab, and
+	// the three window MAXes answer "which tier is in force" without a query per row: the entry's
+	// lifetime is the one it was WRITTEN at, and a read refreshes it at that same tier, so the
+	// tell is whether this session's most recent write was a one-hour write.
+	rows, err := d.sql.Query(`WITH t AS (
+		SELECT r.session_id AS session_id, r.tenant_id AS tenant_id, r.ts AS ts, r.model AS model,
+		       r.cache_read + r.cache_write AS prefix,
+		       ROW_NUMBER() OVER w AS rn,
+		       COUNT(*) OVER w2 AS turns,
+		       MAX(r.ts) OVER w2 AS last_ts,
+		       MAX(CASE WHEN r.cache_write > 0 THEN r.ts ELSE 0 END) OVER w2 AS last_write_ts,
+		       MAX(CASE WHEN r.cache_write_1h > 0 THEN r.ts ELSE 0 END) OVER w2 AS last_1h_ts
+		FROM requests r WHERE `+cond+` AND r.session_id <> ''
+		WINDOW w AS (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts DESC, r.id DESC),
+		       w2 AS (PARTITION BY r.tenant_id, r.session_id))
+		SELECT session_id, tenant_id, model, turns, ts, prefix,
+		       CASE WHEN last_1h_ts > 0 AND last_1h_ts = last_write_ts THEN 1 ELSE 0 END
+		FROM t WHERE rn = 1 AND ts >= ?
+		ORDER BY prefix DESC, session_id`,
+		append(args, now-ttlTTL1h.Milliseconds())...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var r KeepAliveLiveRow
+		var oneHour int
+		if err := rows.Scan(&r.SessionID, &r.TenantID, &r.Model, &r.Turns, &r.LastTS,
+			&r.Prefix, &oneHour); err != nil {
+			return nil, err
+		}
+		ttl := ttlTTL
+		if oneHour == 1 {
+			ttl = ttlTTL1h
+		}
+		r.TTLSeconds = int64(ttl.Seconds())
+		r.RemainingSeconds = float64(r.LastTS+ttl.Milliseconds()-now) / 1000
+		if r.RemainingSeconds <= 0 {
+			continue // the entry is gone; a lifetime that has elapsed is not a lifetime in force
+		}
+		if price != nil && r.Model != "" && r.Prefix > 0 {
+			if p, ok := price(r.Model); ok && !p.Zero() {
+				r.Priced = true
+				// The ping as the request path actually sends it: max_tokens 1, so one output
+				// token is billed. max_tokens 0 is accepted by this gateway and bills none, but
+				// the figure has to match what is sent, not the cheapest shape available.
+				r.PingUSDEach = float64(r.Prefix)*p.CacheRead + p.Output
+				r.MissUSD = float64(r.Prefix) * (p.CacheWrite - p.CacheRead)
+				if r.PingUSDEach > 0 {
+					r.BreakevenPings = int64(r.MissUSD / r.PingUSDEach)
+					r.BreakevenMinutes = CoverageSeconds(idleSeconds, int(r.BreakevenPings)) / 60
+					miss1h := float64(r.Prefix) * (p.Input*write1hMultiple - p.CacheRead)
+					r.Breakeven1hPings = int64(miss1h / r.PingUSDEach)
+					// An hour-long entry needs a ping only once an hour, so the same count of
+					// pings bridges twelve times the wall clock: K x X per span still, but the
+					// lifetime the last one refreshes is 3600 s and not 300.
+					if r.Breakeven1hPings > 0 {
+						r.Breakeven1hMinutes = (float64(r.Breakeven1hPings)*idleSeconds +
+							ttlTTL1h.Seconds()) / 60
+					}
+				}
+			}
+		}
+		out.PotentialUSD += r.MissUSD
+		if r.RemainingSeconds <= out.SoonSeconds {
+			out.Soon++
+			out.SoonUSD += r.MissUSD
+			if !r.Priced {
+				out.SoonUnpriced++
+			}
+		}
+		out.Rows = append(out.Rows, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out.Rows) == 0 {
+		return out, nil
+	}
+	// This session's own keep-alive history, from the same two queries the concentration table
+	// uses, so the two panels cannot disagree about what a session's pings cost.
+	saved, err := d.sumBySession(cond, args, "r.keepalive_saved_usd", "r.keepalive_saved_usd > 0")
+	if err != nil {
+		return nil, err
+	}
+	kaCond, kaArgs := withKeepAlive(f).where()
+	spent, err := d.sumBySession(kaCond, kaArgs, "r.cost_usd", "r.keepalive = 1")
+	if err != nil {
+		return nil, err
+	}
+	pings, err := d.countBySession(kaCond, kaArgs, "r.keepalive = 1")
+	if err != nil {
+		return nil, err
+	}
+	for i := range out.Rows {
+		id := out.Rows[i].SessionID
+		out.Rows[i].SavedUSD, out.Rows[i].PingUSD = saved[id], spent[id]
+		out.Rows[i].Pings = pings[id]
+	}
+	return out, nil
+}
+
 // countBySession counts rows per session under an extra predicate.
 func (d *DB) countBySession(cond string, args []any, extra string) (map[string]int64, error) {
 	rows, err := d.sql.Query(`SELECT r.session_id, COUNT(*) FROM requests r
@@ -747,6 +968,75 @@ func PingsPerSpan(gap, idleSeconds float64, maxPings int) int {
 	return n
 }
 
+// kaGateMinPrefix is the billed-prefix floor a replay gates on: the shipped default, mirroring
+// config.DefaultKeepAliveMinPrefix, which this package may not import. Pinned by
+// TestTheReplayGateMatchesTheShippedPolicy.
+const kaGateMinPrefix = 20000
+
+// pingSpan is one idle span a live keep-alive would send pings in.
+type pingSpan struct {
+	session string
+	// gap is the seconds until the next request in the session. Open says there was none.
+	gap  float64
+	open bool
+}
+
+// pings is how many pings this span attracts under (X, K).
+//
+// An OPEN span gets the full K. That is the whole correction: a live policy cannot know a
+// session has ended, so it sends its K and stops — 7,782 of the 9,234 pings in the adjudicated
+// replay were session-final, and a LAG-based span list, which exists only BETWEEN two requests,
+// charges for none of them.
+func (s pingSpan) pings(idleSeconds float64, maxPings int) int {
+	if s.open {
+		return maxPings
+	}
+	return PingsPerSpan(s.gap, idleSeconds, maxPings)
+}
+
+// pingSpans is the ONE definition of "the idle spans a live keep-alive would ping in", shared by
+// the calculator and by the recommendation's bootstrap so the two cannot disagree about what a
+// policy costs.
+//
+// It replaced a LAG over `requests` that was wrong in both directions at once, and the two
+// errors did not cancel: it charged NO pings for a session-final request, where a live policy
+// must send K, and it charged pings on turn-0 and small-prefix spans that the shipped gate
+// (`turn >= 1 AND prefix >= MinPrefixTokens`) never touches. Replayed on the production corpus
+// the LAG form counted 1,452 pings against a blanket policy's 9,234 — a 6.4x under-count, enough
+// to flip the sign of the calculator's headline from +$70 to -$785.
+//
+// The gate is the request path's, in the same order: proxy/keepalive.go's kaEntry.pingable().
+func (d *DB) pingSpans(f Filter, minPrefix int64) ([]pingSpan, error) {
+	cond, args := f.where()
+	// LEAD, not LAG: a span belongs to the request that OPENS it, which is the request the gate
+	// is evaluated on, and LEAD is NULL exactly on the session-final row.
+	rows, err := d.sql.Query(`WITH s AS (
+		SELECT r.session_id AS session_id,
+		       ROW_NUMBER() OVER (PARTITION BY r.tenant_id, r.session_id
+		                          ORDER BY r.ts, r.id) - 1 AS turn,
+		       r.cache_read + r.cache_write AS prefix,
+		       (LEAD(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts, r.id)
+		         - r.ts) / 1000.0 AS gap_s
+		FROM requests r WHERE `+cond+`)
+		SELECT session_id, gap_s FROM s
+		WHERE turn >= 1 AND prefix >= ? AND (gap_s IS NULL OR gap_s > 0)`,
+		append(args, minPrefix)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []pingSpan
+	for rows.Next() {
+		var sess string
+		var gap sql.NullFloat64
+		if err := rows.Scan(&sess, &gap); err != nil {
+			return nil, err
+		}
+		out = append(out, pingSpan{session: sess, gap: gap.Float64, open: !gap.Valid})
+	}
+	return out, rows.Err()
+}
+
 // CalcRow is one rung of the K ladder.
 type CalcRow struct {
 	MaxPings int     `json:"max_pings"`
@@ -757,10 +1047,14 @@ type CalcRow struct {
 	ConvertibleUSD float64 `json:"convertible_usd"`
 	SharePct       float64 `json:"share_of_addressable_pct"`
 	Pings          int64   `json:"pings"`
-	PingUSD        float64 `json:"ping_usd"`
-	SavedUSD       float64 `json:"saved_usd"`
-	NetUSD         float64 `json:"net_usd"`
-	Current        bool    `json:"current,omitempty"`
+	// omitempty on the three dollar fields, so an unpriced ladder puts no `0` on the wire at all.
+	// "A field that exists gets rendered" is this project's own rule, and a 0 that means "no rate
+	// on the operator's list" is the shape every zero-as-a-measurement defect on this dashboard has
+	// had. The UI gates on `priced` as well; both, because either alone has failed before.
+	PingUSD  float64 `json:"ping_usd,omitempty"`
+	SavedUSD float64 `json:"saved_usd,omitempty"`
+	NetUSD   float64 `json:"net_usd,omitempty"`
+	Current  bool    `json:"current,omitempty"`
 }
 
 // KeepAliveCalc is the calculator's whole answer.
@@ -826,28 +1120,12 @@ func (d *DB) KeepAliveCalc(f Filter, idleSeconds float64, prefix int64, model st
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	// EVERY idle span, not only the ones that expired: the ping cost is paid on all of them,
-	// and counting only the spans that paid off is how a calculator flatters its own feature.
-	var spans []float64
-	cond, args := f.where()
-	rows, err = d.sql.Query(`WITH s AS (
-		SELECT (r.ts - LAG(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts))
-		         / 1000.0 AS gap_s
-		FROM requests r WHERE `+cond+`)
-		SELECT gap_s FROM s WHERE gap_s IS NOT NULL AND gap_s > 0`, args...)
+	// EVERY idle span the gate admits, not only the ones that expired: the ping cost is paid on
+	// all of them, and counting only the spans that paid off is how a calculator flatters its own
+	// feature. Session-final spans included — see pingSpans, and see the PINGS column's own note
+	// on the panel, which says which pings are counted.
+	spans, err := d.pingSpans(f, kaGateMinPrefix)
 	if err != nil {
-		return nil, err
-	}
-	for rows.Next() {
-		var g float64
-		if err := rows.Scan(&g); err != nil {
-			rows.Close()
-			return nil, err
-		}
-		spans = append(spans, g)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	if out.Priced {
@@ -866,8 +1144,8 @@ func (d *DB) KeepAliveCalc(f Filter, idleSeconds float64, prefix int64, model st
 		if out.AddressableUSD > 0 {
 			row.SharePct = 100 * row.ConvertibleUSD / out.AddressableUSD
 		}
-		for _, g := range spans {
-			row.Pings += int64(PingsPerSpan(g, idleSeconds, k))
+		for _, sp := range spans {
+			row.Pings += int64(sp.pings(idleSeconds, k))
 		}
 		if out.Priced {
 			row.PingUSD = float64(row.Pings) * out.PingUSDEach
@@ -978,8 +1256,11 @@ const (
 type KeepAliveRecommendation struct {
 	// Refused is the reason, when there is one. Its presence is the branch.
 	Refused string `json:"refused,omitempty"`
-	// IdleSeconds and MaxPings are the recommendation. K = 1 is NEVER returned: one ping
-	// reaches about 4.7 minutes, inside the free TTL, and it is -$71 service-wide.
+	// IdleSeconds and MaxPings are the recommendation. K = 1 is NEVER returned, and the reason
+	// is REACH, not a loss: coverage is K*X + TTL, so one ping reaches 580 s against two pings'
+	// 860 s. The "4.7 minutes / -$71 service-wide" this comment used to give is the K*X coverage
+	// error CoverageSeconds exists to refuse — under correct coverage K=1 is +$101.56 in the
+	// adjudicated sweep and K=2 is +$170.08, so K=2 dominates on size and not on sign.
 	IdleSeconds int `json:"idle_seconds,omitempty"`
 	MaxPings    int `json:"max_pings,omitempty"`
 	// LoUSD/HiUSD is the 90% interval over a window like this one. A RANGE, always, and the UI
@@ -1072,12 +1353,31 @@ func (d *DB) KeepAliveRecommend(f Filter) (*KeepAliveRecommendation, error) {
 	if err != nil {
 		return nil, err
 	}
-	spans, err := d.spansBySession(f)
+	spans, err := d.pingSpans(f, kaGateMinPrefix)
 	if err != nil {
 		return nil, err
 	}
-	keys := make([]string, 0, len(bySession))
+	bySpan := map[string][]pingSpan{}
+	for _, sp := range spans {
+		bySpan[sp.session] = append(bySpan[sp.session], sp)
+	}
+	// The resampling unit is EVERY session in the window, not only the ones that expired.
+	//
+	// Resampling only the sessions with an addressable expiry drew the saving side and the cost
+	// side from different populations: it charged ping cost over 53 of 3,891 sessions and omitted
+	// 42.4% of even the intra-session pings, on top of every session-final one. Both omissions
+	// push the interval UP — the direction that makes the rule fire when it should refuse — and
+	// condition 3 is the load-bearing test that decides whether this is recommended at all.
+	// Resampling over sessions with zero expiries is exactly how a bootstrap sees the cost side.
+	all := map[string]bool{}
 	for s := range bySession {
+		all[s] = true
+	}
+	for s := range bySpan {
+		all[s] = true
+	}
+	keys := make([]string, 0, len(all))
+	for s := range all {
 		keys = append(keys, s)
 	}
 	sort.Strings(keys) // deterministic draw order for a given seed
@@ -1089,8 +1389,8 @@ func (d *DB) KeepAliveRecommend(f Filter) (*KeepAliveRecommendation, error) {
 				v += m.usd * recRecoverableShare
 			}
 		}
-		for _, g := range spans[s] {
-			v -= float64(PingsPerSpan(g, recIdleSeconds, k)) * pingUSD
+		for _, sp := range bySpan[s] {
+			v -= float64(sp.pings(recIdleSeconds, k)) * pingUSD
 		}
 		return v
 	}
@@ -1189,31 +1489,6 @@ func (d *DB) medianPingUSD(f Filter) (float64, error) {
 		return 0, err
 	}
 	return pctlF(xs, 0.50), nil
-}
-
-// spansBySession is every idle span per session, for the ping-cost half of a replay.
-func (d *DB) spansBySession(f Filter) (map[string][]float64, error) {
-	cond, args := f.where()
-	rows, err := d.sql.Query(`WITH s AS (
-		SELECT r.session_id,
-		       (r.ts - LAG(r.ts) OVER (PARTITION BY r.tenant_id, r.session_id ORDER BY r.ts))
-		         / 1000.0 AS gap_s
-		FROM requests r WHERE `+cond+`)
-		SELECT session_id, gap_s FROM s WHERE gap_s IS NOT NULL AND gap_s > 0`, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	out := map[string][]float64{}
-	for rows.Next() {
-		var s string
-		var g float64
-		if err := rows.Scan(&s, &g); err != nil {
-			return nil, err
-		}
-		out[s] = append(out[s], g)
-	}
-	return out, rows.Err()
 }
 
 // trimZero renders a number to at most one decimal place and drops a trailing ".0", so a band

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -998,14 +998,24 @@ func (s pingSpan) pings(idleSeconds float64, maxPings int) int {
 // the calculator and by the recommendation's bootstrap so the two cannot disagree about what a
 // policy costs.
 //
-// It replaced a LAG over `requests` that was wrong in both directions at once, and the two
-// errors did not cancel: it charged NO pings for a session-final request, where a live policy
-// must send K, and it charged pings on turn-0 and small-prefix spans that the shipped gate
-// (`turn >= 1 AND prefix >= MinPrefixTokens`) never touches. Replayed on the production corpus
-// the LAG form counted 1,452 pings against a blanket policy's 9,234 — a 6.4x under-count, enough
-// to flip the sign of the calculator's headline from +$70 to -$785.
+// It replaced a LAG over `requests` that was wrong in two directions: it charged NO pings for a
+// session-final request, where a live policy must send K because it cannot know the session ended,
+// and it charged pings on the turn-0 and small-prefix spans the shipped gate
+// (`turn >= 1 AND prefix >= MinPrefixTokens`) never touches.
 //
-// The gate is the request path's, in the same order: proxy/keepalive.go's kaEntry.pingable().
+// The two errors PARTLY CANCEL, and the direction is the opposite of what it looks like. Replayed
+// on the 19,805-request snapshot at X=280, K=2: the LAG form counts 1,452, this form counts 1,060,
+// and a BLANKET policy would send 9,234. So the old column over-charged the shipped policy by
+// 1.37x — correcting it makes NET slightly more positive on that corpus. The "6.4x under-count"
+// that is easy to quote is the gap to a blanket policy, which the calculator does not model.
+//
+// What this buys is therefore not a different headline: it is a column that models the policy it
+// names, so it MOVES when the gate or K moves instead of silently ignoring both.
+//
+// The gate is the request path's, in the same order: proxy/keepalive.go's kaEntry.pingable(). It
+// gates at the shipped 20k default and not at the account's own configured floor, because this
+// package does not read tenant configuration — an account that tuned its floor sees a replay of
+// the default policy, and the panel's copy names 20k so the page stays self-consistent.
 func (d *DB) pingSpans(f Filter, minPrefix int64) ([]pingSpan, error) {
 	cond, args := f.where()
 	// LEAD, not LAG: a span belongs to the request that OPENS it, which is the request the gate

--- a/dash/keepaliveapi.go
+++ b/dash/keepaliveapi.go
@@ -3,9 +3,10 @@ package dash
 import (
 	"net/http"
 	"strconv"
+	"time"
 )
 
-// The keep-alive tab's five read routes.
+// The keep-alive tab's six read routes.
 //
 // All in API.routes(), which is the table Mount walks AND the table both scoping tests walk —
 // TestEveryMountedRouteDeclaresItsScope and TestNoRouteServesContentTextFromAnUntrustedAddress.
@@ -23,6 +24,7 @@ func (a *API) keepAliveRoutes() []route {
 		{"GET /api/keepalive/behaviour", scopeTenant, a.keepAliveBehaviour},
 		{"GET /api/keepalive/sessions", scopeTenant, a.keepAliveSessions},
 		{"GET /api/keepalive/calc", scopeTenant, a.keepAliveCalc},
+		{"GET /api/keepalive/live", scopeTenant, a.keepAliveLive},
 		{"GET /api/keepalive/recommend", scopeTenant, a.keepAliveRecommend},
 	}
 }
@@ -114,7 +116,16 @@ func (a *API) keepAliveCalc(w http.ResponseWriter, r *http.Request) {
 			httpErr(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		prefix, source = p, "account_median"
+		// "account_median" only when there IS one. On an account with no addressable expiry the
+		// median comes back 0, and labelling that a measurement is the same defect the whole tab
+		// polices: `prefix_source` is on the wire so nobody reads a typed number as a measured
+		// one, and it was reporting a measurement where there was no number at all.
+		prefix = p
+		if p > 0 {
+			source = "account_median"
+		} else {
+			source = "none"
+		}
 		// The account's own most-used model on those expiries, not a blend and not a default:
 		// without it the panel reported "not priced" on a deployment whose price list was fine,
 		// simply because nothing had named a model. Still refuses to invent a rate.
@@ -128,6 +139,30 @@ func (a *API) keepAliveCalc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	out.PrefixSource = source
+	writeJSON(w, out)
+}
+
+// keepAliveLive serves the sessions whose provider cache entry has not lapsed yet: the lifetime
+// in force on each, what is left of it, and what one ping and one lapse cost on that session's
+// own prefix.
+//
+// x and k come from the caller's current policy, as on /behaviour, because the reach figures are
+// arithmetic on them. The clock is the SERVER'S: a countdown computed against a browser clock
+// that is minutes out reads "2 minutes left" on an entry that expired ten ago.
+func (a *API) keepAliveLive(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	q := r.URL.Query()
+	x, _ := strconv.ParseFloat(q.Get("x"), 64)
+	k, _ := strconv.Atoi(q.Get("k"))
+	out, err := a.rec.DB().KeepAliveLive(f, time.Now().UnixMilli(), x, k, a.priceFn(r))
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	writeJSON(w, out)
 }
 

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -778,9 +778,11 @@ func TestKeepAliveRoutesAnswerOnAnEmptyDatabase(t *testing.T) {
 //   - it applied no gate, charging pings on the turn-0 and small-prefix spans that the shipped
 //     `turn >= 1 AND prefix >= 20k` never touches.
 //
-// Net on the production corpus: 1,452 pings against a blanket policy's 9,234, a 6.4x under-count
-// that turned the panel's +$70 headline into -$785. NET = SAVED - PINGS x EACH, so a ping count
-// that under-states by 6.4x does not make the column approximate, it flips its sign.
+// Measured on the 19,805-request snapshot at X=280, K=2: the LAG form 1,452, this form 1,060, a
+// blanket policy 9,234. The two errors partly cancel, so the old column over-charged the SHIPPED
+// policy by 1.37x rather than under-charging it 6.4x — that 6.4x is the gap to a blanket policy the
+// calculator does not model. NET = SAVED - PINGS x EACH either way, so a column counting a
+// different population than it names is a dollar figure about nothing in particular.
 //
 // The fixture separates the two errors: the gated session's spans differ between the LAG and LEAD
 // forms, and the small-prefix session is charged by one form and not the other.

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -218,6 +218,25 @@ func TestTheReplayCeilingCountsAgentTurnsNotPings(t *testing.T) {
 		t.Errorf("a ping BEFORE the reduction changed the ceiling: %d -> %d; only LATER rows can "+
 			"replay it", a.ReplayProjectedTokens, c.ReplayProjectedTokens)
 	}
+	// And the correction is deliberately NOT scoped to the window, because the main query's inner
+	// count is not either: it counts every later turn in the SESSION, so a ping that falls outside
+	// the filtered slice still inflates a ceiling computed inside it. Scoping the correction to the
+	// window is the plausible-looking change that would silently stop correcting exactly here.
+	clipped := Filter{TenantAll: true, Since: 950_000, Until: 1_140_000}
+	d, err := with.db.Overview(clipped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := without.db.Overview(clipped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.ReplayProjectedTokens != e.ReplayProjectedTokens {
+		t.Errorf("with a window that CLIPS THE PING OUT the ceiling still moved: %d -> %d. The "+
+			"inner count spans the whole session, so a ping outside the window inflates it just "+
+			"the same and the correction has to reach outside too", e.ReplayProjectedTokens,
+			d.ReplayProjectedTokens)
+	}
 }
 
 // The headline takes the keep-alive's NET and not its gross, so a window where the pings cost
@@ -745,5 +764,220 @@ func TestKeepAliveRoutesAnswerOnAnEmptyDatabase(t *testing.T) {
 		if !json.Valid(w.Body.Bytes()) {
 			t.Errorf("%s did not answer with JSON: %s", path, w.Body)
 		}
+	}
+}
+
+// The calculator's PINGS column is a policy somebody could actually run.
+//
+// It was a LAG over `requests`, which is wrong in both directions at once and the errors do not
+// cancel:
+//
+//   - a LAG span exists only BETWEEN two requests, so it charged nothing for a session-final
+//     request — where a live policy must send K, because it cannot know the session ended.
+//     7,782 of the 9,234 pings in the adjudicated replay were session-final.
+//   - it applied no gate, charging pings on the turn-0 and small-prefix spans that the shipped
+//     `turn >= 1 AND prefix >= 20k` never touches.
+//
+// Net on the production corpus: 1,452 pings against a blanket policy's 9,234, a 6.4x under-count
+// that turned the panel's +$70 headline into -$785. NET = SAVED - PINGS x EACH, so a ping count
+// that under-states by 6.4x does not make the column approximate, it flips its sign.
+//
+// The fixture separates the two errors: the gated session's spans differ between the LAG and LEAD
+// forms, and the small-prefix session is charged by one form and not the other.
+func TestTheCalculatorChargesThePingsAPolicyWouldActuallySend(t *testing.T) {
+	const t0 = int64(1_700_000_000_000)
+	sec := func(n int64) int64 { return n * 1000 }
+	evs := []*Event{
+		// A gated session: prefix 50k throughout. turn 0, then a 300 s gap, then a 1000 s gap,
+		// then nothing — the last request opens a span a live policy pings in and never closes.
+		kaAgent(t0, "big", 0.10),
+		kaAgent(t0+sec(300), "big", 0.10),
+		kaAgent(t0+sec(1300), "big", 0.10),
+		// Below the 20k prefix floor: the shipped gate never pings this session at all.
+		smallPrefix(kaAgent(t0, "small", 0.10)),
+		smallPrefix(kaAgent(t0+sec(1000), "small", 0.10)),
+	}
+	fx := newKAFixture(t, evs...)
+	calc, err := fx.db.KeepAliveCalc(Filter{TenantAll: true}, 280, 100_000, "aws/claude-sonnet-5",
+		func(string) (modelinfo.Price, bool) {
+			return modelinfo.Price{Input: 3e-6, Output: 15e-6, CacheRead: 3e-7, CacheWrite: 3.75e-6}, true
+		}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row *CalcRow
+	for i := range calc.Rows {
+		if calc.Rows[i].MaxPings == 2 {
+			row = &calc.Rows[i]
+		}
+	}
+	if row == nil {
+		t.Fatal("no K=2 rung on the ladder")
+	}
+	// "big" turn 1 opens a 1000 s span (2 pings at K=2) and turn 2 opens an unbounded one (K=2).
+	// turn 0 is not pingable and "small" never reaches the prefix floor.
+	if row.Pings != 4 {
+		t.Errorf("PINGS at K=2 = %d, want 4: two from the gated session's 1000 s span and two "+
+			"from its session-final span. 3 is the LAG form (it charges turn 0's span and none "+
+			"of the session-final one); 5 adds the sub-floor session the gate never touches",
+			row.Pings)
+	}
+	// And the money follows the count, so the column cannot be right while NET is wrong.
+	if want := float64(row.Pings) * calc.PingUSDEach; math.Abs(row.PingUSD-want) > 1e-12 {
+		t.Errorf("PING COST = %.6f, want pings x each = %.6f", row.PingUSD, want)
+	}
+	if want := row.SavedUSD - row.PingUSD; math.Abs(row.NetUSD-want) > 1e-12 {
+		t.Errorf("NET = %.6f, want SAVED - PING COST = %.6f", row.NetUSD, want)
+	}
+}
+
+// smallPrefix drops a fixture row's billed prefix below the replay gate's floor.
+func smallPrefix(e *Event) *Event {
+	e.CacheRead, e.CacheWrite = 1_000, 0
+	return e
+}
+
+// The replay gate is the request path's gate. A drift here is a calculator modelling a policy
+// nobody runs, which is the whole of F5.
+func TestTheReplayGateMatchesTheShippedPolicy(t *testing.T) {
+	if kaGateMinPrefix != 20000 {
+		t.Errorf("kaGateMinPrefix = %d; config.DefaultKeepAliveMinPrefix is 20000 and the replay "+
+			"has to gate on what the request path gates on", kaGateMinPrefix)
+	}
+}
+
+// The live panel's arithmetic: which lifetime is in force, what is left of it, and the breakeven.
+//
+// Three things it has to get right, and each has a wrong answer that looks plausible on screen:
+//
+//   - the TTL in force is the tier this session's MOST RECENT WRITE landed in, read off
+//     cache_write_1h. Not configuration: a `ttl: "1h"` request that the model does not support
+//     comes back a perfectly normal 200 with the entry granted for five minutes, so the billed
+//     tier is the only honest source. A later 5-minute write REPLACES an earlier one-hour entry.
+//   - the lifetime runs from the request's START, per the provider's documented rule, and an
+//     entry whose life has already elapsed is not returned at all.
+//   - the breakeven is MissUSD / PingUSDEach, and it is what the whole panel exists to say.
+func TestTheLivePanelPricesOneSessionsOwnBreakeven(t *testing.T) {
+	now := int64(1_700_000_000_000)
+	ago := func(sec int64) int64 { return now - sec*1000 }
+	// A session's last request: 100k of billed prefix, written at the tier `oneHour` names.
+	live := func(ts int64, session string, read, write, write1h int64) *Event {
+		e := kaAgent(ts, session, 0.10)
+		e.CacheRead, e.CacheWrite, e.CacheWrite1h = read, write, write1h
+		return e
+	}
+	fx := newKAFixture(t,
+		// Five-minute entry, 100 s old: 200 s left.
+		live(ago(100), "five", 0, 100_000, 0),
+		// One-hour entry, 100 s old, and its last request is a pure READ — the tier is the one
+		// the entry was WRITTEN at, and a read refreshes it at that same tier.
+		live(ago(400), "hour", 0, 100_000, 100_000),
+		live(ago(100), "hour", 100_000, 0, 0),
+		// An hour-long entry REPLACED by a later five-minute write. The most recent write decides,
+		// so this session has 200 s left and not 3500.
+		live(ago(400), "downgraded", 0, 100_000, 100_000),
+		live(ago(100), "downgraded", 0, 100_000, 0),
+		// Written 400 s ago at five minutes: gone, and not a row.
+		live(ago(400), "lapsed", 0, 100_000, 0),
+	)
+	price := func(string) (modelinfo.Price, bool) {
+		// 0.1x read, 1.25x write, on a $3/MTok input rate: the shipped Anthropic shape.
+		return modelinfo.Price{Input: 3e-6, Output: 15e-6, CacheRead: 3e-7, CacheWrite: 3.75e-6}, true
+	}
+	got, err := fx.db.KeepAliveLive(Filter{TenantAll: true}, now, 280, 2, price)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := map[string]KeepAliveLiveRow{}
+	for _, r := range got.Rows {
+		rows[r.SessionID] = r
+	}
+	if _, ok := rows["lapsed"]; ok {
+		t.Error("a session whose entry expired 100 s ago is on the live list; the page would be " +
+			"stating a lifetime that has already elapsed")
+	}
+	for _, c := range []struct {
+		session   string
+		ttl       int64
+		remaining float64
+	}{
+		{"five", 300, 200},
+		{"hour", 3600, 3500},
+		{"downgraded", 300, 200},
+	} {
+		r, ok := rows[c.session]
+		if !ok {
+			t.Errorf("session %q is missing from the live list", c.session)
+			continue
+		}
+		if r.TTLSeconds != c.ttl {
+			t.Errorf("%s: ttl_seconds = %d, want %d — the tier in force is the one this "+
+				"session's MOST RECENT write was billed at", c.session, r.TTLSeconds, c.ttl)
+		}
+		if math.Abs(r.RemainingSeconds-c.remaining) > 0.001 {
+			t.Errorf("%s: remaining_seconds = %.3f, want %.3f — measured from the request's "+
+				"START, which is what the provider measures it from", c.session,
+				r.RemainingSeconds, c.remaining)
+		}
+	}
+	// The breakeven, in full, on the five-minute row. Both terms scale with the prefix, so this
+	// is a ratio of the model's own rates and it comes out the same on any session on this model:
+	// a lapse costs 11.49 pings, so eleven pings are cheaper than letting it go.
+	r := rows["five"]
+	if !r.Priced {
+		t.Fatal("the row is not priced; every figure below is vacuous")
+	}
+	for _, c := range []struct {
+		name      string
+		got, want float64
+		why       string
+	}{
+		{"ping_usd_each", r.PingUSDEach, 100_000*3e-7 + 15e-6,
+			"the prefix at the cache-READ rate plus the one output token the ping asks for"},
+		{"miss_usd", r.MissUSD, 100_000 * (3.75e-6 - 3e-7),
+			"the avoidable WRITE PREMIUM, not the whole re-read: a resuming request pays to " +
+				"read its prefix either way"},
+		{"breakeven_minutes", r.BreakevenMinutes, (11*280 + 300) / 60.0,
+			"K x X + TTL at the breakeven count, which is the idle time one lapse pays to bridge"},
+		{"breakeven_1h_minutes", r.Breakeven1hMinutes, (18*280 + 3600) / 60.0,
+			"an hour-long entry needs a ping only once an hour, so the same pings bridge " +
+				"twelve times the wall clock"},
+	} {
+		if math.Abs(c.got-c.want) > 1e-9 {
+			t.Errorf("%s = %.9f, want %.9f: %s", c.name, c.got, c.want, c.why)
+		}
+	}
+	if r.BreakevenPings != 11 {
+		t.Errorf("breakeven_pings = %d, want 11: one lapse costs $%.6f and one ping $%.6f, so "+
+			"11.49 pings are what a lapse buys and eleven of them are cheaper than it",
+			r.BreakevenPings, r.MissUSD, r.PingUSDEach)
+	}
+	// A one-hour entry is dearer to re-create (2.0x base against 1.25x), so a lapse pays for MORE
+	// pings — the figure has to move in that direction and by that amount.
+	if r.Breakeven1hPings != 18 {
+		t.Errorf("breakeven_1h_pings = %d, want 18: a 1h write is 2.0x base input against the "+
+			"5m tier's 1.25x, so the premium at risk is larger", r.Breakeven1hPings)
+	}
+	// The warning's totals are the SERVER's, not a sum the browser assembled: "five" and
+	// "downgraded" have 200 s left, inside the 330 s threshold; "hour" has 3500 s and is not.
+	if got.Soon != 2 {
+		t.Errorf("soon = %d, want 2 — the two five-minute rows are inside the %.0f s threshold "+
+			"and the one-hour row is not", got.Soon, got.SoonSeconds)
+	}
+	if want := 2 * rows["five"].MissUSD; math.Abs(got.SoonUSD-want) > 1e-9 {
+		t.Errorf("soon_usd = %.6f, want %.6f: the write premium of the two rows about to lapse",
+			got.SoonUSD, want)
+	}
+	if want := 3 * rows["five"].MissUSD; math.Abs(got.PotentialUSD-want) > 1e-9 {
+		t.Errorf("potential_usd = %.6f, want %.6f: every live row, not only the urgent ones",
+			got.PotentialUSD, want)
+	}
+	if got.Now != now || got.IdleSeconds != 280 || got.MaxPings != 2 {
+		t.Errorf("the policy and the clock the figures were computed at are not on the wire: %+v",
+			struct {
+				Now         int64
+				IdleSeconds float64
+				MaxPings    int
+			}{got.Now, got.IdleSeconds, got.MaxPings})
 	}
 }

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -378,6 +378,24 @@ const splitMoved = `r.split_stable_tokens > 0 AND r.split_tail_hash <> 0
 		  AND (p.ts < r.ts OR (p.ts = r.ts AND p.id < r.id))
 		ORDER BY p.ts DESC, p.id DESC LIMIT 1), r.split_tail_hash + 1)`
 
+// afterOurMutation is the ONE definition of "the session's previous turn mutated something",
+// in SQL, shared by the prefix-change cost and its request count so the two cannot drift.
+//
+// `p.keepalive = 0` is load-bearing. A keep-alive ping is a row in `requests` like any other,
+// so without the predicate a ping becomes "the previous turn"; a ping has no
+// `request_components` rows, the EXISTS goes false, and a genuine prefix_change row silently
+// drops out of the diagnostic. That is the flattering direction on the one figure that
+// measures our OWN harm — it made context-guru look less responsible for prefix changes than
+// it is. Filter.where() already keeps pings out of every agent aggregate for the same reason;
+// this subquery reaches past it because it names `requests` itself.
+const afterOurMutation = `EXISTS (
+			SELECT 1 FROM request_components c WHERE c.mutated = 1 AND c.request_id = (
+				SELECT p.id FROM requests p
+				WHERE p.session_id = r.session_id AND p.keepalive = 0
+				  AND (p.ts < r.ts OR (p.ts = r.ts AND p.id < r.id))
+				ORDER BY p.ts DESC, p.id DESC LIMIT 1)
+		)`
+
 // Overview computes the headline aggregates for the filtered window.
 func (d *DB) Overview(f Filter) (*Overview, error) {
 	cond, args := f.where()
@@ -421,18 +439,8 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		-- the cache missed on a changed prefix AND the session's previous turn had mutated
 		-- something. Derived, never stored, and never netted off — see the field's comment for
 		-- why a correlation this confounded may not be turned into a debt.
-		COALESCE(SUM(CASE WHEN r.cache_miss_reason = 'prefix_change' AND EXISTS (
-			SELECT 1 FROM request_components c WHERE c.mutated = 1 AND c.request_id = (
-				SELECT p.id FROM requests p
-				WHERE p.session_id = r.session_id AND (p.ts < r.ts OR (p.ts = r.ts AND p.id < r.id))
-				ORDER BY p.ts DESC, p.id DESC LIMIT 1)
-		) THEN r.cost_usd ELSE 0 END),0),
-		COALESCE(SUM(CASE WHEN r.cache_miss_reason = 'prefix_change' AND EXISTS (
-			SELECT 1 FROM request_components c WHERE c.mutated = 1 AND c.request_id = (
-				SELECT p.id FROM requests p
-				WHERE p.session_id = r.session_id AND (p.ts < r.ts OR (p.ts = r.ts AND p.id < r.id))
-				ORDER BY p.ts DESC, p.id DESC LIMIT 1)
-		) THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.cache_miss_reason = 'prefix_change' AND `+afterOurMutation+` THEN r.cost_usd ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.cache_miss_reason = 'prefix_change' AND `+afterOurMutation+` THEN 1 ELSE 0 END),0),
 		-- The whole prefix_change bucket, unconditional: the total exposure of the failure
 		-- mode, not only the part adjacent to one of our own mutations.
 		COALESCE(SUM(CASE WHEN r.cache_miss_reason = 'prefix_change' THEN r.cost_usd ELSE 0 END),0),
@@ -514,12 +522,11 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// into a row fetch per candidate. Measured: 231 ms to 277 ms on the 10,000-row perf
 	// fixture, and 10.6 s to 15.3 s of that same test under -race, which is enough to blow its
 	// budget on a loaded box. The correction below is driven from the PING side instead, which
-	// is a tiny population — one linear pass plus an index lookup per ping — and costs exactly
-	// nothing on a deployment where the mechanism has never run.
+	// is a tiny population — one linear pass plus an index lookup per ping.
 	//
 	// The bug this fixes: the inner count had NO predicate at all, so a ping counted as a later
-	// turn that could replay the reduction. On a fixture with three pings it inflated the
-	// ceiling from 30 to 70 tokens and dragged replay_realized_pct down with it, which reads as
+	// turn that could replay the reduction. On a fixture with ONE ping it inflated the ceiling
+	// from 30 to 50 tokens and dragged replay_realized_pct down with it, which reads as
 	// compaction realising less of its value than it does. Found by
 	// TestPingRowsStayOutOfAgentAggregates, which compares the whole Overview key by key rather
 	// than the aggregates somebody thought of.
@@ -534,32 +541,27 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		FROM requests r WHERE `+cond+` AND r.saved_unique > 0`, args...).Scan(&o.ReplayProjectedTokens); err != nil {
 		return nil, err
 	}
-	// The correction, and it is GATED so that it costs nothing where there is nothing to
-	// correct. Two gates, both cheap: the `IN` set is materialised once and is empty on a
-	// deployment that has never pinged (so every row fails a hash lookup and the correlated
-	// count is never evaluated), and the outer `EXISTS` skips even that. Pings are ~1% of rows
-	// and concentrated in a handful of sessions, so where the set is non-empty it is small.
-	var anyPing int64
-	if err := d.sql.QueryRow(`SELECT EXISTS(SELECT 1 FROM requests WHERE keepalive = 1)`).Scan(
-		&anyPing); err != nil {
+	// The correction, driven from the PING side: one pass to find the pings, then ONE indexed sum
+	// per ping over the earlier rows of its own session. O(pings x session) rather than a second
+	// full pass over the filtered rows, and pings are ~1% of rows — on a deployment that has never
+	// pinged it is a single index scan over an empty set.
+	//
+	// It used to sit behind an `EXISTS(SELECT 1 FROM requests WHERE keepalive = 1)` gate, claiming
+	// the correction then "costs literally nothing where the mechanism has never run". It does not:
+	// `keepalive` is in no index, so the EXISTS is itself a scan. Timed alternately on the
+	// 10,000-row perf fixture, 5 trials: gated 52.7 ms against 53.0 ms ungated at 0 pings, and
+	// 58.0 against 57.3 at 100 — one extra scan for no measurable saving, so it is gone.
+	var inflation int64
+	if err := d.sql.QueryRow(`SELECT COALESCE(SUM((
+			SELECT COALESCE(SUM(r.saved_unique),0) FROM requests r
+			  WHERE r.session_id = p.session_id AND r.saved_unique > 0
+			    AND (r.ts < p.ts OR (r.ts = p.ts AND r.id < p.id))
+			    AND `+cond+`)),0)
+		FROM requests p WHERE p.keepalive = 1`, args...).Scan(&inflation); err != nil {
 		return nil, err
 	}
-	if anyPing != 0 {
-		// Driven from the PING side: one pass to find the pings, then ONE indexed sum per ping
-		// over the earlier rows of its own session. That is O(pings x session) rather than a
-		// second full pass over the filtered rows, and pings are ~1% of rows.
-		var inflation int64
-		if err := d.sql.QueryRow(`SELECT COALESCE(SUM((
-				SELECT COALESCE(SUM(r.saved_unique),0) FROM requests r
-				  WHERE r.session_id = p.session_id AND r.saved_unique > 0
-				    AND (r.ts < p.ts OR (r.ts = p.ts AND r.id < p.id))
-				    AND `+cond+`)),0)
-			FROM requests p WHERE p.keepalive = 1`, args...).Scan(&inflation); err != nil {
-			return nil, err
-		}
-		if o.ReplayProjectedTokens -= inflation; o.ReplayProjectedTokens < 0 {
-			o.ReplayProjectedTokens = 0
-		}
+	if o.ReplayProjectedTokens -= inflation; o.ReplayProjectedTokens < 0 {
+		o.ReplayProjectedTokens = 0
 	}
 	if o.ReplayProjectedTokens > 0 {
 		o.ReplayRealizedPct = float64(o.ReplayTokens) / float64(o.ReplayProjectedTokens) * 100

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -882,10 +882,13 @@ const TILE_INFO = {
     how: 'The shipped default, offered only when your own history can tell its effect apart '
       + 'from zero: at least 20 addressable cache expiries, at least 200 requests, and a 90% '
       + 'interval that excludes no-change.',
-    catch: 'One ping is never suggested \u2014 it reaches about 4.7 minutes, inside the free '
-      + 'lifetime, and it is $71 worse than nothing service-wide. Two and three pings are a '
-      + 'measured tie on our own traffic, so two is chosen for the lower request volume and not '
-      + 'for a dollar reason. Nothing is applied for you.',
+    catch: 'One ping is never suggested. Not because it loses money \u2014 it does not \u2014 '
+      + 'but because it reaches only 9.7 minutes against two pings\u2019 14.3 (K\u00d7280s plus '
+      + 'the 5-minute lifetime the last ping itself refreshes), for a cost that scales with the '
+      + 'pings sent. The K ladder above shows what each rung converts on YOUR OWN gaps; that is '
+      + 'the comparison to make, not a service-wide figure. Two and three pings are a measured '
+      + 'tie on our traffic, so two is chosen for the lower request volume and not for a dollar '
+      + 'reason. Nothing is applied for you.',
   },
   'saved-usd': {
     what: 'What compaction alone avoided, after paying for the model calls context-guru '
@@ -7429,7 +7432,8 @@ Object.assign(loaders, { feedback: loadFeedback });
 // to an entity and never to a rank.
 
 /** kaState holds the tab's loaded payloads, so a control redraw need not refetch. */
-const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], x: 280, k: 2,
+const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], live: null,
+  x: 280, k: 2,
   // canArm is false on a single-tenant deployment, which mounts no control plane at all — so
   // there is nothing to POST an arm to. Drawing the button anyway would put an affordance on the
   // page whose only possible outcome is a 404, which is the same defect as a removal command
@@ -7456,6 +7460,7 @@ async function loadKeepAlive() {
   }
   // The rest, each from its own request: one slow panel must not blank the others.
   loadKASessions();
+  loadKALive();
   loadKABehaviour();
   loadKACalc();
   loadKAArmed();
@@ -7616,7 +7621,11 @@ function renderKASessions() {
       // 0 here means the last request reported no usage at all, which is an absence rather than
       // a prompt of no size — and it is also the reason such a session cannot be priced.
       el('td', { class: 'num' }, s.last_prefix > 0 ? compact(s.last_prefix) : '—'),
-      el('td', {}, kaState.canArm
+      // Not drawn on another tenant's session. Arming keys on the AUTHENTICATED principal by
+      // design, so an override armed here against a foreign session id lands under the manager's
+      // own key and can never match a request — the route returns a cheerful 200 and nothing is
+      // kept warm. The affordance whose only outcome is a no-op does not belong on the page.
+      el('td', {}, kaState.canArm && mySession(s)
         ? el('button', {
           class: 'ghost small', 'data-testid': 'ka-arm-' + s.session_id,
           onclick: () => armSession(s),
@@ -7627,7 +7636,12 @@ function renderKASessions() {
   // sorted by cost invites exactly the inference the split-half test refutes.
   // The concentration is only a finding when there is something to concentrate: "the top 7 of
   // these hold $81.40 of $81.40" is a tautology, and it is what the first live render said.
-  const all = kaState.sessions.reduce((a, s) => a + s.expiry_usd, 0);
+  // The denominator is the ACCOUNT's addressable total, not the sum of the rows this page
+  // happens to be showing. The table is a page of 20, so summing it made the concentration read
+  // 66% where it is 58% and moved the figure whenever `limit` did — the same defect as the
+  // "$81.40 of $81.40" tautology, one step less degenerate: the numerator was fixed and the
+  // denominator was not. The account's total is already on the page, in "Still on the table".
+  const all = (kaState.ledger || {}).addressable_usd || 0;
   const lead = kaState.sessions.length > 8
     ? `The top 8 of these hold ${usd(kaState.sessions.slice(0, 8).reduce((a, s) => a + s.expiry_usd, 0))}`
       + ` of ${usd(all)}. That concentration is real and it does NOT transfer forward: `
@@ -7669,12 +7683,143 @@ async function armSession(s) {
       ? `at worst ${num(out.worst_case_pings)} pings costing ${usd(out.worst_case_usd)}`
       : `at worst ${num(out.worst_case_pings)} pings — this model is not on the price list, ` +
         'so the cost cannot be stated';
+    // Both guards in force, stated. The per-ping ceiling resolves to the service default on an
+    // account that configured none, and the prefix floor is whatever this override set — which
+    // may be lower than the account's, and 0 means every request on the session is pingable.
+    const guards = `No single ping may cost more than ${usd(out.max_usd_per_ping)}, and ` +
+      (out.min_prefix_tokens > 0
+        ? `only requests with a cached prompt over ${compact(out.min_prefix_tokens)} ` +
+          'tokens are pinged'
+        : 'there is NO prefix floor on this override, so every request on the session is pingable');
     alert(`Armed until ${when(out.until)}.\n\n` +
       `Your credential may be held for up to ${out.hold_minutes.toFixed(0)} minutes at a ` +
       `time ((K+1) × X), and this authorization is ${cost}.\n\n` +
+      guards + '.\n\n' +
       'It is cleared if the service restarts. The arm is recorded in your audit log.');
     loadKAArmed();
   } catch (e) { alert('Not armed: ' + e.message); }
+}
+
+/**
+ * loadKALive fills "Your sessions right now": one row per session whose provider cache entry
+ * has not lapsed yet.
+ *
+ * Its own request, and re-fetched rather than counted down in the browser, because the clock
+ * that matters is the SERVER'S. A countdown driven by the client's own clock reads "2 minutes
+ * left" on an entry that expired ten minutes ago whenever the two disagree, and the whole point
+ * of the panel is the number of seconds left.
+ */
+async function loadKALive() {
+  const body = $('#ka-live-body');
+  loadingRows(body, 11);
+  try {
+    kaState.live = await api('keepalive/live', { x: kaState.x, k: kaState.k });
+  } catch (e) {
+    if (aborted(e)) return;
+    tableMessage(body, 11, 'Could not read your live sessions', e.message, { error: true });
+    return;
+  }
+  renderKALive();
+}
+
+/**
+ * renderKALive draws the live table, the expiry warning above it, and the potential-saving
+ * sentence below it.
+ *
+ * Separate from the fetch for the reason renderKASessions is: the arm column has to be redrawn
+ * once the control plane's absence is known, without buttons that can only 404.
+ */
+function renderKALive() {
+  const live = kaState.live;
+  if (!live) return;
+  const body = clear($('#ka-live-body'));
+  const warn = clear($('#ka-live-warning'));
+  const wide = wideScope();
+  showScopeCol('[data-testid="ka-live-table"]', wide);
+  const rows = live.rows || [];
+  if (!rows.length) {
+    tableMessage(body, 11, 'No session of yours has a live cache entry',
+      'Every session in this window has been idle longer than its own prompt-cache lifetime, so '
+      + 'there is nothing left to keep warm. This is an ABSENCE, not a zero saving.');
+    $('#ka-live-hint').textContent = '';
+    return;
+  }
+  // The expiry warning. Every figure in it is the SERVER's, counted against the server's clock:
+  // the money at risk is the write premium those sessions would pay to re-create what they are
+  // about to lose, and this page does not add up dollars.
+  if (live.soon) {
+    warn.appendChild(el('div', { class: 'banner warn', 'data-testid': 'ka-live-expiring' },
+      el('strong', {}, `${num(live.soon)} of your ${num(rows.length)} live `
+        + `session${rows.length === 1 ? '' : 's'} expire${live.soon === 1 ? 's' : ''} within `
+        + `${Math.round(live.soon_seconds / 60)} minutes.`),
+      ' ',
+      live.soon_usd > 0
+        ? `Between them they would pay ${usd(live.soon_usd)} to re-create what they are about to lose`
+          + (live.soon_unpriced
+            ? `, excluding ${num(live.soon_unpriced)} with no rate on the price list`
+            : '')
+          + '. That is a CEILING on what arming them could save: it is only spent if the session '
+          + 'actually resumes after the entry has gone, and the provider’s cache is keyed on '
+          + 'content, so another session sending the same prefix would refresh it for nothing.'
+        : 'None of them has a rate on the operator’s price list, so what they would pay '
+          + 'cannot be stated — it is unknown, not zero.'));
+  }
+  for (const r of rows) {
+    const left = r.remaining_seconds;
+    const urgent = left <= live.soon_seconds;
+    body.appendChild(el('tr', {},
+      el('td', {}, el('code', { class: 'clip', text: r.session_id })),
+      wide ? el('td', {}, r.tenant_id || '—') : el('td', { hidden: 'hidden' }),
+      el('td', { class: 'num' }, num(r.turns)),
+      el('td', { class: 'num' }, r.prefix_tokens > 0 ? compact(r.prefix_tokens) : '—'),
+      // The tier the provider BILLED, which is the only honest source for what is in force.
+      el('td', {}, r.ttl_seconds >= 3600 ? '1 hour' : '5 minutes'),
+      el('td', { class: 'num ' + (urgent ? 'bad-text' : '') }, dur(left * 1000)),
+      el('td', { class: 'num' }, r.priced ? usd(r.ping_usd_each) : '—'),
+      el('td', { class: 'num' }, r.priced ? usd(r.miss_usd) : '—'),
+      // The number the whole panel exists to state: how many pings one lapse pays for.
+      el('td', { class: 'num' }, r.priced
+        ? el('span', { title: `${num(r.breakeven_pings)} pings at ${kaState.x}s bridge `
+            + `${r.breakeven_minutes.toFixed(0)} minutes of idle. With a 1-hour entry one lapse `
+            + `would pay for ${num(r.breakeven_1h_pings)}, bridging `
+            + `${r.breakeven_1h_minutes.toFixed(0)} minutes.` },
+          `${num(r.breakeven_pings)} · ${r.breakeven_minutes.toFixed(0)}m`)
+        : '—'),
+      el('td', { class: 'num' }, r.saved_usd || r.ping_usd
+        ? usd(r.saved_usd - r.ping_usd)
+        : '—'),
+      el('td', {}, kaState.canArm && mySession(r)
+        ? el('button', {
+          class: 'ghost small', 'data-testid': 'ka-live-arm-' + r.session_id,
+          onclick: () => armSession(r),
+        }, 'Keep warm')
+        : null)));
+  }
+  // Realised against potential, both from figures already on this page, and the difference
+  // between them named for what it is.
+  const led = kaState.ledger || {};
+  $('#ka-live-hint').textContent =
+    `Realised so far in this window: ${usd(led.saved_usd || 0)} of re-creations avoided against `
+    + `${usd(led.ping_usd || 0)} of pings, a net of ${usd(led.net_usd || 0)}. `
+    + `Still open: these ${num(rows.length)} sessions hold ${usd(live.potential_usd)} of write `
+    + 'premium that '
+    + 'a lapse would charge. Those two figures are not the same KIND of number — the first is '
+    + 'measured on requests that happened, the second is a ceiling on requests that may not, and '
+    + 'it is only earned by a session that resumes AFTER its entry would have gone. PINGS PER '
+    + 'LAPSE is the one to decide on: below it, arming is cheaper than the lapse it prevents.';
+}
+
+/**
+ * mySession answers "can the signed-in principal actually arm this row?".
+ *
+ * An override is stored under the ARMING principal's own tenant, which is the isolation the
+ * design wants and TestOverrideForAnotherTenantsSessionIdAddressesNothing proves. The
+ * consequence is that arming somebody else's session silently does nothing, so a manager's
+ * service-wide view must not offer it. On a single-tenant page every row is the caller's own.
+ */
+function mySession(r) {
+  const mine = (account.tenant || {}).id;
+  return !mine || !r.tenant_id || r.tenant_id === mine;
 }
 
 /** loadKAArmed lists what is armed RIGHT NOW — the live policy, not a stored intention. */
@@ -7692,6 +7837,7 @@ async function loadKAArmed() {
       $('#view-keepalive').querySelectorAll('[data-ka-arm-panel]').forEach((n) => { n.hidden = true; });
       host.hidden = true;
       if (kaState.sessions.length) renderKASessions();
+      renderKALive();
       return;
     }
     errorState(host, 'Could not read what is armed', e);
@@ -7856,6 +8002,7 @@ function renderKACalcControls() {
       kaState.k = Math.max(1, Math.min(4, parseInt(k.value, 10) || 2));
       loadKACalc();
       loadKABehaviour(); // the coverage rule on the gap bands moves with the policy
+      loadKALive();      // and so do the live panel's own reach figures
     } }, 'Recalculate');
   host.appendChild(el('div', { class: 'field-row' },
     el('label', { for: 'ka-x' }, 'Idle seconds (X)'), x,
@@ -7899,7 +8046,11 @@ async function loadKACalc() {
     el('thead', {}, el('tr', {},
       el('th', {}, 'Max pings (K)'), el('th', {}, 'Cache stays alive'),
       el('th', { class: 'num' }, 'Your expiries inside it'),
-      el('th', { class: 'num' }, 'Their cost'), el('th', { class: 'num' }, 'Share of what is reachable'),
+      el('th', { class: 'num' }, 'Their cost'),
+      // The value is convertible_usd / addressable_usd — a share of the DOLLARS, not of the
+      // expiry count, and the old label ("share of what is reachable") named neither.
+      el('th', { class: 'num', title: 'Their cost as a share of every addressable expiry’s cost '
+        + 'in this window' }, 'Share of those dollars'),
       el('th', { class: 'num' }, 'Pings'), el('th', { class: 'num' }, 'Ping cost'),
       el('th', { class: 'num' }, 'Net'))));
   const tb = el('tbody');
@@ -7937,6 +8088,12 @@ async function loadKACalc() {
     title: `${r.convertible_misses} of ${c.addressable_misses} expiries reachable`,
   })), {});
   host.appendChild(el('p', { class: 'hint' },
+    'PINGS is every ping the shipped policy would have sent over this window — gated as the ' +
+    'request path gates (past the session’s first request, cached prompt over 20k tokens) and ' +
+    'INCLUDING the pings a session’s last request attracts, because a live policy cannot know a ' +
+    'session has ended and sends its full K anyway. Counting only the gaps between two requests ' +
+    'under-counted by 6.4× on this service’s own traffic, which is enough to flip the sign of ' +
+    'NET. ' +
     'A replay of your own past gaps, not a forecast — and it counts only expiries that were ' +
     'addressable (the provider wrote a prefix that a ping could have refreshed). Reach grows ' +
     'sharply from one ping to two and then flattens while ping cost keeps climbing, which is ' +
@@ -7970,7 +8127,7 @@ async function loadKARecommend() {
     host.appendChild(el('div', { class: 'banner ' + (wouldCost ? 'bad' : 'warn'),
       'data-testid': 'ka-refused' },
       el('div', {}, el('strong', {},
-        wouldCost ? 'This would not pay for itself on your traffic. ' : 'Not enough history to recommend. '),
+        wouldCost ? 'This would not pay for itself on your traffic: ' : 'Not enough history to recommend: '),
       rec.refused, '.'),
       el('div', { class: 'small' },
         `For scale: measured over 357 cache expiries across this whole service, the 90% `
@@ -8013,9 +8170,11 @@ async function loadKARecommend() {
     },
   }, 'Use these values in Settings')));
   host.appendChild(el('p', { class: 'hint' },
-    'Nothing is ever applied for you. One ping is never suggested: it reaches about 4.7 ' +
-    'minutes, which is inside the free five-minute lifetime, and on this service it is $71 ' +
-    'worse than not running at all.'));
+    'Nothing is ever applied for you. One ping is never suggested because it reaches 9.7 ' +
+    'minutes where two reach 14.3 \u2014 K\u00d7280s plus the five-minute lifetime the last ' +
+    'ping itself refreshes, which is the K ladder\u2019s own COVERAGE column. One ping is not ' +
+    'a loss; it is a smaller win. Compare the rungs on your own gaps above rather than taking ' +
+    'a number from us.'));
 }
 
 /**

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -8095,9 +8095,8 @@ async function loadKACalc() {
     'PINGS is every ping the shipped policy would have sent over this window — gated as the ' +
     'request path gates (past the session’s first request, cached prompt over 20k tokens) and ' +
     'INCLUDING the pings a session’s last request attracts, because a live policy cannot know a ' +
-    'session has ended and sends its full K anyway. Counting only the gaps between two requests ' +
-    'under-counted by 6.4× on this service’s own traffic, which is enough to flip the sign of ' +
-    'NET. ' +
+    'session has ended and sends its full K anyway. Counting only the gaps BETWEEN two requests, ' +
+    'and counting them ungated, charged a different population from the one this column names. ' +
     'A replay of your own past gaps, not a forecast — and it counts only expiries that were ' +
     'addressable (the provider wrote a prefix that a ping could have refreshed). Reach grows ' +
     'sharply from one ping to two and then flattens while ping cost keeps climbing, which is ' +

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -7739,8 +7739,9 @@ function renderKALive() {
   const rows = live.rows || [];
   if (!rows.length) {
     tableMessage(body, 11, 'No session of yours has a live cache entry',
-      'Every session in this window has been idle longer than its own prompt-cache lifetime, so '
-      + 'there is nothing left to keep warm. This is an ABSENCE, not a zero saving.');
+      'Either every session in the selected window has been idle longer than its own prompt-cache '
+      + 'lifetime, or the window itself ends more than an hour ago — this panel is about NOW, and '
+      + 'the filter above still applies to it. Both are an ABSENCE, not a zero saving.');
     $('#ka-live-hint').textContent = '';
     return;
   }
@@ -7751,7 +7752,10 @@ function renderKALive() {
     warn.appendChild(el('div', { class: 'banner warn', 'data-testid': 'ka-live-expiring' },
       el('strong', {}, `${num(live.soon)} of your ${num(rows.length)} live `
         + `session${rows.length === 1 ? '' : 's'} expire${live.soon === 1 ? 's' : ''} within `
-        + `${Math.round(live.soon_seconds / 60)} minutes.`),
+        // The threshold is 330 s, which is 5.5 minutes: Math.round made the banner say "within
+        // 6 minutes" about a 5.5-minute rule, which is 30 seconds of overclaim in the direction
+        // of "you have longer than you do".
+        + `${(live.soon_seconds / 60).toFixed(1).replace(/\.0$/, '')} minutes.`),
       ' ',
       live.soon_usd > 0
         ? `Between them they would pay ${usd(live.soon_usd)} to re-create what they are about to lose`

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -557,7 +557,7 @@
     <div class="scroll-x">
       <table class="tbl" data-testid="ka-live-table">
         <thead><tr>
-          <th>SESSION</th><th data-ka-live-scope hidden>TENANT</th>
+          <th>SESSION</th><th data-scope-col hidden>TENANT</th>
           <th class="num">TURNS</th><th class="num">PREFIX</th>
           <th>TTL IN FORCE</th><th class="num">LEFT</th>
           <th class="num">ONE PING</th><th class="num">ONE LAPSE</th>

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -544,6 +544,31 @@
     <p class="hint" id="ka-sessions-note"></p>
   </div>
 
+  <div class="panel" id="ka-live-panel">
+    <h2>Your sessions right now</h2>
+    <p class="note" data-testid="ka-live-note">Every session of yours whose prompt cache has not
+      lapsed yet: the lifetime <em>in force on it</em>, what is left of that lifetime, and what one
+      ping and one lapse would each cost on that session&rsquo;s own prefix. The lifetime is read
+      off the tier the provider BILLED, not off configuration &mdash; a <code>ttl: "1h"</code>
+      request on a model that does not support it comes back a normal 200 with a five-minute
+      entry. It runs from each request&rsquo;s START, so a response that streamed for four minutes
+      has already spent four minutes of its own entry&rsquo;s life.</p>
+    <div id="ka-live-warning" data-testid="ka-live-warning"></div>
+    <div class="scroll-x">
+      <table class="tbl" data-testid="ka-live-table">
+        <thead><tr>
+          <th>SESSION</th><th data-ka-live-scope hidden>TENANT</th>
+          <th class="num">TURNS</th><th class="num">PREFIX</th>
+          <th>TTL IN FORCE</th><th class="num">LEFT</th>
+          <th class="num">ONE PING</th><th class="num">ONE LAPSE</th>
+          <th class="num">PINGS PER LAPSE</th><th class="num">REALISED</th><th></th>
+        </tr></thead>
+        <tbody id="ka-live-body"></tbody>
+      </table>
+    </div>
+    <p class="hint" id="ka-live-hint"></p>
+  </div>
+
   <div class="panel">
     <h2>Your TTL expiries</h2>
     <p class="note">A cached prefix has a five-minute lifetime, and a session idle longer

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -1355,7 +1355,7 @@ function copyBox(text, label) {
  * `state` is one of: 'idle' (not asked for yet), 'loading', 'ok', 'absent' (the endpoint is
  * not there — an older proxy), 'error'.
  */
-const prompt = { state: 'idle', view: null, byName: new Map() };
+const promptView = { state: 'idle', view: null, byName: new Map() };
 
 /**
  * loadPrompt fetches the prefix text once and repaints only the reveals that are open.
@@ -1365,20 +1365,20 @@ const prompt = { state: 'idle', view: null, byName: new Map() };
  * Each reveal registers a repaint of its own body instead.
  */
 async function loadPrompt() {
-  if (prompt.state === 'loading' || prompt.state === 'ok') return;
-  prompt.state = 'loading';
+  if (promptView.state === 'loading' || promptView.state === 'ok') return;
+  promptView.state = 'loading';
   repaintPrompt();
   try {
     const v = await api('prompt');
-    prompt.view = v;
-    prompt.byName = new Map();
-    for (const r of v.regions || []) prompt.byName.set(r.kind + '/' + r.name, r);
-    prompt.state = 'ok';
+    promptView.view = v;
+    promptView.byName = new Map();
+    for (const r of v.regions || []) promptView.byName.set(r.kind + '/' + r.name, r);
+    promptView.state = 'ok';
   } catch (err) {
     if (aborted(err)) return;
     // A 404 is an older proxy that has the report and not this route. That is "the feature
     // is not there", not "something broke", and the two must not read the same.
-    prompt.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
+    promptView.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
   }
   repaintPrompt();
 }
@@ -1411,20 +1411,20 @@ function promptTextReveal(t) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'idle' || prompt.state === 'loading') {
+    if (promptView.state === 'idle' || promptView.state === 'loading') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptView.state === 'absent') {
       body.appendChild(el('p', { class: 'hint' }, 'This proxy records the token weight of each '
         + 'declaration but not its text. The weight above is exact.'));
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptView.state === 'error') {
       body.appendChild(el('p', { class: 'hint' }, 'Could not read the prompt text.'));
       return;
     }
-    const reg = prompt.byName.get(t.kind + '/' + t.name);
+    const reg = promptView.byName.get(t.kind + '/' + t.name);
     if (reg && reg.has_text) {
       body.appendChild(el('p', { class: 'hint' }, num(reg.tokens) + ' tokens, '
         + pct(reg.share, 1) + ' of the prefix that session carried.'));
@@ -1451,7 +1451,7 @@ let promptWaiters = [];
  * prevent — the same one captureState fixes on the server.
  */
 function notCapturedState(host) {
-  const v = prompt.view || {};
+  const v = promptView.view || {};
   if (v.blocked_by === 'operator') {
     return emptyState(host, 'Prompt text is not stored on this deployment',
       'The operator has content capture switched off service-wide, so no prompt or transcript '
@@ -1540,21 +1540,21 @@ function renderPromptPanel(host, rep) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'loading' || prompt.state === 'idle') {
+    if (promptView.state === 'loading' || promptView.state === 'idle') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptView.state === 'absent') {
       emptyState(body, 'This proxy does not record prompt text',
         'It records the token weight of every region, which is what the figures above are. '
         + 'Reading the text needs a newer proxy.');
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptView.state === 'error') {
       emptyState(body, 'Could not read the prompt text', 'The figures above are unaffected.');
       return;
     }
-    const v = prompt.view || {};
+    const v = promptView.view || {};
     if (!v.captured) { notCapturedState(body); return; }
     body.appendChild(el('p', { class: 'note' }, 'One session\'s actual prefix — '
       + num(v.tokens) + ' tokens across ' + num((v.regions || []).length) + ' regions, captured '

--- a/dash/uikeepalive_test.go
+++ b/dash/uikeepalive_test.go
@@ -399,7 +399,11 @@ func TestEveryScopeColumnUsesTheAttributeShowScopeColReads(t *testing.T) {
 		t.Fatal("no showScopeCol call sites found; this check needs rewriting")
 	}
 	for _, c := range calls {
-		i := strings.Index(html, c[1])
+		// The QUOTED attribute, not the bare id: `sessions-table` is a substring of
+		// `ka-sessions-table`, so a bare search resolves by file order and would silently inspect
+		// the wrong table's thead if the panels were ever reordered — and PASS, because both carry
+		// the attribute. A check that passes for the wrong reason is worse than no check.
+		i := strings.Index(html, `data-testid="`+c[1]+`"`)
 		if i < 0 {
 			t.Errorf("showScopeCol is called for table %q, which is not in index.html", c[1])
 			continue

--- a/dash/uikeepalive_test.go
+++ b/dash/uikeepalive_test.go
@@ -368,3 +368,56 @@ func TestTheLivePanelSaysWhatItsNumbersAre(t *testing.T) {
 			"button would return 200 and keep nothing warm")
 	}
 }
+
+// Every table with a manager-only scope column marks it with the attribute showScopeCol actually
+// reads, and every table that calls showScopeCol has one.
+//
+// NOT keep-alive-specific — it lives here because it is the same kind of whole-bundle static check
+// as TestNoUIScriptShadowsAWindowMethod, and because no test covered the scope column for ANY
+// table. The live panel shipped its header as `data-ka-live-scope` while showScopeCol queries
+// `thead th[data-scope-col]`, so the attribute was read by nothing: the TENANT header stayed
+// permanently hidden while the row renderer still emitted a visible TENANT cell whenever
+// wideScope() was true — the DEFAULT view for a manager. Eleven cells under ten visible headers,
+// and every column after the hidden one shifted left: ONE LAPSE showed the ping price, PINGS PER
+// LAPSE showed a dollar, REALISED showed the breakeven. Two dollar figures reading as each other,
+// on the one panel whose whole thesis is not mislabelling dollars.
+//
+// The attribute name is EXTRACTED from showScopeCol rather than written down here, so renaming it
+// in app.js cannot leave this check asserting a stale spelling.
+func TestEveryScopeColumnUsesTheAttributeShowScopeColReads(t *testing.T) {
+	app, html := readUI(t, "ui/app.js"), readUI(t, "ui/index.html")
+	m := regexp.MustCompile(`thead th\[([a-z-]+)\]`).FindStringSubmatch(app)
+	if m == nil {
+		t.Fatal("showScopeCol's selector no longer looks like `thead th[attr]`; this check needs " +
+			"rewriting against whatever replaced it")
+	}
+	attr := m[1]
+
+	// Every table told to toggle a scope column must actually have one, under that attribute.
+	calls := regexp.MustCompile(`showScopeCol\('\[data-testid=["']?([a-z-]+)["']?\]'`).FindAllStringSubmatch(app, -1)
+	if len(calls) == 0 {
+		t.Fatal("no showScopeCol call sites found; this check needs rewriting")
+	}
+	for _, c := range calls {
+		i := strings.Index(html, c[1])
+		if i < 0 {
+			t.Errorf("showScopeCol is called for table %q, which is not in index.html", c[1])
+			continue
+		}
+		end := strings.Index(html[i:], "</thead>")
+		if end < 0 || !strings.Contains(html[i:i+end], attr) {
+			t.Errorf("table %q calls showScopeCol but no <th> in its thead carries %q, so the "+
+				"column can never be revealed — while the row renderer still emits the cell. "+
+				"Every body row would then have one more cell than there are visible headers, and "+
+				"every column after it reads as its neighbour.", c[1], attr)
+		}
+	}
+	// And no header may mark itself with a DIFFERENT scope-ish attribute: that is the defect
+	// itself, and it is invisible because a `hidden` <th> that is never un-hidden looks deliberate.
+	for _, bad := range regexp.MustCompile(`data-[a-z-]*scope[a-z-]*`).FindAllString(html, -1) {
+		if bad != attr {
+			t.Errorf("index.html marks a scope column %q, but showScopeCol only reads %q, so that "+
+				"header stays hidden forever. Use %q.", bad, attr, attr)
+		}
+	}
+}

--- a/dash/uikeepalive_test.go
+++ b/dash/uikeepalive_test.go
@@ -122,8 +122,15 @@ func TestTheRecommendationRendersARangeAndRefusesThinHistory(t *testing.T) {
 		t.Fatal("loadKARecommend is gone; this check needs rewriting")
 	}
 	body := src[i : i+min(len(src)-i, 4000)]
-	if !strings.Contains(body, "rec.lo_usd") || !strings.Contains(body, "rec.hi_usd") {
-		t.Error("the recommendation does not render an interval")
+	// The SEPARATOR is pinned, not merely the two field names. Asserting only that both names
+	// appear leaves `usd((rec.lo_usd + rec.hi_usd) / 2)` — a single hero midpoint — passing, which
+	// is precisely what this check exists to forbid, and it did pass: the whole dash package
+	// stayed green with the tile rendering a point.
+	if !regexp.MustCompile(`rec\.lo_usd[\s\S]{0,40}\x{2013}[\s\S]{0,40}rec\.hi_usd`).MatchString(body) {
+		t.Error("the recommendation tile does not render lo and hi as a RANGE with a dash between " +
+			"them. Two field names in the same function is not enough: a midpoint of the two " +
+			"mentions both and is a hero number, which is the one thing this payload has no " +
+			"point estimate on the wire in order to prevent")
 	}
 	if !strings.Contains(body, "rec.refused") {
 		t.Error("the recommendation has no refusal branch; below 20 addressable expiries a real " +
@@ -231,4 +238,133 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// No UI script may declare a top-level binding named after a window method.
+//
+// dash/ui/*.js are CLASSIC scripts, so they share one global scope, and a top-level
+// `const prompt = {...}` in tools.js creates a binding in the global declarative
+// environment that shadows `window.prompt` for every bare `prompt(...)` in every other
+// script on the page — app.js included, regardless of load order, because the reference is
+// resolved at call time. That shipped: the "Keep warm" button and the "copy this token now"
+// dialog both threw `prompt is not a function` and failed SILENTLY, which is the only
+// reason it survived review.
+//
+// The declaration and the call site are in different files, so nothing local to either one
+// can catch this. It is a whole-bundle property, and this is the cheapest place to assert it.
+func TestNoUIScriptShadowsAWindowMethod(t *testing.T) {
+	// The window methods a classic script can plausibly call bare. Not exhaustive by
+	// design — it is the set whose shadowing would be silent, which is the dangerous kind.
+	shadowable := []string{
+		"prompt", "alert", "confirm", "open", "close", "print", "focus", "blur", "stop",
+		"find", "scroll", "scrollTo", "scrollBy", "postMessage", "fetch", "atob", "btoa",
+		"setTimeout", "setInterval", "clearTimeout", "clearInterval", "queueMicrotask",
+		"requestAnimationFrame", "cancelAnimationFrame", "structuredClone", "reportError",
+		"getComputedStyle", "matchMedia", "getSelection", "name", "status", "length",
+	}
+	decl := regexp.MustCompile(`(?m)^(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)`)
+	for _, f := range []string{"ui/app.js", "ui/tools.js"} {
+		src := stripJSComments(readUI(t, f))
+		for _, m := range decl.FindAllStringSubmatch(src, -1) {
+			for _, bad := range shadowable {
+				if m[1] != bad {
+					continue
+				}
+				t.Errorf("%s declares a top-level %q, which shadows window.%s for every bare "+
+					"%s(...) call in every classic script on the page, in any load order.\n"+
+					"Rename it (promptView, openPanel, …). A shadow like this fails silently: "+
+					"the control just does nothing.", f, bad, bad, bad)
+			}
+		}
+	}
+}
+
+// The K rule's copy states its REACH, and the two refuted numbers may not come back.
+//
+// The page used to justify "one ping is never suggested" with "it reaches about 4.7 minutes" and
+// "it is $71 worse than nothing". Both are the K*X coverage error: coverage is K*X + TTL, because
+// the last ping is itself a cache read and a read refreshes the entry — which is the arithmetic
+// CoverageSeconds carries a warning about, and which the page's own K-ladder prints correctly
+// three panels away. Under correct coverage one ping is +$101.56 in the adjudicated sweep, not
+// -$71, so the page was contradicting itself AND arguing from a refuted figure.
+//
+// Pinned against CoverageSeconds itself, so reverting the reach to K*X fails here rather than
+// only in a review: at X=280 the wrong arithmetic gives 4.7 and 9.3 minutes where the right one
+// gives 9.7 and 14.3.
+func TestTheKRuleCopyStatesItsReachAndNotTheRefutedNumbers(t *testing.T) {
+	src := readUI(t, "ui/app.js")
+	for _, dead := range []string{"4.7 minute", "$71 worse", "71 worse than"} {
+		if strings.Contains(src, dead) {
+			t.Errorf("the refuted figure %q is back in the tab's copy. Coverage is K*X + TTL; "+
+				"one ping reaches 9.7 minutes at X=280 and is a smaller win, not a loss", dead)
+		}
+	}
+	for k, want := range map[int]string{1: "9.7", 2: "14.3"} {
+		if got := trimZero(CoverageSeconds(280, k) / 60); got != want {
+			t.Fatalf("CoverageSeconds(280,%d) is %s minutes, not %s — this check's expected "+
+				"strings need rewriting along with the copy", k, got, want)
+		}
+		if !strings.Contains(src, want) {
+			t.Errorf("the copy does not state the K=%d reach of %s minutes; the rule has to be "+
+				"argued from the coverage the code actually enforces", k, want)
+		}
+	}
+}
+
+// The live panel's three honesty properties, in the markup and in the renderer.
+//
+// Each one is invisible on screen when it is wrong — the page looks completely fine — which is
+// what earns a source-level assertion, exactly as the tiles' explanations do:
+//
+//   - the TTL shown is the tier the provider BILLED, not one read off configuration. A
+//     `ttl: "1h"` request on a model that does not support it returns a normal 200 with a
+//     five-minute entry, so configuration is not evidence about what is in force.
+//   - the potential saving is a CEILING and says so. It is only spent if the session resumes
+//     after its entry has gone, and the provider's cache is content-keyed.
+//   - the countdown is computed against the SERVER's clock, which is on the wire for that reason.
+func TestTheLivePanelSaysWhatItsNumbersAre(t *testing.T) {
+	html := readUI(t, "ui/index.html")
+	if !strings.Contains(html, `data-testid="ka-live-table"`) {
+		t.Fatal("the live-sessions table is gone; this check needs rewriting")
+	}
+	note := html[strings.Index(html, `data-testid="ka-live-note"`):]
+	note = note[:strings.Index(note, "</p>")]
+	if !strings.Contains(note, "BILLED") {
+		t.Error("the live panel does not say the lifetime it shows is the tier the provider " +
+			"BILLED. A `ttl: \"1h\"` request on a model that does not grant it comes back a " +
+			"normal 200 with a 5-minute entry, so configuration is not evidence")
+	}
+	if !strings.Contains(note, "START") {
+		t.Error("the live panel does not say the lifetime runs from each request's START. " +
+			"Anchoring it at the response instead is the single change that flips the sign of " +
+			"this whole feature, and a countdown that gets it wrong is over-optimistic by the " +
+			"length of the response")
+	}
+	src := readUI(t, "ui/app.js")
+	i := strings.Index(src, "function renderKALive(")
+	if i < 0 {
+		t.Fatal("renderKALive is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 6000)]
+	if !strings.Contains(body, "CEILING") {
+		t.Error("the expiring-soon warning states a dollar figure without calling it a CEILING. " +
+			"It is only spent if the session resumes AFTER its entry lapsed, and the provider's " +
+			"cache is keyed on content, so another session sending the same prefix refreshes it " +
+			"for nothing")
+	}
+	if !strings.Contains(body, "ABSENCE") {
+		t.Error("the empty state does not distinguish an absence from a zero saving; every other " +
+			"coverage state on this tab does")
+	}
+	// The countdown must come from the server's clock, and the field has to be read for that to
+	// mean anything.
+	if !strings.Contains(body, "live.soon_seconds") || !strings.Contains(src, "'keepalive/live'") {
+		t.Error("the live panel does not read the server's own threshold; a countdown driven by " +
+			"the browser's clock reads \"2 minutes left\" on an entry that expired ten ago")
+	}
+	if !strings.Contains(body, "mySession(r)") {
+		t.Error("the arm button is drawn without checking the row is the caller's own. An override " +
+			"is keyed to the principal that arms it, so on a manager's service-wide view every " +
+			"button would return 200 and keep nothing warm")
+	}
 }

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -944,20 +944,23 @@ func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
 //
 // max_tokens is 1 rather than 0, and the reason is now MEASURED rather than assumed.
 //
-// `max_tokens: 0` is the provider's own documented cache pre-warm shape and it works on this
-// gateway: probed live against aws/claude-sonnet-5, it returned 200 with
-// `cache_read_input_tokens: 5851`, `cache_creation_input_tokens: 0` and `output_tokens: 0` —
-// a full cache read for no output at all. So the cheaper shape exists and is real.
+// `max_tokens: 0` is the provider's documented cache pre-warm shape, and on THIS gateway it is
+// MODEL-DEPENDENT, which is the whole reason 1 wins:
 //
-// It stays at 1 anyway, on the balance of the two measured quantities. The saving is ONE output
-// token, $0.000015 on sonnet against the $0.0018 the read itself costs on the same prefix — under
-// a percent of a ping. Against that, the docs list four bodies `max_tokens: 0` is REJECTED for:
-// `stream: true`, extended thinking, structured outputs, and `tool_choice` of type `tool` or
-// `any`. This ping forces `stream: false` and refuses thinking-enabled sessions, but it resends
-// the caller's body verbatim and does not touch `tool_choice` — because touching it would change
-// the hashed prefix and the ping would miss the entry it exists to refresh. An agent that sets
-// `tool_choice: {"type": "any"}` would therefore get a 400 on every ping, and the failure mode of
-// this request is that a cache entry lapses. A tenth of a percent is not worth that branch.
+//   - aws/claude-sonnet-5: 200, `cache_read_input_tokens: 5851`, `cache_creation_input_tokens: 0`,
+//     `output_tokens: 0` — a full cache read for no output at all.
+//   - claude-haiku-4-5:    **400**, `max_tokens: must be greater than or equal to 1`.
+//
+// So the cheaper shape is real on some routes and a hard failure on others, and the routing is not
+// this function's to know: `model` comes from the caller's own body. A ping that 400s is a cache
+// entry allowed to lapse, which is the one outcome this request exists to prevent.
+//
+// The prize for taking that risk is ONE output token: $0.0000076 against the $0.0073304 the read
+// itself costs on a 48k-token prefix, i.e. 0.1% of a ping. The docs additionally list four bodies
+// 0 is rejected for — `stream: true`, extended thinking, structured outputs, and `tool_choice` of
+// type `tool` or `any`. This ping forces `stream: false` and refuses thinking-enabled sessions, but
+// it resends the caller's body verbatim and does not touch `tool_choice`, because touching it would
+// change the hashed prefix and miss the entry. 0.1% does not buy that many ways to fail.
 //
 // stream is false so the response is one small JSON body with its usage block in it, rather
 // than an SSE stream this would have to read to the end to price.

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -150,6 +150,9 @@ type CachePolicy struct {
 	// cost is bimodal (p50 $0.0004, p99 $0.2275, max $0.3780) while a per-SESSION budget
 	// truncates exactly the long large-prefix sessions holding the value — capping the
 	// window's pings per session at 20 drops the net from +$164 to $92.34.
+	//
+	// Read it through Ceiling(), never directly: zero here means UNCONFIGURED, and for a spend
+	// guard that has to resolve to the default rather than to infinity.
 	MaxUSDPerPing float64
 	// MinPrefixTokens is the billed-prefix floor (the previous request's cache_read +
 	// cache_write) a session must reach before it is pinged. With the first-request skip this
@@ -298,8 +301,35 @@ func (e *kaEntry) due(now time.Time) bool {
 // after `tool_use`, and 83.7% of the recoverable dollars sit behind it.
 func (e *kaEntry) pingable() bool {
 	return e.turn >= 1 && e.prefix >= int64(e.pol.MinPrefixTokens) &&
-		(e.pol.MaxUSDPerPing <= 0 || e.pingUSD <= e.pol.MaxUSDPerPing)
+		e.pingUSD <= e.pol.Ceiling()
 }
+
+// Ceiling is the per-ping cost guard that is actually ENFORCED.
+//
+// The whole of this method is the sentinel. `MaxUSDPerPing == 0` means "nobody configured
+// one", and the shipped code read that as "no cap": `MaxUSDPerPing <= 0 || cost <= cap`. On
+// an account whose keep-alive is OFF the config builder hands the request path a zero
+// CachePolicy, and enabling one session by hand is precisely the use case a per-session
+// override exists for — so the one path where the guard was written to matter was the one
+// path that ran without it, while the arm response cheerfully reported a ceiling of $0.00.
+//
+// Zero in a money guard resolves to the DEFAULT. A caller that genuinely wants no ceiling has
+// to say so with a negative value, which is a thing somebody has to type on purpose.
+func (p CachePolicy) Ceiling() float64 {
+	switch {
+	case p.MaxUSDPerPing > 0:
+		return p.MaxUSDPerPing
+	case p.MaxUSDPerPing < 0:
+		return math.Inf(1)
+	default:
+		return DefaultMaxUSDPerPing
+	}
+}
+
+// DefaultMaxUSDPerPing mirrors config.DefaultKeepAliveMaxUSDPerPing, which this package may not
+// import (proxy does not depend on the configuration loader). They are pinned equal by
+// TestTheProxysPingCeilingDefaultMatchesTheConfigLoaders.
+const DefaultMaxUSDPerPing = 0.25
 
 // keeper runs the keep-alive. One goroutine per handler, one map, one lock.
 type keeper struct {
@@ -912,12 +942,22 @@ func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
 // invalidate the prefix — the model, the tools, `tool_choice`, the thinking parameters, any
 // system or message content — is left exactly as it was sent.
 //
-// max_tokens is 1 rather than 0. The reason is NOT that 0 is rejected alongside streaming and
-// thinking — this ping sets `stream: false` and refuses thinking-enabled sessions, so neither
-// applies to it. It is that 1 is the value every backend on this path accepts without
-// negotiation, and the difference is one output token: $0.0000076 on sonnet against the
-// $0.0073 the read itself costs, i.e. a tenth of a percent. Not worth a compatibility risk on
-// the one request that must not fail for a surprising reason.
+// max_tokens is 1 rather than 0, and the reason is now MEASURED rather than assumed.
+//
+// `max_tokens: 0` is the provider's own documented cache pre-warm shape and it works on this
+// gateway: probed live against aws/claude-sonnet-5, it returned 200 with
+// `cache_read_input_tokens: 5851`, `cache_creation_input_tokens: 0` and `output_tokens: 0` —
+// a full cache read for no output at all. So the cheaper shape exists and is real.
+//
+// It stays at 1 anyway, on the balance of the two measured quantities. The saving is ONE output
+// token, $0.000015 on sonnet against the $0.0018 the read itself costs on the same prefix — under
+// a percent of a ping. Against that, the docs list four bodies `max_tokens: 0` is REJECTED for:
+// `stream: true`, extended thinking, structured outputs, and `tool_choice` of type `tool` or
+// `any`. This ping forces `stream: false` and refuses thinking-enabled sessions, but it resends
+// the caller's body verbatim and does not touch `tool_choice` — because touching it would change
+// the hashed prefix and the ping would miss the entry it exists to refresh. An agent that sets
+// `tool_choice: {"type": "any"}` would therefore get a 400 on every ping, and the failure mode of
+// this request is that a cache entry lapses. A tenth of a percent is not worth that branch.
 //
 // stream is false so the response is one small JSON body with its usage block in it, rather
 // than an SSE stream this would have to read to the end to price.

--- a/proxy/keepalivectl.go
+++ b/proxy/keepalivectl.go
@@ -168,14 +168,18 @@ func (h *Handler) armedView(t *tenant.Tenant, session string, o sessionOverride)
 		"durable":           false,
 		"min_prefix_tokens": o.pol.MinPrefixTokens,
 	}
-	// The account's own per-ping guard, reported because the body's value is ignored. Resolved
-	// from the account's own document through the same builder the request path uses, so the
-	// number shown is the number that will be enforced.
+	// The per-ping guard that will actually be ENFORCED, reported because the body's value is
+	// ignored. Through CachePolicy.Ceiling(), so the number shown is the number enforced: the
+	// account's document stores 0 for "unconfigured", and reporting that raw told the operator
+	// the ceiling was $0.00 on exactly the accounts — keep-alive off, one session armed by hand
+	// — where the guard resolves to the default instead.
+	ceiling := CachePolicy{}.Ceiling()
 	if h.opts.Tenants != nil {
 		if tn, err := h.opts.Tenants.ForTenant(t); err == nil {
-			out["max_usd_per_ping"] = tn.Cache.MaxUSDPerPing
+			ceiling = CachePolicy{MaxUSDPerPing: tn.Cache.MaxUSDPerPing}.Ceiling()
 		}
 	}
+	out["max_usd_per_ping"] = ceiling
 	// The worst case, priced from THIS SESSION's own last billed prefix at its own model's
 	// cache-read rate — never a service-wide average, because per-ping cost is bimodal. Absent
 	// rather than zero when the model has no rate on the operator's list.
@@ -198,20 +202,23 @@ func (h *Handler) armedView(t *tenant.Tenant, session string, o sessionOverride)
 // worstCase is the ceiling on what one armed override can cost: the session's last billed
 // prefix, its model, and the most pings the override can send before it expires.
 //
-// The ping count is K per idle span and one span is at most (K+1) x Idle long — the hard
-// retention deadline — so the number of spans left until `until` bounds the total. Deliberately
-// a CEILING and not an estimate: a session that goes quiet sends none of them, and the honest
-// thing to show somebody authorizing a spend is the most it can be.
+// The count is `time until expiry / X`, one ping per idle interval, and NOT `K pings per
+// (K+1)X span`. A span ends the instant a real request arrives, so the worst case is not a
+// session that goes quiet — it is one whose requests land just after each ping, restarting the
+// clock every time and sending one ping per X for the whole hold. The span form under-states by
+// (K+1)/K: 8 against a true 12 at the shipped defaults, and 2x at K=1. Under-stating a ceiling
+// on a spend authorization is the one direction that cannot be defended.
+//
+// Deliberately a CEILING and not an estimate: a session that goes quiet sends none of them, and
+// the honest thing to show somebody authorizing a spend is the most it can be.
 func (h *Handler) worstCase(tenantID, session string, o sessionOverride) (prefix int64, model string, pings int64) {
-	spanSeconds := o.hold().Seconds()
-	if spanSeconds <= 0 {
+	if o.pol.Idle <= 0 {
 		return 0, "", 0
 	}
-	spans := int64(time.Until(o.until).Seconds() / spanSeconds)
-	if spans < 1 {
-		spans = 1
+	pings = int64(time.Until(o.until).Seconds() / o.pol.Idle.Seconds())
+	if pings < 1 {
+		pings = 1
 	}
-	pings = spans * int64(o.pol.MaxPings)
 	if h.rec == nil {
 		return 0, "", pings
 	}

--- a/proxy/keepalivectl_test.go
+++ b/proxy/keepalivectl_test.go
@@ -161,6 +161,30 @@ func TestArmingIgnoresAPostedPerPingBudget(t *testing.T) {
 	if got, has := out["max_usd_per_ping"].(float64); has && got == 99 {
 		t.Error("a posted per-ping budget of $99 was accepted; the guard is the account's own")
 	}
+	// The reported ceiling is the ENFORCED one, and this is the assertion that was missing.
+	//
+	// "not 99" passes on a raw 0, which is exactly the defect: an account that configured no
+	// ceiling stores 0, the request path resolves that to the default through
+	// CachePolicy.Ceiling(), and reporting the raw 0 told the operator the ceiling was $0.00 while
+	// the default was enforced. REVIEW-96 called that "worse than omitting it", the fix went in,
+	// and nothing held it there — reverting armedView to `tn.Cache.MaxUSDPerPing` left the whole
+	// package green. The number on the wire has to be a number somebody could act on.
+	got, has := out["max_usd_per_ping"].(float64)
+	if !has {
+		t.Fatal("the arm response states no per-ping ceiling at all; it is the guard the caller " +
+			"is authorizing spend against")
+	}
+	if got <= 0 {
+		t.Errorf("max_usd_per_ping = %v on an account that configured none. 0 is the document's "+
+			"\"unconfigured\" sentinel, not a ceiling: the request path resolves it to $%v and "+
+			"enforces that, so reporting 0 states a limit of nothing while infinity looks plausible "+
+			"to whoever reads it.", got, DefaultMaxUSDPerPing)
+	}
+	if got != DefaultMaxUSDPerPing {
+		t.Errorf("max_usd_per_ping = %v, want the enforced default %v — the report and the guard "+
+			"must come from the same resolver (CachePolicy.Ceiling()) or they will drift again",
+			got, DefaultMaxUSDPerPing)
+	}
 }
 
 // Every arm and every disarm leaves a DURABLE audit row with the resolved parameters. That row is

--- a/proxy/keepalivectl_test.go
+++ b/proxy/keepalivectl_test.go
@@ -62,9 +62,9 @@ func TestASaveFromAStalePageIsRefused(t *testing.T) {
 			before.ConfigYAML, after.ConfigYAML)
 	}
 
-	// The SAME body with a base that matches is accepted, and `extract` survives because the
-	// client did not claim to have drawn it... it did claim it, so it is removed. `linecap` was
-	// NOT claimed, so it survives at its own index. Both halves of the rule in one save.
+	// The SAME body with a base that matches is accepted. `extract` IS claimed in
+	// pipeline_known and absent from `pipeline`, so it is removed; `linecap` is not claimed, so it
+	// survives at its own index. Both halves of the rule in one save.
 	ok := `{"config":{"pipeline":["format","toon"],` +
 		`"pipeline_known":["format","toon","extract"],` +
 		`"pipeline_base":["format","linecap","extract"],` +
@@ -313,5 +313,30 @@ func TestArmingIsRateLimited(t *testing.T) {
 	}
 	if !limited {
 		t.Errorf("more than %d arms an hour were accepted", overrideArmsPerHour)
+	}
+}
+
+// A REORDER-ONLY stale render is refused too.
+//
+// sameNames documents itself as an ordered comparison — "order is part of a pipeline's meaning" —
+// and nothing enforced it: replacing it with a multiset comparison left the whole proxy package
+// green, so a page that rendered the same components in a different order sailed through the 409.
+// It is the same class of stale render as a page that rendered a different SET, and it silently
+// rewrites the order the components run in.
+func TestASaveFromAPageThatReorderedThePipelineIsRefused(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, id := f.signUpJar(t, "boss@ibm.com")
+	const stored = "pipeline:\n  - format\n  - linecap\n  - extract\nmode: sync\n"
+	setDoc(t, f, id, stored)
+	// The same three names, permuted: as a SET this matches the stored pipeline exactly.
+	body := `{"config":{"pipeline":["format","linecap","extract"],` +
+		`"pipeline_known":["format","linecap","extract"],` +
+		`"pipeline_base":["linecap","format","extract"],` +
+		`"components":{},"cache":{"keepalive":false,"head_ttl_1h":false}}}`
+	w, _ := f.do(t, http.MethodPut, "/api/me", body, mgrJar)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("a save whose pipeline_base is the stored pipeline REORDERED = %d, want 409. "+
+			"Order is part of a pipeline's meaning, so a page that rendered a different order "+
+			"rendered a different configuration: %s", w.Code, w.Body)
 	}
 }

--- a/proxy/keepaliveoverride.go
+++ b/proxy/keepaliveoverride.go
@@ -59,7 +59,15 @@ const (
 	// maxOverrideHold is the operator's ceiling on the CREDENTIAL HOLD an override may buy.
 	// The hard deadline is (K+1)x X (see kaEntry.timer), and the Settings copy promises "up to
 	// about 14 minutes" at the shipped defaults — an override changes that number, so the arm
-	// dialog states the computed hold and this refuses anything past an hour.
+	// dialog states the computed hold.
+	//
+	// It is CURRENTLY UNREACHABLE, and saying so is more useful than implying an independent
+	// rule: the two caps above bound (K+1)x X at 12 x 290 s = 58 minutes, so the real ceiling on
+	// the hold is 58 minutes and it is a consequence of them. This stays as the bound that keeps
+	// holding if either of those is ever widened — a credential-retention limit is the wrong place
+	// to rely on an emergent property of two unrelated caps — but no test can exercise it without
+	// changing one of them, and TestOverrideRespectsTheCredentialHoldCeiling asserts the 58
+	// minutes that is actually enforced.
 	maxOverrideHold = time.Hour
 	// Bounds on the map itself. Same order as maxKeepAliveSessions, and both are needed for
 	// the same reason that bound has two: many accounts with a few, or one account with many.
@@ -107,6 +115,19 @@ func validOverride(session string, idle time.Duration, pings, minPrefix int,
 	}
 	if strings.ContainsRune(session, 0) {
 		return sessionOverride{}, fmt.Errorf("that is not a session id")
+	}
+	// A session id whose `tenant:base` prefix names SOMEBODY ELSE is refused rather than armed.
+	//
+	// Overrides are keyed under the authenticated principal, which is the isolation this feature
+	// wants — so a foreign session id becomes a key under the caller's own tenant that no request
+	// will ever match. Arming it did nothing and returned 200, and the response then reported
+	// `last_prefix_tokens: 0` and `priced: false` because the worst-case lookup is scoped to the
+	// arming principal too. A manager's service-wide session list is full of these rows, so this
+	// is reachable by clicking, not only by hand.
+	if t, _, ok := strings.Cut(session, ":"); ok && t != by {
+		return sessionOverride{}, fmt.Errorf(
+			"that session belongs to another account. An override is keyed to the principal that " +
+				"arms it, so this one would match no request and keep nothing warm")
 	}
 	if until.IsZero() {
 		return sessionOverride{}, fmt.Errorf("an override must state when it expires")

--- a/proxy/keepaliveoverride_test.go
+++ b/proxy/keepaliveoverride_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/config"
 	"github.com/rossoctl/context-guru/dash"
 	"github.com/rossoctl/context-guru/metrics"
 )
@@ -60,19 +61,40 @@ func TestOverrideCannotRaiseThePerPingBudget(t *testing.T) {
 	}
 }
 
-// The credential-hold ceiling. (K+1) x X is the hard retention deadline, so an override changes
-// how long this service may hold somebody's key — which is why it is refused past an hour and
-// why the accepted one's timer fires at exactly that.
+// The credential-hold ceiling that is ACTUALLY ENFORCED: 58 minutes, and it comes from the idle
+// and ping caps rather than from maxOverrideHold.
+//
+// (K+1) x X is the hard retention deadline, so an override changes how long this service may hold
+// somebody's key. The `maxOverrideHold = time.Hour` constant reads as an independent third rule
+// and is not one: 12 x 290 s = 58 minutes is the most the other two caps allow, so the hour is
+// unreachable and no override can be refused by it. This test used to claim to reach it — "12
+// would be 62.7 minutes, so reach the ceiling through X" — and then could not, because X is capped
+// too, ending up asserting hold() arithmetic on ACCEPTED overrides. It asserts the real ceiling
+// now, in both directions.
 func TestOverrideRespectsTheCredentialHoldCeiling(t *testing.T) {
 	now := time.Now()
-	// 11 pings 290 s apart is (11+1) x 290 = 58 minutes: accepted, just inside.
-	if _, err := validOverride("s", 290*time.Second, 11, 0, now.Add(time.Hour), now, "t1"); err != nil {
-		t.Errorf("58 minutes of hold was refused: %v", err)
+	// The maximum hold any override can buy: both caps at their limit.
+	o, err := validOverride("s", maxOverrideIdle, maxOverridePings, 0, now.Add(time.Hour), now, "t1")
+	if err != nil {
+		t.Fatalf("the largest override the caps allow was refused: %v", err)
 	}
-	// 12 would be 62.7 minutes — but K is capped at 11 first, so reach the ceiling through X.
-	_, err := validOverride("s", 290*time.Second, 12, 0, now.Add(time.Hour), now, "t1")
-	if err == nil {
-		t.Error("K = 12 was accepted; the band is 1..11")
+	if got, want := o.hold(), 58*time.Minute; got != want {
+		t.Errorf("the maximum credential hold is %v, want %v ((%d+1) x %v). If this moved, the "+
+			"Settings copy and maxOverrideHold both need revisiting — the hour is unreachable "+
+			"only because of these two caps", got, want, maxOverridePings, maxOverrideIdle)
+	}
+	if o.hold() > maxOverrideHold {
+		t.Errorf("the caps now allow a hold of %v, past the operator ceiling of %v: the ceiling "+
+			"has stopped being unreachable and needs its own refusal test", o.hold(), maxOverrideHold)
+	}
+	// One past each cap is refused, so the 58 minutes is a real bound and not a coincidence.
+	if _, err := validOverride("s", maxOverrideIdle, maxOverridePings+1, 0, now.Add(time.Hour), now, "t1"); err == nil {
+		t.Errorf("K = %d was accepted; the band is %d..%d", maxOverridePings+1,
+			minOverridePings, maxOverridePings)
+	}
+	if _, err := validOverride("s", maxOverrideIdle+time.Second, maxOverridePings, 0, now.Add(time.Hour), now, "t1"); err == nil {
+		t.Errorf("X = %v was accepted; past %v the first ping lands after the lifetime has lapsed",
+			maxOverrideIdle+time.Second, maxOverrideIdle)
 	}
 	// And the message has to name the number the person is authorizing.
 	if _, err := validOverride("s", 280*time.Second, 11, 0, now.Add(time.Hour), now, "t1"); err != nil {
@@ -278,13 +300,38 @@ func TestArmingIsRefusedWithoutAnAuditSinkOrWithTheKillSwitchOn(t *testing.T) {
 	}
 }
 
-// A session id whose `tenant:uuid` prefix names SOMEBODY ELSE addresses nothing: the keeper keys
-// on the AUTHENTICATED principal, never on a value out of the body, so such an arm becomes a key
-// under the caller's own tenant that no request will ever match.
-func TestOverrideForAnotherTenantsSessionIdAddressesNothing(t *testing.T) {
+// A session id whose `tenant:uuid` prefix names SOMEBODY ELSE is REFUSED, and if one ever got
+// past that it would still address nothing: the keeper keys on the AUTHENTICATED principal, never
+// on a value out of the body.
+//
+// Two layers, and both are the test. The refusal is the fix for a real path — a manager's
+// service-wide session list is entirely other tenants' rows, so arming one was a click away, and
+// it returned a cheerful 200 having kept nothing warm. The isolation underneath it is defence in
+// depth and stays asserted directly against the keeper, because it is what makes the refusal a
+// usability fix rather than the only thing standing between two accounts.
+func TestOverrideForAnotherTenantsSessionIdIsRefusedAndWouldAddressNothing(t *testing.T) {
 	k, _, clock := testKeeper(t, Limits{})
 	victim := "t-victim:9f3a-1c2b"
-	armOn(t, k, victim, 60*time.Second, 4, clock.now().Add(time.Hour))
+	now := clock.now()
+	if _, err := validOverride(victim, 60*time.Second, 4, 0, now.Add(time.Hour), now, "t1"); err == nil {
+		t.Error("arming a session id that names another account was accepted; it can only ever " +
+			"be a no-op, and the arm response would report a 0-token prefix and no price")
+	}
+	// The caller's OWN prefix is of course fine, as is a bare id with no tenant prefix at all.
+	for _, ok := range []string{"t1:9f3a-1c2b", "9f3a-1c2b"} {
+		if _, err := validOverride(ok, 60*time.Second, 4, 0, now.Add(time.Hour), now, "t1"); err != nil {
+			t.Errorf("session id %q was refused for the principal that owns it: %v", ok, err)
+		}
+	}
+	// Defence in depth: installed directly, past the check, it is still inert for the victim.
+	o, err := validOverride("t1:9f3a-1c2b", 60*time.Second, 4, 0, now.Add(time.Hour), now, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.pol.Idle = 60 * time.Second
+	if err := k.arm("t1", victim, o); err != nil {
+		t.Fatal(err)
+	}
 	// The victim's own traffic is unaffected: resolution is under THEIR tenant id.
 	off := CachePolicy{Idle: 280 * time.Second, MaxPings: 2}
 	if k.overrideFor("t-victim", victim, off).on() {
@@ -302,7 +349,6 @@ func TestOverrideForAnotherTenantsSessionIdAddressesNothing(t *testing.T) {
 		t.Errorf("the arming principal's own list shows %d entries, want 1", len(got))
 	}
 	// And a session id that is not one is refused before it becomes a map key.
-	now := clock.now()
 	for _, bad := range []string{"", strings.Repeat("x", maxSessionIDBytes+1), "a\x00b"} {
 		if _, err := validOverride(bad, 280*time.Second, 2, 0, now.Add(time.Hour), now, "t1"); err == nil {
 			t.Errorf("session id %q was accepted", bad)
@@ -398,5 +444,89 @@ func TestArmedSessionsAreNotDurableAndSayItOnTheWire(t *testing.T) {
 	k.Stop()
 	if got := len(k.armedFor("t1")); got != 0 {
 		t.Errorf("%d overrides survived Stop()", got)
+	}
+}
+
+// A session armed on an account whose keep-alive is OFF still has a per-ping cost ceiling.
+//
+// This is the case the guard was written for and the one case it did not cover. cachePolicy()
+// hands the request path a ZERO CachePolicy when nothing in the account's `cache:` block is
+// switched on, `pingable()` read `MaxUSDPerPing <= 0` as "no cap", and the arm response
+// reported `max_usd_per_ping: 0` — so the operator was told the ceiling was $0.00 while
+// infinity was enforced, on the one path where per-ping cost is unbounded by anything else.
+func TestAnOverrideOnAKeepAliveOffAccountStillHasAPingCeiling(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	armOn(t, k, "sess-1", 280*time.Second, 2, clock.now().Add(time.Hour))
+	// The account default: keep-alive off, nothing configured — a zero policy.
+	pol := k.overrideFor("t1", "sess-1", CachePolicy{})
+	if !pol.on() {
+		t.Fatal("the override did not enable the mechanism; the rest of this test is vacuous")
+	}
+	if pol.Ceiling() != DefaultMaxUSDPerPing {
+		t.Errorf("Ceiling() = %v on an unconfigured policy, want the default %v — 0 means "+
+			"nobody configured a ceiling, and in a spend guard that may not mean infinity",
+			pol.Ceiling(), DefaultMaxUSDPerPing)
+	}
+	// And it BITES: an entry whose projected ping cost is over the default is refused.
+	over := &kaEntry{turn: 1, prefix: 1_000_000, pol: pol, pingUSD: DefaultMaxUSDPerPing + 0.01}
+	if over.pingable() {
+		t.Errorf("a ping projected at $%.2f passed the guard on an account with no configured "+
+			"ceiling; the p99 ping is $0.2275 and the max $0.3780, which is what the guard is "+
+			"for", over.pingUSD)
+	}
+	under := &kaEntry{turn: 1, prefix: 1_000_000, pol: pol, pingUSD: DefaultMaxUSDPerPing - 0.01}
+	if !under.pingable() {
+		t.Error("a ping inside the default ceiling was refused; the guard has become a block")
+	}
+	// A caller who really wants no ceiling has to type a negative number.
+	none := &kaEntry{turn: 1, prefix: 1_000_000, pingUSD: 99,
+		pol: CachePolicy{KeepAlive: true, Idle: time.Second, MaxPings: 1, MaxUSDPerPing: -1}}
+	if !none.pingable() {
+		t.Error("an explicitly negative ceiling did not mean unlimited; that is the only way to " +
+			"ask for it and it has to keep working")
+	}
+}
+
+// worst_case_pings is a CEILING, so it counts one ping per idle interval and not K per span.
+//
+// A span ends the instant a real request arrives. The worst case is therefore not a session
+// that goes quiet — it is one whose requests land just after each ping, restarting the clock
+// every time. `until/((K+1)X) x K` under-states that by (K+1)/K: 8 against 12 at the shipped
+// defaults, 2x at K=1. It is labelled CEILING in the arm dialog somebody reads before
+// authorizing a spend.
+func TestWorstCasePingsIsAnActualCeiling(t *testing.T) {
+	h := &Handler{}
+	now := time.Now()
+	o, err := validOverride("s", 280*time.Second, 2, 0, now.Add(time.Hour), now, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, pings := h.worstCase("t1", "s", o)
+	// 3600/280 = 12.85 -> 12. The span form gives 3600/840 = 4 spans x 2 = 8.
+	if pings != 12 {
+		t.Errorf("worst_case_pings = %d over an hour at X=280s, want 12 (3600/280). 8 is the "+
+			"(K+1)X-span form, which under-states the ceiling by (K+1)/K", pings)
+	}
+	// K=1 is where the span form is wrong by 2x, so it is worth pinning too.
+	o1, err := validOverride("s", 280*time.Second, 1, 0, now.Add(time.Hour), now, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, p1 := h.worstCase("t1", "s", o1); p1 != 12 {
+		t.Errorf("worst_case_pings = %d at K=1, want 12: the ceiling is set by the idle interval, "+
+			"not by K", p1)
+	}
+}
+
+// The default this package enforces is the one the configuration loader documents.
+//
+// proxy may not import config, so the constant is duplicated, and a duplicated money default
+// that drifts is worse than no default at all: the account document would say one thing and the
+// request path enforce another.
+func TestTheProxysPingCeilingDefaultMatchesTheConfigLoaders(t *testing.T) {
+	if DefaultMaxUSDPerPing != config.DefaultKeepAliveMaxUSDPerPing {
+		t.Errorf("proxy.DefaultMaxUSDPerPing = %v, config.DefaultKeepAliveMaxUSDPerPing = %v; "+
+			"an unconfigured account would be told one ceiling and have another enforced",
+			DefaultMaxUSDPerPing, config.DefaultKeepAliveMaxUSDPerPing)
 	}
 }


### PR DESCRIPTION
# Make the keep-alive tab's controls work, and its numbers defensible

PR #96 shipped the keep-alive tab with five blocking defects found in review and merged anyway.
All five were live. This fixes them at the root, adds the per-session view the tab was missing, and
replaces the two refuted figures the page used to justify its own recommendation.

Everything numeric below was measured on this branch, by me, including the figures I inherited from
the review — one of which turned out to be framed the wrong way round (see F5). Where a figure could
not be measured it says so instead of estimating.

## The mechanism, proven live for the first time

The whole feature rests on one provider behaviour: **a cache read refreshes the entry's TTL for
free.** That had never been demonstrated here, only cited.

**1. The provider behaviour, straight at the gateway.** Paired arms, identical bytes, each
replicate carrying its own nonce because the provider's cache is content-keyed:

| arm | ping | read at | n | result |
|---|---|---|--:|---|
| 5-minute TTL | at t+240 s | t+482 s | 3 | **3/3 HIT** — `cache_read 5,861`, `cache_write 0` |
| 5-minute TTL, control | none | t+482 s | 3 | **3/3 MISS** — `cache_read 0`, `cache_write 5,860` |

The read is 182 s past the entry's original expiry, so nothing but a refresh explains the hit, and
the paired control is what makes the hit mean that.

**2. The shipped mechanism, end to end through a local proxy**, on real Claude Code request bodies
(~48k-token prefix). Two arms, own nonce each, three turns: two together, then a 330 s idle gap.
Replicated twice, identical both times:

| | keep-alive ON | control |
|---|---|---|
| turn 1 | `cold_start`, wrote 48,210 | `cold_start`, wrote 48,210 |
| turn 2 | `hit`, read 48,210 | `hit`, read 48,210 |
| during the gap | **ping** at +280 s: read 48,226, wrote **0** | — |
| turn 3 | **`hit`**, read 48,226 | **`ttl_expiry`**, `cache_read 0`, wrote 48,243 |

The lapsed turn carries `cache_read = 0`, which is the condition a cold-turn claim requires.

Priced on the input side only, so neither arm's own reply length enters the comparison:

```
rescued turn, read at 0.1x       $0.0073304
lapsed turn, written at 1.25x    $0.0916617
one ping                         $0.0073380
net on this one turn             $0.0769934
```

**And the panel's prediction matches what the gateway billed.** `/api/keepalive/live` computed
`miss_usd = $0.0843288` for that session before the fact; the write premium the control arm
actually paid is `48,243 x (1.25 - 0.1) x the model's input rate = $0.0843288`. The service's own
`keepalive_saved_usd` credit was `$0.0842990` — 0.035% below, i.e. it slightly UNDER-claims. All
four stored `cost_usd` values reconcile against the configured price list to **0.00%**.

**The first-request gate is real, and it caught my own first attempt.** A one-turn arm produced
`pings: 0, skipped: 1`: the shipped policy never pings after a session's first request. That is
documented behaviour (single-request sessions are 79% of pings and 0.9% of the value), and it is
why the run above needs two turns before the gap.

**The cheapest ping shape — and it is MODEL-DEPENDENT, which is the reason to keep 1.**
`max_tokens: 0` is the provider's documented pre-warm shape. On this gateway:

```
aws/claude-sonnet-5   200  cache_read=5851  cache_creation=0  output_tokens=0  stop_reason=max_tokens
claude-haiku-4-5      400  max_tokens: must be greater than or equal to 1
```

Both from my own runs; the 400s are in `refresh.jsonl` from the ping path. **I reported "accepted on
this gateway" in an earlier version of this and that was wrong** — the 400s were sitting in a log I
had written off as a bad arm and never read. Corrected here and in the code comment.

So the cheap shape is real on some routes and a hard failure on others, and `pingBody` cannot know
which: `model` comes from the caller's body. A ping that 400s is a cache entry allowed to lapse,
which is the one outcome the request exists to prevent. The prize for taking that risk is **one
output token — $0.0000076 against the $0.0073304 the read costs on a 48k prefix, 0.1% of a ping.**
Keeping `max_tokens: 1` now rests on a measurement, not on the docs' list.

## 1-hour TTL: the refresh works, but the tier is not granted for the models this service runs

**The refresh, proven on a real 1-hour entry.** Paired arms on `aws/claude-sonnet-4-5`, which does
grant the tier:

| arm | ping | read at | n | result |
|---|---|---|--:|---|
| 1-hour TTL | at t+3000 s (minute 50) | t+4202 s (minute 70) | 2 | **2/2 HIT** — `cache_read 3,617`, no write |
| 1-hour TTL, control | none | t+4202 s | 2 | **2/2 MISS** — `cache_read 0`, re-written as `ephemeral_1h 3,617` |

The read is **10 minutes past the entry's original 60-minute expiry** and the paired control missed
at the same instant, so a single `max_tokens: 0` read at minute 50 bought another full hour — for
one cache read at 0.1x and **zero** output tokens. The ping mechanism is not 5-minute-specific.

**But `ttl: "1h"` is accepted with a 200 and silently downgraded to a five-minute entry** on the
models this service actually runs. The only tell is the per-tier breakdown:

Seven model ids, each probed at BOTH sizes, all 14 raw `usage` blocks saved:

| model | ~3.6k `5m` / `1h` | ~18–29k `5m` / `1h` | 1h? |
|---|--:|--:|:--|
| aws/claude-sonnet-5 | 5,858 / 0 | 29,218 / **0** | no |
| aws/claude-opus-5 | 5,856 / 0 | 29,216 / **0** | no |
| claude-opus-4-8 | 5,858 / 0 | 29,218 / **0** | no |
| aws/claude-sonnet-4-5 | 0 / 3,614 | 0 / **18,014** | yes |
| claude-sonnet-4-6 | 0 / 3,615 | 0 / **18,015** | yes |
| claude-haiku-4-5 | **0 / 0** | 0 / **18,014** | yes |
| aws/claude-haiku-4-5 | **0 / 0** | 0 / **18,014** | yes |

Two consequences the code now reflects:

- the lifetime a session is under is read off **the tier the provider billed** (`cache_write_1h`),
  never off configuration, because a downgraded request is indistinguishable from a granted one at
  the HTTP level;
- every 1-hour figure on the page is labelled as a *what it would be*.

Every row above was re-run at a ~18k-token prefix after a first pass at ~3.6k produced a false
negative on Haiku: **4,096 tokens is Haiku 4.5's minimum cacheable length**, and a prefix below it is
silently not cached at all — no error, both counters zero, exactly as documented. The
5-minute-only rows were re-confirmed at 29,218 tokens, 5.9x that minimum, so they are a real tier
refusal and not a size artifact. Probe both sizes or you will measure your own filler.

## F1 — the "Keep warm" button threw. Root cause, not the call site.

`dash/ui/tools.js` declared a top-level `const prompt = {...}`. These are **classic** scripts
sharing one global scope, so that binding shadowed `window.prompt` for every bare `prompt(...)` in
every script on the page, in any load order — and the failure was silent: the button simply did
nothing.

Renamed to `promptView`. Three call sites come back to life, one of which was #96's own stated
mitigation for comment loss and one of which shows a freshly minted token exactly once.

`TestNoUIScriptShadowsAWindowMethod` scans every `dash/ui/*.js` for a top-level binding named after
a shadowable `window` method. The declaration and the call site are in different files, so nothing
local to either can catch this; it is a whole-bundle property.

## F2 — two refuted numbers, and the page contradicting itself

The tab justified "one ping is never suggested" with *"it reaches about 4.7 minutes"* and with a
service-wide dollar figure saying it loses money. Both come from the `K·X` coverage error —
coverage is `K·X + TTL`, because the last ping is itself a cache read — which `CoverageSeconds`
carries an explicit warning about, and which the page's own K-ladder prints correctly three panels
away. Under correct coverage one ping is a smaller win rather than a loss, and the page's own
calculator was already reporting it as positive in a table directly above the sentence saying it
lost money.

The rule survives; the reason is replaced. One ping reaches **9.7 minutes** against two pings'
**14.3**, and the copy points at the account's own K-ladder rather than at any service-wide dollar
— which is the right comparison anyway, since the decision is per account.

`TestTheKRuleCopyStatesItsReachAndNotTheRefutedNumbers` pins the two dead strings out and pins the
two live figures **against `CoverageSeconds` itself**, so reverting to `K·X` fails here.

## F3 — a ping was still contaminating `prefix_change`, and `SeedSessions`

Two instances of the same defect, both fixed at the shared definition:

**`prefix_change`** asked whether *the session's previous turn* mutated something, with no
`keepalive = 0`. A ping became "the previous turn", carries no `request_components` rows, the
`EXISTS` went false, and a genuine `prefix_change` row dropped out — under-reporting our own harm on
the one diagnostic that measures it. The subquery was also duplicated between the cost and the
count; it is now one `afterOurMutation` constant, the same pattern `splitMoved` already uses, so the
two cannot drift.

**`SeedSessions`** seeded session recency from each session's *latest* row, which for a pinged
session is usually a ping. Across a restart that re-dates the session and makes the next real
request's gap read as the time since the ping — a twenty-minute gap reading as four, no
`ttl_expiry` recorded. `proxy/keepalive.go` promises in as many words that a ping never touches the
recency map; this is that promise kept on the one path the ping code cannot reach.

## F4 — the per-ping ceiling was reported as $0.00 and enforced as infinity

`pingable()` read `MaxUSDPerPing <= 0` as "no cap". The config builder hands the request path a
**zero** `CachePolicy` when nothing in the account's `cache:` block is on — and enabling one session
by hand on an otherwise-off account is exactly what a per-session override is for. So the one path
the guard was written for ran without it, while the arm response reported a ceiling of `$0.00`.

Fixed at the sentinel, not the call site: `CachePolicy.Ceiling()` resolves 0 to the default, and a
caller who genuinely wants no ceiling has to type a negative number. Both the guard and the report
go through it, so they cannot disagree again. `DefaultMaxUSDPerPing` is pinned equal to
`config.DefaultKeepAliveMaxUSDPerPing` by a test, because a duplicated money default that drifts is
worse than none.

The arm dialog now states **both** guards in force — the ceiling and the prefix floor, including
the case where an override has lowered the floor to 0 and every request on the session is pingable.

## F5 — the calculator's PINGS column was not a policy anyone could run

It was a `LAG` over `requests`, wrong in two directions that do not cancel cleanly. It charged
**nothing** for a session-final request — where a live policy must send K, because it cannot know
the session ended — and it applied **no gate**, charging pings on the turn-0 and small-prefix spans
the shipped `turn ≥ 1 AND prefix ≥ 20k` never touches.

Replayed by me on a production snapshot at X=280, K=2, as RATIOS — the absolute counts are in the
internal write-up:

| what is counted | relative to the shipped policy |
|---|--:|
| the shipped `LAG` form (no gate, no session-final) | **1.37x** |
| **the shipped gate, session-final charged** — what the panel now reports | 1.00x |
| a blanket policy (no gate, session-final charged) | 8.7x |

**The two errors partly cancel, and the direction is the opposite of what it looks like.** The `LAG`
form charged **1.37x** what the shipped policy actually sends, so it *over*-charged, and correcting
it makes NET slightly **more** positive here — it does not flip the sign. The widely-quoted "6.4x
under-count" is the gap between the `LAG` form and a **blanket** policy, which the calculator does
not model and does not claim to. I checked this rather than carrying it forward, and the review I
built from had the comparison the other way round.

What the fix buys is not a different headline: it is a column that models the policy it names, so
the number moves when the gate or K moves, and a future change to either is visible here instead of
silently ignored.

One shared `pingSpans` definition now serves the calculator **and** the recommendation's bootstrap,
gated as the request path gates, with session-final spans included as open spans that attract the
full K.

**The same omission was inside the recommendation's own bootstrap**, where it decides whether to
recommend at all. It resampled only the sessions that had an addressable expiry — a small minority
of them — so the saving side and the cost side came from different populations. Both omissions push
the interval **up**, the direction that makes the rule fire when it should refuse, and that interval
is the load-bearing condition. It resamples **every** session in the window now.

**One limitation, stated:** the replay gates at the shipped 20k default (`kaGateMinPrefix`), not at
the account's own configured `keepalive_min_prefix_tokens`, because the dashboard layer does not
read tenant configuration. An account that tuned its floor sees a replay of the default policy. The
panel's own copy names 20k, so the page is at least self-consistent, and a test pins the constant to
the config default.

The panel says which pings it counts, and the mislabelled `SHARE OF WHAT IS REACHABLE` column is now
`Share of those dollars`, which is what the value is.

## New: "Your sessions right now"

The tab could tell you about expiries that had already happened and nothing about the session in
front of you. One route, one panel:

- **the lifetime in force**, from the tier the provider billed, and **what is left of it**, counted
  from the request's START per the documented rule — a response that streamed for four minutes has
  already spent four minutes of its entry's life;
- **an expiry warning** for entries inside one idle interval of lapsing, with the money at risk,
  labelled a ceiling;
- **the economics, per session, from that session's own prefix and its own model's rates**: what one
  ping costs, what one lapse costs, and therefore **how many pings one lapse pays for**.

That last number is the one that decides whether to arm, and it is nearly prefix-independent — both
terms scale with the prefix, so it collapses to a ratio of the model's own rates. At the shipped
Anthropic shape (read 0.1×, 5m write 1.25×) **a lapse pays for 11 pings**, which at X=280 bridges
**56 minutes** of idle. At the 1-hour tier (write 2.0×) it pays for **18**, bridging **144
minutes** — if a model grants it, which on this deployment's own models it does not.

Realised savings and the still-open potential are shown together, with the difference between them
named: one is measured on requests that happened, the other is a ceiling on requests that may not.

## Overview integration

Already correct on the Go side and verified rather than changed: `TotalSavedUSD = NetSavedUSD +
CachesplitSavedUSD + KeepAliveNetUSD`, the keep-alive enters as a **net** (its ping spend appears
nowhere else, since ping rows are excluded from agent traffic), and the waterfall carries
`keepalive_ping` and `keepalive_saved` as their own identified steps.

## The nits, and what did not pay

- **The `EXISTS` gate is deleted.** It claimed the ceiling correction "costs literally nothing where
  the mechanism has never run". It does not: `keepalive` is in no index, so the `EXISTS` is itself a
  scan. Timed alternately on the 10k-row fixture, 5 trials: **52.7 ms gated against 53.0 ms
  ungated** at 0 pings. One extra scan for no measurable saving.
- **A false number in a code comment**: the fixture has one ping and the value is 30 → **50**, not
  three pings and 30 → 70. Reproduced by mutation while adding the test below.
- **The concentration sentence divided by the page it was showing** (20 rows), reading a materially wrong share and moving whenever `limit` did. It uses the account's addressable total now.
- **`worst_case_pings` was not a ceiling.** A span ends the instant a real request arrives, so the
  worst case is requests landing just after each ping: `until/X`, not `until/((K+1)X) × K`. Reported
  8 where the true ceiling is 12, and 2× low at K=1.
- **The arm button was drawn on rows the caller cannot arm**, and the route answered 200. An
  override is keyed to the arming principal, so a foreign session id could only ever be a no-op —
  and a manager's service-wide list is entirely foreign rows, so this was a click away. Refused at
  `validOverride` now; the keeper's own isolation stays asserted underneath as defence in depth.
- **`maxOverrideHold` (60 min) is unreachable** and now says so: the idle and ping caps bound the
  hold at 12 × 290 s = **58 minutes**. Its test claimed to reach the hour, could not, and ended up
  asserting `hold()` arithmetic on accepted overrides; it asserts the real 58 minutes in both
  directions now, and fails if the caps ever widen past the constant.
- **`prefix_source` claimed `account_median` when the median was 0** — a measurement label on an
  absence.
- `CalcRow`'s three dollar fields get `omitempty`, so an unpriced ladder puts no `0` on the wire.
- Sentence case in the refusal banner; stale self-contradicting prose in a test comment.

**Four tests that were green on defects, made to bite:**

| the mutation review proved was GREEN | now |
|---|---|
| render the recommendation as a hero midpoint | **RED** — the separator is pinned, not just the two field names |
| `sameNames` → a multiset comparison (reorder-only stale render) | **RED** |
| a re-save flipping `cache.keepalive` ON | **RED** |
| `child()` reverted so no cache block is written (Bug 1 returns) | **RED** |

## Every new test was made to fail on purpose

Each was run against a deliberate mutation, the failure recorded, and the mutation reverted:

| test | mutation | observed |
|---|---|---|
| `TestNoUIScriptShadowsAWindowMethod` | rename `promptView` back to `prompt` | RED, naming the file and the method |
| `TestTheKRuleCopyStatesItsReachAndNotTheRefutedNumbers` | reach → `K·X` (4.7 / 9.3 min) | RED on both halves |
| `TestPrefixChangeCostIsAnObservationNotADebt` | drop `p.keepalive = 0` | RED: $0.50 for $0.80, n=1 for 2 |
| `TestARestartDoesNotRecoverRecencyFromAPing` | seed recency from any last row | RED: gap 60,000 ms for 1,200,000 |
| `TestAnOverrideOnAKeepAliveOffAccountStillHasAPingCeiling` | restore `MaxUSDPerPing <= 0 \|\| …` | RED: a $0.26 ping passed |
| `TestWorstCasePingsIsAnActualCeiling` | restore the `(K+1)X`-span form | RED: 8 for 12, and 6 for 12 at K=1 |
| `TestTheCalculatorChargesThePingsAPolicyWouldActuallySend` | restore the LAG form | RED: 5 pings for 4 |
| `TestTheLivePanelPricesOneSessionsOwnBreakeven` | any-1h-write-ever wins the tier | RED: 3600 s for 300 |
| ” | remaining ignores the clock | RED on all three rows and the lapsed one |
| `TestTheReplayCeilingCountsAgentTurnsNotPings` | scope the correction to the window | RED: 50 for 30 |
| `TestTheLivePanelSaysWhatItsNumbersAre` | drop "CEILING" from the warning | RED |
| `TestASaveFromAPageThatReorderedThePipelineIsRefused` | `sameNames` → multiset | RED: 200 for 409 |
| `TestTheColdCacheKeysSurviveASaveThatDoesNotMentionThem` | force `keepalive = true` | RED |
| ” | `child()` detached (Bug 1) | RED on both paths |

## What this does not do

- **No per-session 1-hour TTL control.** The refresh works on a 1-hour entry (proven above), but
  `ttl: "1h"` is silently downgraded to five minutes on every model this service runs, so the
  control would do nothing here. The lifetime is shown as data instead. A **model allowlist** is
  the shape a 1h feature has to take, and it needs its own measurement of whether the 2.0x write
  premium ever pays — the 1h breakeven on the page (18 pings, 144 minutes) says what the prize
  would be, not that it is worth taking.
- **No change to `max_tokens: 1`,** for the measured reason above. If you want the 0.1%, say so and
  it is a two-line guard on `tool_choice`.
- **The end-to-end proof is n=2 pairs**, not a sweep. The outcome is binary (`hit` versus
  `ttl_expiry` with `cache_read = 0`), both pairs were identical, and the gateway-level arms behind
  it are 3/3 and 2/2 with paired controls — but this is a demonstration that the mechanism works,
  not a new estimate of what it is worth. The adjudicated window figures stand unchanged.

## The cost of the fix, measured

`pingSpans` replaced a plain `LAG` with `ROW_NUMBER + LEAD` over the same partition plus a prefix
filter, and it runs on every load of two routes. **PAIRED** measurement, 40 pairs against one
server per arm:

```
/keepalive/calc       +0.0562 s  ± 0.0145   slower in 36 of 40 pairs   (~+18.9%)
/keepalive/recommend  +0.0479 s  ± 0.0135   slower in 37 of 40 pairs
```

Both intervals exclude zero, so unlike my first attempt this **is** a resolved figure.

My own earlier run reported +27.7% for `calc` and I am correcting it down: I restarted the server
process per trial, which put startup noise inside the arm and inflated the gap. The paired form with
one server per arm removes that, and the honest number is ~+19%. Same direction, smaller size — the
methodology was the error, not the mechanism.

~0.06 s on a user-initiated page load, for a column that otherwise counts a different population
than it names.

## Verification

```
CGO_ENABLED=1 go test -race -count=1 -timeout 25m ./...   # 25 packages, EXIT=0, dash 648.2s
gofmt -l .   # empty
go vet ./... # clean
```
