### PR TITLE
fix(dash): stop tools.js shadowing window.prompt, which killed "Mint a token"

### DIFF
--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -1354,8 +1354,28 @@ function copyBox(text, label) {
  *
  * `state` is one of: 'idle' (not asked for yet), 'loading', 'ok', 'absent' (the endpoint is
  * not there — an older proxy), 'error'.
+ *
+ * NOT named `prompt`, and nothing at this level may be. app.js and this file are both
+ * CLASSIC scripts, so they share one global lexical scope: a top-level `const prompt` here
+ * shadowed window.prompt for every bare prompt() call in BOTH files, while leaving
+ * window.prompt itself a function — so nothing looked wrong in app.js, in the markup or in
+ * any test, and the only symptom was a TypeError thrown inside a click handler. It shipped
+ * that way, and it broke three things by taking out four call sites in app.js:
+ *
+ *   - Settings → "Mint a token" threw on its FIRST statement, so the button did nothing at
+ *     all: no dialog, no request, no token.
+ *   - Tenants → "Reissue token" threw AFTER its POST had succeeded, so the replacement
+ *     token was minted and then never shown. Tokens are stored hashed, so each click left
+ *     the account one live credential nobody holds.
+ *   - the keep-alive's "how many hours?" threw before it could ask, so arming a session
+ *     did nothing.
+ *
+ * The fourth, the audit trail's "copy the document as it was before this save", is a
+ * clipboard fallback, so only a browser that refuses clipboard access reached it.
+ *
+ * TestUIScriptsDoNotShadowBrowserGlobals now fails on any such name.
  */
-const prompt = { state: 'idle', view: null, byName: new Map() };
+const promptState = { state: 'idle', view: null, byName: new Map() };
 
 /**
  * loadPrompt fetches the prefix text once and repaints only the reveals that are open.
@@ -1365,20 +1385,20 @@ const prompt = { state: 'idle', view: null, byName: new Map() };
  * Each reveal registers a repaint of its own body instead.
  */
 async function loadPrompt() {
-  if (prompt.state === 'loading' || prompt.state === 'ok') return;
-  prompt.state = 'loading';
+  if (promptState.state === 'loading' || promptState.state === 'ok') return;
+  promptState.state = 'loading';
   repaintPrompt();
   try {
     const v = await api('prompt');
-    prompt.view = v;
-    prompt.byName = new Map();
-    for (const r of v.regions || []) prompt.byName.set(r.kind + '/' + r.name, r);
-    prompt.state = 'ok';
+    promptState.view = v;
+    promptState.byName = new Map();
+    for (const r of v.regions || []) promptState.byName.set(r.kind + '/' + r.name, r);
+    promptState.state = 'ok';
   } catch (err) {
     if (aborted(err)) return;
     // A 404 is an older proxy that has the report and not this route. That is "the feature
     // is not there", not "something broke", and the two must not read the same.
-    prompt.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
+    promptState.state = /404|not found/i.test(String((err && err.message) || err)) ? 'absent' : 'error';
   }
   repaintPrompt();
 }
@@ -1411,20 +1431,20 @@ function promptTextReveal(t) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'idle' || prompt.state === 'loading') {
+    if (promptState.state === 'idle' || promptState.state === 'loading') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptState.state === 'absent') {
       body.appendChild(el('p', { class: 'hint' }, 'This proxy records the token weight of each '
         + 'declaration but not its text. The weight above is exact.'));
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptState.state === 'error') {
       body.appendChild(el('p', { class: 'hint' }, 'Could not read the prompt text.'));
       return;
     }
-    const reg = prompt.byName.get(t.kind + '/' + t.name);
+    const reg = promptState.byName.get(t.kind + '/' + t.name);
     if (reg && reg.has_text) {
       body.appendChild(el('p', { class: 'hint' }, num(reg.tokens) + ' tokens, '
         + pct(reg.share, 1) + ' of the prefix that session carried.'));
@@ -1451,7 +1471,7 @@ let promptWaiters = [];
  * prevent — the same one captureState fixes on the server.
  */
 function notCapturedState(host) {
-  const v = prompt.view || {};
+  const v = promptState.view || {};
   if (v.blocked_by === 'operator') {
     return emptyState(host, 'Prompt text is not stored on this deployment',
       'The operator has content capture switched off service-wide, so no prompt or transcript '
@@ -1540,21 +1560,21 @@ function renderPromptPanel(host, rep) {
   det.appendChild(body);
   const paint = () => {
     clear(body);
-    if (prompt.state === 'loading' || prompt.state === 'idle') {
+    if (promptState.state === 'loading' || promptState.state === 'idle') {
       body.appendChild(el('p', { class: 'hint' }, 'Reading…'));
       return;
     }
-    if (prompt.state === 'absent') {
+    if (promptState.state === 'absent') {
       emptyState(body, 'This proxy does not record prompt text',
         'It records the token weight of every region, which is what the figures above are. '
         + 'Reading the text needs a newer proxy.');
       return;
     }
-    if (prompt.state === 'error') {
+    if (promptState.state === 'error') {
       emptyState(body, 'Could not read the prompt text', 'The figures above are unaffected.');
       return;
     }
-    const v = prompt.view || {};
+    const v = promptState.view || {};
     if (!v.captured) { notCapturedState(body); return; }
     body.appendChild(el('p', { class: 'note' }, 'One session\'s actual prefix — '
       + num(v.tokens) + ' tokens across ' + num((v.regions || []).length) + ' regions, captured '

--- a/dash/uishadow_test.go
+++ b/dash/uishadow_test.go
@@ -1,0 +1,104 @@
+package dash
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// uiScripts are the dashboard's scripts, which index.html loads with a plain <script src>
+// — CLASSIC scripts, not modules. That is the whole reason this file exists: classic
+// scripts do not get a scope each, they SHARE one global lexical scope, so a top-level
+// declaration in either one is visible to both and to nothing else on the page.
+var uiScripts = []string{"ui/app.js", "ui/tools.js"}
+
+// topLevelDecl matches a binding declared at the start of a line, which in these files
+// means module scope: every nested statement is indented, and JSDoc continuation lines
+// begin with " *".
+var topLevelDecl = regexp.MustCompile(
+	`(?m)^(?:const|let|var|class|function|async function)\s+([A-Za-z_$][\w$]*)`)
+
+// shadowableGlobals name the browser surface that a top-level UI binding must not reuse.
+//
+// The production bug. tools.js declared `const prompt = { state: 'idle', … }` for the
+// Inventory tab's prompt-text cache. Because the two scripts share one global lexical
+// scope, that const shadowed window.prompt for every BARE prompt() call in BOTH files —
+// and only the bare form: window.prompt itself stayed a function, so app.js read
+// correctly, the markup was correct, the endpoint was correct and every existing test
+// passed. The only symptom was "TypeError: prompt is not a function", thrown inside
+// whichever handler called it, which took out four call sites in app.js:
+//
+//   - Settings → "Mint a token" threw on its first statement: no dialog, no request, no
+//     token. The button did nothing whatsoever.
+//   - Tenants → "Reissue token" threw AFTER its POST had already succeeded, so the token
+//     was minted and never displayed. Tokens are stored hashed, so every click left the
+//     account one live credential that nobody holds.
+//   - the keep-alive's "how many hours?" threw before it could ask, so arming a session
+//     did nothing.
+//   - the audit trail's "copy the document as it was before this save" is a clipboard
+//     fallback, so only a browser that refuses clipboard access reached it.
+//
+// The names below are the globals these scripts call bare, plus the short noun-shaped
+// window properties most likely to be reused for a cache or a state object. Go cannot
+// enumerate Window, so this is a list and not a reflection of the platform: extend it if
+// a new collision is ever found.
+var shadowableGlobals = []string{
+	// Called bare by the UI. prompt is the one that shipped broken.
+	"prompt", "alert", "confirm",
+	"fetch", "EventSource", "AbortController",
+	"setTimeout", "setInterval", "clearTimeout", "clearInterval", "requestAnimationFrame",
+	"URL", "URLSearchParams", "encodeURIComponent", "decodeURIComponent",
+	"document", "window", "location", "history", "navigator", "localStorage", "sessionStorage",
+	"Array", "Date", "Error", "Map", "Set", "String", "Number", "Object", "Promise",
+	"Math", "JSON", "Intl", "Uint32Array", "isFinite", "parseInt", "parseFloat",
+	// Not called here, but they are window properties with ordinary-noun names — exactly
+	// the shape of a variable somebody reaches for next.
+	"name", "status", "length", "origin", "event", "screen", "frames", "parent", "self",
+	"top", "open", "close", "focus", "blur", "print", "stop", "find", "scroll",
+}
+
+// TestUIScriptsDoNotShadowBrowserGlobals is the guard for the defect described above: a
+// top-level binding whose name the browser already defines, which silently disables that
+// API for every bare call on the page.
+func TestUIScriptsDoNotShadowBrowserGlobals(t *testing.T) {
+	forbidden := make(map[string]bool, len(shadowableGlobals))
+	for _, g := range shadowableGlobals {
+		forbidden[g] = true
+	}
+
+	found := 0
+	for _, script := range uiScripts {
+		src := readUI(t, script)
+		for _, m := range topLevelDecl.FindAllStringSubmatch(src, -1) {
+			found++
+			if forbidden[m[1]] {
+				t.Errorf("%s declares a top-level %q, which shadows window.%s for every bare "+
+					"%s(...) call in EVERY dashboard script — window.%s stays intact, so the only "+
+					"symptom is a TypeError inside whichever handler calls it. Rename the binding.",
+					script, m[1], m[1], m[1], m[1])
+			}
+		}
+	}
+	// A regex that silently stopped matching would make this test vacuously green.
+	if found < 100 {
+		t.Fatalf("found only %d top-level declarations across %v; the matcher is broken, "+
+			"not the code", found, uiScripts)
+	}
+}
+
+// TestDashboardUIScriptsShareOneGlobalScope pins the premise the test above rests on. If
+// the dashboard ever moves to <script type="module">, each file gets its own scope, the
+// shadowing hazard disappears, and shadowableGlobals can go — but until then a reader of
+// tools.js has no local reason to think its top-level names reach app.js.
+func TestDashboardUIScriptsShareOneGlobalScope(t *testing.T) {
+	html := readUI(t, "ui/index.html")
+	for _, script := range uiScripts {
+		base := strings.TrimPrefix(script, "ui/")
+		tag := `<script src="` + base + `"></script>`
+		if !strings.Contains(html, tag) {
+			t.Errorf("index.html no longer loads %s as a classic script (%s not found). If it is "+
+				"now a module, the shadowing hazard above no longer applies and this file can go.",
+				base, tag)
+		}
+	}
+}

--- a/docs/dashboard-inventory-page.md
+++ b/docs/dashboard-inventory-page.md
@@ -14,6 +14,12 @@ shared page carries exactly one line about it (`<script src="tools.js"></script>
 `tile()`, `tileGroup()`, `emptyState()`, `sortRows()`, `rangeLabel()` — is `app.js`'s, so
 the page belongs to the same design system rather than shipping a second one.
 
+Mounting itself is not the same as having its own scope. Both files are **classic** scripts,
+so `tools.js`'s top-level declarations are globals that `app.js` sees too — which is how a
+`const prompt` here once shadowed `window.prompt` and broke Settings → *Mint a token* in the
+other file. Name top-level bindings in this file as if they were `app.js`'s; the guard is
+`TestUIScriptsDoNotShadowBrowserGlobals`.
+
 ## What is on the page, top to bottom
 
 | Section | Answers |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,10 +16,21 @@ route, including [`/stats`](reference/routes.md), is byte-for-byte unchanged.
 ![The dashboard's Overview](img/dashboard/01-overview.jpg)
 
 !!! info "No CDN, no build step, no network"
-    The whole UI is three files (`index.html`, `style.css`, `app.js`) embedded in the
-    binary with `go:embed`, served under a `default-src 'self'` CSP. Charts are
-    hand-drawn SVG — no chart library, no framework, no npm. The page fetches nothing
-    off-origin, so it works in a VPC or fully air-gapped, and a test asserts that.
+    The whole UI is five files (`index.html`, `style.css`, `app.js`, and the Inventory
+    tab's `tools.js` / `tools.css`) embedded in the binary with `go:embed`, served under a
+    `default-src 'self'` CSP. Charts are hand-drawn SVG — no chart library, no framework,
+    no npm. The page fetches nothing off-origin, so it works in a VPC or fully air-gapped,
+    and a test asserts that.
+
+!!! warning "The two scripts share one global scope"
+    `app.js` and `tools.js` are loaded as **classic** scripts, not modules, so they do not
+    get a scope each: every top-level `const`, `let`, `function` and `class` in either file
+    is one shared global binding. A top-level name that collides with a browser API
+    silently disables that API for every *bare* call on the page — `window.<name>` keeps
+    working, so nothing reads as wrong until a handler throws. `tools.js` shipped a
+    top-level `const prompt` once, which is what broke Settings → **Mint a token**; see
+    `TestUIScriptsDoNotShadowBrowserGlobals` in `dash/uishadow_test.go`, which now fails on
+    any such name.
 
 ## What it shows
 


### PR DESCRIPTION
## What was broken

Settings → **Mint a token** did nothing when clicked. No dialog, no request, no token, no
error on screen. The button, its click handler, its route (`POST /api/me/tokens`), its scope
gate and `tenant.MintToken` were all correct and all covered by passing tests.

## Root cause

`dash/ui/index.html` loads `app.js` and `tools.js` with a plain `<script src>` — **classic**
scripts, not modules — so they do not get a scope each. They share one global lexical scope.

`tools.js` declared a top-level binding for the Inventory tab's prompt-text cache (added in
#93):

```js
const prompt = { state: 'idle', view: null, byName: new Map() };
```

That `const` shadowed `window.prompt` for every **bare** `prompt(...)` call in *both* files.
Only the bare form — `window.prompt` itself stayed a function — which is why nothing looked
wrong in `app.js`, in the markup, in the endpoint, or in any existing test. The only symptom
was `TypeError: prompt is not a function`, thrown inside whichever handler called it.

Measured in the page, before the fix:

```
typeof prompt         -> 'object'      // the tools.js cache
typeof window.prompt  -> 'function'    // untouched
```

## Blast radius — four call sites in `app.js`, three broken features

| Where | What happened |
|---|---|
| Settings → **Mint a token** | threw on the handler's first statement: no dialog, no request, no token |
| Tenants → **Reissue token** (manager) | threw **after** its POST had already succeeded — the token was minted and then never shown. Tokens are stored hashed, so every click left that account one live credential nobody holds |
| Keep-alive → *"how many hours?"* | threw before it could ask, so arming a session did nothing |
| Settings → audit → *"copy the document as it was"* | a clipboard **fallback**, so only a browser that refuses clipboard access reached it |

## The fix

Rename the binding to `promptState` (`dash/ui/tools.js`, 17 lines). The Inventory tab is its
only user; nothing else referenced it. `window.prompt` is one function again for both scripts.

An audit of **all 302 top-level declarations** across both scripts against the real
`Window` property names found exactly one collision — this one.

## The guard

`TestUIScriptsDoNotShadowBrowserGlobals` (`dash/uishadow_test.go`) walks every top-level
declaration in both UI scripts and fails on any name the browser already defines. It targets
the **class** of defect, not this instance:

- it **fails on the original code** and passes on this branch (verified both ways);
- it refuses to pass vacuously — if the matcher stops finding declarations, it fails instead;
- a sibling test pins the premise, so if the dashboard ever moves to `<script type="module">`
  the guard says it can go.

## Verification

Built the binary and drove the real dashboard in headless Chromium against a hosted-mode
proxy, signed in as a real account.

**Before:** click → `pageerror: prompt is not a function`, 0 dialogs, 0 requests, token list unchanged.

**After:**

```
DIALOG prompt  "Name this token (e.g. laptop, ci):"  default="new-token"
RESP   POST /api/me/tokens -> 201
DIALOG prompt  "Copy this token now — it is shown once and cannot be recovered:"
               default="cg_live_BCXXWLQKXQYMOXNBK67B5YTF7M"
token list: 3 rows, newest first
```

The minted token is a real credential, not just a string: the proxy answers it with
`no provider credential; send your own API key` (i.e. it authenticated and stopped for lack
of an upstream key), while a bogus token gets `unknown or revoked context-guru token`.

Also confirmed in the page after the fix: `prompt === window.prompt` and both are functions,
which is what un-breaks the other three call sites. The renamed Inventory state object still
works — `loadPrompt()` transitions `idle → ok` and `repaintPrompt()` runs, with zero page
errors across the Inventory, Settings, Keep-alive and Overview tabs.

`go test ./...` green (25 packages), `go vet` clean, `gofmt` clean.

## Docs

- `docs/dashboard.md` — the "no CDN, no build step" box claimed the UI is **three** files; it
  is five. Corrected, and given the shared-global-scope constraint that this bug is an
  instance of.
- `docs/dashboard-inventory-page.md` — said `tools.js` "mounts itself" with "no edit to
  `app.js`", which reads as *has its own scope*. Now says what mounting itself does not buy.
- `dash/ui/tools.js` — the renamed binding carries a comment saying why it may not be called
  `prompt`, so it does not get renamed back.
