### PR TITLE
fix(proxy): the Inventory switch was offered to every account and refused for most of them

### DIFF
--- a/dash/uiinventory_test.go
+++ b/dash/uiinventory_test.go
@@ -133,11 +133,41 @@ func TestTheRemovalSwitchIsNotRoleGated(t *testing.T) {
 				"change the route's permission with it.", gate)
 		}
 	}
-	// And the switch's own disabled condition must stay about the ROW and the PROXY, not the
+	// And every switch's disabled condition must stay about the ROW and the PROXY, not the
 	// reader: `fixed` is a provider-side tool, `!tools.control` is a proxy offering no control.
-	if n := strings.Count(src, "disabled: fixed || !tools.control"); n != 2 {
-		t.Errorf("found %d of the 2 expected switch disabled conditions; if the condition moved, "+
-			"check it still turns on the row and the proxy rather than the reader's role", n)
+	//
+	// Asserted as a PROPERTY over however many conditions exist, not as a count of them. The
+	// first version of this check required exactly 2, which is what main happens to have —
+	// and the branch that moves built-in tools into their own section correctly leaves that
+	// table with no switch at all, so it has 1. A count assertion fails on that legitimate
+	// change, and fails with a message pointing at the role gate, which is the opposite of
+	// what happened. Verified against that branch's tools.js, not just this one's.
+	conds := 0
+	for _, line := range strings.Split(src, "\n") {
+		i := strings.Index(line, "disabled:")
+		if i < 0 {
+			continue
+		}
+		cond := line[i:]
+		conds++
+		if !strings.Contains(cond, "fixed") || !strings.Contains(cond, "!tools.control") {
+			t.Errorf("a switch's disabled condition is not about the row and the proxy: %s\n"+
+				"every one must gate on `fixed` (a provider-side tool) and `!tools.control` (a "+
+				"proxy offering no control), and on nothing about the reader", strings.TrimSpace(cond))
+		}
+		for _, gate := range []string{"isManager", "wideScope", "manager", "role"} {
+			if strings.Contains(cond, gate) {
+				t.Errorf("a switch's disabled condition consults %q: %s — a user's switch would "+
+					"become a no-op that only alerts, which is the defect the route gate was",
+					gate, strings.TrimSpace(cond))
+			}
+		}
+	}
+	// Zero would mean the view stopped drawing a switch at all, which passes every assertion
+	// above by having nothing to check.
+	if conds == 0 {
+		t.Error("the Inventory view declares no switch disabled condition at all; either the " +
+			"switch is gone or it moved somewhere this check cannot see")
 	}
 }
 

--- a/dash/uiinventory_test.go
+++ b/dash/uiinventory_test.go
@@ -111,6 +111,36 @@ func TestTheRemovalCommandIsInTheActionableList(t *testing.T) {
 	}
 }
 
+// TestTheRemovalSwitchIsNotRoleGated pins the assumption POST /api/toolfilter now rests on.
+//
+// That route accepts a plain account because this page OFFERS a plain account the switch: the
+// tab is mounted unconditionally, and the only thing that disables a checkbox is a provider-side
+// row or a proxy that reports no control. The route's permission was written to match. If a
+// role gate is ever added here, the two ends disagree in the direction that is invisible on
+// screen — every account still sees the analysis, managers still see a working switch, and a
+// user's switch silently does nothing but alert — which is the exact defect the route gate was.
+//
+// A static check because there is no DOM here, and a grep for the role helpers is enough: they
+// are the only way this view could learn a caller's role, since it is handed a report and a
+// control document and neither carries one.
+func TestTheRemovalSwitchIsNotRoleGated(t *testing.T) {
+	src := readUI(t, "ui/tools.js")
+	for _, gate := range []string{"isManager(", "wideScope(", "'manager'", `"manager"`} {
+		if strings.Contains(src, gate) {
+			t.Errorf("the Inventory view consults %s. Its switch is offered to every account "+
+				"and POST /api/toolfilter accepts every account to match; gating the control on "+
+				"a role here makes a user's switch a no-op that only alerts. Hide nothing, or "+
+				"change the route's permission with it.", gate)
+		}
+	}
+	// And the switch's own disabled condition must stay about the ROW and the PROXY, not the
+	// reader: `fixed` is a provider-side tool, `!tools.control` is a proxy offering no control.
+	if n := strings.Count(src, "disabled: fixed || !tools.control"); n != 2 {
+		t.Errorf("found %d of the 2 expected switch disabled conditions; if the condition moved, "+
+			"check it still turns on the row and the proxy rather than the reader's role", n)
+	}
+}
+
 func readUI(t *testing.T, name string) string {
 	t.Helper()
 	b, err := uiFS.ReadFile(name)

--- a/docs/how-to/declaration-removal.md
+++ b/docs/how-to/declaration-removal.md
@@ -29,9 +29,20 @@ switch per declaration, which posts one change to `POST /api/toolfilter`
 (`{kind, name, server, action:"exclude"|"include"}`) and repaints from the document the server
 answers with. That route is part of the **control plane**, not the dashboard, on purpose — the
 removal list is your compaction configuration, so it goes through the same account-update path
-as `PUT /api/me` and inherits its validation, its audit entry and its manager gate. A junk name
-or a wildcard is a 400; changing what we send is attributable; and setting it is a manager's
-action, like every other decision about what runs on the traffic.
+as `PUT /api/me` and inherits its validation and its audit entry. A junk name or a wildcard is a
+400, and changing what we send is attributable.
+
+It does **not** inherit that route's manager gate. Any signed-in account can switch off the
+declarations it added itself — MCP tools, MCP servers, and any other client-side tool that is not
+one of Claude Code's own — because those are on your own bill, and shrinking your own prompt is
+not a decision anyone else has to make for you. The write only ever touches your own account,
+only ever the removal list, and is recorded against you in the audit log.
+
+The exception is Claude Code's **own** tools. Switching one of those off does not trim a little
+fat, it takes away equipment the model is expected to have, so `POST /api/toolfilter` answers
+403 for a plain account and a manager has to make that change. Putting one back is never
+refused — that is the repair. The Inventory page offers no switch for a built-in to anyone; the
+danger warning and the paste-able command in its collapsed section are the whole interface.
 
 `GET /api/toolfilter` is the read half, served by the dashboard:
 

--- a/proxy/control.go
+++ b/proxy/control.go
@@ -88,8 +88,9 @@ func (h *Handler) ctlRoutes() []ctlRoute {
 		{"GET /api/me/audit", ctlTenant, h.ctlAudit},
 		// Declaration removal: the WRITE half of the inventory page's switch. Here rather
 		// than beside its read route in dash because the removal list is part of the
-		// compaction configuration, so it must go through the same validation, audit entry
-		// and manager gate as PUT /api/me — see proxy/toolfilterctl.go.
+		// compaction configuration, so it must go through the same validation and audit
+		// entry as PUT /api/me. NOT its manager gate: one declaration is a user's own bill
+		// to stop paying — see proxy/toolfilterctl.go.
 		{"POST /api/toolfilter", ctlTenant, h.ctlToolFilter},
 		{"GET /api/options", ctlTenant, h.ctlOptions},
 		{"GET /api/tenants", ctlManager, h.ctlTenants},

--- a/proxy/toolfilterctl.go
+++ b/proxy/toolfilterctl.go
@@ -4,11 +4,15 @@ package proxy
 //
 // It lives in the control plane rather than beside the read route in dash for one reason:
 // the removal list is part of an account's compaction configuration, and the rules that
-// govern writing that — strict validation of the whole document, an audit entry naming the
-// field, and the manager gate — already exist here on PUT /api/me. A second writer with its
-// own copy of those rules is how one of the two ends up missing one; this route reuses the
-// same Form round trip and the same registry Update, so the only thing it adds is the shape
-// a single switch posts.
+// govern writing that — strict validation of the whole document and an audit entry naming the
+// field — already exist here on PUT /api/me. A second writer with its own copy of those rules
+// is how one of the two ends up missing one; this route reuses the same Form round trip and the
+// same registry Update, so the only thing it adds is the shape a single switch posts.
+//
+// What it does NOT inherit is that route's manager gate. A user may drop the declarations they
+// added themselves — their own MCP tools and MCP servers — because what their prompt carries is
+// their own bill. declConfigName says which kinds are removable at all; ctlToolFilter says the
+// one removable thing a user may not drop, and why.
 //
 // It also inherits what the route table gives every control-plane write: the ctlTenant gate,
 // cookie-only identity (a pasted proxy token cannot change a configuration), and the
@@ -97,13 +101,6 @@ func (h *Handler) ctlToolFilter(w http.ResponseWriter, r *http.Request) {
 		readErr(w, err)
 		return
 	}
-	// The same gate PUT /api/me applies to config_yaml, and for the same reason: this decides
-	// what runs on the traffic. Enforced here and not only by hiding the switch — a hidden
-	// control is not a permission, and this route is one curl away.
-	if !t.IsManager() {
-		ctlErr(w, http.StatusForbidden, "a manager sets the compaction configuration")
-		return
-	}
 	name, err := declConfigName(in.Kind, in.Name, in.Server)
 	if err != nil {
 		ctlErr(w, http.StatusBadRequest, err.Error())
@@ -112,6 +109,25 @@ func (h *Handler) ctlToolFilter(w http.ResponseWriter, r *http.Request) {
 	exclude := in.Action == "exclude"
 	if !exclude && in.Action != "include" {
 		ctlErr(w, http.StatusBadRequest, `action must be "exclude" or "include"`)
+		return
+	}
+	// NOT the config_yaml gate PUT /api/me applies, and deliberately so: what a user carries
+	// in their own prompt is their own bill, and the inventory page exists to let them stop
+	// paying it. This route is narrower than that gate by construction — ONE validated
+	// declaration name, PipelineKnown pinned to this component so nothing else in the document
+	// can move, and reg.Update confining the write to the caller's own account and auditing it.
+	//
+	// A built-in is the one exception, and only on the way OUT. Removing one does not degrade
+	// the agent gracefully, it breaks it, and the page offers no switch for one to anybody — so
+	// a hand-crafted POST gets a reason rather than a configuration whose next session fails.
+	// Checked on the RESOLVED name and not the claimed kind, because the kind is caller-supplied:
+	// {"kind":"mcp_tool","name":"Read"} resolves to `Read` and must not slip past a kind test.
+	// A manager keeps it because refusing them here would be theatre — they can write the same
+	// line through PUT /api/me, which is exactly the privilege a user does not have. And an
+	// `include` is never refused: re-adding a built-in is the repair, not the damage.
+	if exclude && !t.IsManager() && dash.IsBuiltinTool(dash.KindTool, name) {
+		ctlErr(w, http.StatusForbidden, "removing one of Claude Code's own tools breaks the "+
+			"agent rather than saving you anything, so a manager has to make that change")
 		return
 	}
 	reg := h.registry()

--- a/proxy/toolfilterctl_test.go
+++ b/proxy/toolfilterctl_test.go
@@ -9,11 +9,13 @@ import (
 // The write half of declaration removal has to inherit three things from the control plane
 // rather than reimplement them, and each of them is a way the switch could go wrong:
 //
-//	the manager gate  — the removal list decides what runs on the traffic, exactly like
-//	                    config_yaml, so a plain user cannot set it for themselves;
 //	validation        — the stored document must still build, or the account's next turn
 //	                    fails on a configuration a settings page accepted;
 //	the audit trail   — a change to what we send must be attributable.
+//
+// It must NOT inherit the fourth: PUT /api/me's manager gate. One declaration off a user's own
+// prompt is that user's own bill, so any signed-in account may do it — with the single
+// exception of a built-in, which is not a saving but a broken agent.
 //
 // It also has to be a real round trip: excluding then re-including must leave a document that
 // runs the same pipeline as before, because that is the recovery path.
@@ -84,21 +86,147 @@ func TestToolFilterExcludeRoundTrip(t *testing.T) {
 	}
 }
 
-// TestToolFilterIsAManagersDecision: a hidden control is not a permission, and this route is
-// one curl away. Same rule PUT /api/me applies to config_yaml.
-func TestToolFilterIsAManagersDecision(t *testing.T) {
+// TestToolFilterIsTheUsersOwnDecision: a plain account may stop carrying its own MCP tools and
+// MCP servers. This is the whole point of the inventory page — it is shown to every account, so
+// a route that answered 403 made the switch a lie.
+//
+// The audit row matters as much as the 200: the write goes through reg.Update as the USER, so
+// "who changed what runs on my traffic" has to name the user and not a manager who never
+// touched it.
+func TestToolFilterIsTheUsersOwnDecision(t *testing.T) {
 	f := ctlFixture(t)
-	w, _ := f.signUp(t, "boss@ibm.com", "l") // the fixture's manager
-	_ = w
-	w, _ = f.signUp(t, "user@ibm.com", "u")
-	userJar := w.Result().Cookies()
-	if w, _ := f.do(t, "POST", "/api/toolfilter",
-		`{"kind":"tool","name":"Workflow","action":"exclude"}`, userJar); w.Code != http.StatusForbidden {
-		t.Errorf("a plain user set the removal list: %d", w.Code)
+	f.signUp(t, "boss@ibm.com", "l") // the bootstrap account is the manager
+	w, _ := f.signUp(t, "user@ibm.com", "u")
+	jar := w.Result().Cookies()
+	_, me := f.do(t, "GET", "/api/me", "", jar)
+	tn, _ := me["tenant"].(map[string]any)
+	userID, _ := tn["id"].(string)
+	if userID == "" {
+		t.Fatalf("no tenant id for the plain account: %v", me)
 	}
-	// And with no session at all.
+	if mgr, _ := tn["role"].(string); mgr == "manager" {
+		t.Fatalf("the second account is a manager, so this test proves nothing: %v", tn)
+	}
+
+	for _, body := range []string{
+		`{"kind":"mcp_tool","name":"mcp__playwright__click","server":"playwright","action":"exclude"}`,
+		`{"kind":"mcp_server","server":"playwright","action":"exclude"}`,
+	} {
+		if w, _ := f.do(t, "POST", "/api/toolfilter", body, jar); w.Code != http.StatusOK {
+			t.Fatalf("a plain account could not filter its own declaration: %s = %d %s",
+				body, w.Code, w.Body)
+		}
+	}
+	_, me = f.do(t, "GET", "/api/me", "", jar)
+	tn, _ = me["tenant"].(map[string]any)
+	doc, _ := tn["effective_config_yaml"].(string)
+	if !strings.Contains(doc, "mcp__playwright__click") || !strings.Contains(doc, "toolfilter") {
+		t.Fatalf("the user's own document does not carry the removal: %q", doc)
+	}
+
+	// Attributable TO THE USER. A manager id here would mean the write borrowed a privilege.
+	_, audit := f.do(t, "GET", "/api/me/audit", "", jar)
+	entries, _ := audit["audit"].([]any)
+	found := 0
+	for _, e := range entries {
+		m, ok := e.(map[string]any)
+		if !ok || m["field"] != "config_yaml" {
+			continue
+		}
+		if m["actor"] != userID || m["target"] != userID {
+			t.Errorf("config change attributed to actor=%v target=%v, want the user itself",
+				m["actor"], m["target"])
+		}
+		found++
+	}
+	if found != 2 {
+		t.Errorf("audit recorded %d config changes of 2: %v", found, entries)
+	}
+}
+
+// TestToolFilterUserCannotDropABuiltin: the one thing a plain account may not switch off.
+//
+// Removing Claude Code's own tool does not trim fat, it takes away equipment the model is
+// expected to have — and the page offers no switch for one to ANYBODY, so only a hand-crafted
+// POST can get here. The check is on the resolved name rather than the caller's `kind`, because
+// the kind is caller-supplied and a kind test is one lie away from being bypassed.
+func TestToolFilterUserCannotDropABuiltin(t *testing.T) {
+	f := ctlFixture(t)
+	w, _ := f.signUp(t, "boss@ibm.com", "l")
+	mgrJar := w.Result().Cookies()
+	w, _ = f.signUp(t, "user@ibm.com", "u")
+	jar := w.Result().Cookies()
+
+	for _, body := range []string{
+		`{"kind":"tool","name":"Read","action":"exclude"}`,
+		// The bypass: claim a kind whose branch does not classify built-ins.
+		`{"kind":"mcp_tool","name":"Read","action":"exclude"}`,
+		`{"kind":"","name":"Bash","action":"exclude"}`,
+	} {
+		w, _ := f.do(t, "POST", "/api/toolfilter", body, jar)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("a plain account removed a built-in: %s = %d %s", body, w.Code, w.Body)
+		}
+		if strings.Contains(w.Body.String(), "compaction configuration") {
+			t.Errorf("the refusal still blames the compaction-configuration gate, which is no "+
+				"longer why this is refused: %s", w.Body)
+		}
+	}
+	// A name that is not one of Claude Code's own is not a built-in, whatever it looks like.
 	if w, _ := f.do(t, "POST", "/api/toolfilter",
-		`{"kind":"tool","name":"Workflow","action":"exclude"}`, nil); w.Code == http.StatusOK {
+		`{"kind":"tool","name":"Workflow","action":"exclude"}`, jar); w.Code != http.StatusOK {
+		t.Errorf("another agent's client-side tool was refused as a built-in: %d %s", w.Code, w.Body)
+	}
+	// A manager keeps the escape hatch: refusing them here would be theatre, since they can
+	// write the same line through PUT /api/me.
+	if w, _ := f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"tool","name":"Read","action":"exclude"}`, mgrJar); w.Code != http.StatusOK {
+		t.Errorf("a manager could not remove a built-in: %d %s", w.Code, w.Body)
+	}
+	// PUTTING ONE BACK is the repair, so it is never refused — otherwise a user whose manager
+	// dropped Read for them cannot un-break their own agent.
+	if w, _ := f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"tool","name":"Read","action":"include"}`, jar); w.Code != http.StatusOK {
+		t.Errorf("a plain account could not re-include a built-in: %d %s", w.Code, w.Body)
+	}
+}
+
+// TestToolFilterGrantsNothingElse: dropping the gate must widen this route and nothing around
+// it. A user who can post one declaration name must still not be able to write a configuration
+// document, and must not be able to reach anything the route does not model.
+func TestToolFilterGrantsNothingElse(t *testing.T) {
+	f := ctlFixture(t)
+	f.signUp(t, "boss@ibm.com", "l")
+	w, _ := f.signUp(t, "user@ibm.com", "u")
+	jar := w.Result().Cookies()
+
+	// A whole config document through PUT /api/me is still a manager's privilege — that gate is
+	// the reason this one could be dropped, so it is the one that must not have moved.
+	for _, body := range []string{
+		`{"config_yaml":"pipeline: []\n"}`,
+		`{"config":{"pipeline":["toolfilter"]}}`,
+	} {
+		if w, _ := f.do(t, "PUT", "/api/me", body, jar); w.Code != http.StatusForbidden {
+			t.Errorf("a plain account wrote a configuration document: %s = %d %s",
+				body, w.Code, w.Body)
+		}
+	}
+
+	// The route models one component, so a save must leave the rest of the document alone —
+	// including a pipeline entry it has no business knowing about.
+	if w, _ := f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"mcp_server","server":"playwright","action":"exclude"}`, jar); w.Code != http.StatusOK {
+		t.Fatalf("exclude = %d %s", w.Code, w.Body)
+	}
+	_, me := f.do(t, "GET", "/api/me", "", jar)
+	tn, _ := me["tenant"].(map[string]any)
+	if role, _ := tn["role"].(string); role != "user" {
+		t.Errorf("the account's role changed through the toolfilter route: %q", role)
+	}
+
+	// And with no session at all it is nobody's own bill.
+	if w, _ := f.do(t, "POST", "/api/toolfilter",
+		`{"kind":"mcp_server","server":"playwright","action":"exclude"}`, nil); w.Code == http.StatusOK {
 		t.Error("an unauthenticated caller changed a configuration")
 	}
 }


### PR DESCRIPTION
## The problem

The Inventory page draws a removal switch for **every** signed-in account. Nothing in
`dash/ui/tools.js` consults a role — the tab is mounted unconditionally, `GET /api/toolfilter`
reports `enabled: true` regardless of role, and the only thing that disables a checkbox is a
provider-side row or a proxy that offers no control at all.

`POST /api/toolfilter` then answered **403 `a manager sets the compaction configuration`**. So a
plain account was shown a live switch and refused when it used it: `toggleExcluded` turns any
non-ok response into `alert('Could not change this: …')` and repaints from the last known state
(`dash/ui/tools.js:846-858`). The control was never hidden — it was offered and then refused.

The 403 below is measured against a running proxy; the alert is what that response produces in
the browser by inspection of that path, not something this PR drove a browser to observe.

Reproduced against `main` (df85918) with a real non-manager account on a throwaway hosted proxy:

```
BEFORE (main @ df85918), acting as role = user
  GET  /api/toolfilter -> 200  enabled=True   <- the switch is DRAWN for this account
  POST whole MCP server  -> 403  'a manager sets the compaction configuration'
  POST one MCP tool      -> 403  'a manager sets the compaction configuration'
  POST a skill           -> 403  'a manager sets the compaction configuration'
```

That third line is a second bug: the gate ran *before* `declConfigName`, so a user asking to
remove a skill was told a manager sets the compaction configuration. The real reason is that the
kind is not removable at all.

**So this is a bug fix, not a new privilege.** The page already draws this control for every
account; the change makes it tell the truth about it. A control that is offered and then refused
is worse than one that is hidden and worse than one that is disabled — the reader has no way to
know which of the two it is looking at.

## The change

Drop the gate. Three lines of new refusal replace it, and the check moves below
`declConfigName` so the refusal reason is the accurate one.

## Why this is not a widening of config editing

The gate was borrowed from `PUT /api/me`'s `config_yaml` gate, but this route is **narrower than
that one by construction**, and each of these was verified rather than assumed:

| | `PUT /api/me` | `POST /api/toolfilter` |
|---|---|---|
| Input | a whole configuration document | one `{kind, name, server, action}` |
| Names | anything the schema allows | `declConfigName` + `validDeclName`: no globs, no wildcards, ≤128 chars |
| Reach | every component, mode, cache setting | `PipelineKnown = ["toolfilter"]`, so nothing else in the document can move |
| Target | own account | own account (`reg.Update(t, t.ID, …)`) |
| Audit | one row | one row, same transaction |

And `tenant.Registry.Update` does **not** treat `ConfigYAML` as privileged — the privileged set is
`Role`, `MaxRows`, `Disabled`, `Variant`, `DisabledReason` (`tenant/tenant.go`). A non-manager
updating its own config already passed the registry's own permission model; only the handler
refused. `PUT /api/me` is untouched.

The substantive argument: what an account's prompt carries is that account's own bill, and the
whole purpose of the Inventory page is to let the person paying it stop paying. A manager is not
more entitled to shrink someone's prompt than its owner is.

## The decision on built-ins

**A plain account cannot exclude one of Claude Code's own tools. A manager still can.**

Reasoning, since this is the judgement call in the PR:

1. **The grant should be no wider than the request.** The ask was to filter MCP tools, MCP
   servers and skills. Removing `Read` was never part of it, and dropping the gate wholesale
   would have handed every account a capability nobody asked for.
2. **It is the only line that matches the UI.** The built-ins section has no switch for
   *anybody* — it is a collapsed panel behind a danger warning offering a paste-able command
   (`dash/ui/tools.js: renderBuiltins`). So the route now permits exactly the set the page
   offers a switch for. "A hidden control is not a permission" says do not rely on hiding to
   enforce a permission; it does not say every UI omission must become a route rule. Here the
   two happen to coincide, which is what makes the rule non-arbitrary rather than decorative.
3. **The asymmetry with managers is honest, not theatre.** A manager can write the same line
   through `PUT /api/me`, so refusing them here would block nothing. A user cannot, so the
   refusal is a real boundary for exactly the caller it applies to.
4. **`include` is never refused.** Re-adding a built-in is the repair, not the damage — a user
   whose manager dropped `Read` for them must be able to un-break their own agent.
5. **Checked on the resolved name, not the caller's `kind`.** `kind` is caller-supplied.
   `{"kind":"mcp_tool","name":"Read"}` resolves to `Read` and must not walk past a kind test.
   `dash.IsBuiltinTool(dash.KindTool, name)` reuses the existing classifier rather than adding
   a second list that could drift from it.

The new copy: `removing one of Claude Code's own tools breaks the agent rather than saving you
anything, so a manager has to make that change`. Nothing a user can do now says "a manager sets
the compaction configuration".

## Real-run evidence

A throwaway hosted-mode proxy on loopback (never port 4000, never the production service, never
the production database), a manager account and a **non-manager** account, and real Claude Code
sessions with a real stdio MCP server attached. Gateway key read from the environment at start
time; never printed or stored.

One trap worth recording for the next person: `ANTHROPIC_BASE_URL` in the shell is silently
overridden by the `env` block in `~/.claude/settings.json`, so the first sessions answered
normally while never touching the proxy. Every run below uses `claude --settings '{"env":{…}}'`,
and a negative control against a dead port confirms the proxy is genuinely in the path (it
fails rather than answering).

**Baseline, as recorded from real sessions:** 27 declarations, 25,328 tokens per request,
including `mcp__demo__add` (50 tok, used once) and `mcp__demo__echo` (43 tok, never used).

**What the non-manager could then do** (role confirmed `user` from `GET /api/me`):

```
--- WHAT A PLAIN ACCOUNT MAY NOW DO
  whole MCP server 'demo'  -> 200  excluded now = ['mcp__demo']
  one MCP tool             -> 200  excluded now = ['mcp__demo', 'mcp__demo__echo']
  another agent's tool     -> 200  excluded now = ['Workflow', 'mcp__demo', 'mcp__demo__echo']

--- WHAT IT STILL MAY NOT DO
  built-in Read               -> 403  removing one of Claude Code's own tools breaks the agent …
  built-in via a lied kind    -> 403  removing one of Claude Code's own tools breaks the agent …
  built-in Bash, no kind      -> 403  removing one of Claude Code's own tools breaks the agent …

--- PUTTING A BUILT-IN BACK IS THE REPAIR, never refused
  include Read -> 200
```

**Did the declarations actually stop being sent?** Three independent checks.

*Accounting.* `GET /api/toolfilter` after two more real sessions:
`requests: 2, sessions: 2, reads: 10214, usd: 0.0137889, priced: true` — 5,107 tokens per
request, which is exactly `Workflow 5014 + mcp__demo__add 50 + mcp__demo__echo 43`.

*Byte level.* A recording upstream captured the body the proxy forwards, A/B on the same prompt:

```
filter OFF -> 27 tools forwarded
filter ON  -> 24 tools forwarded
difference  : ['Workflow', 'mcp__demo__add', 'mcp__demo__echo']
only-when-on: (none)
```

Built-ins (`Read`, `Bash`) still forwarded; no `mcp__` name left.

*Behavioural.* The MCP server stayed connected client-side, identical `--mcp-config`. The prompt
that produced a real tool call and `42` before the filter, after it:

> I don't have access to an MCP "add" tool in my current toolset — no demo MCP server is
> connected in this session. I can't complete that request as-is.

**The refusal reasons are now the right ones** for a plain account:

```
  a skill          -> 400  'a skill is declared as prose inside the transcript rather than as a tool, …'
  a provider tool  -> 400  'a provider-side tool is resolved by the provider from its type, …'
  a wildcard       -> 400  'toolfilter: "Cron*" is not a declaration name'
  a bogus action   -> 400  'action must be "exclude" or "include"'
```

**The audit trail names the user, not a manager:**

```
config_yaml audit rows for the plain account: 6
every actor is the user itself : True
every target is the user itself: True
any row actored by the manager : False
```

The actor and target are the same id here and inherently cannot differ — a user updating itself
— so the assertion's value is that neither is a manager's; M6 below proves it is live.

**The negatives hold.** A whole configuration document is still refused
(`PUT /api/me {"config_yaml":…}` → 403, `{"config":…}` → 403), the account's role is unchanged
after the saves, an unauthenticated POST is refused, and the emptied removal list took
`toolfilter` back out of the pipeline (the recovery path).

## Mutation results

Every new assertion was verified by breaking its subject and confirming RED, then reverting.

| | Mutation | Result |
|---|---|---|
| M1 | restore the `!t.IsManager()` gate | RED ×3 tests |
| M2 | delete the built-in refusal | RED — all three built-in cases returned 200 |
| M3 | classify by `in.Kind` instead of the resolved name | RED — the `mcp__tool`/`Read` bypass returned 200 |
| M4 | gate `include` as well as `exclude` | RED — the repair path 403'd |
| M5a | drop `PUT /api/me`'s `config_yaml` gate | RED |
| M5b | drop `PUT /api/me`'s config-**form** gate only | **GREEN — reported, not hidden** |
| M5c | drop both `PUT /api/me` gates | RED ×2 — both assertions live |
| M6 | write a different actor into the audit row | RED |
| M7 | add `isManager()` to the switch's disabled condition | RED |
| M8 | move the switch's disabled condition elsewhere | RED |

**M5b is worth stating plainly.** It passed with the gate broken, which normally means a dead
test. The cause is benign and was checked rather than assumed: the form path assigns
`in.ConfigYAML = &doc` and then falls into the `config_yaml` gate, so the two gates are in
series and breaking one leaves the other. M5c breaks both and the assertion goes red, so it is
live — just double-guarded. No test here passes with its subject genuinely unguarded.

`go test ./... -race -timeout 25m`: green.

## What is NOT in this PR

**Skills.** `declConfigName` on `main` refuses them for *every* role — server-side skill removal
is #98's work (`internal/skills`, `skills.RemovePrefix`). This PR is role logic only, so the two
compose instead of colliding.

Verified on a **throwaway local merge** of this branch with #98 — built and run locally, **not
pushed** and not proposed as a merge here. No conflicts, `go build` and `./proxy
./internal/skills ./apply` green, and a **non-manager excluding a real skill** works end to end —

```
plain account excludes the dataviz SKILL -> 200
  filter OFF: dataviz forwarded = True  | bytes 161129
  filter ON : dataviz forwarded = False | bytes 160125
  listing entries: 43 -> 42
  entries that disappeared: ['dataviz']
```

Exactly one listing entry stopped being sent, 1,004 bytes off a real request. Once #98 lands, the
user's full ask — MCP tools, MCP servers **and** skills, for every account — is satisfied.

Two things to be precise about, so nobody reads more assurance into that than it carries. The
figures above are a **real run, not test coverage**: #98's own review found its skills wiring has
no test, so this is a demonstration that the path works for a non-manager, not evidence that a
regression in it would be caught. That test is #98's to add and is already reported there.

And the two branches both edit `ctlToolFilter`, so expect a **~3-line conflict at the gate**.
Either merge order resolves it trivially — #98 changes `declConfigName` further down the file
while this branch replaces the gate above it, and the resolution is simply to keep both. The
throwaway merge above was in fact clean; the conflict only appears if one of the two rebases.

**No UI change.** There was nothing to expose: `grep -n 'isManager\|wideScope' dash/ui/tools.js`
is empty, and the switch was already offered to every account. `TestTheRemovalSwitchIsNotRoleGated`
pins that, since the route's new permission is an assumption about this page.
