### PR TITLE
feat(dash): the KV-cache TTL analysis page and its strategy simulator

### DIFF
--- a/dash/api.go
+++ b/dash/api.go
@@ -239,7 +239,10 @@ func (a *API) routes() []route {
 	rs = append(rs, a.toolRoutes()...)
 	// The keep-alive tab's reads, declared beside their handlers in keepaliveapi.go and
 	// appended here for the same reason: this table is what both scoping tests walk.
-	return append(rs, a.keepAliveRoutes()...)
+	rs = append(rs, a.keepAliveRoutes()...)
+	// The KV-cache TTL analysis and strategy simulator, declared beside its handlers in
+	// kvcacheapi.go and appended here for the same reason.
+	return append(rs, a.kvCacheRoutes()...)
 }
 
 // Mount registers every dashboard route on a mux under the given prefix
@@ -597,6 +600,7 @@ func filterFrom(r *http.Request) Filter {
 		Effort:     q.Get("effort"),
 		Thinking:   q.Get("thinking"),
 		StopReason: q.Get("stop_reason"),
+		TTL:        q.Get("ttl"),
 		Q:          q.Get("q"),
 	}
 	f.Since = atoi64(q.Get("since"))

--- a/dash/assetversion_test.go
+++ b/dash/assetversion_test.go
@@ -68,17 +68,25 @@ func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
 		// Fail loudly if the reference extraction stops finding anything: a reshaped
 		// index.html that no longer matches must break this test, not quietly ship
 		// unversioned URLs.
-		if checked < 3 {
-			t.Errorf("%s: found only %d local asset references; index.html references at least style.css, app.js and tools.js", entry, checked)
+		if checked < 4 {
+			t.Errorf("%s: found only %d local asset references; index.html references at least style.css, app.js, tools.js and kvcache.js", entry, checked)
 		}
 	}
 
-	// tools.css is fetched by tools.js, not by the HTML, and it goes stale the same
-	// way. The rewrite covers any text asset, so the reference inside the served
-	// script is versioned too.
-	js := get("/dashboard/tools.js").Body.String()
-	if !strings.Contains(js, "'tools.css?v="+assetVersion+"'") {
-		t.Error("tools.js still asks for an unversioned tools.css")
+	// Some references are built at RUNTIME by a script rather than written in the HTML —
+	// a self-mounting view links its own stylesheet — and those go stale the same way. The
+	// rewrite covers any text asset, so the reference inside the served script is versioned
+	// too. Enumerated as DATA, because the count below is checked against it: a view added
+	// later must appear here or the rewrite total will not add up.
+	runtimeRefs := []struct{ asset, ref string }{
+		{"tools.js", "tools.css"},
+		{"kvcache.js", "kvcache.css"},
+	}
+	for _, rr := range runtimeRefs {
+		js := get("/dashboard/" + rr.asset).Body.String()
+		if !strings.Contains(js, "'"+rr.ref+"?v="+assetVersion+"'") {
+			t.Errorf("%s still asks for an unversioned %s", rr.asset, rr.ref)
+		}
 	}
 
 	// Versioned URLs are what make the hour of caching safe; keep it.
@@ -97,13 +105,13 @@ func TestServedUIVersionsEveryAssetItReferences(t *testing.T) {
 	// attribute AND in a JS object literal — so a quoted asset name that is NOT a
 	// reference gets versioned too, silently. Totalling the rewrites and comparing them
 	// with the references enumerated above turns that into a red test: index.html's
-	// references, plus the one tools.js builds.
+	// references, plus the ones a self-mounting view builds at runtime.
 	rewrites := 0
 	for _, b := range versionedUI {
 		rewrites += strings.Count(string(b), "?v="+assetVersion)
 	}
-	if want := checked + 1; rewrites != want {
-		t.Errorf("versionedUI rewrote %d references but this test accounts for %d — either a quoted asset name that is not a reference is being versioned, or a reference is no longer found", rewrites, want)
+	if want := checked + len(runtimeRefs); rewrites != want {
+		t.Errorf("versionedUI rewrote %d references but this test accounts for %d (%d in index.html plus %d built at runtime) — either a quoted asset name that is not a reference is being versioned, or a reference is no longer found", rewrites, want, checked, len(runtimeRefs))
 	}
 }
 

--- a/dash/kvcache.go
+++ b/dash/kvcache.go
@@ -1,0 +1,989 @@
+package dash
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The KV-cache tab's read side: turn stored request rows into the analysis dataset package
+// kvcache works on, and aggregate that dataset for the page.
+//
+// # Where the arithmetic is, and where it is not
+//
+// Nothing here prices anything or decides anything. The dataset is DERIVED here because the
+// derivation is a SQL window function over the store; every dollar and every policy is in
+// package kvcache, which the request path will one day share. The browser gets numbers, enum
+// labels and ids, and does no arithmetic at all — the same split the keep-alive tab keeps, for
+// the same reason: the browser has twice duplicated a table the server owns and drifted from it.
+//
+// # The one thing this file gets right that a naive version would not
+//
+// A filter is applied in TWO PLACES, deliberately, and which predicate goes where changes the
+// answer:
+//
+//   - The predicates that select WHICH CONVERSATIONS are in scope — the tenant, the time
+//     window, one session, the exclusion of ping rows — run INSIDE the window function. They
+//     remove whole conversations or bound the window, and neither can corrupt a remaining
+//     conversation's successor.
+//   - Every predicate that selects WHICH REQUESTS TO SHOW — model, provider, agent, TTL tier,
+//     time-of-day, has-a-successor — runs OUTSIDE it, over the already-derived rows. Running
+//     `model = X` inside the partition would make a request's successor the next request ON
+//     THAT MODEL, which is not the next request in the conversation. On the production corpus
+//     that is not a corner case: 121 of 1,772 conversations use more than one model and they
+//     hold 12,035 of 14,407 requests, so the naive version overstates the idle time of five
+//     sixths of the traffic.
+//
+// The outer predicate is the shared Filter.where() applied to the CTE aliased as `r`, so every
+// dimension the rest of the dashboard supports works here for free AND the tenant predicate is
+// re-applied over the derived rows — the same guard twice, which is the right number of times
+// for the one that keeps accounts apart.
+
+// kvCacheMaxRows bounds one analysis read.
+//
+// The point of this dataset is that percentiles, a survival curve and a chronological replay
+// all need the ROWS rather than a pre-aggregate, so there is a real ceiling on how much history
+// one request can answer over — and it is stated rather than discovered. At the production
+// corpus's density (14,407 rows over 57 hours) this is roughly a year of one deployment's
+// traffic. Past it the read keeps the NEWEST rows and every payload carries scanned, total and
+// truncated: a silent cap reads as "this is your whole history", which is the one thing a
+// savings figure must never imply.
+const kvCacheMaxRows = 200_000
+
+// idleEdges are the idle-gap histogram's fixed edges, in seconds; the last band is unbounded.
+//
+// Fine at the bottom and coarse at the top, because that is where the data is: the production
+// corpus's median gap is 14.9 s and its 90th percentile is 106 s, so a first bucket of
+// "0–5 minutes" would put 95% of the traffic in one bar and say nothing. The 300 s and 3600 s
+// edges are LOAD-BEARING — they are the two provider tiers, so a band boundary has to fall
+// exactly on each or the page's own percentages would not line up with its own chart.
+// TestIdleHistogramEdgesLineUpWithTheHorizons is that assertion.
+var idleEdges = []float64{0, 10, 30, 60, kvcache.Horizon5m.Seconds(), 900,
+	kvcache.Horizon1h.Seconds(), 21600}
+
+// survivalLadder are the elapsed times the survival view reports, in seconds. Both provider
+// horizons are rungs BY CONSTRUCTION rather than by interpolation between neighbours, because
+// those two are the numbers a TTL is actually chosen against.
+var survivalLadder = []float64{5, 10, 30, 60, 120, kvcache.Horizon5m.Seconds(), 600, 1800,
+	kvcache.Horizon1h.Seconds(), 7200, 21600, 86400}
+
+// KVCacheOptions are the narrowings that exist only on this page, plus the table's paging.
+//
+// They are separate from Filter because all three narrowings are DERIVED — a reconstructed
+// tier, a time-of-day band, and whether a successor exists at all — and none of them is a
+// column any other view could filter on.
+type KVCacheOptions struct {
+	Limit  int
+	Offset int
+	// Sort is a key of kvCacheSortKeys; Dir is "asc" or "desc".
+	Sort string
+	Dir  string
+	// Bucket is a kvcache.Bucket name, or "" for every band. UTC.
+	Bucket string
+	// TTL is "none", string(kvcache.TTL5m), string(kvcache.TTL1h), or "" for every tier. It
+	// selects on the RECONSTRUCTED tier, not on the raw column — see observedTTL.
+	TTL string
+	// HasNext is "yes" (requests followed by another in the same conversation), "no" (the last
+	// request of a conversation), or "" for both.
+	//
+	// Its own dimension rather than a sentinel on some other field, because "the requests
+	// nobody came back to" is a population an operator asks about directly — and it is the
+	// population every average on this page has to exclude.
+	HasNext string
+}
+
+// kvCacheSortKeys maps a sort key to its ORDER BY body, with one %s for the direction.
+//
+// A closed map, and kvCacheOptionsFrom rejects anything not in it, because the value arrives
+// from a query string and lands in SQL.
+//
+// `idle` is the one entry that is not a bare column, and the reason is honesty rather than
+// SQL: a request with no successor has NO idle time, so it must sort LAST in BOTH directions.
+// A plain ORDER BY on a nullable column puts nulls at one end ascending and the other end
+// descending, which in the ascending case parades every final request at the top of the table
+// as though it had returned instantly. The null-ness is therefore the PRIMARY key of the sort,
+// always ascending, and the value only breaks ties within it.
+var kvCacheSortKeys = map[string]string{
+	"ts":           "r.ts %[1]s, r.id %[1]s",
+	"user":         "r.tenant_id %s, r.ts DESC",
+	"conversation": "r.session_id %s, r.ts DESC",
+	"model":        "r.model %s, r.ts DESC",
+	"input":        "r.fresh_input %s",
+	"output":       "r.output_tokens %s",
+	"read":         "r.cache_read %s",
+	"write":        "r.cache_write %s",
+	"cached":       "(r.cache_read + r.cache_write) %s",
+	"ttl":          "r.cache_ttl %s, r.ts DESC",
+	"hit":          "(r.cache_miss_reason = 'hit') %s, r.cache_miss_reason ASC",
+	"idle":         "(r.next_ts IS NULL) ASC, (r.next_ts - r.ts) %s",
+	"cost":         "r.cost_usd %s",
+}
+
+// observedTTL reconstructs a request's prompt-cache tier and says HOW WELL IT IS KNOWN.
+//
+// Three states, never two, and the third is the whole reason this function exists. `cache_ttl`
+// arrived as an ADDITIVE column with DEFAULT ”, so a blank on an old row means NOT RECORDED —
+// and a request that genuinely carried no cache_control also reads blank. Two pieces of
+// evidence separate them:
+//
+//   - the provider billed part of the write at the one-hour tier (cache_write_1h > 0), which is
+//     the only proof a requested 1h was honoured rather than silently downgraded. That is an
+//     OBSERVED tier: not on the row, but deducible from what was billed.
+//   - nothing was billed at any cache tier at all, which is a request that really did cache
+//     nothing. Also observed.
+//
+// What is left cached something at a tier nobody wrote down. It is reported as UNKNOWN and
+// taken as the provider's five-minute default so a simulation has something to replay — and the
+// count is on the coverage panel, and the observed-policy arm reports how much of itself rested
+// on it. An unrecognised recorded value ('ephemeral_10m' from a future build) is treated the
+// same way: not trusted, never coerced into the tier it superficially resembles.
+func observedTTL(recorded string, write1h, cached int64) (kvcache.TTL, string) {
+	if t := kvcache.TTL(recorded); t == kvcache.TTL5m || t == kvcache.TTL1h {
+		return t, kvcache.TTLSourceConfigured
+	}
+	if write1h > 0 {
+		return kvcache.TTL1h, kvcache.TTLSourceObserved
+	}
+	if cached > 0 {
+		return kvcache.TTL5m, kvcache.TTLSourceUnknown
+	}
+	return kvcache.TTLNone, kvcache.TTLSourceObserved
+}
+
+// ttlPredicate is observedTTL as SQL, so the tier filter narrows in the database instead of
+// dragging every row into Go to be thrown away.
+//
+// It sits directly beneath observedTTL because the two are one definition in two languages, and
+// TestTheTierFilterAgreesWithTheTierReconstruction asserts they agree over every combination
+// rather than leaving the reader to compare them by eye.
+func ttlPredicate(tier string) string {
+	const notRecorded = `r.cache_ttl <> 'ephemeral_5m' AND r.cache_ttl <> 'ephemeral_1h'`
+	switch tier {
+	case string(kvcache.TTL5m):
+		// The row's OWN tier only. A request that recorded nothing is replayed AS IF it were
+		// five minutes, but it is not evidence of a five-minute policy, so it is not in this
+		// group — see TTLUnrecorded.
+		return `r.cache_ttl = 'ephemeral_5m'`
+	case string(kvcache.TTL1h):
+		return `(r.cache_ttl = 'ephemeral_1h' OR (` + notRecorded + ` AND r.cache_write_1h > 0))`
+	case "none":
+		return `(` + notRecorded + ` AND r.cache_write_1h = 0 AND (r.cache_read + r.cache_write) = 0)`
+	case TTLUnrecorded:
+		return `(` + notRecorded + ` AND r.cache_write_1h = 0 AND (r.cache_read + r.cache_write) > 0)`
+	}
+	return ""
+}
+
+// TTLUnrecorded is the filter value and the group key for requests that cached something at a
+// tier NOBODY WROTE DOWN.
+//
+// It is a fourth group rather than a footnote on the five-minute one, and that is the whole
+// honesty rule of this page applied to its own grouped table. Those rows are REPLAYED as five
+// minutes so a simulation has something to run, but they are not evidence of a five-minute
+// policy — and folding them in said "3,106 of your requests used the 5-minute tier" about a
+// window where 295 of them recorded no tier at all, under a heading that called the group
+// "configured". The coverage banner above it was reporting the same 295 as not recorded, so the
+// page contradicted itself in two panels.
+const TTLUnrecorded = "unrecorded"
+
+// kvCacheScope splits one Filter into the two predicates described at the top of this file.
+//
+// The inner filter keeps ONLY the conversation-defining dimensions, copied field by field so
+// that a dimension added to Filter later lands OUTSIDE by default. That is the safe direction: a
+// new predicate applied outside narrows the rows shown, while the same predicate applied inside
+// would silently change every idle time on the page.
+func kvCacheScope(f Filter) Filter {
+	return Filter{
+		Since: f.Since, Until: f.Until,
+		// Both, verbatim: TenantAll is what makes "" mean "every account" rather than "the
+		// single-tenant one", so carrying one without the other would widen the scope of the
+		// read that decides which conversations exist.
+		Tenant: f.Tenant, TenantAll: f.TenantAll,
+		Session:       f.Session,
+		WithKeepAlive: f.WithKeepAlive,
+	}
+}
+
+// kvCacheCTE is the window function. The LEAD is partitioned by (tenant_id, session_id, model)
+// and ordered by (ts, id).
+//
+// All THREE columns, and the model is the one that is easy to leave out. It has to be here
+// because the partition must be exactly kvcache.Conversation — a cache entry does not transfer
+// between models, so an opus request cannot read a sonnet request's entry, and linking the two as
+// successor grants the second a hit at 0.1x on something it could never have matched. The bias is
+// one-directional: every arm looks cheaper and hits more often than it can. On this deployment's
+// corpus that is 124 extra trajectories (1,896 keyed with the model against 1,772 without) and it
+// reaches the 12,035 requests that sit in a session using more than one model.
+//
+// The tenant is here because a session id is CLIENT-SUPPLIED, so two accounts can present the
+// same one; on the session alone this derives a gap across an account boundary, which is both a
+// wrong measurement and a cross-account read. And the id breaks the ORDER BY tie because 9 of the
+// corpus's 12,635 consecutive pairs share a millisecond — without it the successor of such a row
+// is whichever the planner happened to emit, so the same window would derive two datasets.
+//
+// This partition and kvcache.Conversation are one definition in two languages;
+// TestTheSQLPartitionIsExactlyTheConversationKey is the assertion that they agree.
+const kvCacheCTE = `WITH s AS (SELECT r.id, r.ts, r.tenant_id, r.session_id, r.model,
+		r.provider, r.agent, r.preset, r.mode, r.token_accounting, r.reasoning_effort,
+		r.thinking_mode, r.stop_reason, r.uncompressed_reason, r.cache_ttl, r.keepalive,
+		r.fresh_input, r.output_tokens, r.cache_read, r.cache_write, r.cache_write_1h,
+		r.cache_miss_reason, r.cost_usd, r.upstream_ms,
+		LEAD(r.ts) OVER w AS next_ts, LEAD(r.id) OVER w AS next_id
+	FROM requests r WHERE %s
+	WINDOW w AS (PARTITION BY r.tenant_id, r.session_id, r.model ORDER BY r.ts, r.id))`
+
+// kvCacheQuery renders the CTE plus the outer predicate for one filter, one set of options and
+// one projection.
+//
+// The projection is a PARAMETER rather than a %s left in the string for a later Sprintf, and
+// that is not style: the time-of-day predicate contains a strftime('%H'), and a second Sprintf
+// over the assembled query consumed it as a verb — turning every bucket filter into a
+// comparison against the literal "%!H", which matched nothing and looked exactly like a quiet
+// afternoon. There is one format step here and it happens before any SQL text is appended.
+func kvCacheQuery(f Filter, o KVCacheOptions, projection string) (string, []any) {
+	inCond, inArgs := kvCacheScope(f).where()
+	outCond, outArgs := f.where()
+	conds, derivedArgs := kvCacheDerivedPreds(o)
+	q := strings.Replace(kvCacheCTE, "%s", inCond, 1) +
+		" SELECT " + projection + " FROM s r WHERE " + outCond
+	for _, c := range conds {
+		q += " AND " + c
+	}
+	args := append(append([]any(nil), inArgs...), outArgs...)
+	return q, append(args, derivedArgs...)
+}
+
+// kvCacheDerivedPreds renders the three page-only narrowings.
+//
+// The hour range is BOUND rather than interpolated. It comes from a closed table and could not
+// carry an injection, but a bound parameter cannot be eaten by a format verb either, which is
+// the failure this shape prevents.
+func kvCacheDerivedPreds(o KVCacheOptions) ([]string, []any) {
+	var out []string
+	var args []any
+	if lo, hi, ok := bucketHours(kvcache.Bucket(o.Bucket)); ok {
+		out = append(out, "CAST(strftime('%H', r.ts/1000, 'unixepoch') AS INTEGER) BETWEEN ? AND ?")
+		args = append(args, lo, hi)
+	}
+	if p := ttlPredicate(o.TTL); p != "" {
+		out = append(out, p)
+	}
+	switch o.HasNext {
+	case "yes":
+		out = append(out, "r.next_ts IS NOT NULL")
+	case "no":
+		out = append(out, "r.next_ts IS NULL")
+	}
+	return out, args
+}
+
+// bucketHours is one time-of-day band's UTC hour range, inclusive.
+func bucketHours(b kvcache.Bucket) (lo, hi int, ok bool) {
+	switch b {
+	case kvcache.BucketNight:
+		return 0, 5, true
+	case kvcache.BucketMorning:
+		return 6, 11, true
+	case kvcache.BucketAfternoon:
+		return 12, 17, true
+	case kvcache.BucketEvening:
+		return 18, 23, true
+	}
+	return 0, 0, false
+}
+
+// kvCacheCols is the row projection, in scan order.
+const kvCacheCols = `r.id, r.ts, r.tenant_id, r.session_id, r.model, r.provider, r.agent,
+	r.cache_ttl, r.fresh_input, r.output_tokens, r.cache_read, r.cache_write, r.cache_write_1h,
+	r.cache_miss_reason, r.token_accounting, r.cost_usd, r.upstream_ms, r.keepalive,
+	r.next_ts, r.next_id`
+
+// scanKVCacheRequest reads one row and fills everything derived from it.
+//
+// The idle fields come from the SQL LEAD rather than from kvcache.Derive, and that is not a
+// duplication of the derivation — it is the only correct source here. Derive works from a row's
+// NEIGHBOUR in the slice, so over a FILTERED or CAPPED read it would treat whichever row
+// happened to be next as the successor, and treat the oldest kept row's real predecessor as
+// absent. The window function saw the whole conversation.
+func scanKVCacheRequest(rows interface{ Scan(...any) error }) (*kvcache.Request, error) {
+	var r kvcache.Request
+	var cacheTTL, missReason, accounting string
+	var nextTS, nextID sql.NullInt64
+	var keepAlive int
+	if err := rows.Scan(&r.ID, &r.TS, &r.User, &r.ConversationID, &r.Model, &r.Provider,
+		&r.Agent, &cacheTTL, &r.InputTokens, &r.OutputTokens, &r.CacheRead, &r.CacheWrite,
+		&r.CacheWrite1h, &missReason, &accounting, &r.CostUSD, &r.UpstreamMs, &keepAlive,
+		&nextTS, &nextID); err != nil {
+		return nil, err
+	}
+	r.KeepAlive = keepAlive != 0
+	r.MissReason = missReason
+	r.Hit = missReason == CacheHit
+	r.CachedContext = r.CacheRead + r.CacheWrite
+	r.HourUTC = time.UnixMilli(r.TS).UTC().Hour()
+	r.Bucket = kvcache.BucketOf(r.HourUTC)
+	r.TTL, r.TTLSource = observedTTL(cacheTTL, r.CacheWrite1h, r.CachedContext)
+	// An incomplete-accounting row has NO cost. cost_usd is 0 on it and 0 is also a legitimate
+	// cost, so the accounting column is the only thing that can tell the two apart.
+	r.CostKnown = accounting == AccountingComplete
+	if !r.CostKnown {
+		r.CostUSD = 0
+	}
+	if nextTS.Valid {
+		idle := nextTS.Int64 - r.TS
+		if idle < 0 {
+			idle = 0 // impossible after the CTE's ORDER BY; clamped rather than trusted
+		}
+		v := idle
+		r.HasNext, r.NextTS, r.NextID, r.IdleMs = true, nextTS.Int64, nextID.Int64, &v
+		r.Within5m = time.Duration(idle)*time.Millisecond <= kvcache.Horizon5m
+		r.Within1h = time.Duration(idle)*time.Millisecond <= kvcache.Horizon1h
+	}
+	return &r, nil
+}
+
+// KVCacheDataset reads the derived dataset for one filter, CHRONOLOGICALLY, and reports how
+// many rows matched.
+//
+// Chronological regardless of the table's own sort, because the replay walks it in wall-clock
+// order and the table's sort is a view of the same rows. Over the cap the NEWEST rows are kept:
+// an analysis of the recent past is useful, and one that silently stopped at some point in the
+// middle of the window is not.
+func (d *DB) KVCacheDataset(f Filter, o KVCacheOptions) ([]*kvcache.Request, int64, error) {
+	total, err := d.kvCacheCount(f, o)
+	if err != nil {
+		return nil, 0, err
+	}
+	q, args := kvCacheQuery(f, o, kvCacheCols)
+	q += " ORDER BY r.ts DESC, r.id DESC LIMIT ?"
+	rows, err := d.sql.Query(q, append(args, kvCacheMaxRows)...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	out := []*kvcache.Request{}
+	for rows.Next() {
+		r, err := scanKVCacheRequest(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	// Read newest-first so the cap keeps the newest; handed back oldest-first so the replay can
+	// walk it.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, total, nil
+}
+
+// kvCacheCount is how many rows match, before the cap and before paging.
+func (d *DB) kvCacheCount(f Filter, o KVCacheOptions) (int64, error) {
+	q, args := kvCacheQuery(f, o, "COUNT(*)")
+	var n int64
+	err := d.sql.QueryRow(q, args...).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return n, err
+}
+
+// KVCacheRow is one dataset row plus the two ways back out of the analysis.
+type KVCacheRow struct {
+	*kvcache.Request
+	// RequestURL and ConversationURL are the links to the existing request drawer and session
+	// diff. Built here rather than in the page because a session id is CLIENT-SUPPLIED text —
+	// it can contain a slash, a space, a hash — and a link assembled by string concatenation in
+	// JavaScript is where that becomes a broken URL or worse.
+	RequestURL      string `json:"request_url"`
+	ConversationURL string `json:"conversation_url"`
+}
+
+// KVCacheRowPage is one page of the detail table.
+type KVCacheRowPage struct {
+	Rows []*KVCacheRow `json:"rows"`
+	// Total is how many rows match the filter, so the pager can say "51–100 of 14,407".
+	Total  int64 `json:"total"`
+	Offset int   `json:"offset"`
+	Limit  int   `json:"limit"`
+	// Truncated says the ANALYSIS over this filter is capped, so the table's own total and the
+	// figures above it describe different row counts. On the wire because the pager prints it.
+	Truncated bool `json:"truncated"`
+}
+
+// KVCacheRows reads one page of the sortable detail table.
+//
+// Offset paging, not keyset, because this table is SORTABLE on thirteen columns: a keyset
+// cursor is a value in the sort order, so every re-sort would invalidate it. The page is
+// bounded and the derivation is unaffected by the boundary — the window function runs over the
+// whole scoped window inside the CTE and only the outer SELECT is paged, so a row on page 7
+// carries the same successor it would on page 1.
+func (d *DB) KVCacheRows(f Filter, o KVCacheOptions) (*KVCacheRowPage, error) {
+	if o.Limit <= 0 || o.Limit > 500 {
+		o.Limit = 50
+	}
+	if o.Offset < 0 {
+		o.Offset = 0
+	}
+	total, err := d.kvCacheCount(f, o)
+	if err != nil {
+		return nil, err
+	}
+	dir := "DESC"
+	if o.Dir == "asc" {
+		dir = "ASC"
+	}
+	order, ok := kvCacheSortKeys[o.Sort]
+	if !ok {
+		order = kvCacheSortKeys["ts"]
+	}
+	q, args := kvCacheQuery(f, o, kvCacheCols)
+	q += " ORDER BY " + fmt.Sprintf(order, dir) + " LIMIT ? OFFSET ?"
+	rows, err := d.sql.Query(q, append(args, o.Limit, o.Offset)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := &KVCacheRowPage{Rows: []*KVCacheRow{}, Total: total, Offset: o.Offset, Limit: o.Limit,
+		Truncated: total > kvCacheMaxRows}
+	for rows.Next() {
+		r, err := scanKVCacheRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		out.Rows = append(out.Rows, &KVCacheRow{Request: r,
+			RequestURL:      fmt.Sprintf("#requests?req=%d", r.ID),
+			ConversationURL: "#sessions?diff=" + url.PathEscape(r.ConversationID)})
+	}
+	return out, rows.Err()
+}
+
+// modelsOf is the distinct models in a dataset, sorted, for a price list.
+func modelsOf(rows []*kvcache.Request) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, r := range rows {
+		if r.Model == "" || seen[r.Model] {
+			continue
+		}
+		seen[r.Model] = true
+		out = append(out, r.Model)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ── the aggregates ─────────────────────────────────────────────────────────
+
+// KVCacheCoverage answers "is a zero here a measurement or an absence?".
+//
+// Every field counts rows that could NOT answer something, and they are on the wire because
+// three of them are routinely nonzero on real history: a snapshot written before the cache_ttl
+// column records no tier, a row whose token accounting was incomplete has no cost, and a
+// conversation with one request in the window contributes a final request and no gap at all. A
+// page that rendered those as 5m, $0.00 and 0 s would fabricate three measurements at once.
+type KVCacheCoverage struct {
+	// The three tier states, counted apart rather than blended. See observedTTL.
+	TTLConfigured int64 `json:"ttl_configured"`
+	TTLObserved   int64 `json:"ttl_observed"`
+	TTLUnknown    int64 `json:"ttl_unknown"`
+	// CostUnknown is rows whose accounting was incomplete: counted everywhere, valued nowhere.
+	CostUnknown int64 `json:"cost_unknown"`
+	// SingleRequestConversations is conversations with exactly one request in this window. On
+	// the production corpus that is 1,551 of 1,772, so a page that did not say so would look
+	// like it had thrown most of the traffic away.
+	SingleRequestConversations int64 `json:"single_request_conversations"`
+	// KeepAliveRows is the ping rows this dataset EXCLUDED. A ping is a request context-guru
+	// sent while nobody was at the keyboard; counted, it would split one real idle gap into two
+	// short ones and make every reuse probability wrong in the flattering direction.
+	KeepAliveRows int64 `json:"keepalive_rows"`
+}
+
+// KVCacheCards is the summary band.
+//
+// Every idle figure's denominator is WithNext, never Requests: a conversation's last request has
+// no gap, and dividing by Requests would count it as a zero-second return.
+type KVCacheCards struct {
+	Requests      int64   `json:"requests"`
+	Scanned       int64   `json:"scanned"`
+	Conversations int64   `json:"conversations"`
+	Users         int64   `json:"users"`
+	Models        int64   `json:"models"`
+	WithNext      int64   `json:"with_next"`
+	FinalRequests int64   `json:"final_requests"`
+	MedianIdleMs  float64 `json:"median_idle_ms"`
+	MeanIdleMs    float64 `json:"mean_idle_ms"`
+	P90IdleMs     float64 `json:"p90_idle_ms"`
+	Within5m      int64   `json:"within_5m"`
+	Within1h      int64   `json:"within_1h"`
+	Within5mPct   float64 `json:"within_5m_pct"`
+	Within1hPct   float64 `json:"within_1h_pct"`
+	Hits          int64   `json:"hits"`
+	// HitRatePct is the share the PROVIDER served from cache, as recorded. An observation of
+	// what happened, never a simulated figure — the simulated ones live on kvcache.Result.
+	HitRatePct  float64 `json:"hit_rate_pct"`
+	CostUSD     float64 `json:"cost_usd"`
+	CostUnknown int64   `json:"cost_unknown"`
+	// CachedContextP50 is the median billed prefix in tokens: the size every cache write, cache
+	// read and keep-alive on this page is proportional to.
+	CachedContextP50 int64 `json:"cached_context_p50"`
+}
+
+// KVCacheGroup is the OBSERVED dataset restricted to one user, model, tier or time-of-day band.
+//
+// Not kvcache.Group, which is a SIMULATED result. The two deliberately do not share a type: with
+// the same field names a reader would eventually compare a measurement with a projection.
+type KVCacheGroup struct {
+	Key           string  `json:"key"`
+	Requests      int64   `json:"requests"`
+	Conversations int64   `json:"conversations"`
+	WithNext      int64   `json:"with_next"`
+	FinalRequests int64   `json:"final_requests"`
+	MedianIdleMs  float64 `json:"median_idle_ms"`
+	MeanIdleMs    float64 `json:"mean_idle_ms"`
+	Within5mPct   float64 `json:"within_5m_pct"`
+	Within1hPct   float64 `json:"within_1h_pct"`
+	// Hits is the numerator of HitRatePct, and it is on the wire for two reasons. A rate without
+	// its own count cannot be checked — a share accidentally expressed as a fraction stays inside
+	// [0,100] and no range assertion can see it, so only recomputing it from its numerator and
+	// denominator catches that — and the page can say "2,599 of 3,391" instead of a bare
+	// percentage, which is the standard the rest of this dashboard already keeps.
+	Hits        int64   `json:"hits"`
+	HitRatePct  float64 `json:"hit_rate_pct"`
+	CostUSD     float64 `json:"cost_usd"`
+	CostUnknown int64   `json:"cost_unknown"`
+	// Source is set only on the TTL groups, naming how that tier was known.
+	Source string `json:"source,omitempty"`
+}
+
+// SurvivalPoint is one rung of "has the conversation come back yet".
+//
+// The survival view answers the question a TTL is chosen against, which a histogram does not: a
+// histogram says how many gaps were four to five minutes long, and a policy needs the
+// CUMULATIVE share still inside a horizon. Both are on the page — the histogram shows the shape,
+// this shows the decision.
+type SurvivalPoint struct {
+	Seconds float64 `json:"seconds"`
+	Label   string  `json:"label"`
+	// Arrived is how many gaps had closed by then, out of N — which is the count of requests
+	// WITH a successor, repeated on every point so a reader never has to hunt for the
+	// denominator.
+	Arrived    int64   `json:"arrived"`
+	ArrivedPct float64 `json:"arrived_pct"`
+	N          int64   `json:"n"`
+	// TTL marks the rungs that are a provider tier rather than an arbitrary ladder step, so the
+	// chart can draw them as the thresholds they are.
+	TTL string `json:"ttl,omitempty"`
+}
+
+// KVCacheAnalysis is the whole analysis read: one request, one consistent set of denominators.
+//
+// Deliberately ONE payload rather than a panel per endpoint. Every figure shares the dataset it
+// came from, and the failure that avoids is two tiles on one page reporting different totals
+// because two queries disagreed about which rows were in scope — which this repo has shipped.
+type KVCacheAnalysis struct {
+	Cards     KVCacheCards    `json:"cards"`
+	Coverage  KVCacheCoverage `json:"coverage"`
+	IdleBands []Band          `json:"idle_bands"`
+	Survival  []SurvivalPoint `json:"survival"`
+	HourBins  []Band          `json:"hour_bins"`
+	ByTTL     []KVCacheGroup  `json:"by_ttl"`
+	ByBucket  []KVCacheGroup  `json:"by_bucket"`
+	ByUser    []KVCacheGroup  `json:"by_user"`
+	ByModel   []KVCacheGroup  `json:"by_model"`
+	// Assumptions is the server's own statement of every formula and caveat, so the page prints
+	// the arithmetic rather than restating it in a template nothing tests.
+	Assumptions KVCacheAssumptions `json:"assumptions"`
+	Pricing     *kvcache.PriceList `json:"pricing"`
+	// FirstTS and LastTS are the span the rows actually cover, so a quiet window is
+	// distinguishable from a narrow one.
+	FirstTS int64 `json:"first_ts"`
+	LastTS  int64 `json:"last_ts"`
+
+	Scanned   int64 `json:"scanned"`
+	Total     int64 `json:"total"`
+	Truncated bool  `json:"truncated"`
+}
+
+// KVCacheAnalyze reads the dataset and aggregates it.
+func (d *DB) KVCacheAnalyze(f Filter, o KVCacheOptions, p modelinfo.Pricer,
+	cfg KVCacheSimConfig) (*KVCacheAnalysis, error) {
+	rows, total, err := d.KVCacheDataset(f, o)
+	if err != nil {
+		return nil, err
+	}
+	out := analyseKVCache(rows)
+	out.Total, out.Scanned = total, int64(len(rows))
+	out.Truncated = out.Scanned < total
+	out.Assumptions = kvCacheAssumptions(cfg)
+	out.Pricing = kvcache.NewPriceList(context.Background(), modelsOf(rows), p,
+		cfg.Multipliers, cfg.Overrides)
+	// Destructured, not passed as a tuple: QueryRow takes (string, ...any), so handing it a
+	// two-value call passes the whole []any as ONE argument and the driver rejects it.
+	kaQ, kaArgs := kvCacheKeepAliveCount(f)
+	if err := d.sql.QueryRow(kaQ, kaArgs...).Scan(&out.Coverage.KeepAliveRows); err != nil &&
+		err != sql.ErrNoRows {
+		return nil, err
+	}
+	return out, nil
+}
+
+// kvCacheKeepAliveCount counts the ping rows the dataset excluded. Its own small query rather
+// than a CASE inside an aggregate, for the reason keepalive.go states: one predicate, one
+// meaning.
+func kvCacheKeepAliveCount(f Filter) (string, []any) {
+	inner := kvCacheScope(f)
+	inner.WithKeepAlive = true
+	cond, args := inner.where()
+	return `SELECT COUNT(*) FROM requests r WHERE ` + cond + ` AND r.keepalive = 1`, args
+}
+
+// analyseKVCache is the aggregation, over rows and nothing else.
+//
+// Split out from KVCacheAnalyze so it is testable without a database, and so there is exactly
+// one pass: every card, band, rung and group below is filled from the same loop, which is what
+// makes it impossible for two of them to disagree about the denominator.
+func analyseKVCache(rows []*kvcache.Request) *KVCacheAnalysis {
+	out := &KVCacheAnalysis{IdleBands: []Band{}, Survival: []SurvivalPoint{}, HourBins: []Band{},
+		ByTTL: []KVCacheGroup{}, ByBucket: []KVCacheGroup{}, ByUser: []KVCacheGroup{},
+		ByModel: []KVCacheGroup{}}
+	whole := newKVCacheAcc()
+	byTTL, byBucket, byUser, byModel := kvAccMap(), kvAccMap(), kvAccMap(), kvAccMap()
+	bandN := make([]int64, len(idleEdges))
+	bandUSD := make([]float64, len(idleEdges))
+	hourN := make([]int64, 24)
+	hourUSD := make([]float64, 24)
+	var prefixes, gaps []float64
+	users, models := map[string]bool{}, map[string]bool{}
+	turns := map[kvcache.Conversation]int{}
+
+	for _, r := range rows {
+		if out.FirstTS == 0 || r.TS < out.FirstTS {
+			out.FirstTS = r.TS
+		}
+		if r.TS > out.LastTS {
+			out.LastTS = r.TS
+		}
+		users[r.User] = true
+		models[r.Model] = true
+		turns[r.Key()]++
+		whole.add(r)
+		kvAccFor(byTTL, ttlGroupKey(r)).addTier(r)
+		kvAccFor(byBucket, string(r.Bucket)).add(r)
+		kvAccFor(byUser, r.User).add(r)
+		kvAccFor(byModel, r.Model).add(r)
+		prefixes = append(prefixes, float64(r.CachedContext))
+		if r.HourUTC >= 0 && r.HourUTC < 24 {
+			hourN[r.HourUTC]++
+			hourUSD[r.HourUTC] += r.CostUSD
+		}
+		// Only rows that HAVE a successor reach the histogram and the ladder. A final request
+		// in the first band would be reported as an instant return.
+		if idle, ok := r.Idle(); ok {
+			gaps = append(gaps, idle.Seconds())
+			i := bandOf(idleEdges, idle.Seconds())
+			bandN[i]++
+			bandUSD[i] += r.CostUSD
+		}
+	}
+
+	out.Cards = whole.cards(len(users), len(models), prefixes)
+	out.Coverage = whole.coverage(turns)
+	for i, label := range bandLabels(idleEdges, kvCacheSecs) {
+		out.IdleBands = append(out.IdleBands, Band{Label: label, N: bandN[i], USD: bandUSD[i],
+			// Beyond de-emphasises the bands the provider's DEFAULT five-minute lifetime cannot
+			// reach. The same meaning the keep-alive tab's Band gives it: outside the coverage
+			// the current policy provides.
+			Beyond: idleEdges[i] >= kvcache.Horizon5m.Seconds()})
+	}
+	for h := 0; h < 24; h++ {
+		out.HourBins = append(out.HourBins, Band{Label: fmt.Sprintf("%02d", h), N: hourN[h],
+			USD: hourUSD[h]})
+	}
+	out.Survival = survivalOf(gaps)
+	out.ByTTL = finishKVAccs(byTTL, ttlOrder)
+	out.ByBucket = finishKVAccs(byBucket, bucketOrder())
+	out.ByUser = finishKVAccs(byUser, nil)
+	out.ByModel = finishKVAccs(byModel, nil)
+	return out
+}
+
+// survivalOf is the empirical CDF of the idle gap over the ladder.
+func survivalOf(gaps []float64) []SurvivalPoint {
+	out := make([]SurvivalPoint, 0, len(survivalLadder))
+	n := int64(len(gaps))
+	for _, sec := range survivalLadder {
+		p := SurvivalPoint{Seconds: sec, Label: kvCacheSecs(sec), N: n}
+		for _, g := range gaps {
+			if g <= sec {
+				p.Arrived++
+			}
+		}
+		if n > 0 {
+			p.ArrivedPct = 100 * float64(p.Arrived) / float64(n)
+		}
+		switch sec {
+		case kvcache.Horizon5m.Seconds():
+			p.TTL = kvcache.TTL5m.Label()
+		case kvcache.Horizon1h.Seconds():
+			p.TTL = kvcache.TTL1h.Label()
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// kvCacheAcc accumulates one group. The reuse fields hold COUNTS until finish(), which is the
+// one place they become percentages.
+type kvCacheAcc struct {
+	g       KVCacheGroup
+	convs   map[kvcache.Conversation]bool
+	gaps    []float64
+	hits    int64
+	within5 int64
+	within1 int64
+	sources map[string]int64
+	tiers   map[string]int64
+}
+
+func newKVCacheAcc() *kvCacheAcc {
+	return &kvCacheAcc{convs: map[kvcache.Conversation]bool{}, sources: map[string]int64{},
+		tiers: map[string]int64{}}
+}
+
+func kvAccMap() map[string]*kvCacheAcc { return map[string]*kvCacheAcc{} }
+
+func kvAccFor(m map[string]*kvCacheAcc, key string) *kvCacheAcc {
+	if a := m[key]; a != nil {
+		return a
+	}
+	a := newKVCacheAcc()
+	a.g.Key = key
+	m[key] = a
+	return a
+}
+
+func (a *kvCacheAcc) add(r *kvcache.Request) {
+	a.g.Requests++
+	a.convs[r.Key()] = true
+	a.sources[r.TTLSource]++
+	a.tiers[string(r.TTL)]++
+	if r.Hit {
+		a.hits++
+	}
+	if r.CostKnown {
+		a.g.CostUSD += r.CostUSD
+	} else {
+		a.g.CostUnknown++
+	}
+	if idle, ok := r.Idle(); ok {
+		a.g.WithNext++
+		a.gaps = append(a.gaps, idle.Seconds())
+		if r.Within5m {
+			a.within5++
+		}
+		if r.Within1h {
+			a.within1++
+		}
+		return
+	}
+	a.g.FinalRequests++
+}
+
+// addTier is add plus nothing extra; the tier group's Source comes from the same tally add()
+// already keeps. A separate name because a reader of the TTL grouping should see that the
+// source is deliberate there and absent elsewhere.
+func (a *kvCacheAcc) addTier(r *kvcache.Request) { a.add(r) }
+
+func (a *kvCacheAcc) finish() KVCacheGroup {
+	g := a.g
+	g.Conversations = int64(len(a.convs))
+	if g.WithNext > 0 {
+		g.Within5mPct = 100 * float64(a.within5) / float64(g.WithNext)
+		g.Within1hPct = 100 * float64(a.within1) / float64(g.WithNext)
+		g.MedianIdleMs = pctlF(a.gaps, 0.50) * 1000
+		var sum float64
+		for _, s := range a.gaps {
+			sum += s
+		}
+		g.MeanIdleMs = sum / float64(g.WithNext) * 1000
+	}
+	g.Hits = a.hits
+	if g.Requests > 0 {
+		g.HitRatePct = 100 * float64(a.hits) / float64(g.Requests)
+	}
+	// The dominant way this group's tier was known. Ties broken by name so the same window
+	// gives the same answer twice.
+	var best string
+	for _, s := range sortedStrings(a.sources) {
+		if best == "" || a.sources[s] > a.sources[best] {
+			best = s
+		}
+	}
+	g.Source = best
+	return g
+}
+
+func (a *kvCacheAcc) cards(users, models int, prefixes []float64) KVCacheCards {
+	g := a.finish()
+	return KVCacheCards{
+		Requests: g.Requests, Scanned: g.Requests, Conversations: g.Conversations,
+		Users: int64(users), Models: int64(models),
+		WithNext: g.WithNext, FinalRequests: g.FinalRequests,
+		MedianIdleMs: g.MedianIdleMs, MeanIdleMs: g.MeanIdleMs,
+		P90IdleMs: pctlF(a.gaps, 0.90) * 1000,
+		Within5m:  a.within5, Within1h: a.within1,
+		Within5mPct: g.Within5mPct, Within1hPct: g.Within1hPct,
+		Hits: a.hits, HitRatePct: g.HitRatePct,
+		CostUSD: g.CostUSD, CostUnknown: g.CostUnknown,
+		CachedContextP50: int64(pctlF(prefixes, 0.50)),
+	}
+}
+
+// coverage counts the three tier states and the single-request conversations.
+func (a *kvCacheAcc) coverage(turns map[kvcache.Conversation]int) KVCacheCoverage {
+	c := KVCacheCoverage{
+		TTLConfigured: a.sources[kvcache.TTLSourceConfigured],
+		TTLObserved:   a.sources[kvcache.TTLSourceObserved],
+		TTLUnknown:    a.sources[kvcache.TTLSourceUnknown],
+		CostUnknown:   a.g.CostUnknown,
+	}
+	for _, n := range turns {
+		if n == 1 {
+			c.SingleRequestConversations++
+		}
+	}
+	return c
+}
+
+// ttlGroupKey is the group a row belongs to in the by-TTL table: its tier where the tier is
+// KNOWN, and TTLUnrecorded where it is not. Doubles as the value that filters on that group, so
+// clicking a row in the table narrows to exactly the rows behind it.
+func ttlGroupKey(r *kvcache.Request) string {
+	if r.TTLSource == kvcache.TTLSourceUnknown {
+		return TTLUnrecorded
+	}
+	if r.TTL == kvcache.TTLNone {
+		return "none"
+	}
+	return string(r.TTL)
+}
+
+// ttlOrder and bucketOrder are the presentation orders for the two groupings whose order
+// carries meaning. A bar chart of these must not sort by size: tier is a scale and a
+// time-of-day band is a clock. TTLUnrecorded is LAST, because it is an absence rather than a
+// tier and must not sit between two real ones.
+var ttlOrder = []string{string(kvcache.TTL5m), string(kvcache.TTL1h), "none", TTLUnrecorded}
+
+func bucketOrder() []string {
+	out := make([]string, 0, len(kvcache.Buckets))
+	for _, b := range kvcache.Buckets {
+		out = append(out, string(b))
+	}
+	return out
+}
+
+// finishKVAccs sorts a group map. `order` fixes the sequence where it carries meaning; nil
+// sorts by request count descending, with the key as a stable tie-break. Anything the fixed
+// order does not name still appears, or a tier from a future build would vanish from a page
+// whose totals include it.
+func finishKVAccs(m map[string]*kvCacheAcc, order []string) []KVCacheGroup {
+	out := make([]KVCacheGroup, 0, len(m))
+	named := map[string]bool{}
+	for _, k := range order {
+		named[k] = true
+		if a := m[k]; a != nil {
+			out = append(out, a.finish())
+		}
+	}
+	rest := make([]KVCacheGroup, 0, len(m))
+	for _, k := range sortedStrings(m) {
+		if !named[k] {
+			rest = append(rest, m[k].finish())
+		}
+	}
+	if order == nil {
+		sort.SliceStable(rest, func(i, j int) bool { return rest[i].Requests > rest[j].Requests })
+	}
+	return append(out, rest...)
+}
+
+// kvCacheSecs renders a duration in seconds the way a person reads it — the same rounding the
+// keep-alive tab's band labels use, so two charts on one dashboard do not spell 9.7 minutes two
+// different ways.
+func kvCacheSecs(v float64) string {
+	switch {
+	case v >= 86400:
+		return trimZero(v/86400) + "d"
+	case v >= 3600:
+		return trimZero(v/3600) + "h"
+	case v >= 60:
+		return trimZero(v/60) + "m"
+	default:
+		return trimZero(v) + "s"
+	}
+}
+
+// ── the assumptions payload ────────────────────────────────────────────────
+
+// KVCacheFormula is one cost formula: what it is called, the expression, and the sentence that
+// says what it means and where it can mislead.
+//
+// A struct rather than prose in the UI for one reason: a formula typed into a JavaScript
+// template is a SECOND definition of the arithmetic, and nothing tests it against the first.
+// These travel with the data and are asserted against the functions that implement them.
+type KVCacheFormula struct {
+	Name string `json:"name"`
+	// Formula and Note are spelled the way the page reads them. Renaming either is a silent
+	// break: the expression renders into an empty <code> element, so the panel lists eleven
+	// formula NAMES with eleven blank boxes under them and looks like a styling glitch rather
+	// than a contract mismatch. TestThePageReadsTheFormulaFieldsTheServerSends is the guard.
+	Formula string `json:"formula"`
+	Note    string `json:"note"`
+}
+
+// KVCacheSchedule is the keep-alive schedule a simulation ran with, in seconds.
+//
+// Two intervals, because the interval is the whole cost difference between the two tiers: one
+// ping costs the same either way (it is a cache read), but a five-minute entry has to be touched
+// roughly twelve times as often as a one-hour one to be held for the same span.
+type KVCacheSchedule struct {
+	IdleSeconds   float64 `json:"idle_seconds"`
+	IdleSeconds1h float64 `json:"idle_seconds_1h"`
+	MaxPings      int     `json:"max_pings"`
+}
+
+// KVCacheAssumptions is the server's own statement of what every figure on the page rests on:
+// the units, the two horizons, the pricing multiples, the provider cache semantics, the
+// keep-alive schedule, the cost formulas and the caveats.
+//
+// It is on the wire so the page PRINTS it rather than restating it. Every number here is one the
+// simulation actually used, echoed back — so a reader checking a figure against a formula is
+// checking it against the arithmetic that produced it.
+type KVCacheAssumptions struct {
+	// TimeZone is UTC, always, and it is a field rather than a constant in the page because the
+	// claim has to travel with the data: the store carries no per-user timezone, so a local one
+	// would be invented.
+	TimeZone string `json:"time_zone"`
+	TimeUnit string `json:"time_unit"`
+
+	Horizon5mSeconds float64 `json:"horizon_5m_seconds"`
+	Horizon1hSeconds float64 `json:"horizon_1h_seconds"`
+
+	Multipliers kvcache.Multipliers `json:"multipliers"`
+	Semantics   kvcache.Semantics   `json:"semantics"`
+	Schedule    KVCacheSchedule     `json:"schedule"`
+
+	Formulas []KVCacheFormula `json:"formulas"`
+	Notes    []string         `json:"notes"`
+}

--- a/dash/kvcache_test.go
+++ b/dash/kvcache_test.go
@@ -1,0 +1,740 @@
+package dash
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The KV-cache page's DB and API layer.
+//
+// The arithmetic itself is asserted in package kvcache, which needs no database. What is
+// asserted here is the part only this layer can get wrong: the SQL derivation of each
+// request's successor, the tier reconstruction over history that recorded none, the derived
+// filters, the JSON on the wire, and the two guards this dashboard has broken before — a
+// keep-alive ping row inside an agent aggregate, and a cap applied without saying so.
+
+// kvEvent builds one request row for the KV-cache dataset. Deliberately not mkEvent: that one
+// carries a component report and a compaction, and every field here is about cache tiers.
+func kvEvent(tenant, session, model string, ts int64, read, write int64) *Event {
+	return &Event{TS: ts, TenantID: tenant, SessionID: session, Model: model,
+		Provider: "anthropic", Agent: "claude-code", Mode: ModeActive,
+		TokensBefore: 1000, TokensAfter: 1000, FreshInput: 100, OutputTokens: 50,
+		CacheRead: read, CacheWrite: write, CostUSD: 0.5, UpstreamMs: 1000,
+		TokenAccounting: AccountingComplete, CacheMissReason: CacheHit,
+		CacheTTL: "ephemeral_5m"}
+}
+
+// seedKV writes rows and returns the DB.
+func seedKV(t *testing.T, evs ...*Event) *DB {
+	t.Helper()
+	db := openTestDB(t)
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+const kvBase = int64(1_786_967_311_185)
+
+func allTenants() Filter { return Filter{TenantAll: true} }
+
+// The successor of a request comes from SQL, over (tenant, session) — the PAIR. A session id
+// is client-supplied, so two accounts can present the same one; partitioned on the session
+// alone this dataset derives a 1-second gap where the truth is that neither account came back.
+func TestKVCacheDatasetDerivesTheSuccessorPerAccountAndSession(t *testing.T) {
+	shared := "same-session-id"
+	db := seedKV(t,
+		kvEvent("tenant-a", shared, "m", kvBase, 1000, 0),
+		kvEvent("tenant-b", shared, "m", kvBase+1_000, 1000, 0),
+		kvEvent("tenant-a", shared, "m", kvBase+60_000, 1000, 0),
+	)
+	rows, total, err := db.KVCacheDataset(allTenants(), KVCacheOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(rows) != 3 {
+		t.Fatalf("read %d of %d rows, want 3 of 3", len(rows), total)
+	}
+	byKey := map[kvcache.Conversation][]*kvcache.Request{}
+	for _, r := range rows {
+		byKey[r.Key()] = append(byKey[r.Key()], r)
+	}
+	a := byKey[kvcache.Conversation{User: "tenant-a", Conversation: shared, Model: "m"}]
+	if len(a) != 2 {
+		t.Fatalf("tenant-a has %d rows", len(a))
+	}
+	if idle, ok := a[0].Idle(); !ok || idle != 60*time.Second {
+		t.Errorf("tenant-a's gap = %v (ok=%v), want 60s — tenant-b must not shorten it", idle, ok)
+	}
+	b := byKey[kvcache.Conversation{User: "tenant-b", Conversation: shared, Model: "m"}]
+	if len(b) != 1 || b[0].HasNext {
+		t.Errorf("tenant-b has one request and no successor; got %d rows, has_next=%v",
+			len(b), len(b) > 0 && b[0].HasNext)
+	}
+}
+
+// A keep-alive PING row is not in this dataset. Counted, it would split one real idle gap into
+// two short ones and make every reuse probability on the page wrong in the flattering
+// direction — which is the whole reason Filter.where() has that predicate.
+func TestKVCacheDatasetExcludesKeepAlivePings(t *testing.T) {
+	ping := kvEvent("t", "s", "m", kvBase+280_000, 1000, 0)
+	ping.KeepAlive = true
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 1000, 0),
+		ping,
+		kvEvent("t", "s", "m", kvBase+600_000, 1000, 0),
+	)
+	rows, total, err := db.KVCacheDataset(allTenants(), KVCacheOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("the ping is in the dataset: %d of %d rows", len(rows), total)
+	}
+	if idle, _ := rows[0].Idle(); idle != 600*time.Second {
+		t.Errorf("the gap is %v; the ping split one 600 s idle span into two", idle)
+	}
+	for _, r := range rows {
+		if r.KeepAlive {
+			t.Error("a ping row reached the analysis dataset")
+		}
+	}
+}
+
+// The tier is reconstructed with three different degrees of confidence, and the page counts
+// each separately: `cache_ttl` arrived as an ADDITIVE column defaulting to ”, so on a row
+// written before it a blank means NOT RECORDED, and reporting that as "no cache_control" would
+// say a deployment that has always cached never cached at all.
+func TestObservedTTLSaysHowWellItKnows(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		recorded   string
+		write1h    int64
+		cached     int64
+		wantTTL    kvcache.TTL
+		wantSource string
+	}{
+		{"the row recorded its own tier", "ephemeral_1h", 0, 50_000,
+			kvcache.TTL1h, kvcache.TTLSourceConfigured},
+		{"a 5m tier recorded", "ephemeral_5m", 0, 50_000,
+			kvcache.TTL5m, kvcache.TTLSourceConfigured},
+		{"no tier, but the provider billed at the 1h tier", "", 40_000, 50_000,
+			kvcache.TTL1h, kvcache.TTLSourceObserved},
+		{"no tier, something was cached", "", 0, 50_000,
+			kvcache.TTL5m, kvcache.TTLSourceUnknown},
+		{"no tier and nothing cached at all", "", 0, 0,
+			kvcache.TTLNone, kvcache.TTLSourceObserved},
+		{"an unrecognised tier is not trusted", "ephemeral_10m", 0, 50_000,
+			kvcache.TTL5m, kvcache.TTLSourceUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src := observedTTL(tc.recorded, tc.write1h, tc.cached)
+			if got != tc.wantTTL || src != tc.wantSource {
+				t.Errorf("observedTTL(%q, %d, %d) = %q/%s, want %q/%s",
+					tc.recorded, tc.write1h, tc.cached, got, src, tc.wantTTL, tc.wantSource)
+			}
+		})
+	}
+}
+
+// The coverage panel counts the three tier states rather than blending them.
+func TestAnalysisCountsTheThreeTierStates(t *testing.T) {
+	configured := kvEvent("t", "s1", "m", kvBase, 1000, 100)
+	observed1h := kvEvent("t", "s2", "m", kvBase+1000, 1000, 100)
+	observed1h.CacheTTL, observed1h.CacheWrite1h = "", 100
+	unknown := kvEvent("t", "s3", "m", kvBase+2000, 1000, 100)
+	unknown.CacheTTL = ""
+	uncached := kvEvent("t", "s4", "m", kvBase+3000, 0, 0)
+	uncached.CacheTTL = ""
+	db := seedKV(t, configured, observed1h, unknown, uncached)
+
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := out.Coverage
+	if c.TTLConfigured != 1 || c.TTLObserved != 2 || c.TTLUnknown != 1 {
+		t.Errorf("coverage = %+v; want 1 configured, 2 observed (one 1h, one uncached), 1 unknown", c)
+	}
+	if c.SingleRequestConversations != 4 {
+		t.Errorf("single-request conversations = %d, want 4 — the page must say so, or it looks "+
+			"like most of the traffic was thrown away", c.SingleRequestConversations)
+	}
+}
+
+// The summary cards: every idle average is over the requests that HAVE a successor, and the
+// final requests are reported beside them rather than folded in as zero gaps.
+func TestSummaryCardsKeepFinalRequestsOutOfEveryAverage(t *testing.T) {
+	// One conversation: gaps of 10 s, 600 s, 10 s. Four requests, three gaps, one final.
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 100_000, 0),
+		kvEvent("t", "s", "m", kvBase+10_000, 100_000, 0),
+		kvEvent("t", "s", "m", kvBase+610_000, 100_000, 0),
+		kvEvent("t", "s", "m", kvBase+620_000, 100_000, 0),
+	)
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := out.Cards
+	if c.Requests != 4 || c.WithNext != 3 || c.FinalRequests != 1 {
+		t.Fatalf("requests=%d with_next=%d final=%d, want 4/3/1",
+			c.Requests, c.WithNext, c.FinalRequests)
+	}
+	if c.Conversations != 1 {
+		t.Errorf("conversations = %d, want 1", c.Conversations)
+	}
+	// Mean over the three real gaps is (10 + 600 + 10)/3 = 206.67 s. Counting the final
+	// request as a zero would give 155 s.
+	if want := 206_666.6667; c.MeanIdleMs < want-1 || c.MeanIdleMs > want+1 {
+		t.Errorf("mean idle = %.1f ms, want ~%.1f (three gaps, not four)", c.MeanIdleMs, want)
+	}
+	if c.MedianIdleMs != 10_000 {
+		t.Errorf("median idle = %.0f ms, want 10000", c.MedianIdleMs)
+	}
+	// Two of three gaps are inside five minutes; all three are inside an hour.
+	if c.Within5m != 2 || c.Within1h != 3 {
+		t.Errorf("within 5m/1h = %d/%d, want 2/3", c.Within5m, c.Within1h)
+	}
+	if got, want := c.Within5mPct, 200.0/3; got < want-0.01 || got > want+0.01 {
+		t.Errorf("within_5m_pct = %.4f, want %.4f (denominator is with_next, not requests)",
+			got, want)
+	}
+	if c.Within1hPct != 100 {
+		t.Errorf("within_1h_pct = %.2f, want 100", c.Within1hPct)
+	}
+	if c.CachedContextP50 != 100_000 {
+		t.Errorf("median cached context = %d, want 100000", c.CachedContextP50)
+	}
+	near2(t, "cost", c.CostUSD, 4*0.5)
+}
+
+// The idle histogram's 5-minute and 1-hour edges are load-bearing: every percentage on the
+// page is measured against them, so a band that straddled either would make the chart and the
+// cards disagree.
+func TestIdleHistogramEdgesLineUpWithTheHorizons(t *testing.T) {
+	var have5m, have1h bool
+	for _, e := range idleEdges {
+		if e == kvcache.Horizon5m.Seconds() {
+			have5m = true
+		}
+		if e == kvcache.Horizon1h.Seconds() {
+			have1h = true
+		}
+	}
+	if !have5m || !have1h {
+		t.Fatalf("idleEdges %v does not have an edge at 300 s and at 3600 s", idleEdges)
+	}
+	// A gap of exactly five minutes belongs to the band STARTING at five minutes, and that
+	// band is the first one marked beyond a five-minute lifetime.
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 1000, 0),
+		kvEvent("t", "s", "m", kvBase+300_000, 1000, 0),
+	)
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int64
+	for _, b := range out.IdleBands {
+		n += b.N
+		if strings.HasPrefix(b.Label, "5m") && (b.N != 1 || !b.Beyond) {
+			t.Errorf("the 5m band holds %d gaps (beyond=%v), want 1 and beyond", b.N, b.Beyond)
+		}
+	}
+	if n != 1 {
+		t.Errorf("the histogram holds %d gaps; only the request WITH a successor has one", n)
+	}
+}
+
+// The survival view is the empirical CDF of the idle gap, and the two provider horizons are ON
+// its ladder rather than interpolated between rungs.
+func TestSurvivalCurveSamplesTheTwoHorizonsExactly(t *testing.T) {
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 1000, 0),
+		kvEvent("t", "s", "m", kvBase+10_000, 1000, 0),    // 10 s gap
+		kvEvent("t", "s", "m", kvBase+1_810_000, 1000, 0), // 30 min gap
+		kvEvent("t", "s", "m", kvBase+9_000_000, 1000, 0), // ~2 h gap
+	)
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := map[float64]SurvivalPoint{}
+	for _, p := range out.Survival {
+		at[p.Seconds] = p
+	}
+	for _, s := range []float64{kvcache.Horizon5m.Seconds(), kvcache.Horizon1h.Seconds()} {
+		if _, ok := at[s]; !ok {
+			t.Fatalf("the survival ladder has no rung at %.0f s", s)
+		}
+	}
+	if got := at[300]; got.Arrived != 1 || got.ArrivedPct < 33 || got.ArrivedPct > 34 {
+		t.Errorf("by 5 minutes: %d of 3 gaps (%.1f%%), want 1 (33.3%%)", got.Arrived, got.ArrivedPct)
+	}
+	if got := at[3600]; got.Arrived != 2 {
+		t.Errorf("by an hour: %d of 3 gaps, want 2", got.Arrived)
+	}
+	if got := at[21600]; got.Arrived != 3 || got.ArrivedPct != 100 {
+		t.Errorf("by six hours: %d of 3 gaps (%.1f%%), want all of them",
+			got.Arrived, got.ArrivedPct)
+	}
+}
+
+// The three derived filters narrow the same dataset the summary is computed from, so the table
+// and the cards cannot disagree.
+func TestDerivedFiltersNarrowTheDataset(t *testing.T) {
+	long := kvEvent("t", "s", "m", kvBase, 1000, 0)
+	long.CacheTTL = "ephemeral_1h"
+	// A request that carried no cache_control at all: no recorded tier and nothing billed at a
+	// cache tier either, which is the one combination that reads as "cached nothing".
+	uncached := kvEvent("u", "s2", "m", kvBase+20_000, 0, 0)
+	uncached.CacheTTL = ""
+	db := seedKV(t, long,
+		kvEvent("t", "s", "m", kvBase+10_000, 1000, 0),
+		uncached,
+	)
+	for _, tc := range []struct {
+		name string
+		o    KVCacheOptions
+		want int
+	}{
+		{"unfiltered", KVCacheOptions{}, 3},
+		{"only requests with a successor", KVCacheOptions{HasNext: "yes"}, 1},
+		{"only final requests", KVCacheOptions{HasNext: "no"}, 2},
+		{"only the 1h tier", KVCacheOptions{TTL: string(kvcache.TTL1h)}, 1},
+		{"only the 5m tier", KVCacheOptions{TTL: string(kvcache.TTL5m)}, 1},
+		{"only requests that cached nothing", KVCacheOptions{TTL: "none"}, 1},
+		{"one time-of-day band", KVCacheOptions{Bucket: string(kvcache.BucketAt(kvBase))}, 3},
+		{"a different band", KVCacheOptions{Bucket: otherBucket(kvBase)}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, _, err := db.KVCacheDataset(allTenants(), tc.o)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != tc.want {
+				t.Errorf("got %d rows, want %d", len(rows), tc.want)
+			}
+		})
+	}
+}
+
+// otherBucket names a UTC band that is not the one an instant falls in.
+func otherBucket(ts int64) string {
+	in := kvcache.BucketAt(ts)
+	for _, b := range kvcache.Buckets {
+		if b != in {
+			return string(b)
+		}
+	}
+	return ""
+}
+
+// A request with no successor sorts LAST in BOTH directions. Letting a nil idle sort as zero
+// would put every final request at the top of an ascending sort as though it had returned
+// instantly, which is the same lie as averaging it in.
+func TestTheDetailTableSortsFinalRequestsLastInBothDirections(t *testing.T) {
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 1000, 0),
+		kvEvent("t", "s", "m", kvBase+10_000, 1000, 0),
+		kvEvent("t", "s2", "m", kvBase+20_000, 1000, 0),
+	)
+	for _, dir := range []string{"asc", "desc"} {
+		page, err := db.KVCacheRows(allTenants(), KVCacheOptions{Sort: "idle", Dir: dir, Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Rows) != 3 {
+			t.Fatalf("%s: %d rows", dir, len(page.Rows))
+		}
+		if !page.Rows[0].HasNext {
+			t.Errorf("%s: a request with no idle time sorted first", dir)
+		}
+		for _, r := range page.Rows[1:] {
+			if r.HasNext {
+				t.Errorf("%s: a request WITH an idle time sorted after one without", dir)
+			}
+		}
+	}
+}
+
+// Every row carries the way back to the request and to the conversation it came from, so the
+// analysis is never a dead end.
+func TestEveryTableRowLinksBackToItsRequestAndConversation(t *testing.T) {
+	db := seedKV(t, kvEvent("t", "sess/with space", "m", kvBase, 1000, 0))
+	page, err := db.KVCacheRows(allTenants(), KVCacheOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Rows) != 1 {
+		t.Fatalf("%d rows", len(page.Rows))
+	}
+	r := page.Rows[0]
+	if !strings.HasPrefix(r.RequestURL, "#requests?req=") || r.RequestURL == "#requests?req=0" {
+		t.Errorf("request link = %q", r.RequestURL)
+	}
+	if want := "#sessions?diff=sess%2Fwith%20space"; r.ConversationURL != want {
+		t.Errorf("conversation link = %q, want %q — a session id is client-supplied and has to "+
+			"be encoded", r.ConversationURL, want)
+	}
+}
+
+// The whole simulation, end to end over rows in a database: the arms run, the savings are
+// measured against one baseline, and a strategy that costs more reports a negative saving.
+func TestSimulationRunsEveryArmAndReportsNegativeSavings(t *testing.T) {
+	// A conversation that always comes back in ten seconds: the 1-hour tier pays 2.0x input to
+	// protect something a 1.25x write already held.
+	var evs []*Event
+	for i := int64(0); i < 8; i++ {
+		evs = append(evs, kvEvent("t", "s", "m", kvBase+i*10_000, 0, 100_000))
+	}
+	db := seedKV(t, evs...)
+	cfg := KVCacheSimConfig{Baseline: KVStrategyFixed5m}
+	out, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet}, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Baseline != KVStrategyFixed5m {
+		t.Fatalf("baseline = %q", out.Baseline)
+	}
+	if len(out.Results) != len(KVCacheDefaultStrategies) {
+		t.Fatalf("ran %d arms, want %d", len(out.Results), len(KVCacheDefaultStrategies))
+	}
+	if len(out.Savings) != len(out.Results) {
+		t.Fatalf("%d savings for %d results", len(out.Savings), len(out.Results))
+	}
+	byName := map[string]kvcache.Savings{}
+	for _, s := range out.Savings {
+		byName[s.Strategy] = s
+	}
+	if s := byName[KVStrategyFixed5m]; s.AbsoluteUSD != 0 || !s.Known {
+		t.Errorf("the baseline's own saving must be exactly zero and defined: %+v", s)
+	}
+	if s := byName[KVStrategyFixed1h]; s.AbsoluteUSD >= 0 {
+		t.Errorf("the 1h arm should cost MORE on 10-second gaps; saving = %.6f", s.AbsoluteUSD)
+	}
+	if s := byName[KVStrategyNoCache]; s.AbsoluteUSD >= 0 {
+		t.Errorf("not caching a 100k prefix at all should cost more: %.6f", s.AbsoluteUSD)
+	}
+	// The observed-policy arm reports how much of itself rested on a recorded tier.
+	for _, r := range out.Results {
+		if r.Strategy != KVStrategyObserved {
+			continue
+		}
+		if r.ObservedCoverage == nil || r.ObservedCoverage.Recorded != 8 {
+			t.Errorf("observed coverage = %+v, want 8 recorded", r.ObservedCoverage)
+		}
+	}
+	if out.WindowEnd != kvBase+7*10_000 {
+		t.Errorf("window end = %d; an open idle span must be bounded by the data, never by "+
+			"time.Now()", out.WindowEnd)
+	}
+}
+
+// A baseline the caller did not ask to see is still replayed, because every percentage on the
+// page is divided by its total — and an unknown one is an error rather than a substitution.
+func TestAnUnrunBaselineIsStillComputedAndAnUnknownOneIsRefused(t *testing.T) {
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 0, 100_000),
+		kvEvent("t", "s", "m", kvBase+10_000, 100_000, 0),
+	)
+	out, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{
+			Strategies: []string{KVStrategyFixed1h}, Baseline: KVStrategyNoCache})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Results) != 1 || out.Results[0].Strategy != KVStrategyFixed1h {
+		t.Fatalf("the arms on screen changed: %d results", len(out.Results))
+	}
+	if out.Baseline != KVStrategyNoCache || out.Savings[0].BaselineUSD <= 0 {
+		t.Errorf("the unrun baseline was not priced: %+v", out.Savings[0])
+	}
+	if _, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, nil,
+		KVCacheSimConfig{Baseline: "not-a-strategy"}); err == nil {
+		t.Error("an unknown baseline was accepted; every percentage is divided by it")
+	}
+	// And an unknown ARM is named rather than silently replaced.
+	named, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, nil,
+		KVCacheSimConfig{Strategies: []string{KVStrategyFixed5m, "wishful-thinking"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(named.Unknown) != 1 || named.Unknown[0] != "wishful-thinking" {
+		t.Errorf("unknown strategies = %v", named.Unknown)
+	}
+}
+
+// An unpriced model produces no dollars anywhere, and says so. An unpriced request is not a
+// free one — the defect class this project has shipped five times.
+func TestAnUnpricedModelIsReportedNotZeroed(t *testing.T) {
+	db := seedKV(t,
+		kvEvent("t", "s", "mystery-model", kvBase, 0, 100_000),
+		kvEvent("t", "s", "mystery-model", kvBase+10_000, 100_000, 0),
+	)
+	out, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range out.Results {
+		if r.TotalUSD != 0 || r.Unpriced != 2 || r.Requests != 2 {
+			t.Errorf("%s: total=%v unpriced=%d requests=%d", r.Strategy, r.TotalUSD,
+				r.Unpriced, r.Requests)
+		}
+	}
+	for _, s := range out.Savings {
+		if s.Known {
+			t.Errorf("%s reported a percentage against a zero baseline", s.Strategy)
+		}
+	}
+	if len(out.Pricing.Models) != 1 || out.Pricing.Models[0].Known {
+		t.Errorf("the price list did not report the model as unpriced: %+v", out.Pricing.Models)
+	}
+}
+
+// A per-model rate typed into the page reaches the simulation, and it is read in USD per
+// MILLION tokens — the unit every price page uses, converted once at the boundary.
+func TestARateTypedIntoThePageRepricesTheWindow(t *testing.T) {
+	db := seedKV(t,
+		kvEvent("t", "s", "m", kvBase, 0, 100_000),
+		kvEvent("t", "s", "m", kvBase+10_000, 100_000, 0),
+	)
+	// input $3/MTok, output $15/MTok, read $0.30/MTok, 5m write $3.75/MTok, 1h write $6/MTok.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/kvcache/simulate?rate=m:3:15:0.30:3.75:6&strategy=fixed-5m&baseline=no-cache", nil)
+	cfg := kvCacheConfigFrom(req)
+	ov, ok := cfg.Overrides["m"]
+	if !ok {
+		t.Fatal("the rate override did not parse")
+	}
+	if ov.Input == nil || *ov.Input != 3e-6 {
+		t.Errorf("input override = %v, want 3e-6 (per-token, from $3 per MTok)", ov.Input)
+	}
+	if ov.Write1h == nil || *ov.Write1h != 6e-6 {
+		t.Errorf("write_1h override = %v, want 6e-6", ov.Write1h)
+	}
+	out, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, nil, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("%d arms", len(out.Results))
+	}
+	r := out.Results[0]
+	// A miss writing 100k at $3.75/MTok plus a hit reading 100k at $0.30/MTok, plus 100 fresh
+	// input and 50 output on each.
+	want := (100*3e-6 + 100_000*3.75e-6 + 50*15e-6) + (100*3e-6 + 100_000*0.3e-6 + 50*15e-6)
+	near2(t, "the repriced total", r.TotalUSD, want)
+	if out.Pricing.Models[0].Source != "override" {
+		t.Errorf("source = %q; nobody may read a typed number as a configured one",
+			out.Pricing.Models[0].Source)
+	}
+}
+
+// A malformed rate is DROPPED rather than half-applied: a partially parsed price is a wrong
+// price, and the panel shows what it got back so an ignored edit is visible.
+func TestAMalformedRateIsDroppedWholeAndAModelNameMayContainSlashes(t *testing.T) {
+	for _, spec := range []string{"m:3:15", "m:3:15:0.3:3.75", ":1:2:3:4:5", "m:x:15:0.3:3.75:6",
+		"m:-1:15:0.3:3.75:6", "m:::::"} {
+		if _, _, ok := parseRateOverride(spec); ok {
+			t.Errorf("%q was accepted", spec)
+		}
+	}
+	// A gateway route name carries a slash and a dot, and needs no escaping.
+	model, ov, ok := parseRateOverride("us.anthropic/claude-opus-5:3:15::3.75:6")
+	if !ok {
+		t.Fatal("a qualified model id was rejected")
+	}
+	if model != "us.anthropic/claude-opus-5" {
+		t.Errorf("model = %q", model)
+	}
+	if ov.CacheRead != nil {
+		t.Error("an empty field must mean 'not overridden', not zero")
+	}
+	if ov.Write5m == nil || *ov.Write5m != 3.75e-6 {
+		t.Errorf("write_5m = %v", ov.Write5m)
+	}
+}
+
+// The keep-alive schedule mirrors the one the keep-alive tab's own calculator uses, and the
+// two arithmetics cannot drift because this asserts they agree.
+//
+// They are separate functions because the dependency runs one way: dash imports kvcache, so
+// kvcache cannot call back into this package. A shared table is the alternative to a shared
+// function, and this is that table.
+func TestPingScheduleMatchesTheKeepAliveTab(t *testing.T) {
+	for _, gap := range []float64{0, 1, 279, 280, 281, 559, 560, 600, 1800, 3600, 14400, 86400} {
+		for _, idle := range []float64{60, 280, 300, 3360} {
+			for k := 0; k <= 4; k++ {
+				want := PingsPerSpan(gap, idle, k)
+				got := kvcache.PingsPerSpan(time.Duration(gap)*time.Second,
+					time.Duration(idle)*time.Second, k)
+				if got != want {
+					t.Fatalf("gap=%.0f idle=%.0f k=%d: kvcache says %d, the keep-alive tab says %d",
+						gap, idle, k, got, want)
+				}
+			}
+		}
+	}
+}
+
+// The four routes answer on an EMPTY database, which is the state every new deployment is in
+// and the one an empty-panel bug hides in.
+func TestKVCacheRoutesAnswerOnAnEmptyDatabase(t *testing.T) {
+	a, _ := newTestAPI(t, Options{})
+	for _, path := range []string{"/api/kvcache", "/api/kvcache/rows",
+		"/api/kvcache/simulate", "/api/kvcache/pricing"} {
+		w, body := get(t, a, path, "")
+		if w.Code != http.StatusOK {
+			t.Errorf("%s -> %d: %s", path, w.Code, w.Body.String())
+		}
+		if body == nil {
+			t.Errorf("%s served no JSON object", path)
+		}
+	}
+}
+
+// The wire shape: the fields the page reads are present and spelled as the UI expects, and an
+// idle time is `null` on a final request rather than 0.
+func TestKVCacheJSONSerialization(t *testing.T) {
+	a, rec := newTestAPI(t, Options{})
+	seed(t, rec,
+		kvEvent("", "s", "aws/claude-sonnet-5", kvBase, 0, 100_000),
+		kvEvent("", "s", "aws/claude-sonnet-5", kvBase+10_000, 100_000, 0),
+	)
+	w, body := get(t, a, "/api/kvcache", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("%d: %s", w.Code, w.Body.String())
+	}
+	for _, key := range []string{"cards", "idle_bands", "by_ttl", "by_user", "by_model",
+		"by_bucket", "survival", "coverage", "assumptions", "pricing", "scanned", "total",
+		"truncated"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("/api/kvcache has no %q", key)
+		}
+	}
+	cards, _ := body["cards"].(map[string]any)
+	for _, key := range []string{"requests", "conversations", "with_next", "final_requests",
+		"median_idle_ms", "mean_idle_ms", "within_5m_pct", "within_1h_pct", "hit_rate_pct",
+		"cost_usd", "cached_context_p50"} {
+		if _, ok := cards[key]; !ok {
+			t.Errorf("cards has no %q", key)
+		}
+	}
+	assumptions, _ := body["assumptions"].(map[string]any)
+	if assumptions["time_zone"] != "UTC" {
+		t.Errorf("the page does not state its timezone: %v", assumptions["time_zone"])
+	}
+	if f, _ := assumptions["formulas"].([]any); len(f) < 8 {
+		t.Errorf("the cost formulas are not on the wire: %d of them", len(f))
+	}
+
+	// The rows route, and the nil idle.
+	rw, _ := get(t, a, "/api/kvcache/rows?limit=10&sort=ts&dir=asc", "")
+	if rw.Code != http.StatusOK {
+		t.Fatalf("rows -> %d: %s", rw.Code, rw.Body.String())
+	}
+	var page struct {
+		Rows []struct {
+			ID       int64  `json:"id"`
+			HasNext  bool   `json:"has_next"`
+			IdleMs   *int64 `json:"idle_ms"`
+			TTL      string `json:"ttl"`
+			Source   string `json:"ttl_source"`
+			Cached   int64  `json:"cached_context_tokens"`
+			ReqURL   string `json:"request_url"`
+			ConvURL  string `json:"conversation_url"`
+			Within5m bool   `json:"within_5m"`
+		} `json:"rows"`
+		Total int64 `json:"total"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Rows) != 2 || page.Total != 2 {
+		t.Fatalf("%d of %d rows", len(page.Rows), page.Total)
+	}
+	if page.Rows[0].IdleMs == nil || *page.Rows[0].IdleMs != 10_000 || !page.Rows[0].Within5m {
+		t.Errorf("the first row's idle = %v", page.Rows[0].IdleMs)
+	}
+	if page.Rows[1].HasNext || page.Rows[1].IdleMs != nil {
+		t.Errorf("the final row must serialize idle as null, got %v", page.Rows[1].IdleMs)
+	}
+	if !strings.Contains(rw.Body.String(), `"idle_ms":null`) {
+		t.Error("a final request's idle time is not null on the wire; 0 would read as " +
+			"'it came back instantly'")
+	}
+	if page.Rows[0].Cached != 100_000 || page.Rows[0].TTL != "ephemeral_5m" {
+		t.Errorf("row = %+v", page.Rows[0])
+	}
+}
+
+// The pricing route shows the configured rate AND what it comes to on this window's own
+// median prefix. A per-token rate is not a number anybody can act on.
+func TestPricingRouteShowsBothTheRateAndItsCost(t *testing.T) {
+	a, rec := newTestAPI(t, Options{})
+	a.SetPricer(staticPricer{ibmSonnet})
+	seed(t, rec,
+		kvEvent("", "s", "aws/claude-sonnet-5", kvBase, 0, 100_000),
+		kvEvent("", "s", "aws/claude-sonnet-5", kvBase+10_000, 100_000, 0),
+	)
+	w, body := get(t, a, "/api/kvcache/pricing", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("%d: %s", w.Code, w.Body.String())
+	}
+	if got, _ := body["prefix_tokens"].(float64); got != 100_000 {
+		t.Errorf("median prefix = %v, want 100000", got)
+	}
+	costs, _ := body["costs"].([]any)
+	if len(costs) != 1 {
+		t.Fatalf("%d cost rows", len(costs))
+	}
+	c, _ := costs[0].(map[string]any)
+	for _, key := range []string{"uncached_usd", "read_usd", "write_5m_usd", "write_1h_usd",
+		"keep_alive_usd", "late_5m_usd", "late_1h_usd", "hold_5m_usd", "hold_1h_usd"} {
+		if _, ok := c[key]; !ok {
+			t.Errorf("the cost row has no %q", key)
+		}
+	}
+	// One hit on 100k at the IBM read rate.
+	near2(t, "read cost", c["read_usd"].(float64), 100_000*ibmSonnet.CacheRead)
+	// The 1h tier is 2.0x input, derived because no gateway publishes it.
+	near2(t, "1h write cost", c["write_1h_usd"].(float64), 100_000*2*ibmSonnet.Input)
+	if c["write_1h_usd"].(float64) <= c["write_5m_usd"].(float64) {
+		t.Error("the 1h write is not dearer than the 5m one")
+	}
+}
+
+// The cap is announced. A silent top-N would read as "this is your whole history", which is
+// the failure this dashboard has already shipped once.
+func TestATruncatedAnalysisSaysSo(t *testing.T) {
+	db := seedKV(t, kvEvent("t", "s", "m", kvBase, 1000, 0))
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, nil, KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Truncated || out.Scanned != out.Total || out.Total != 1 {
+		t.Errorf("an untruncated window reported scanned=%d total=%d truncated=%v",
+			out.Scanned, out.Total, out.Truncated)
+	}
+	if kvCacheMaxRows < 100_000 {
+		t.Errorf("the analysis cap is %d rows, which is below the live service's own window",
+			kvCacheMaxRows)
+	}
+}
+
+// near2 is a float comparison for this file. Named apart from package kvcache's own helper
+// because the two files are in different packages and the tolerance here is a money one.
+func near2(t *testing.T, what string, got, want float64) {
+	t.Helper()
+	if diff := got - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("%s = %.12f, want %.12f", what, got, want)
+	}
+}

--- a/dash/kvcacheapi.go
+++ b/dash/kvcacheapi.go
@@ -1,0 +1,309 @@
+package dash
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The KV-cache tab's four read routes.
+//
+// All in API.routes(), which is the table Mount walks AND the table both scoping tests walk —
+// TestEveryMountedRouteDeclaresItsScope and TestNoRouteServesContentTextFromAnUntrustedAddress.
+// A route mounted beside that table would be a route whose scope nothing checks, which is
+// exactly how three unauthenticated routes and then /api/prompt shipped.
+//
+// Every one is scopeTenant and every one returns NUMBERS, ENUM LABELS AND IDS ONLY: no prompt
+// text, no transcript, no tool schema. Session ids are returned — they are the caller's own,
+// the same as /api/sessions — but nothing behind them. If any field here ever grows text it
+// must apply a.trusted(r) exactly as a.prompt does.
+//
+// # Why they are all GET
+//
+// The pricing experiment is a set of inputs, and the obvious shape for it is a POST with a
+// JSON body. It is a GET with query parameters instead, for two reasons that are worth more
+// than the tidiness: every other route in this package is a GET, so the two scoping tests
+// probe the table with a GET and a POST route would be a route neither of them could check;
+// and a simulation is a VIEW, so its whole input belongs in a URL that can be bookmarked,
+// pasted into an issue, and reproduced by whoever reads it.
+func (a *API) kvCacheRoutes() []route {
+	return []route{
+		{"GET /api/kvcache", scopeTenant, a.kvCache},
+		{"GET /api/kvcache/rows", scopeTenant, a.kvCacheRows},
+		{"GET /api/kvcache/simulate", scopeTenant, a.kvCacheSimulate},
+		{"GET /api/kvcache/pricing", scopeTenant, a.kvCachePricing},
+	}
+}
+
+// kvCache serves the analysis: the summary cards, the histograms, the grouped views, the
+// survival curve, the coverage statement and the price list.
+func (a *API) kvCache(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	out, err := a.rec.DB().KVCacheAnalyze(f, kvCacheOptionsFrom(r), a.pricer, kvCacheConfigFrom(r))
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, out)
+}
+
+// kvCacheRows serves one page of the sortable detail table.
+func (a *API) kvCacheRows(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	out, err := a.rec.DB().KVCacheRows(f, kvCacheOptionsFrom(r))
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, out)
+}
+
+// kvCacheSimulate replays the window under the requested strategies.
+func (a *API) kvCacheSimulate(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	out, err := a.rec.DB().KVCacheSimulate(f, kvCacheOptionsFrom(r), a.pricer, kvCacheConfigFrom(r))
+	if err != nil {
+		httpErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, out)
+}
+
+// kvCachePricing serves the price list for the models in this window, plus the assumptions.
+//
+// A route of its own so the pricing panel can load and re-price without re-running the whole
+// simulation, which is what makes editing a rate feel like editing a rate.
+func (a *API) kvCachePricing(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	cfg := kvCacheConfigFrom(r)
+	models, err := a.rec.DB().KVCacheModels(f)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	prefix, err := a.rec.DB().KVCacheMedianPrefix(f)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, kvCachePriceView(models, prefix, a.pricer, cfg))
+}
+
+// kvCacheOptionsFrom parses the page-specific narrowings and the table's paging.
+//
+// Every enum is validated against a closed set rather than passed through: these values reach
+// a comparison, not a query, but a filter that silently accepts "afternnon" and returns an
+// empty table is indistinguishable from a window with no traffic in it.
+func kvCacheOptionsFrom(r *http.Request) KVCacheOptions {
+	q := r.URL.Query()
+	o := KVCacheOptions{
+		Limit:  atoiDefault(q.Get("limit"), 50),
+		Offset: atoiDefault(q.Get("offset"), 0),
+		Sort:   q.Get("sort"),
+		Dir:    q.Get("dir"),
+	}
+	if b := kvcache.Bucket(q.Get("bucket")); q.Get("bucket") != "" {
+		for _, known := range kvcache.Buckets {
+			if b == known {
+				o.Bucket = string(b)
+			}
+		}
+	}
+	switch t := q.Get("ttl"); t {
+	case "none", TTLUnrecorded, string(kvcache.TTL5m), string(kvcache.TTL1h):
+		o.TTL = t
+	}
+	switch n := q.Get("has_next"); n {
+	case "yes", "no":
+		o.HasNext = n
+	}
+	if _, ok := kvCacheSortKeys[o.Sort]; !ok {
+		o.Sort = ""
+	}
+	if o.Dir != "asc" {
+		o.Dir = "desc"
+	}
+	return o
+}
+
+// kvCacheConfigFrom parses the pricing experiment, the cache semantics, the keep-alive
+// schedule and the strategy selection.
+//
+// The whole simulation input is in the query string, so a result is a URL. Nothing here has a
+// default of its own: every zero falls through to package kvcache's shipped default, which is
+// the one place those numbers live.
+func kvCacheConfigFrom(r *http.Request) KVCacheSimConfig {
+	q := r.URL.Query()
+	cfg := KVCacheSimConfig{
+		Multipliers: kvcache.Multipliers{
+			CacheRead: atof(q.Get("mult_read")),
+			Write5m:   atof(q.Get("mult_w5m")),
+			Write1h:   atof(q.Get("mult_w1h")),
+		},
+		Semantics: kvcache.Semantics{
+			// The provider's documented behaviour is the default, so an absent parameter means
+			// "as documented" and only an explicit 0 turns one off.
+			HitRefreshesTTL:  boolParam(q.Get("hit_refresh"), true),
+			PingRefreshesTTL: boolParam(q.Get("ping_refresh"), true),
+			ZeroGeneration:   boolParam(q.Get("zero_gen"), false),
+		},
+		PingIdle:   secondsParam(q.Get("x")),
+		PingIdle1h: secondsParam(q.Get("x1h")),
+		MaxPings:   atoiDefault(q.Get("k"), 0),
+		Baseline:   q.Get("baseline"),
+		Custom: KVCacheCustom{
+			P5m:        atof(q.Get("p5m")),
+			P1h:        atof(q.Get("p1h")),
+			MinPrefix:  atoi64(q.Get("min_prefix")),
+			AlwaysPing: boolParam(q.Get("always_ping"), false),
+		},
+	}
+	cfg.Strategies = listParam(q["strategy"])
+	cfg.Overrides = rateOverrides(q)
+	return cfg
+}
+
+// rateOverrides parses the per-model rate edits.
+//
+// One repeated `rate` parameter per model, colon-separated:
+//
+//	rate=<model>:<input>:<output>:<cache_read>:<write_5m>:<write_1h>
+//
+// Rates are USD per MILLION tokens, because that is the unit every vendor's price page and
+// every gateway admin UI uses — the same decision, and the same reason, as
+// internal/modelinfo.Table: a hand-edited per-token float invites a factor-of-a-thousand typo
+// that nothing would catch. They are converted once, here.
+//
+// An EMPTY field means "not overridden", which is why Override's fields are pointers: a rate
+// of zero is a legitimate thing to experiment with, and a sentinel could not say so.
+//
+// The model is everything before the LAST five colons, so a gateway route name with a slash or
+// a dot in it needs no escaping.
+func rateOverrides(q map[string][]string) map[string]kvcache.Override {
+	out := map[string]kvcache.Override{}
+	// The two ping-overhead parameters are provider facts rather than model rates, so they
+	// apply to every model through the wildcard key.
+	var all kvcache.Override
+	if v := q["ping_in"]; len(v) > 0 && v[0] != "" {
+		n := atoi64(v[0])
+		all.PingInputTokens = &n
+	}
+	if v := q["ping_out"]; len(v) > 0 && v[0] != "" {
+		n := atoi64(v[0])
+		all.PingOutputTokens = &n
+	}
+	if !all.Empty() {
+		out[kvcache.OverrideAll] = all
+	}
+	for _, spec := range q["rate"] {
+		model, ov, ok := parseRateOverride(spec)
+		if !ok {
+			continue
+		}
+		out[model] = ov
+	}
+	return out
+}
+
+// perMTok is the divisor from the file/UI unit to the per-token unit this package works in.
+const perMTok = 1e6
+
+// parseRateOverride reads one `rate=` specification. A malformed one is DROPPED rather than
+// half-applied: a partially parsed price is a wrong price, and the panel shows the rates it
+// got back, so an ignored edit is visible on screen.
+func parseRateOverride(spec string) (string, kvcache.Override, bool) {
+	parts := strings.Split(spec, ":")
+	if len(parts) < 6 {
+		return "", kvcache.Override{}, false
+	}
+	// The last five fields are the rates; everything before them is the model name, rejoined.
+	cut := len(parts) - 5
+	model := strings.Join(parts[:cut], ":")
+	if model == "" {
+		return "", kvcache.Override{}, false
+	}
+	var ov kvcache.Override
+	fields := []**float64{&ov.Input, &ov.Output, &ov.CacheRead, &ov.Write5m, &ov.Write1h}
+	for i, raw := range parts[cut:] {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil || v < 0 {
+			return "", kvcache.Override{}, false
+		}
+		perToken := v / perMTok
+		*fields[i] = &perToken
+	}
+	if ov.Empty() {
+		return "", kvcache.Override{}, false
+	}
+	return model, ov, true
+}
+
+// listParam accepts a repeated parameter, a comma-joined one, or both.
+func listParam(vals []string) []string {
+	var out []string
+	for _, v := range vals {
+		for _, part := range strings.Split(v, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
+// boolParam reads 1/0, true/false, on/off, with a default for an absent parameter. The
+// default matters: the cache semantics default to the provider's DOCUMENTED behaviour, so an
+// absent parameter must not read as false.
+func boolParam(v string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return def
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// secondsParam reads a duration given in seconds. 0 (and anything unparseable) falls through
+// to package kvcache's own default rather than to a zero interval, which would mean "never
+// ping" — a silently different policy from the one the caller asked for.
+func secondsParam(v string) time.Duration {
+	f := atof(v)
+	if f <= 0 {
+		return 0
+	}
+	return time.Duration(f * float64(time.Second))
+}
+
+// atof parses a float, returning 0 for anything unparseable so the caller's own default
+// applies.
+func atof(v string) float64 {
+	f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+	if err != nil || f < 0 {
+		return 0
+	}
+	return f
+}

--- a/dash/kvcachearms_test.go
+++ b/dash/kvcachearms_test.go
@@ -1,0 +1,341 @@
+package dash
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The seam between the dashboard and the strategy registry.
+//
+// These exist because of a failure that was invisible in every other way: package kvcache
+// shipped ten arms and this package carried a closed list of six, so four working, tested arms —
+// two keep-alive policies, the extend-to-1h policy, and the exact cost ceiling — could not be
+// selected from the dashboard at all. Nothing was red. The code read correctly on both sides.
+
+// Every arm the domain publishes is reachable through this API, or is explicitly marked as not
+// selectable with a reason. There is no third state, and no arm may be silently absent.
+func TestEveryRegistryArmIsOfferedOrExplicitlyMarkedUnselectable(t *testing.T) {
+	arms := KVCacheArms()
+	byName := map[string]KVCacheArm{}
+	for _, a := range arms {
+		byName[a.Name] = a
+	}
+	for _, spec := range kvcache.Registry() {
+		a, ok := byName[spec.Name]
+		if !ok {
+			t.Errorf("arm %q exists in kvcache.Registry() and is not offered by the dashboard at "+
+				"all. An arm nobody can select is an arm nobody compares against.", spec.Name)
+			continue
+		}
+		if a.Unreachable != spec.Unreachable || a.Description != spec.Description {
+			t.Errorf("arm %q was re-described by this layer: %+v vs %+v", spec.Name, a.StrategySpec,
+				spec)
+		}
+		// Selectable arms must actually build. A spec that says NeedsDataset builds from the real
+		// rows, so it is probed with one.
+		rows := []*kvcache.Request{
+			{ID: 1, User: "t", ConversationID: "s", TS: kvBase, Model: "m", CachedContext: 1000},
+			{ID: 2, User: "t", ConversationID: "s", TS: kvBase + 10_000, Model: "m", CachedContext: 1000},
+		}
+		kvcache.Derive(rows)
+		got := buildStrategy(spec.Name, rows, KVCacheSimConfig{}, kvcache.Config{Prices: testPriceList()})
+		if a.Selectable && got == nil {
+			t.Errorf("arm %q is offered as selectable and cannot be built", spec.Name)
+		}
+		if !a.Selectable && got != nil {
+			t.Errorf("arm %q is marked unselectable but builds fine; the marking is wrong and the "+
+				"page is hiding a working arm", spec.Name)
+		}
+	}
+	// The custom arm is this layer's own, and it is the only name here that is NOT in the
+	// registry: it carries the page's thresholds and the in-process Predictor seam.
+	c, ok := byName[KVStrategyCustom]
+	if !ok || !c.Selectable {
+		t.Errorf("the custom arm is not offered: %+v", c)
+	}
+	if buildStrategy(KVStrategyCustom, nil, KVCacheSimConfig{}, kvcache.Config{}) == nil {
+		t.Error("the custom arm does not build")
+	}
+	// And a name that is not an arm builds nothing, rather than falling back to one.
+	if buildStrategy("wishful-thinking", nil, KVCacheSimConfig{}, kvcache.Config{}) != nil {
+		t.Error("an unknown name resolved to a strategy; the page would then report one policy's " +
+			"savings under another's label")
+	}
+}
+
+// `replay` is in the registry and must NOT be a checkbox: its whole input is an action list
+// supplied in the process, so no query string can ask for it. It is listed and marked, not
+// dropped — a reader who has seen it named in the domain has to be able to find out why it is
+// not on the picker.
+func TestTheReplayArmIsListedButNotSelectable(t *testing.T) {
+	var found bool
+	for _, a := range KVCacheArms() {
+		if a.Name != kvcache.StrategyReplay {
+			continue
+		}
+		found = true
+		if a.Selectable {
+			t.Error("the replay arm is offered as selectable; nothing in a URL can supply its " +
+				"action list")
+		}
+	}
+	if !found {
+		t.Error("the replay arm was dropped from the payload rather than marked")
+	}
+}
+
+// The exact ceiling is marked unreachable all the way to the wire, and it is NOT the default
+// denominator.
+//
+// It reads the true next-request time, so a percentage measured against it would be a share of a
+// number no policy can reach. Two separate properties: the flag survives to the payload, and the
+// default baseline is a reachable arm.
+func TestTheCeilingArmIsMarkedAndIsNeverTheDefaultBaseline(t *testing.T) {
+	var ceilings int
+	for _, a := range KVCacheArms() {
+		if a.Unreachable {
+			ceilings++
+		}
+	}
+	if ceilings == 0 {
+		t.Fatal("no arm is marked unreachable; the exact ceiling has stopped being labelled as one")
+	}
+	base := kvCacheDefaultBaseline()
+	for _, a := range KVCacheArms() {
+		if a.Name == base && a.Unreachable {
+			t.Errorf("the default baseline %q reads the future; every percentage on the page "+
+				"would be a share of an unreachable number", base)
+		}
+	}
+	// The default comes from the registry's own flag rather than from a constant here, so the
+	// two cannot disagree about the one number every percentage is divided by.
+	var flagged string
+	for _, s := range kvcache.Registry() {
+		if s.Baseline {
+			flagged = s.Name
+		}
+	}
+	if flagged == "" {
+		t.Skip("the registry flags no baseline arm")
+	}
+	if base != flagged {
+		t.Errorf("the default baseline is %q but the registry flags %q", base, flagged)
+	}
+}
+
+// Every default arm resolves. A default set naming an arm that cannot be built would leave the
+// page's first render reporting a strategy as "not a strategy".
+func TestEveryDefaultArmResolves(t *testing.T) {
+	for _, name := range KVCacheDefaultStrategies {
+		rows := []*kvcache.Request{{ID: 1, User: "t", ConversationID: "s", TS: kvBase, Model: "m"}}
+		kvcache.Derive(rows)
+		if buildStrategy(name, rows, KVCacheSimConfig{}, kvcache.Config{Prices: testPriceList()}) == nil {
+			t.Errorf("default arm %q does not resolve", name)
+		}
+	}
+}
+
+// The tier filter is observedTTL expressed as SQL, and this is the assertion that the two agree.
+//
+// They are one definition in two languages: the Go function decides what a row's tier IS, and
+// the predicate decides which rows a filter KEEPS. A disagreement would be a page whose group
+// table says 400 requests used the one-hour tier and whose detail table, filtered to that tier,
+// shows a different number — with nothing to say which was right.
+func TestTheTierFilterAgreesWithTheTierReconstruction(t *testing.T) {
+	// Every combination that produces a distinct answer, plus an unrecognised tier.
+	type row struct {
+		recorded    string
+		write1h     int64
+		read, write int64
+	}
+	cases := []row{
+		{"ephemeral_5m", 0, 1000, 0},
+		{"ephemeral_5m", 0, 0, 0},
+		{"ephemeral_1h", 0, 1000, 0},
+		{"ephemeral_1h", 500, 0, 1000},
+		{"", 0, 1000, 0},
+		{"", 0, 0, 1000},
+		{"", 500, 0, 1000},
+		{"", 0, 0, 0},
+		{"ephemeral_10m", 0, 1000, 0},
+		{"ephemeral_10m", 0, 0, 0},
+		{"ephemeral_10m", 700, 0, 1000},
+	}
+	var evs []*Event
+	want := map[string]int{} // tier -> how many rows observedTTL puts in it
+	for i, c := range cases {
+		e := kvEvent("t", "s", "m", kvBase+int64(i)*1000, c.read, c.write)
+		e.CacheTTL, e.CacheWrite1h = c.recorded, c.write1h
+		evs = append(evs, e)
+		tier, src := observedTTL(c.recorded, c.write1h, c.read+c.write)
+		want[ttlGroupKey(&kvcache.Request{TTL: tier, TTLSource: src})]++
+	}
+	db := seedKV(t, evs...)
+
+	for _, tier := range []string{string(kvcache.TTL5m), string(kvcache.TTL1h), "none",
+		TTLUnrecorded} {
+		rows, total, err := db.KVCacheDataset(allTenants(), KVCacheOptions{TTL: tier})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(total) != want[tier] || len(rows) != want[tier] {
+			t.Errorf("filter ttl=%q kept %d rows (total %d); observedTTL puts %d rows in that "+
+				"tier — the SQL predicate and the Go reconstruction disagree",
+				tier, len(rows), total, want[tier])
+		}
+		// And every row the filter kept really is in that group by the Go function's own reckoning.
+		for _, r := range rows {
+			if got := ttlGroupKey(r); got != tier {
+				t.Errorf("filter ttl=%q returned a row whose reconstructed tier is %q", tier, got)
+			}
+		}
+	}
+	// The three tiers partition the dataset: no row is in two of them and none is in none.
+	all, total, err := db.KVCacheDataset(allTenants(), KVCacheOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := want[string(kvcache.TTL5m)] + want[string(kvcache.TTL1h)] + want["none"] +
+		want[TTLUnrecorded]
+	if sum != len(all) {
+		t.Errorf("the four groups hold %d of %d rows; a tier filter that does not partition the "+
+			"dataset drops rows from the page silently", sum, total)
+	}
+	// The unrecorded group is a group of its OWN and is never folded into the five-minute one.
+	// That absorption is what made the grouped table say "3,106 requests used the 5-minute tier"
+	// about a window whose own coverage banner reported 295 of them as not recorded.
+	if want[TTLUnrecorded] == 0 {
+		t.Fatal("this fixture no longer contains a row that cached something at an unrecorded " +
+			"tier, so it cannot check that such rows are kept apart")
+	}
+	for _, r := range all {
+		if r.TTLSource == kvcache.TTLSourceUnknown && ttlGroupKey(r) == string(kvcache.TTL5m) {
+			t.Error("a row whose tier was never recorded is grouped as a 5-minute one; the page " +
+				"would report it as evidence of a policy nobody configured")
+		}
+	}
+}
+
+// The time-of-day filter really narrows by the hour, in UTC.
+//
+// It is here because the first version of this predicate was assembled with a fmt.Sprintf that
+// consumed the strftime('%H') as a format verb — so every bucket filter compared the hour against
+// the literal "%!H", matched nothing, and rendered as an empty table. An empty table is exactly
+// what a quiet afternoon looks like, which is why this asserts a POSITIVE match rather than only
+// that the query runs.
+func TestTheTimeOfDayFilterMatchesTheHourItNames(t *testing.T) {
+	db := seedKV(t, kvEvent("t", "s", "m", kvBase, 1000, 0))
+	in := string(kvcache.BucketAt(kvBase))
+	rows, _, err := db.KVCacheDataset(allTenants(), KVCacheOptions{Bucket: in})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the row's own band %q kept %d rows, want 1", in, len(rows))
+	}
+	if got := string(rows[0].Bucket); got != in {
+		t.Errorf("the row's bucket is %q but it matched the filter for %q", got, in)
+	}
+	for _, b := range kvcache.Buckets {
+		if string(b) == in {
+			continue
+		}
+		other, _, err := db.KVCacheDataset(allTenants(), KVCacheOptions{Bucket: string(b)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(other) != 0 {
+			t.Errorf("band %q kept %d rows from a different band", b, len(other))
+		}
+	}
+}
+
+// testPriceList is a price list for the arms that need one at CONSTRUCTION time — the exact
+// ceiling computes its plan from the rates, so building it against no prices makes every action
+// free and the plan meaningless.
+func testPriceList() *kvcache.PriceList {
+	return kvcache.NewPriceList(context.Background(), []string{"m"}, staticPricer{ibmSonnet},
+		kvcache.Multipliers{}, nil)
+}
+
+// The SQL partition IS kvcache.Conversation, and this is the assertion that they have not drifted.
+//
+// They are one definition in two languages: the Go type says what a trajectory is, and the window
+// function in kvCacheCTE has to group by exactly that. When kvcache.Conversation gained `Model` —
+// because a cache entry does not transfer between models, so an opus request cannot read a sonnet
+// request's entry — the SQL kept partitioning on (tenant, session) and started linking two
+// different models' requests as successor. Every arm then gets a hit at 0.1x on an entry it could
+// never have matched, and the bias is one-directional: everything looks cheaper and hits more often
+// than it can. Nothing failed on the derivation itself; a key lookup in an unrelated test failed
+// with "tenant-a has 0 rows", which is how it surfaced.
+//
+// Two halves, because the structural one alone would not have caught it and the behavioural one
+// alone would not say why.
+func TestTheSQLPartitionIsExactlyTheConversationKey(t *testing.T) {
+	// STRUCTURAL: a field added to the key is a field the partition needs. This fails on the ADD,
+	// naming what to do, rather than leaving it to be discovered from a wrong number.
+	want := []string{"User", "Conversation", "Model"}
+	typ := reflect.TypeOf(kvcache.Conversation{})
+	var got []string
+	for i := 0; i < typ.NumField(); i++ {
+		got = append(got, typ.Field(i).Name)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("kvcache.Conversation is %v, and this package's window function partitions by "+
+			"(tenant_id, session_id, model). They must be the same grouping. If a field was added, "+
+			"add the matching column to kvCacheCTE's PARTITION BY in the same change; if one was "+
+			"removed, take the column out.", got)
+	}
+	for _, col := range []string{"r.tenant_id", "r.session_id", "r.model"} {
+		if !strings.Contains(kvCacheCTE, col) {
+			t.Errorf("the CTE does not partition by %s", col)
+		}
+	}
+
+	// BEHAVIOURAL: two requests in one session on DIFFERENT models are not each other's successor.
+	db := seedKV(t,
+		kvEvent("t", "s", "aws/claude-opus-5", kvBase, 1000, 0),
+		kvEvent("t", "s", "aws/claude-sonnet-5", kvBase+30_000, 1000, 0),
+		kvEvent("t", "s", "aws/claude-opus-5", kvBase+90_000, 1000, 0),
+	)
+	rows, _, err := db.KVCacheDataset(allTenants(), KVCacheOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[int64]*kvcache.Request{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+	var opusFirst, sonnet *kvcache.Request
+	for _, r := range rows {
+		switch {
+		case r.Model == "aws/claude-sonnet-5":
+			sonnet = r
+		case opusFirst == nil || r.TS < opusFirst.TS:
+			opusFirst = r
+		}
+	}
+	if opusFirst == nil || sonnet == nil {
+		t.Fatal("the fixture did not produce one request per model")
+	}
+	// The opus request's successor is the LATER OPUS request, 90 s away — not the sonnet request
+	// 30 s away, whose entry it could not have read.
+	idle, ok := opusFirst.Idle()
+	if !ok {
+		t.Fatal("the first opus request has no successor at all")
+	}
+	if idle != 90*time.Second {
+		t.Errorf("the opus request's idle gap is %v, want 90s. A %v gap means it was linked to the "+
+			"sonnet request, whose cache entry it could never have matched — which grants a hit at "+
+			"the read rate on an entry that does not exist.", idle, idle)
+	}
+	// And the sonnet request is the only one of its model, so it has no successor.
+	if sonnet.HasNext {
+		t.Error("the sonnet request was given a successor; it is the only request on its model")
+	}
+}

--- a/dash/kvcacheidentity_test.go
+++ b/dash/kvcacheidentity_test.go
@@ -1,0 +1,169 @@
+package dash
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The cost identities, as a pure function plus a proof that it FIRES.
+//
+// dash/kvcachesemantics_test.go asserts four of these over a real replay, and they were green and
+// unproven: the fields they guard live in package kvcache, so the only way to watch them fail was
+// to corrupt that package and revert — which is an edit to someone else's tree, and a race with
+// whoever else is in it. Four green lines nobody has seen go red are four lines that might be
+// checking nothing.
+//
+// So the identities are a function over a Result, and the negative cases are Results built by hand
+// with one field deliberately wrong. No simulator is corrupted, no other package is touched, and
+// the check is proven in both directions: TestTheCostIdentitiesHoldOnARealReplay says real replays
+// satisfy them, TestEachCostIdentityFires says the function notices when they do not.
+//
+// Two definitions of an identity would be worse than none, so this is offered as the single one:
+// the semantics test's inline assertions can call this and drop their own copies.
+
+// costIdentityFailures returns one message per identity `arm` violates, given the `baseline` it was
+// scored against and the Savings that compared them. Empty means every identity holds.
+//
+// Every identity here is arithmetic that must hold BY CONSTRUCTION — not a measurement, not a
+// property of the traffic. A violation is a bug in the cost model or a field that has changed
+// meaning while keeping its name, which is the one failure class no nominal wire check can see.
+func costIdentityFailures(arm, baseline *kvcache.Result, s kvcache.Savings) []string {
+	var out []string
+	bad := func(what string, got, want float64) {
+		if d := got - want; d > 1e-9 || d < -1e-9 {
+			out = append(out, fmt.Sprintf("%s: %s = %.12f, want %.12f", arm.Strategy, what, got, want))
+		}
+	}
+	// The decomposition IS the total. Five components and nothing else, so a sixth cost that
+	// forgot to join the sum shows up here rather than as a quietly low total.
+	bad("total_usd against the sum of its five parts", arm.TotalUSD,
+		arm.FreshInputUSD+arm.CacheReadUSD+arm.CacheWriteUSD+arm.OutputUSD+arm.PingUSD)
+	// The premium is a DIFFERENCE, and its sign is the whole meaning: negative means the cache paid
+	// for itself. A sign flip here inverts every premium cell on the page.
+	bad("cache_premium_usd", arm.CachePremium, arm.TotalUSD-arm.UncachedUSD)
+	// Savings are baseline − strategy, unclamped, and the baseline's own is exactly zero.
+	bad("absolute_usd", s.AbsoluteUSD, baseline.TotalUSD-arm.TotalUSD)
+	bad("baseline_usd", s.BaselineUSD, baseline.TotalUSD)
+	bad("strategy_usd", s.StrategyUSD, arm.TotalUSD)
+	// Hits and misses partition the requests. Unpriced rows are in the split, so a reader who
+	// assumed hit% + miss% = 100 needs this to be true rather than nearly true.
+	if got, want := arm.Hits+arm.Misses, arm.Requests; got != want {
+		out = append(out, fmt.Sprintf("%s: hits + misses = %d, want %d requests",
+			arm.Strategy, got, want))
+	}
+	// And the two rates are recomputable from those counts. This is the check that catches a
+	// percentage that became a FRACTION — a range assertion cannot, because 0.766 is a legal value
+	// in [0,100], which is the negative result the semantics pass established.
+	if arm.Requests > 0 {
+		bad("hit_rate_pct against its own counts", arm.HitRate,
+			100*float64(arm.Hits)/float64(arm.Hits+arm.Misses))
+		bad("miss_rate_pct against its own counts", arm.MissRate,
+			100*float64(arm.Misses)/float64(arm.Hits+arm.Misses))
+	}
+	return out
+}
+
+// Real replays satisfy every identity. Without this the negative test below could pass over a
+// function that is simply wrong about what the fields mean.
+func TestTheCostIdentitiesHoldOnARealReplay(t *testing.T) {
+	db := seedKV(t, productionShaped()...)
+	sim, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]*kvcache.Result{}
+	for _, r := range sim.Results {
+		byName[r.Strategy] = r
+	}
+	base := byName[sim.Baseline]
+	if base == nil {
+		t.Fatalf("the baseline %q was not among the replayed arms", sim.Baseline)
+	}
+	if len(sim.Savings) == 0 {
+		t.Fatal("no savings were computed; the identities below would be vacuous")
+	}
+	for _, s := range sim.Savings {
+		arm := byName[s.Strategy]
+		if arm == nil {
+			t.Fatalf("a saving for %q with no result", s.Strategy)
+		}
+		for _, f := range costIdentityFailures(arm, base, s) {
+			t.Error(f)
+		}
+	}
+}
+
+// And each identity FIRES when it is broken. One case per identity, each corrupting exactly one
+// field of an otherwise consistent pair, so a check that silently stopped looking cannot pass.
+func TestEachCostIdentityFires(t *testing.T) {
+	// A consistent arm and baseline, built by hand: 100 fresh + 20 read + 300 write + 50 output +
+	// 30 pings = 500, against an uncached equivalent of 900.
+	consistent := func() (*kvcache.Result, *kvcache.Result, kvcache.Savings) {
+		arm := &kvcache.Result{
+			Strategy: "arm", Requests: 10, Hits: 6, Misses: 4, HitRate: 60, MissRate: 40,
+			FreshInputUSD: 100, CacheReadUSD: 20, CacheWriteUSD: 300, OutputUSD: 50, PingUSD: 30,
+			TotalUSD: 500, UncachedUSD: 900, CachePremium: -400,
+		}
+		base := &kvcache.Result{Strategy: "base", TotalUSD: 800}
+		return arm, base, kvcache.Savings{Strategy: "arm", Baseline: "base",
+			BaselineUSD: 800, StrategyUSD: 500, AbsoluteUSD: 300}
+	}
+	if arm, base, s := consistent(); len(costIdentityFailures(arm, base, s)) != 0 {
+		t.Fatalf("the consistent fixture already violates an identity: %v",
+			costIdentityFailures(arm, base, s))
+	}
+
+	for _, tc := range []struct {
+		name    string
+		corrupt func(*kvcache.Result, *kvcache.Result, *kvcache.Savings)
+		want    string
+	}{
+		{"a sixth cost that forgot to join the total",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.TotalUSD = 470 },
+			"total_usd against the sum of its five parts"},
+		{"the premium's sign inverted",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.CachePremium = 400 },
+			"cache_premium_usd"},
+		{"a saving clamped at zero",
+			func(_, _ *kvcache.Result, s *kvcache.Savings) { s.AbsoluteUSD = 0 },
+			"absolute_usd"},
+		{"the baseline total drifting from the baseline arm",
+			func(_, b *kvcache.Result, _ *kvcache.Savings) { b.TotalUSD = 810 },
+			"baseline_usd"},
+		{"the strategy total drifting from the arm",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.TotalUSD = 500.5 },
+			"strategy_usd"},
+		{"a request in neither the hits nor the misses",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.Requests = 11 },
+			"hits + misses"},
+		// The one a range assertion cannot see: 0.6 is a perfectly legal value in [0,100].
+		{"a hit rate expressed as a fraction rather than a share",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.HitRate = 0.6 },
+			"hit_rate_pct against its own counts"},
+		{"a miss rate expressed as a fraction",
+			func(a, _ *kvcache.Result, _ *kvcache.Savings) { a.MissRate = 0.4 },
+			"miss_rate_pct against its own counts"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			arm, base, s := consistent()
+			tc.corrupt(arm, base, &s)
+			got := costIdentityFailures(arm, base, s)
+			if len(got) == 0 {
+				t.Fatalf("the identity did not fire; %s is unguarded", tc.want)
+			}
+			var found bool
+			for _, g := range got {
+				if strings.Contains(g, tc.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("fired, but not on %q: %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/dash/kvcachesemantics_test.go
+++ b/dash/kvcachesemantics_test.go
@@ -1,0 +1,250 @@
+package dash
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The one class of wire break that NOMINAL checks cannot see: a key that keeps its name and
+// changes its MEANING.
+//
+// Three separate guards now protect the contract between this package's payloads and the page
+// that reads them, and all three are nominal — the receiver-scoped read check in
+// uikvcache_test.go catches a key that vanished from the payloads, kvcache's own golden set
+// catches one that moved between shapes or gained an omitempty, and the JSON-serialization test
+// catches a shape that stopped being emitted. None of them would notice `hit_rate_pct` becoming
+// a fraction, or `total_usd` becoming a premium. The field is still there, still spelled the
+// same, and every consumer silently renders it wrong: 0.766 formatted as "0.8%", or a cost
+// comparison whose winner inverts.
+//
+// This file is pointed at the meanings instead. Every assertion is an INVARIANT the value must
+// satisfy whatever it is called, checked over a production-shaped replay, so a unit change or a
+// redefinition fails here rather than reaching a reader.
+//
+// It is a new file rather than an addition to kvcacheshape_test.go deliberately: that one asserts
+// the SHAPE of a distribution (are the reuse probabilities plausible, is the ceiling really a
+// ceiling), which catches some of this class by accident. Accidental coverage is worth having and
+// is not a guard. These are by design.
+
+// Every field whose name ends in `_pct` is a SHARE, and a share is in [0,100].
+//
+// WHAT THIS ALONE CANNOT CATCH, measured rather than assumed: a share expressed as a FRACTION.
+// 0.766 is inside [0,100], so dropping the ×100 from a hit rate passes this check untouched — I
+// verified that by dropping it, and this test stayed green. Only recomputing a percentage from its
+// own numerator and denominator catches it, which is what
+// TestEveryRateIsRecomputableFromItsOwnCounts below does, and which is why KVCacheGroup carries
+// `hits` at all. The range check earns its place on the fields where no count exists to
+// recompute from; it is not the whole guard.
+//
+// Walked by reflection over the real payload values rather than a hand-listed set of fields, so a
+// new percentage is covered the day it lands and cannot be forgotten. The naming convention is
+// load-bearing and is the reason a signed comparison is called `percent_usd` and not
+// `percent_usd_pct`: that one is a difference against a baseline, legitimately negative and
+// legitimately past 100, and it must not be filed under the same rule.
+func TestEveryPercentageFieldIsAShareAndNotAFraction(t *testing.T) {
+	db := seedKV(t, productionShaped()...)
+	an, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sim, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := db.KVCacheRows(allTenants(), KVCacheOptions{Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checked int
+	for _, root := range []any{an, sim, page} {
+		walkPercentages(t, reflect.ValueOf(root), "", &checked)
+	}
+	// A positive assertion that the walk found something: a reflection check that silently
+	// traversed nothing is the failure mode that makes this whole file worthless.
+	if checked < 12 {
+		t.Errorf("only %d percentage fields were checked; the payloads carry more than that, so "+
+			"the walk is not reaching them", checked)
+	}
+	t.Logf("checked %d percentage fields", checked)
+}
+
+// walkPercentages descends a payload and asserts the range of every `_pct` float it finds.
+func walkPercentages(t *testing.T, v reflect.Value, path string, n *int) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if !v.IsNil() {
+			walkPercentages(t, v.Elem(), path, n)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			walkPercentages(t, v.Index(i), path+"[]", n)
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			walkPercentages(t, v.MapIndex(k), path+"."+k.String(), n)
+		}
+	case reflect.Struct:
+		typ := v.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if f.PkgPath != "" {
+				continue
+			}
+			name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+			if name == "" || name == "-" {
+				name = f.Name
+			}
+			child := path + "." + name
+			if v.Field(i).Kind() == reflect.Float64 && strings.HasSuffix(name, "_pct") {
+				*n++
+				got := v.Field(i).Float()
+				if got < 0 || got > 100 {
+					t.Errorf("%s = %v, which is not a share. A percentage field outside [0,100] "+
+						"is either a fraction wearing a percentage's name — every consumer then "+
+						"renders 0.77 as \"0.8%%\" — or a signed comparison that belongs under a "+
+						"different name.", strings.TrimPrefix(child, "."), got)
+				}
+				continue
+			}
+			walkPercentages(t, v.Field(i), child, n)
+		}
+	}
+}
+
+// Every rate is recomputable from the counts beside it, which is the only thing that catches a
+// share silently expressed as a fraction.
+//
+// The range check above is blind to it — 0.766 is a legal value in [0,100] — so this is where a
+// missing ×100 fails. It is also where a swapped denominator fails: an observed group's hit rate is
+// over its OWN requests, and a rate computed against some wider total would read plausibly and be
+// wrong everywhere.
+func TestEveryRateIsRecomputableFromItsOwnCounts(t *testing.T) {
+	db := seedKV(t, productionShaped()...)
+	an, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	near2(t, "cards hit_rate_pct against its own counts", an.Cards.HitRatePct,
+		100*float64(an.Cards.Hits)/float64(an.Cards.Requests))
+	groups := map[string][]KVCacheGroup{"by_ttl": an.ByTTL, "by_bucket": an.ByBucket,
+		"by_user": an.ByUser, "by_model": an.ByModel}
+	var checked int
+	for name, rows := range groups {
+		for _, g := range rows {
+			if g.Requests == 0 {
+				continue
+			}
+			checked++
+			near2(t, name+"["+g.Key+"] hit_rate_pct against its own counts", g.HitRatePct,
+				100*float64(g.Hits)/float64(g.Requests))
+			if g.Hits > g.Requests {
+				t.Errorf("%s[%s]: %d hits out of %d requests", name, g.Key, g.Hits, g.Requests)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no group carried any requests, so nothing here was checked")
+	}
+	// The groups' hits sum to the whole dataset's, for the groupings that partition it.
+	for _, name := range []string{"by_ttl", "by_bucket", "by_user", "by_model"} {
+		var sum int64
+		for _, g := range groups[name] {
+			sum += g.Hits
+		}
+		if sum != an.Cards.Hits {
+			t.Errorf("%s holds %d hits, the dataset has %d", name, sum, an.Cards.Hits)
+		}
+	}
+}
+
+// The COST identities — total_usd against its five parts, the premium, and the three savings
+// fields — are asserted in kvcacheidentity_test.go, as costIdentityFailures(), and deliberately
+// not restated here.
+//
+// Two definitions of an identity are worse than none: they drift, and then a reader has two green
+// lines and no way to tell which one describes the arithmetic. That file states them once, proves
+// each one FIRES against a hand-built Result with exactly one field wrong, and checks them over a
+// real replay so the negative cases cannot pass over a function that is simply wrong about what
+// the fields mean.
+//
+// What stays in this file is the half that file does not reach: the OBSERVED dataset. Its
+// identities are per-arm over kvcache.Result, and KVCacheCards and KVCacheGroup are a different
+// measurement — what happened, rather than what a strategy would have cost.
+
+// The reuse percentages are recomputable from their own numerator and denominator, and the two
+// horizons NEST.
+//
+// Two meanings that could drift without the name changing: the denominator becoming Requests
+// rather than WithNext — which silently folds every conversation's last request in as a
+// zero-second return, the exact lie this page is built to avoid — and the horizons ceasing to
+// nest, which would mean one of them is no longer measuring "arrived within".
+func TestTheReuseSharesAreRecomputableAndTheHorizonsNest(t *testing.T) {
+	db := seedKV(t, productionShaped()...)
+	an, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := an.Cards
+	if c.WithNext == 0 {
+		t.Fatal("the fixture produced no gaps, so nothing here is being checked")
+	}
+	near2(t, "within_5m_pct against its own counts", c.Within5mPct,
+		100*float64(c.Within5m)/float64(c.WithNext))
+	near2(t, "within_1h_pct against its own counts", c.Within1hPct,
+		100*float64(c.Within1h)/float64(c.WithNext))
+	// The denominator is WithNext and NOT Requests. Stated as its own assertion because the
+	// difference is invisible in the value alone on a corpus with few final requests, and this
+	// corpus has many.
+	if c.FinalRequests == 0 {
+		t.Fatal("the fixture has no final requests, so it cannot tell the two denominators apart")
+	}
+	if wrong := 100 * float64(c.Within5m) / float64(c.Requests); sameFloat(c.Within5mPct, wrong) {
+		t.Errorf("within_5m_pct (%.4f) is indistinguishable from the same count over REQUESTS "+
+			"(%.4f); the denominator must be the requests that have a successor", c.Within5mPct,
+			wrong)
+	}
+	for _, g := range append(append([]KVCacheGroup{}, an.ByTTL...), an.ByModel...) {
+		if g.WithNext == 0 {
+			continue
+		}
+		if g.Within1hPct < g.Within5mPct {
+			t.Errorf("%s: within_1h_pct %.2f < within_5m_pct %.2f; an hour contains five minutes, "+
+				"so the shares must nest", g.Key, g.Within1hPct, g.Within5mPct)
+		}
+	}
+	// The survival curve is a CDF: non-decreasing, and its last rung is the widest.
+	var prev float64
+	for _, p := range an.Survival {
+		if p.ArrivedPct < prev {
+			t.Errorf("the survival curve falls at %s: %.2f%% after %.2f%%. A cumulative share "+
+				"cannot decrease.", p.Label, p.ArrivedPct, prev)
+		}
+		prev = p.ArrivedPct
+		if p.N > 0 && !sameFloat(p.ArrivedPct, 100*float64(p.Arrived)/float64(p.N)) {
+			t.Errorf("survival at %s: arrived_pct %.4f does not match %d of %d", p.Label,
+				p.ArrivedPct, p.Arrived, p.N)
+		}
+	}
+	// And it agrees with the cards at the two horizons, which is the cross-panel check: two views
+	// of one measurement that disagree is the defect this dashboard has shipped before.
+	at := map[float64]SurvivalPoint{}
+	for _, p := range an.Survival {
+		at[p.Seconds] = p
+	}
+	near2(t, "the survival curve at five minutes against the summary card",
+		at[kvcache.Horizon5m.Seconds()].ArrivedPct, c.Within5mPct)
+	near2(t, "the survival curve at one hour against the summary card",
+		at[kvcache.Horizon1h.Seconds()].ArrivedPct, c.Within1hPct)
+}
+
+// sameFloat is the tolerance the recomputation checks above use. Named apart from meta_test.go's
+// own `near`, which this package already owns for a different comparison.
+func sameFloat(a, b float64) bool { return a-b < 1e-9 && b-a < 1e-9 }

--- a/dash/kvcacheshape_test.go
+++ b/dash/kvcacheshape_test.go
@@ -1,0 +1,233 @@
+package dash
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// One test over a dataset shaped like the real one.
+//
+// Every other test in this package pins a specific behaviour on three or four rows. This one asks
+// a different question: on traffic that LOOKS like production, are the figures the page puts on
+// screen the right shape? It is the check that catches a page which is correct in every unit and
+// nonsense in aggregate — a reuse probability of 4%, a median idle of half an hour, a ceiling
+// that costs more than a real arm.
+//
+// The shape is taken from the live service's own snapshot (14,407 requests, 1,772 conversations,
+// 2026-08-17 → 08-19 UTC), scaled down by ten so the suite stays quick:
+//
+//	1,772 conversations, of which 1,551 hold a single request
+//	12,635 within-conversation gaps: p50 14.9 s, p90 106 s, 95.27% ≤ 5 min, 99.26% ≤ 1 h
+//	median billed prefix (cache_read + cache_write) 124,845 tokens
+//
+// Nothing here asserts a figure copied from that snapshot. What is asserted is the RELATIONSHIPS
+// that have to hold on any such distribution, which is what makes it a test rather than a golden
+// file: a corpus where almost every conversation returns inside five minutes must report a high
+// five-minute reuse probability, the one-hour tier must lose money on it, and the exact ceiling
+// can never be beaten by a policy that cannot see the future.
+func TestThePageIsTheRightShapeOnProductionLikeTraffic(t *testing.T) {
+	db := seedKV(t, productionShaped()...)
+
+	out, err := db.KVCacheAnalyze(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := out.Cards
+	t.Logf("requests=%d conversations=%d with_next=%d final=%d median_idle=%.0fms p90=%.0fms "+
+		"reuse5m=%.2f%% reuse1h=%.2f%% hit=%.1f%% prefix_p50=%d cost=$%.2f",
+		c.Requests, c.Conversations, c.WithNext, c.FinalRequests, c.MedianIdleMs, c.P90IdleMs,
+		c.Within5mPct, c.Within1hPct, c.HitRatePct, c.CachedContextP50, c.CostUSD)
+
+	// Every conversation contributes exactly one final request, and the idle denominator is
+	// everything else. This is the invariant the whole page's honesty rests on.
+	if c.FinalRequests != c.Conversations {
+		t.Errorf("final requests %d != conversations %d; a conversation has exactly one last "+
+			"request in a window", c.FinalRequests, c.Conversations)
+	}
+	if c.WithNext+c.FinalRequests != c.Requests {
+		t.Errorf("with_next %d + final %d != requests %d", c.WithNext, c.FinalRequests, c.Requests)
+	}
+	// A corpus where almost everything returns in seconds must SAY so. A page reporting a low
+	// five-minute reuse probability on this traffic is a page whose derivation is broken.
+	if c.Within5mPct < 85 || c.Within5mPct > 99.5 {
+		t.Errorf("five-minute reuse = %.2f%%; production-shaped traffic returns inside five "+
+			"minutes almost always, and this figure decides every TTL on the page", c.Within5mPct)
+	}
+	if c.Within1hPct < c.Within5mPct {
+		t.Errorf("one-hour reuse %.2f%% is below five-minute reuse %.2f%%; the horizons nest",
+			c.Within1hPct, c.Within5mPct)
+	}
+	if c.MedianIdleMs <= 0 || c.MedianIdleMs > 120_000 {
+		t.Errorf("median idle = %.0f ms; the shape has a p50 of about 15 s", c.MedianIdleMs)
+	}
+	if c.P90IdleMs < c.MedianIdleMs {
+		t.Error("p90 idle is below the median")
+	}
+	// The single-request conversations are the majority and the page must say so, or it looks
+	// like it discarded most of the traffic.
+	if out.Coverage.SingleRequestConversations == 0 {
+		t.Error("no single-request conversations were counted on a corpus built to be full of them")
+	}
+
+	// The histogram and the survival curve are two views of the SAME gaps and must agree at the
+	// two horizons. Two panels on one page disagreeing about a percentage is the defect this
+	// dashboard has shipped before.
+	var inHistogram int64
+	for _, b := range out.IdleBands {
+		inHistogram += b.N
+	}
+	if inHistogram != c.WithNext {
+		t.Errorf("the histogram holds %d gaps and the cards count %d", inHistogram, c.WithNext)
+	}
+	at := map[float64]SurvivalPoint{}
+	for _, p := range out.Survival {
+		at[p.Seconds] = p
+	}
+	for _, tc := range []struct {
+		sec  float64
+		want float64
+	}{{kvcache.Horizon5m.Seconds(), c.Within5mPct}, {kvcache.Horizon1h.Seconds(), c.Within1hPct}} {
+		got := at[tc.sec].ArrivedPct
+		if diff := got - tc.want; diff > 0.001 || diff < -0.001 {
+			t.Errorf("at %.0f s the survival curve says %.4f%% and the summary card says %.4f%%",
+				tc.sec, got, tc.want)
+		}
+		if at[tc.sec].N != c.WithNext {
+			t.Errorf("the survival denominator at %.0f s is %d, the cards' is %d", tc.sec,
+				at[tc.sec].N, c.WithNext)
+		}
+	}
+	// The grouped views partition the dataset.
+	for _, g := range []struct {
+		name   string
+		groups []KVCacheGroup
+	}{{"by_ttl", out.ByTTL}, {"by_bucket", out.ByBucket}, {"by_user", out.ByUser},
+		{"by_model", out.ByModel}} {
+		var n int64
+		for _, row := range g.groups {
+			n += row.Requests
+		}
+		if n != c.Requests {
+			t.Errorf("%s holds %d requests, the dataset has %d — a grouped view that does not "+
+				"partition drops rows from the page silently", g.name, n, c.Requests)
+		}
+	}
+
+	// Now the comparison, over every default arm.
+	sim, err := db.KVCacheSimulate(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cost := map[string]float64{}
+	for _, r := range sim.Results {
+		cost[r.Strategy] = r.TotalUSD
+		t.Logf("%-24s $%9.2f  hit %5.1f%%  writes 5m/1h %5d/%-5d pings %5d  premium $%8.2f",
+			r.Strategy, r.TotalUSD, r.HitRate, r.Writes5m, r.Writes1h, r.Pings,
+			r.CachePremium)
+	}
+	for _, s := range sim.Savings {
+		t.Logf("%-24s vs %s: $%9.2f (%.2f%%)", s.Strategy, s.Baseline, s.AbsoluteUSD, s.PercentUSD)
+	}
+
+	// The ceiling is a ceiling. It reads the true next-request time, so nothing that cannot may
+	// beat it — and if anything does, either the DP or the replay is wrong and every savings
+	// figure on the page is suspect.
+	ceil, ok := cost[KVStrategyOptimal]
+	if !ok {
+		t.Fatal("the exact ceiling was not among the default arms")
+	}
+	for name, v := range cost {
+		if name == KVStrategyOptimal {
+			continue
+		}
+		if v < ceil-1e-9 {
+			t.Errorf("%s costs $%.6f, BELOW the exact ceiling's $%.6f. A policy that cannot see "+
+				"the future has beaten the cheapest plan that exists, so one of the two is wrong",
+				name, v, ceil)
+		}
+	}
+	// Caching pays for itself on this traffic: not caching a ~125k prefix that returns in seconds
+	// is the most expensive thing anybody could do.
+	if cost[KVStrategyNoCache] <= cost[KVStrategyFixed5m] {
+		t.Errorf("no-cache ($%.2f) is not dearer than a 5-minute tier ($%.2f) on traffic that "+
+			"returns in seconds", cost[KVStrategyNoCache], cost[KVStrategyFixed5m])
+	}
+	// And the one-hour tier LOSES on it, which is the finding the page exists to make visible:
+	// it pays 2.0x input to protect prompts a 1.25x write already covered.
+	if cost[KVStrategyFixed1h] <= cost[KVStrategyFixed5m] {
+		t.Errorf("the 1h tier ($%.2f) is not dearer than the 5m tier ($%.2f) on short gaps; that "+
+			"is the whole reason hit rate is not the objective",
+			cost[KVStrategyFixed1h], cost[KVStrategyFixed5m])
+	}
+	// Every savings figure is exactly baseline − strategy, unclamped, and the baseline's own is
+	// zero rather than omitted.
+	base := cost[sim.Baseline]
+	for _, s := range sim.Savings {
+		if diff := s.AbsoluteUSD - (base - cost[s.Strategy]); diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("%s: saving $%.9f != baseline $%.9f − strategy $%.9f", s.Strategy,
+				s.AbsoluteUSD, base, cost[s.Strategy])
+		}
+	}
+}
+
+// productionShaped builds a dataset with the live snapshot's own shape, deterministically.
+//
+// A fixed seed, so the same suite run twice produces the same figures: a shape test whose numbers
+// move between runs is one nobody can act on, and this one logs its figures.
+func productionShaped() []*Event {
+	rng := rand.New(rand.NewSource(20260817))
+	models := []string{"aws/claude-opus-5", "aws/claude-sonnet-5", "claude-opus-4-8"}
+	users := []string{"tenant-a", "tenant-b", "tenant-c"}
+	var out []*Event
+	ts := kvBase
+	for c := 0; c < 177; c++ {
+		user := users[c%len(users)]
+		model := models[c%len(models)]
+		session := fmt.Sprintf("sess-%c-%d", rune('a'+c%26), c)
+		// 155 of 177 conversations hold a single request, as 1,551 of 1,772 do on the snapshot.
+		turns := 1
+		if c%8 == 0 {
+			turns = 8 + rng.Intn(50)
+		}
+		// Conversations start spread across the window, so the hour-of-day bands and the
+		// time-of-day grouping have something in every one of them.
+		ts += int64(rng.Intn(900_000))
+		at := kvBase + int64(c)*int64(time.Hour/time.Millisecond)/6
+		for i := 0; i < turns; i++ {
+			// The prefix: around the snapshot's 124,845-token median.
+			prefix := int64(90_000 + rng.Intn(70_000))
+			read, write := prefix, int64(0)
+			e := kvEvent(user, session, model, at, read, write)
+			if i == 0 {
+				// A conversation's first request creates the entry rather than reading one.
+				e.CacheRead, e.CacheWrite = 0, prefix
+				e.CacheMissReason = CacheColdStart
+			}
+			// A tenth of the corpus recorded no tier at all, as a pre-column snapshot does, so the
+			// coverage panel and the observed-policy arm have something to report.
+			if c%10 == 0 {
+				e.CacheTTL = ""
+			}
+			e.UpstreamMs = float64(8_000 + rng.Intn(30_000))
+			out = append(out, e)
+			// The gap: 95% of them inside five minutes and a median around 15 s, with a tail.
+			switch n := rng.Intn(100); {
+			case n < 80:
+				at += int64(3_000 + rng.Intn(40_000)) // seconds to under a minute
+			case n < 95:
+				at += int64(60_000 + rng.Intn(240_000)) // one to five minutes
+			case n < 99:
+				at += int64(300_001 + rng.Intn(3_300_000)) // five minutes to an hour
+			default:
+				at += int64(3_600_001 + rng.Intn(20_000_000)) // past an hour
+			}
+		}
+	}
+	return out
+}

--- a/dash/kvcachesim.go
+++ b/dash/kvcachesim.go
@@ -1,0 +1,516 @@
+package dash
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The KV-cache page's simulation half: turn the page's inputs into strategies, replay the
+// window under each of them, and score them against one baseline.
+//
+// Nothing here decides anything. Every policy, every price and every cache semantic is in
+// package kvcache; this file resolves NAMES to those objects and reports what came back. That
+// separation is what lets a future learned predictor appear on this page without either the
+// simulator or the dashboard changing: it implements kvcache.Predictor, gets a name in
+// kvCacheStrategies, and everything downstream is unchanged.
+
+// KVCacheCustom is the configurable arm's inputs, as the page sends them.
+type KVCacheCustom struct {
+	// P5m and P1h are the reuse-probability thresholds, as fractions.
+	P5m float64 `json:"p_5m"`
+	P1h float64 `json:"p_1h"`
+	// MinPrefix is the prefix below which nothing is cached at all, in tokens.
+	MinPrefix int64 `json:"min_prefix"`
+	// AlwaysPing forces the long hold onto the keep-alive path rather than the cheaper of the
+	// two, for an operator measuring the ping path specifically.
+	AlwaysPing bool `json:"always_ping"`
+}
+
+// KVCacheSimConfig is everything the page can change about a simulation.
+type KVCacheSimConfig struct {
+	// Multipliers and Overrides are the pricing experiment: the multiples used to fill in a
+	// rate the price list does not state, and per-model rates typed in the page.
+	Multipliers kvcache.Multipliers
+	Overrides   map[string]kvcache.Override
+	// Semantics is the provider cache behaviour.
+	Semantics kvcache.Semantics
+	// The keep-alive schedule.
+	PingIdle   time.Duration
+	PingIdle1h time.Duration
+	MaxPings   int
+	// Strategies names the arms to run, and Baseline the one the others are scored against.
+	Strategies []string
+	Baseline   string
+	// Custom is the configurable arm's parameters.
+	Custom KVCacheCustom
+	// Predictor, when non-nil, is wired into the custom arm. There is no way to set this from
+	// an HTTP request and that is deliberate: a predictor is code, not a query parameter. It
+	// is here so an in-process caller — the proxy, a benchmark harness, a test — can score a
+	// learned model against exactly the same baseline the page shows.
+	Predictor kvcache.Predictor
+}
+
+// The strategy names the page may ask for.
+//
+// Every one of them is kvcache's own constant rather than a second spelling of it. The name
+// arrives from a query string and is resolved through kvcache.NewStrategy, so a typo selects
+// nothing rather than something — and there is exactly one list of arms in the process, which
+// is the point: dash used to carry a closed six-name list of its own, and the four arms the
+// domain had gained since (the two keep-alive arms, the extend-to-1h arm and the exact ceiling)
+// were unreachable from the dashboard while looking perfectly present in the code.
+const (
+	KVStrategyNoCache     = kvcache.StrategyNoCache
+	KVStrategyFixed5m     = kvcache.StrategyFixed5m
+	KVStrategyFixed1h     = kvcache.StrategyFixed1h
+	KVStrategyKeepAlive5m = kvcache.StrategyKeepAlive5m
+	KVStrategyKeepAlive1h = kvcache.StrategyKeepAlive1h
+	KVStrategyExtend1h    = kvcache.StrategyExtend1h
+	KVStrategyObserved    = kvcache.StrategyObserved
+	KVStrategyHistorical  = kvcache.StrategyHistorical
+	KVStrategyOptimal     = kvcache.StrategyOptimal
+	// KVStrategyCustom is the one arm that is NOT in kvcache's registry, because it cannot be
+	// built from a name: it carries the page's own thresholds and the in-process Predictor
+	// seam. It is offered beside the registry's arms and scored identically.
+	KVStrategyCustom = "custom"
+)
+
+// KVCacheArm is one selectable arm as the page presents it: the domain's own spec, plus whether
+// this API can actually construct it.
+//
+// Selectable is a real distinction rather than a filter. `replay` is a registry arm whose whole
+// input is an action list supplied in-process, so no query string can ask for it — and dropping
+// it from the payload would leave the page unable to explain why an arm the docs mention is not
+// on the picker. It is listed, marked, and not offered as a checkbox.
+type KVCacheArm struct {
+	kvcache.StrategySpec
+	Selectable bool `json:"selectable"`
+}
+
+// KVCacheArms is every arm the page may show, in the domain's presentation order, with the
+// dash-only custom arm last.
+//
+// The order is kvcache.Registry()'s and is deliberately not re-sorted here: it runs
+// cheapest-to-reason-about first, so a reader meets the baseline before the policies scored
+// against it. Sorting by cost or by hit rate would be the page choosing a winner.
+func KVCacheArms() []KVCacheArm {
+	out := []KVCacheArm{}
+	for _, spec := range kvcache.Registry() {
+		// Probed rather than hardcoded: an arm the domain adds becomes selectable here on the
+		// day it lands, and one that needs an in-process input is marked without this file
+		// having to know which one that is. NeedsDataset arms are constructed with the real
+		// rows at simulate time, so an empty probe set is enough to tell "needs data" from
+		// "cannot be built from a name at all".
+		_, err := kvcache.NewStrategy(spec.Name, nil, kvcache.Config{})
+		out = append(out, KVCacheArm{StrategySpec: spec,
+			Selectable: err == nil || spec.NeedsDataset && !isUnbuildable(spec.Name)})
+	}
+	return append(out, KVCacheArm{Selectable: true, StrategySpec: kvcache.StrategySpec{
+		Name: KVStrategyCustom,
+		Description: "Configured thresholds over your own closed gaps, or an in-process " +
+			"predictor. The seam a learned next-use model plugs into without changing this page.",
+	}})
+}
+
+// isUnbuildable names the arms no HTTP request can construct, whatever their spec says.
+//
+// One name, and it is a name rather than a probe because the probe cannot tell it apart from an
+// arm that merely needs rows: `replay` is scored from an action list decided elsewhere, which is
+// the seam an offline model's answers arrive through.
+func isUnbuildable(name string) bool { return name == kvcache.StrategyReplay }
+
+// KVCacheDefaultStrategies is what the page runs when the caller names none.
+//
+// Seven arms, and each earns its place: the two bounds (no-cache below, optimal above), the two
+// fixed tiers, the cheapest keep-alive arm, the policy already in force, and the one arm that
+// learns from the account's own history. `optimal` is in the DEFAULT set on purpose — it is the
+// only figure that says how much headroom exists at all, and an arm nobody sees by default is
+// one nobody compares against — and it is marked Unreachable so no surface can present it as a
+// result.
+var KVCacheDefaultStrategies = []string{KVStrategyNoCache, KVStrategyFixed5m, KVStrategyFixed1h,
+	KVStrategyKeepAlive5m, KVStrategyObserved, KVStrategyHistorical, KVStrategyOptimal}
+
+// kvCacheDefaultBaseline is the arm every saving is measured against when the caller names none,
+// and it comes from the REGISTRY rather than from a constant here.
+//
+// It matters more than a default usually does. Measured on the production corpus, prompt caching
+// is already saving 53%, so scoring against `no-cache` reports an enormous saving that no
+// decision can act on — the cache is not going to be switched off. The honest denominator is the
+// cheapest thing already in force, which is what the registry's Baseline flag names. A second
+// answer here would be a second definition of the one number every percentage is divided by.
+func kvCacheDefaultBaseline() string {
+	for _, s := range kvcache.Registry() {
+		if s.Baseline {
+			return s.Name
+		}
+	}
+	return KVStrategyFixed5m
+}
+
+// buildStrategy resolves one name against the dataset and the configuration.
+//
+// Every registry arm goes through kvcache.NewStrategy, so this file holds no policy of its own.
+// The custom arm is the exception and the reason is structural: it carries inputs that only exist
+// on this page, and the Predictor an in-process caller supplies.
+//
+// `sim` is THE SAME kvcache.Config the replay will run with, passed through rather than rebuilt.
+// That is not tidiness. An arm that decides by comparing costs needs the PRICE LIST at
+// construction time, and a locally rebuilt Config that omitted it made every action cost zero:
+// the exact ceiling then chose "let it expire" for every request and reported the same total as
+// the no-cache arm — 2.1x the cheapest real policy, presented as the cheapest plan that exists.
+// TestThePageIsTheRightShapeOnProductionLikeTraffic is what caught it, by asserting that nothing
+// which cannot see the future may cost less than the arm that can.
+func buildStrategy(name string, rows []*kvcache.Request, cfg KVCacheSimConfig,
+	sim kvcache.Config) kvcache.Strategy {
+	if name == KVStrategyCustom {
+		return kvcache.Custom{Label: KVStrategyCustom, Predictor: cfg.Predictor,
+			P5m: cfg.Custom.P5m, P1h: cfg.Custom.P1h, MinPrefix: cfg.Custom.MinPrefix,
+			Semantics: cfg.Semantics, PingIdle: cfg.PingIdle, MaxPings: cfg.MaxPings,
+			AlwaysPing: cfg.Custom.AlwaysPing}
+	}
+	if isUnbuildable(name) {
+		return nil
+	}
+	s, err := kvcache.NewStrategy(name, rows, sim)
+	if err != nil {
+		return nil
+	}
+	return s
+}
+
+// KVCacheSimulation is the whole /api/kvcache/simulate payload.
+type KVCacheSimulation struct {
+	// Baseline is the arm every saving below is measured against, by name.
+	Baseline string `json:"baseline"`
+	// Results is one entry per arm, in kvCacheStrategyOrder.
+	Results []*kvcache.Result `json:"results"`
+	// Savings is one entry per arm INCLUDING the baseline (whose own saving is exactly zero,
+	// shown rather than omitted so the table has a row for every arm).
+	Savings []kvcache.Savings `json:"savings"`
+
+	Pricing     *kvcache.PriceList `json:"pricing"`
+	Assumptions KVCacheAssumptions `json:"assumptions"`
+	// Arms is every arm that exists, so the page builds its picker from what the server can
+	// actually run instead of from a list of its own. A hardcoded picker is how four shipped
+	// arms stayed invisible for a day.
+	Arms []KVCacheArm `json:"arms"`
+
+	// Unknown names any requested strategy that does not exist, rather than silently running
+	// something else.
+	Unknown []string `json:"unknown,omitempty"`
+
+	Scanned   int64 `json:"scanned"`
+	Total     int64 `json:"total"`
+	Truncated bool  `json:"truncated"`
+	// WindowEnd is the instant an open idle span is bounded at, and it is on the wire because
+	// PingsOnOpenSpans cannot be read without it.
+	WindowEnd int64 `json:"window_end"`
+}
+
+// KVCacheSimulate replays one window under every requested strategy.
+func (d *DB) KVCacheSimulate(f Filter, o KVCacheOptions, p modelinfo.Pricer,
+	cfg KVCacheSimConfig) (*KVCacheSimulation, error) {
+	rows, total, err := d.KVCacheDataset(f, o)
+	if err != nil {
+		return nil, err
+	}
+	out := &KVCacheSimulation{Baseline: cfg.Baseline, Results: []*kvcache.Result{},
+		Savings: []kvcache.Savings{}, Scanned: int64(len(rows)), Total: total,
+		Truncated: int64(len(rows)) < total, Assumptions: kvCacheAssumptions(cfg),
+		Arms: KVCacheArms()}
+	out.Pricing = kvcache.NewPriceList(context.Background(), modelsOf(rows), p,
+		cfg.Multipliers, cfg.Overrides)
+
+	// The window's own end, used to bound an OPEN idle span. The filter's `until` where it has
+	// one, otherwise the last request in the dataset — never time.Now(), which would make the
+	// same historical window produce a different answer every time it was replayed.
+	windowEnd := f.Until
+	if windowEnd <= 0 {
+		for _, r := range rows {
+			if r.TS > windowEnd {
+				windowEnd = r.TS
+			}
+		}
+	}
+	out.WindowEnd = windowEnd
+
+	sim := kvcache.Config{Prices: out.Pricing, Semantics: cfg.Semantics,
+		PingIdle: cfg.PingIdle, PingIdle1h: cfg.PingIdle1h, MaxPings: cfg.MaxPings,
+		WindowEnd: windowEnd}
+
+	names := cfg.Strategies
+	if len(names) == 0 {
+		names = KVCacheDefaultStrategies
+	}
+	names = orderStrategies(names)
+	byName := map[string]*kvcache.Result{}
+	for _, name := range names {
+		s := buildStrategy(name, rows, cfg, sim)
+		if s == nil {
+			out.Unknown = append(out.Unknown, name)
+			continue
+		}
+		r := kvcache.Simulate(rows, s, sim)
+		out.Results = append(out.Results, r)
+		byName[r.Strategy] = r
+	}
+	// The baseline. A named one that was not run is an error the caller must see, not a
+	// silent substitution — every percentage on the page is divided by this arm's total.
+	baseName := cfg.Baseline
+	if baseName == "" {
+		baseName = kvCacheDefaultBaseline()
+	}
+	baseline := byName[baseName]
+	if baseline == nil {
+		// The baseline must be replayed even when it was not asked for, or the savings column
+		// has no denominator. Adding it to the results as well would change the arms on
+		// screen, so it is computed and used but not listed.
+		s := buildStrategy(baseName, rows, cfg, sim)
+		if s == nil {
+			return nil, fmt.Errorf("dash: unknown baseline strategy %q", cfg.Baseline)
+		}
+		baseline = kvcache.Simulate(rows, s, sim)
+	}
+	out.Baseline = baseline.Strategy
+	for _, r := range out.Results {
+		out.Savings = append(out.Savings, kvcache.Compare(baseline, r))
+	}
+	return out, nil
+}
+
+// orderStrategies puts the requested arms in the registry's presentation order and drops
+// duplicates. An unrecognised name is KEPT, at the end, so KVCacheSimulate can report it rather
+// than silently running something else.
+func orderStrategies(names []string) []string {
+	want := map[string]bool{}
+	for _, n := range names {
+		want[n] = true
+	}
+	out := make([]string, 0, len(want))
+	for _, a := range KVCacheArms() {
+		if want[a.Name] {
+			out = append(out, a.Name)
+			delete(want, a.Name)
+		}
+	}
+	rest := make([]string, 0, len(want))
+	for n := range want {
+		rest = append(rest, n)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+// kvCacheAssumptions is the server's own statement of what every figure on the page rests on.
+//
+// It is DATA rather than prose in the UI for one reason: a formula typed into a JavaScript
+// template is a second definition of the arithmetic, and nothing tests it against the first.
+// These strings are checked against the functions that implement them — see
+// TestTheDocumentedFormulasMatchTheCode.
+func kvCacheAssumptions(cfg KVCacheSimConfig) KVCacheAssumptions {
+	sem := cfg.Semantics
+	if sem == (kvcache.Semantics{}) {
+		sem = kvcache.DefaultSemantics()
+	}
+	idle, idle1h, k := cfg.PingIdle, cfg.PingIdle1h, cfg.MaxPings
+	if idle <= 0 {
+		idle = kvcache.DefaultPingIdle
+	}
+	if idle1h <= 0 {
+		idle1h = kvcache.DefaultPingIdle1h
+	}
+	if k <= 0 {
+		k = kvcache.DefaultMaxPings
+	}
+	a := KVCacheAssumptions{
+		TimeZone:         "UTC",
+		TimeUnit:         "milliseconds",
+		Horizon5mSeconds: kvcache.Horizon5m.Seconds(),
+		Horizon1hSeconds: kvcache.Horizon1h.Seconds(),
+		Multipliers:      cfg.Multipliers.WithDefaults(),
+		Semantics:        sem,
+		Schedule: KVCacheSchedule{IdleSeconds: idle.Seconds(),
+			IdleSeconds1h: idle1h.Seconds(), MaxPings: k},
+	}
+	a.Formulas = []KVCacheFormula{
+		{"Uncached input", "input_tokens × input_rate",
+			"A prompt with no cache_control at all: every token billed once, at the fresh rate."},
+		{"Cache read", "cache_read_tokens × cache_read_rate",
+			"A hit. The read rate defaults to 0.1× input, and a read refreshes the entry's " +
+				"lifetime for no extra charge."},
+		{"Cache write, 5-minute TTL", "written_tokens × write_5m_rate",
+			"Creating an entry that lives five minutes. Defaults to 1.25× input."},
+		{"Cache write, 1-hour TTL", "written_tokens × write_1h_rate",
+			"Creating an entry that lives an hour. Defaults to 2.0× input — no gateway " +
+				"publishes this rate, so it is derived from the multiplier and editable above."},
+		{"Keep-alive ping", "cached_tokens × cache_read_rate + ping_input × input_rate + " +
+			"ping_output × output_rate",
+			"One refresh. It is a cache READ, so a five-minute and a one-hour keep-alive cost " +
+				"the same per ping; what differs is the creation tier that put the entry there " +
+				"and how often a ping is needed."},
+		{"Keep-alive that arrived late", "cached_tokens × write_rate(tier) + ping_input × " +
+			"input_rate + ping_output × output_rate",
+			"A ping that fires after the entry lapsed re-creates it, at 12.5× a read for the " +
+				"5-minute tier and 20× for the 1-hour one. Counted as pings_that_rewrote."},
+		{"Request cost", "uncached_input + cache_read + cache_write + output",
+			"One request's whole bill under a simulated strategy."},
+		{"Total cost", "Σ request_cost + Σ ping_cost", "One strategy's whole bill."},
+		{"Incremental cache premium", "total_cost − uncached_cost",
+			"What the caching machinery itself cost, separate from the bill it sits inside. " +
+				"NEGATIVE means the cache paid for itself."},
+		{"Absolute savings", "baseline_cost − strategy_cost",
+			"Negative where the strategy costs more, and shown that way — never clamped to zero."},
+		{"Percentage savings", "absolute_savings ÷ baseline_cost × 100",
+			"Undefined, not 0%, when the baseline is zero."},
+	}
+	a.Notes = []string{
+		"Every timestamp, hour and time-of-day band on this page is UTC. The store carries no " +
+			"per-user timezone, so a local one would be invented.",
+		"A conversation is (account, session, model). The account is in the key because a " +
+			"session id is client-supplied and can collide between accounts; the MODEL is in it " +
+			"because a cache entry does not transfer between models, so a request on one model " +
+			"cannot read another model's entry and the two are not each other's successor.",
+		"A request with no next request in the same conversation has NO idle time. It is " +
+			"counted separately and excluded from every average, never treated as a zero gap.",
+		"Keep-alive ping rows written by context-guru itself are excluded from this dataset: " +
+			"counted, they would split one real idle gap into two short ones.",
+		"A cache miss recorded as prefix_change or cold_start cannot be rescued by any TTL. " +
+			"Those rows force a miss in every simulated arm and are reported as forced_misses.",
+		"Requests whose token accounting was incomplete have an UNKNOWN cost and contribute " +
+			"nothing to any dollar figure. They are counted, never valued at zero.",
+		"The one-hour write rate is derived from a multiplier because no gateway publishes " +
+			"one. Both the multiplier and the resulting rate are editable above.",
+		"A ping cannot generate nothing on a provider that requires max_tokens ≥ 1, so its " +
+			"minimum output is priced and stated rather than rounded away.",
+		"Latency avoided is derived from THIS window's own means: the mean upstream time of " +
+			"requests that really missed, minus that of requests that really hit. It is " +
+			"absent where either population is under 20 rows.",
+	}
+	return a
+}
+
+// ── the pricing panel ──────────────────────────────────────────────────────
+
+// KVCachePriceCost is one model's rates turned into DOLLARS on this window's own median
+// prefix.
+//
+// It exists because a per-token rate is not a number anybody can act on. "$0.0000060 per
+// token at the one-hour tier" and "$0.75 to hold your median 124,845-token prompt for an
+// hour" are the same fact, and only the second one answers the question the reader has. Both
+// are shown: the rate, because it is what they can edit, and the cost, because it is what
+// they are deciding about.
+type KVCachePriceCost struct {
+	Model string `json:"model"`
+	Known bool   `json:"known"`
+	// Uncached is the prefix billed as fresh input — the no-cache alternative to all of it.
+	Uncached float64 `json:"uncached_usd"`
+	// Read is one cache hit on the prefix; Write5m and Write1h are one creation at each tier.
+	Read    float64 `json:"read_usd"`
+	Write5m float64 `json:"write_5m_usd"`
+	Write1h float64 `json:"write_1h_usd"`
+	// KeepAlive is ONE refresh, and Late is one refresh that arrived after the entry lapsed.
+	KeepAlive float64 `json:"keep_alive_usd"`
+	Late5m    float64 `json:"late_5m_usd"`
+	Late1h    float64 `json:"late_1h_usd"`
+	// Hold5m and Hold1h are the whole cost of holding the prefix at each tier through one idle
+	// span: the creation plus MaxPings refreshes. The two numbers a strategy chooses between.
+	Hold5m float64 `json:"hold_5m_usd"`
+	Hold1h float64 `json:"hold_1h_usd"`
+}
+
+// KVCachePriceView is /api/kvcache/pricing: the editable rates, the assumptions, and what
+// those rates come to on this window's own prefix.
+type KVCachePriceView struct {
+	Pricing     *kvcache.PriceList `json:"pricing"`
+	Assumptions KVCacheAssumptions `json:"assumptions"`
+	// Arms is every arm that exists, so the page builds its picker from what the server can
+	// actually run instead of from a list of its own. A hardcoded picker is how four shipped
+	// arms stayed invisible for a day.
+	Arms []KVCacheArm `json:"arms"`
+	// Prefix is the window's own MEDIAN billed prefix, in tokens, and the size every cost
+	// above is computed on. The median rather than the mean: per-request cache cost is
+	// bimodal on real traffic, so a mean would describe no request.
+	Prefix int64              `json:"prefix_tokens"`
+	Costs  []KVCachePriceCost `json:"costs"`
+}
+
+// KVCachePriceView builds the pricing panel's payload.
+func kvCachePriceView(models []string, prefix int64, p modelinfo.Pricer,
+	cfg KVCacheSimConfig) *KVCachePriceView {
+	list := kvcache.NewPriceList(context.Background(), models, p, cfg.Multipliers, cfg.Overrides)
+	a := kvCacheAssumptions(cfg)
+	out := &KVCachePriceView{Pricing: list, Assumptions: a, Prefix: prefix,
+		Costs: []KVCachePriceCost{}}
+	sem := a.Semantics
+	k := a.Schedule.MaxPings
+	for _, m := range list.Models {
+		c := KVCachePriceCost{Model: m.Model, Known: m.Known}
+		if m.Known {
+			c.Uncached = m.UncachedCost(0, prefix, 0)
+			c.Read = float64(prefix) * m.CacheRead
+			c.Write5m = m.HoldCost(prefix, kvcache.TTL5m, 0, sem)
+			c.Write1h = m.HoldCost(prefix, kvcache.TTL1h, 0, sem)
+			c.KeepAlive = m.KeepAliveCost(prefix, sem)
+			c.Late5m = m.RecreateCost(prefix, kvcache.TTL5m, sem)
+			c.Late1h = m.RecreateCost(prefix, kvcache.TTL1h, sem)
+			c.Hold5m = m.HoldCost(prefix, kvcache.TTL5m, k, sem)
+			c.Hold1h = m.HoldCost(prefix, kvcache.TTL1h, k, sem)
+		}
+		out.Costs = append(out.Costs, c)
+	}
+	return out
+}
+
+// KVCacheModels is the distinct models in one window, so the pricing panel has a row for every
+// model the reader could be pricing — including the ones with no rates.
+func (d *DB) KVCacheModels(f Filter) ([]string, error) {
+	cond, args := f.where()
+	rows, err := d.sql.Query(`SELECT DISTINCT r.model FROM requests r WHERE `+cond+
+		` ORDER BY r.model`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var m string
+		if err := rows.Scan(&m); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// KVCacheMedianPrefix is the window's own median billed prefix (cache_read + cache_write), in
+// tokens.
+//
+// NOT tokens_before, which is message text only and runs a median 3.38x low — the same
+// correction the keep-alive tab's calculator already applies. Exact rather than interpolated,
+// for the reason pctlF is: sorting a few thousand values is free and an estimate here is a
+// number nobody can reproduce.
+func (d *DB) KVCacheMedianPrefix(f Filter) (int64, error) {
+	cond, args := f.where()
+	rows, err := d.sql.Query(`SELECT r.cache_read + r.cache_write FROM requests r WHERE `+cond,
+		args...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var xs []float64
+	for rows.Next() {
+		var v float64
+		if err := rows.Scan(&v); err != nil {
+			return 0, err
+		}
+		xs = append(xs, v)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return int64(pctlF(xs, 0.50)), nil
+}

--- a/dash/query.go
+++ b/dash/query.go
@@ -44,6 +44,15 @@ type Filter struct {
 	Effort     string
 	Thinking   string
 	StopReason string
+	// TTL selects requests by the prompt-cache TTL TIER they asked for: 'ephemeral_5m',
+	// 'ephemeral_1h', or the sentinel "none" for a body that carried no cache_control at all.
+	//
+	// "none" needs a sentinel for the same reason Reason's "compacted" does: the column's
+	// value for that case is the empty string, which is also what "no filter" looks like, so
+	// an empty Filter field cannot mean it. Folding an uncached request in with the 5-minute
+	// ones would be the third answer disappearing, which is the whole reason cache_ttl was
+	// added as a TEXT column rather than a boolean.
+	TTL string
 	// WithKeepAlive includes keep-alive PING rows. Off by default, and that default is the
 	// point: a ping is a request context-guru sent on the user's behalf while they were away,
 	// not traffic their agent produced. Counted in an aggregate it silently inflates the
@@ -95,6 +104,13 @@ func (f Filter) where() (string, []any) {
 		if v != "" {
 			add(col+" = ?", v)
 		}
+	}
+	switch f.TTL {
+	case "":
+	case "none":
+		add("r.cache_ttl = ''")
+	default:
+		add("r.cache_ttl = ?", f.TTL)
 	}
 	switch f.Reason {
 	case "":

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -851,5 +851,7 @@
 <!-- The Inventory view mounts itself: its tab, its section, its stylesheet and its loader
      registration all live in tools.js, so this feature is one line in the shared page. -->
 <script src="tools.js"></script>
+<!-- The KV-cache TTL view mounts itself the same way, from kvcache.js. -->
+<script src="kvcache.js"></script>
 </body>
 </html>

--- a/dash/ui/kvcache.css
+++ b/dash/ui/kvcache.css
@@ -1,0 +1,104 @@
+/* The KV-cache tab's own stylesheet, linked from kvcache.js so mounting the whole view is
+   one line in the shared page — the same arrangement tools.css has.
+
+   Every colour here is a token from style.css. No new hue: the four-hue categorical order,
+   the status palette and the de-emphasis gray are the whole vocabulary, and a fifth colour
+   would mean a chart needs splitting rather than a new swatch. */
+
+/* The page's own filter row: the four dimensions the shared filter bar above does not carry
+   (user, time-of-day band, observed TTL, and whether a request has a successor). Laid out
+   like the keep-alive calculator's controls so the two pages read as one product. */
+.kv-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  align-items: flex-end;
+}
+.kv-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.kv-controls select,
+.kv-controls input[type="number"] {
+  background: var(--bg-raised);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 5px 7px;
+  font: inherit;
+  font-size: 13px;
+}
+.kv-controls input[type="number"] { width: 8ch; }
+
+/* The pricing table's editable rate cells. Narrow, right-aligned and monospaced, so a column
+   of rates lines up on its decimal point and a typo is visible. */
+.kv-rate {
+  width: 9ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  background: var(--bg-raised);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 3px 5px;
+  font-size: 12px;
+}
+.kv-rate:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+/* An edited rate is marked, so nobody reads a typed number as a configured one. */
+.kv-rate.kv-edited { border-color: var(--accent); background: var(--accent-soft); }
+
+/* One cost formula: the expression on its own line, monospaced, with its note beneath. */
+.kv-formula { margin: var(--sp-3) 0; }
+.kv-formula code {
+  display: block;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--bg-sunken);
+  border-radius: var(--r-sm);
+  font-size: 12px;
+  overflow-x: auto;
+  white-space: pre;
+}
+.kv-formula .kv-formula-name { font-weight: 600; font-size: 13px; }
+.kv-formula .kv-formula-note { color: var(--fg-muted); font-size: 12px; margin-top: var(--sp-1); }
+
+/* The strategy picker: one checkbox per arm with its own description under the label. */
+.kv-arms { display: grid; gap: var(--sp-2); }
+.kv-arm { display: flex; gap: var(--sp-2); align-items: flex-start; }
+.kv-arm > input { margin-top: 3px; }
+.kv-arm-name { font-weight: 600; font-size: 13px; }
+.kv-arm-desc { color: var(--fg-muted); font-size: 12px; }
+
+/* The baseline row of the comparison table: it is the denominator of every percentage beside
+   it, so it is marked rather than left for the reader to find. */
+.tbl tbody tr.kv-baseline > td { background: var(--bg-sunken); }
+.tbl tbody tr.kv-baseline > td:first-child { font-weight: 600; }
+
+/* A conversation or request id in a table cell: clipped, monospaced, and a link. */
+.kv-link { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+
+/* An UNREACHABLE arm — one that reads the true next-request time — is the ceiling on what any
+   policy could do, never a result. It gets the de-emphasis gray and a dashed edge so it cannot
+   be mistaken for an option at a glance, in the picker and in the comparison table alike. The
+   word "ceiling" travels with it in the markup; this only makes the distinction visible without
+   reading, and never carries it alone. */
+.kv-arm-ceiling .kv-arm-name,
+.kv-arm-ceiling .kv-arm-desc { color: var(--fg-muted); }
+.tbl tbody tr.kv-ceiling > td {
+  color: var(--fg-muted);
+  border-top: 1px dashed var(--border);
+  border-bottom: 1px dashed var(--border);
+}
+.tbl tbody tr.kv-ceiling > td:first-child { font-style: italic; }
+
+/* The direction word beside a signed difference ("cheaper" / "MORE"). Smaller than the figure
+   and never a replacement for it: the number is the measurement, the word is which way it
+   points, and colour is the third statement of the same fact rather than the only one. */
+.kv-dir { font-size: 11px; letter-spacing: 0.02em; margin-left: 2px; }
+
+/* The comparison table's first column. Held narrow on purpose: thirteen numeric columns follow
+   it, and the two that matter (total cost, vs baseline) have to be visible without scrolling
+   sideways. The strategy's description lives on the picker above and on this cell's title. */
+.kv-sim-name { font-weight: 600; white-space: nowrap; }

--- a/dash/ui/kvcache.js
+++ b/dash/ui/kvcache.js
@@ -1,0 +1,1428 @@
+// The KV-cache TTL view: how long a conversation actually stays idle, what its cached prefix
+// costs to hold, and what a different TTL strategy would have cost on exactly this history.
+//
+// It is one appended file and it mounts itself — the tab, the section, the stylesheet and the
+// loader registration all happen here — so this feature is one line in the shared page. Every
+// helper it uses is app.js's (el, clear, num, compact, usd, pct, dur, when, tile, tileGroup,
+// barRows, lineChart, emptyState, tableMessage, api, go, setFilter, wideScope), because a
+// second design system on one page is how a page stops looking like one product.
+//
+// THE FOUR RULES THIS FILE IS STRUCTURED AROUND. Each is a way this exact page could look
+// completely fine while lying:
+//
+//   1. NO ARITHMETIC HERE. Every dollar, every percentage and every idle average is computed
+//      on the server, in Go, in one place — and so are the cost FORMULAS, which arrive as data
+//      and are printed rather than retyped. The browser has twice duplicated a table the
+//      server owns and drifted from it; a hardcoded rate in a UI component is the specific
+//      version of that mistake this page would make, so there is not one number in this file
+//      that could be a price.
+//   2. A REQUEST WITH NO NEXT REQUEST HAS NO IDLE TIME. Not zero. Every average on this page
+//      is over the requests that have a successor, the rest are counted beside it, and the
+//      table renders "no next request" rather than a duration.
+//   3. A ZERO MAY BE AN ABSENCE. cache_ttl arrived as an additive column defaulting to '', so
+//      on older rows a blank tier means NOT RECORDED. The coverage banner says which of the
+//      three states the window is in, unconditionally.
+//   4. NEGATIVE SAVINGS ARE THE POINT. A strategy that costs more is shown costing more, in
+//      red, with its percentage. Clamping that to zero would remove the only result on this
+//      page that can stop somebody making a change.
+'use strict';
+
+// Its own stylesheet, linked from here rather than from index.html so mounting this feature is
+// ONE line in the shared page. Same-origin, so `style-src 'self'` allows it.
+document.head.appendChild(el('link', { rel: 'stylesheet', href: 'kvcache.css' }));
+
+// ── mount ──────────────────────────────────────────────────────────────────
+// Next to Keep-alive: both are about what a cached prefix costs to hold, and this one is the
+// measurement the other one's calculator is an application of.
+(function mountKVCacheTab() {
+  const tabs = $('.tabs');
+  const tab = el('button', {
+    role: 'tab', class: 'tab', 'data-view': 'kvcache', 'data-testid': 'tab-kvcache',
+    'aria-selected': 'false',
+  }, 'KV-cache');
+  const after = $('.tab[data-view="keepalive"]', tabs);
+  tabs.insertBefore(tab, after ? after.nextSibling : null);
+})();
+
+const kvView = el('section', { class: 'view', id: 'view-kvcache', hidden: 'hidden' });
+$('#main').appendChild(kvView);
+
+// ── local state ────────────────────────────────────────────────────────────
+// Its own state object, NOT app.js's: the shared one is mirrored into the URL for the views
+// that own those keys, so sharing it would make a sort here silently reorder another table.
+//
+// The four filters here are exactly the ones the shared filter bar above does not carry. Model,
+// conversation, agent and the time range come from that bar and are sent by qs() on every
+// request, which is why they are absent from this object.
+const kvc = {
+  analysis: null,
+  sim: null,
+  prices: null,
+  page: null,
+  // The page's own filters.
+  user: '',
+  bucket: '',
+  ttl: '',
+  hasNext: '',
+  // The detail table's paging and sort, both server-side: the server orders the WHOLE dataset
+  // and returns one page of it, so a sorted column shows the real top rows rather than the top
+  // of an arbitrary page. (That is the same distinction app.js draws between Components, which
+  // it sorts client-side over a complete result, and Sessions, which it refuses to sort.)
+  sort: 'ts',
+  dir: 'desc',
+  offset: 0,
+  limit: 50,
+  // The simulation's inputs. Every one of them travels in the query string, so a result is a
+  // URL somebody else can open.
+  arms: null,
+  // '' means "whatever the server's registry says is the honest denominator". Not a literal
+  // name: prompt caching is already on in production and already saving ~53%, so scoring
+  // against no-cache reports a saving no decision can act on. The domain flags its own
+  // baseline arm and the page follows it — a second answer here would be a second definition
+  // of the number every percentage is divided by.
+  baseline: '',
+  // rates holds EDITED rates only, per model, in USD per MILLION tokens exactly as typed. An
+  // absent key means "not edited", which is why this is a sparse object rather than a copy of
+  // the price list: a copy would turn every configured rate into an override the moment
+  // anything was touched.
+  rates: {},
+  mult: { read: '', w5m: '', w1h: '' },
+  ping: { in: '', out: '' },
+  sem: { hit: true, ping: true, zero: false },
+  sched: { x: '', x1h: '', k: '' },
+  custom: { p5m: '', p1h: '', min: '', always: false },
+};
+
+/**
+ * kvArms is every arm the SERVER says exists, in its order.
+ *
+ * There is deliberately no list of arm names in this file. There was one — six names, matching
+ * a closed list the API also carried — and by the time anyone looked the domain had gained four
+ * more (two keep-alive arms, an extend-to-1h arm, and the exact cost ceiling). All four were
+ * shipped, tested, and unreachable from the dashboard, and nothing on this page could have
+ * shown that. The picker is now built from the payload, so an arm added server-side appears the
+ * day it lands.
+ */
+function kvArms() { return (kvc.sim && kvc.sim.arms) || []; }
+
+/** kvArmNames is the arms a caller may ask the server to run. */
+function kvArmNames() { return kvArms().filter((a) => a.selectable).map((a) => a.name); }
+
+/**
+ * kvBaselineArms is the arms that may be a DENOMINATOR.
+ *
+ * An unreachable arm is excluded, and that is not tidiness: `optimal` reads the true
+ * next-request time, so every percentage measured against it would be a share of a number no
+ * policy can reach. It is a ceiling to compare against, never a floor to divide by.
+ */
+function kvBaselineArms() { return kvArms().filter((a) => a.selectable && !a.unreachable); }
+
+/** The detail table's columns, in header order. '' for a header that does not sort. */
+const KV_COLS = ['ts', 'user', 'conversation', 'model', 'input', 'output', 'read', 'write',
+  'cached', 'ttl', 'hit', 'idle', '', '', 'cost', ''];
+
+// ── what the numbers mean ──────────────────────────────────────────────────
+//
+// Into app.js's TILE_INFO rather than a registry of its own, so all the explanations on this
+// dashboard can be read side by side and checked for one voice. Each entry follows the three
+// rules that table states: what it is before how it is computed, the CATCH named out loud, and
+// never a description of a number the code does not compute.
+Object.assign(TILE_INFO, {
+  'kv-requests': {
+    what: 'How many requests are in this analysis.',
+    how: 'Every request matching the filters above, EXCLUDING keep-alive pings that '
+      + 'context-guru sent on your behalf.',
+    catch: 'Pings are excluded deliberately: counted, one of them would split a real idle '
+      + 'gap into two short ones and make every reuse figure on this page look better than '
+      + 'it is. If the analysis was capped, the banner above says so and this is the number '
+      + 'actually read, not the number that matched.',
+  },
+  'kv-conversations': {
+    what: 'How many distinct trajectories those requests belong to.',
+    how: 'A conversation is one account plus one session id, counted as a pair.',
+    catch: 'Never the session id alone: it is chosen by the client, so two accounts can '
+      + 'present the same one, and keying on it would splice two people’s requests into '
+      + 'one trajectory. Conversations with a single request in this window contribute no '
+      + 'idle gap at all — the coverage line says how many.',
+  },
+  'kv-median-idle': {
+    what: 'The middle idle time between one request and the next in the same conversation.',
+    how: 'The exact median over every request that HAS a next request, in this window.',
+    catch: 'Requests with no next request are NOT in it. They have no idle time, and counting '
+      + 'them as zero would drag this number toward "returns instantly". The card beside this '
+      + 'one says how many were left out.',
+  },
+  'kv-mean-idle': {
+    what: 'The average idle time until the next request in the same conversation.',
+    how: 'The arithmetic mean over the same population as the median.',
+    catch: 'Idle gaps are heavily skewed — on this service the median is about 15 seconds '
+      + 'and the 99th percentile is about 40 minutes — so the mean is well above the '
+      + 'typical gap. Read the median for "usually" and this for "what the tail costs".',
+  },
+  'kv-reuse-5m': {
+    what: 'How often a conversation comes back within five minutes — the provider’s '
+      + 'default cache lifetime.',
+    how: 'Requests whose next request arrived no more than five minutes later, over the '
+      + 'requests that have a next request at all.',
+    catch: 'This is the ceiling on what a plain five-minute TTL can hit, not a hit rate: a '
+      + 'prefix that CHANGED will miss inside five minutes too. The denominator excludes '
+      + 'requests with no successor.',
+  },
+  'kv-reuse-1h': {
+    what: 'How often a conversation comes back within an hour — the long tier.',
+    how: 'The same measurement at the one-hour horizon.',
+    catch: 'The gap between this and the five-minute figure is the most a one-hour TTL could '
+      + 'convert, before paying for it. A one-hour write costs 2.0x base input where a '
+      + 'five-minute one costs 1.25x, so a small gap here is easily worth less than the '
+      + 'premium.',
+  },
+  'kv-hit-rate': {
+    what: 'How often the provider actually served this prefix from its cache.',
+    how: 'Requests the provider reported as a cache hit, over all requests in the analysis.',
+    catch: 'This is a MEASUREMENT of what happened, not a simulation. It moves for reasons no '
+      + 'TTL controls — a changed prefix, a cold start — which is why the simulator '
+      + 'below reports those separately as misses no strategy could have rescued.',
+  },
+  'kv-cost': {
+    what: 'What these requests were actually billed.',
+    how: 'The sum of each request’s own cost, priced when it was recorded from the rates '
+      + 'that were in force at the time.',
+    catch: 'Requests whose token accounting was incomplete are NOT in it — their cost is '
+      + 'unknown, not zero, and the coverage line counts them. This is the real bill; every '
+      + 'figure in the simulator below is a re-pricing of the same traffic under a different '
+      + 'policy and at the rates in the pricing panel.',
+  },
+  'kv-final': {
+    what: 'How many requests have no next request in the same conversation.',
+    how: 'The last request of every conversation in this window.',
+    catch: 'These have NO idle time and are excluded from every average and every percentage '
+      + 'above. Their successor may simply be outside the window or not have happened yet, '
+      + 'which is why they are counted rather than dropped.',
+  },
+  'kv-prefix': {
+    what: 'The middle size of the cached prompt, in tokens.',
+    how: 'The median of cache-read plus cache-write tokens per request — the billed '
+      + 'prefix.',
+    catch: 'Every cost in the pricing panel is this number times a rate, which is why it is '
+      + 'the median and not the mean: per-request cache cost is heavily skewed, so a mean '
+      + 'would describe no request. It is not the message text size, which runs about 3.4x '
+      + 'lower.',
+  },
+});
+
+// ── shared bits ────────────────────────────────────────────────────────────
+
+/**
+ * kvMoney renders a dollar figure, or says the model had no rates.
+ *
+ * Rule 1 in one function: usd(0) renders "$0", which is a claim that something was free, and
+ * an unpriced model's cost is unknown. Every dollar cell on this page goes through here.
+ */
+function kvMoney(v, known) {
+  if (known === false) {
+    return el('span', {
+      class: 'pill missing',
+      title: 'This ran on a model with no known rates. Its tokens are counted; its cost is not.',
+    }, 'unpriced');
+  }
+  return document.createTextNode(usd(v));
+}
+
+/**
+ * kvSigned renders a difference against the baseline, IN WORDS as well as by sign, and never
+ * clamps it.
+ *
+ * The word is the whole point. A column of signed dollars under a heading like "saving" was
+ * read as a saving when it was the opposite: -$2,117.80 against the baseline is the arm costing
+ * two thousand dollars MORE, and a reader scanning for the biggest number picks the worst
+ * option. Sign plus colour is not enough either — colour must never carry a judgement alone,
+ * which is the rule the rest of this dashboard already keeps.
+ */
+function kvSigned(v, known) {
+  if (known === false) return el('span', { class: 'pill missing' }, 'unpriced');
+  if (!v) return el('span', { class: 'muted' }, usd(0));
+  const cheaper = v > 0;
+  return el('span', {
+    class: cheaper ? 'good-text' : 'bad-text',
+    title: cheaper ? 'Cheaper than the baseline by this much.'
+      : 'This arm costs MORE than the baseline by this much.',
+  }, usd(Math.abs(v)), el('span', { class: 'kv-dir' }, cheaper ? ' cheaper' : ' MORE'));
+}
+
+/**
+ * kvPremium renders the incremental cache premium.
+ *
+ * Its sign colouring is INVERTED against every other money cell on this page, and that is not
+ * a slip: the premium is what the caching machinery itself cost, so a NEGATIVE one means the
+ * cache paid for itself. The value is printed exactly as the server sent it — nothing here
+ * negates it to make the colour work, because a money figure this page computed would be a
+ * money figure nothing tests.
+ */
+function kvPremium(v, known) {
+  if (known === false) return el('span', { class: 'pill missing' }, 'unpriced');
+  return el('span', {
+    class: v < 0 ? 'good-text' : v > 0 ? 'bad-text' : '',
+    title: v < 0 ? 'Negative: caching this traffic cost less than not caching it.'
+      : v > 0 ? 'Positive: the cache cost more than sending every prompt uncached.'
+        : 'Nothing was cached, so there is no premium either way.',
+    text: usd(v),
+  });
+}
+
+/**
+ * kvIdle renders one row's idle time — or says it has none.
+ *
+ * Rule 2 at the cell level. dur() renders 0 as "—", which would be indistinguishable from
+ * "no successor", so a genuine zero-length gap (tied timestamps: 9 of 12,635 consecutive
+ * pairs on this service) is spelled out.
+ */
+function kvIdle(r) {
+  if (!r.has_next) {
+    return el('span', {
+      class: 'pill missing',
+      title: 'The last request of this conversation in this window. It has no idle time — not '
+        + 'a zero one — so it is excluded from every average on this page.',
+    }, 'no next request');
+  }
+  // === 0, not !idle_ms. A genuine zero-length gap (tied timestamps: 9 of 12,635 consecutive
+  // pairs on this service) is a real measurement and reads as "0 s"; an idle time that is ABSENT
+  // while has_next is true is a broken contract and must not be rendered as one. `!x` catches
+  // both and would print a fabricated zero for the second.
+  if (r.idle_ms === null || r.idle_ms === undefined) {
+    return el('span', {
+      class: 'pill missing',
+      title: 'This request has a successor but carries no idle time, which should not be '
+        + 'possible. Something upstream of this page is wrong; the gap is not zero.',
+    }, 'not recorded');
+  }
+  if (r.idle_ms === 0) return document.createTextNode('0 s');
+  return document.createTextNode(dur(r.idle_ms));
+}
+
+/** kvTTLPill names the tier, and how well the tier is known. */
+const KV_TTL_LABEL = {
+  ephemeral_5m: '5m', ephemeral_1h: '1h', '': 'none', none: 'none',
+  // The fourth group is an ABSENCE, not a tier, and it is labelled as one. Those rows are
+  // replayed as five minutes so a simulation has something to run, but calling them "5m" in the
+  // grouped table said "N of your requests used the 5-minute tier" about rows the coverage banner
+  // directly above was reporting as not recorded.
+  unrecorded: 'not recorded',
+};
+const KV_SOURCE_NOTE = {
+  configured: 'The tier this request asked for, as recorded.',
+  observed: 'Not recorded on the row, but deduced from what the provider billed.',
+  unknown: 'Not recorded and not deducible. Taken as the provider default of five minutes so '
+    + 'the simulation has something to replay, and counted as uncovered above.',
+};
+function kvTTLPill(r) {
+  // A row whose tier was never recorded says SO, in the label.
+  //
+  // It used to render the assumed tier — a pink "5m" pill with the explanation in a tooltip —
+  // and that is the same defect the grouped table had: the visible text asserted a tier nobody
+  // configured, on a page whose own coverage banner was reporting that row as not recorded. A
+  // colour and a hover are not where a contradiction gets resolved.
+  const unknown = r.ttl_source === 'unknown';
+  const label = unknown ? KV_TTL_LABEL.unrecorded
+    : KV_TTL_LABEL[r.ttl] !== undefined ? KV_TTL_LABEL[r.ttl] : r.ttl;
+  const cls = unknown ? 'pill missing' : r.ttl === 'ephemeral_1h' ? 'pill neutral' : 'pill';
+  return el('span', { class: cls, title: KV_SOURCE_NOTE[r.ttl_source] || '' }, label);
+}
+
+/** kvHitPill is the provider's own verdict on this request, with its reason. */
+function kvHitPill(r) {
+  return el('span', { class: 'pill ' + (r.miss_reason || 'unknown'), title: r.miss_reason },
+    r.hit ? 'hit' : r.miss_reason || 'miss');
+}
+
+/** A number cell, and a compacted one for the token counts that run to hundreds of thousands. */
+function kvNum(v) { return el('td', { class: 'num', text: num(v) }); }
+function kvTok(v) {
+  return el('td', { class: 'num', title: num(v) + ' tokens', text: compact(v) });
+}
+
+/**
+ * kvParams is the whole page state as query parameters.
+ *
+ * Everything the simulation depends on is in here, which is what makes a result a URL. Note
+ * the string coercions: qs() drops any extra whose value is '', 0 or undefined, so a boolean
+ * that must be sent as false travels as the STRING '0' and a numeric zero is simply never
+ * sent (the server then applies its own default, which is what an absent parameter means).
+ */
+function kvParams(extra) {
+  const p = {
+    // `tenant` is the shared scoping parameter, and the server decides what a caller may do
+    // with it: a manager may narrow to one account, and anyone else's is ignored. So this is
+    // the user filter, with no second mechanism to keep in step.
+    tenant: kvc.user || undefined,
+    bucket: kvc.bucket || undefined,
+    ttl: kvc.ttl || undefined,
+    has_next: kvc.hasNext || undefined,
+    mult_read: kvc.mult.read || undefined,
+    mult_w5m: kvc.mult.w5m || undefined,
+    mult_w1h: kvc.mult.w1h || undefined,
+    ping_in: kvc.ping.in || undefined,
+    ping_out: kvc.ping.out || undefined,
+    x: kvc.sched.x || undefined,
+    x1h: kvc.sched.x1h || undefined,
+    k: kvc.sched.k || undefined,
+    p5m: kvc.custom.p5m || undefined,
+    p1h: kvc.custom.p1h || undefined,
+    min_prefix: kvc.custom.min || undefined,
+    always_ping: kvc.custom.always ? '1' : undefined,
+    hit_refresh: kvc.sem.hit ? undefined : '0',
+    ping_refresh: kvc.sem.ping ? undefined : '0',
+    zero_gen: kvc.sem.zero ? '1' : undefined,
+  };
+  Object.assign(p, extra || {});
+  return p;
+}
+
+/** kvRateParams is the edited rates, one `rate=` per model, as the server parses them. */
+function kvRateSpecs() {
+  return Object.keys(kvc.rates).sort().map((model) => {
+    const r = kvc.rates[model] || {};
+    return [model, r.in || '', r.out || '', r.read || '', r.w5m || '', r.w1h || ''].join(':');
+  });
+}
+
+/**
+ * kvFetch is api() plus the repeated `rate` parameter, which URLSearchParams can carry more
+ * than once and qs()'s object form cannot.
+ */
+async function kvFetch(path, extra) {
+  const specs = kvRateSpecs();
+  let url = path + '';
+  const q = qs(kvParams(extra));
+  const sep = q ? '&' : '?';
+  const tail = specs.map((s) => 'rate=' + encodeURIComponent(s)).join('&');
+  const res = await fetch('/api/' + url + q + (tail ? sep + tail : ''), {
+    headers: { accept: 'application/json' },
+    signal: state.ac ? state.ac.signal : undefined,
+  });
+  if (!res.ok) {
+    let msg = res.status + ' ' + res.statusText;
+    try { const j = await res.json(); if (j.error) msg = j.error; } catch (_) { /* not json */ }
+    const e = new Error(msg); e.status = res.status; throw e;
+  }
+  return res.json();
+}
+
+// ── the page skeleton, built once ──────────────────────────────────────────
+//
+// Stable hosts, created at mount and only ever cleared. Rebuilding the whole view on every
+// load would throw away the pricing inputs mid-edit and move focus out from under whoever was
+// typing in them.
+
+/** kvPanel is one titled panel with a note and a set of hosts. */
+function kvPanel(title, note, ...kids) {
+  const p = el('div', { class: 'panel' }, el('h2', {}, title));
+  if (note) p.appendChild(el('p', { class: 'note' }, note));
+  for (const k of kids) if (k) p.appendChild(k);
+  kvView.appendChild(p);
+  return p;
+}
+
+/** kvHost is an empty div with an id and a test id. */
+function kvHost(id) { return el('div', { id: id, 'data-testid': id }); }
+
+// 1. What is being measured, and how well. The coverage statement comes FIRST and renders
+//    unconditionally: a reader has to know whether a blank tier means "not cached" or "not
+//    recorded" before any figure below is worth reading.
+kvPanel('What happens after a request',
+  'For every historical request, how long until the same conversation came back — and what '
+  + 'that means for a cached prompt with a five-minute or a one-hour lifetime. Model, '
+  + 'conversation, agent and the time range come from the filter bar at the top of the page; '
+  + 'the four filters here are the ones it does not carry.',
+  kvHost('kv-coverage'), kvHost('kv-controls'), kvHost('kv-tiles'));
+
+// 2. The distribution itself: the histogram, then the same data as "has it come back yet".
+const kvDistPanel = kvPanel('How long until the next request',
+  'The idle gap between one request and the next in the same conversation. Requests with no '
+  + 'next request are not in these charts — they have no idle time.');
+kvDistPanel.appendChild(el('h3', {}, 'Idle time, by band'));
+kvDistPanel.appendChild(el('p', { class: 'note', id: 'kv-idle-note' }));
+kvDistPanel.appendChild(kvHost('kv-idle-bands'));
+kvDistPanel.appendChild(el('h3', {}, 'Has it come back yet?'));
+kvDistPanel.appendChild(el('p', { class: 'note' },
+  'The share of requests whose conversation had returned by each elapsed time. The two rungs '
+  + 'that matter are on the curve rather than between them: five minutes is the provider’s '
+  + 'default lifetime, an hour is the long tier.'));
+kvDistPanel.appendChild(el('div', { class: 'chart', id: 'kv-survival', 'data-testid': 'kv-survival' }));
+
+// 3. Grouped views. By tier first, because that is the dimension the whole page is about.
+const kvGroupPanel = kvPanel('Who waits how long',
+  'The same measurement grouped four ways. A group’s reuse percentages are over ITS OWN '
+  + 'requests that have a successor, so a group of final requests shows no percentage rather '
+  + 'than a zero.');
+kvGroupPanel.appendChild(el('h3', {}, 'By observed TTL'));
+kvGroupPanel.appendChild(kvHost('kv-by-ttl'));
+kvGroupPanel.appendChild(el('h3', {}, 'By user'));
+kvGroupPanel.appendChild(kvHost('kv-by-user'));
+kvGroupPanel.appendChild(el('h3', {}, 'By model'));
+kvGroupPanel.appendChild(kvHost('kv-by-model'));
+kvGroupPanel.appendChild(el('h3', {}, 'By time of day (UTC)'));
+kvGroupPanel.appendChild(kvHost('kv-by-bucket'));
+
+// 4. The prices. Before the simulator, deliberately: every figure below is these rates times a
+//    token count, and a reader who has not seen them cannot judge the result.
+kvPanel('Cache prices',
+  'The rates every figure below is computed from. They come from this deployment’s own price '
+  + 'list; edit any of them to see what a different rate would do. Rates are USD per million '
+  + 'tokens, which is the unit every vendor’s price page uses.',
+  kvHost('kv-pricing'));
+
+// 5. The simulator.
+kvPanel('What a different TTL strategy would have cost',
+  'Each strategy is replayed against exactly this history. At every request it is given only '
+  + 'what was knowable at that moment — never how long the gap turned out to be — and the real '
+  + 'next-request time is used only to score the decision afterwards.',
+  kvHost('kv-arms'), kvHost('kv-sim'));
+
+// 6. The dataset itself.
+const kvTablePanel = kvPanel('Every request in the analysis',
+  'The derived dataset, one row per request, sorted and paged on the server so a sorted '
+  + 'column shows the real top rows rather than the top of one page.',
+  kvHost('kv-table'), kvHost('kv-pager'));
+
+// 7. The assumptions, last and always present.
+kvPanel('Formulas and assumptions',
+  'Every expression below is the one the server actually evaluated — they are sent with the '
+  + 'data rather than written into this page, so they cannot drift from the code.',
+  kvHost('kv-assumptions'));
+
+// ── controls ───────────────────────────────────────────────────────────────
+
+/** kvSelect builds one labelled select and wires it to a state key. */
+function kvSelect(label, value, options, onChange, testid) {
+  const sel = el('select', { 'data-testid': testid, onchange: (ev) => onChange(ev.target.value) });
+  for (const [v, text] of options) {
+    const opt = el('option', { value: v }, text);
+    if (v === value) opt.setAttribute('selected', 'selected');
+    sel.appendChild(opt);
+  }
+  return el('label', {}, label, sel);
+}
+
+/** renderKVControls draws the four page-local filters. */
+function renderKVControls() {
+  const host = clear($('#kv-controls'));
+  const a = kvc.analysis;
+  const users = [['', 'All users']];
+  if (a) for (const g of a.by_user) users.push([g.key, (g.key || '(single-tenant)') + ' · ' + num(g.requests)]);
+  const row = el('div', { class: 'kv-controls' },
+    // The user filter is only offered where the caller can actually use it: the server
+    // ignores a narrowing from anyone but a manager, so drawing it for everybody else would
+    // be a control whose only possible outcome is no change.
+    wideScope() ? kvSelect('User', kvc.user, users, (v) => { kvc.user = v; kvReload(); },
+      'kv-filter-user') : null,
+    kvSelect('Time of day (UTC)', kvc.bucket, [['', 'All'], ['night', 'Night 00–06'],
+      ['morning', 'Morning 06–12'], ['afternoon', 'Afternoon 12–18'], ['evening', 'Evening 18–24']],
+    (v) => { kvc.bucket = v; kvReload(); }, 'kv-filter-bucket'),
+    kvSelect('Observed TTL', kvc.ttl, [['', 'All'], ['ephemeral_5m', '5 minutes'],
+      ['ephemeral_1h', '1 hour'], ['none', 'Not cached']],
+    (v) => { kvc.ttl = v; kvReload(); }, 'kv-filter-ttl'),
+    kvSelect('Next request', kvc.hasNext, [['', 'All'], ['yes', 'Has one'], ['no', 'None (final)']],
+      (v) => { kvc.hasNext = v; kvReload(); }, 'kv-filter-hasnext'));
+  host.appendChild(row);
+}
+
+/**
+ * renderKVCoverage is rule 3: whether a zero on this page is a measurement or an absence.
+ *
+ * Unconditional. It renders on a fully-instrumented window too, because a reader deciding
+ * whether to act on these figures has to know how much of the window recorded its own tier —
+ * and on a database with any history at all, some of it did not.
+ */
+function renderKVCoverage() {
+  const host = clear($('#kv-coverage'));
+  const a = kvc.analysis;
+  if (!a) return;
+  const c = a.coverage;
+  if (!a.total) {
+    emptyState(host, 'No requests match these filters',
+      'Widen the time range at the top of the page, or clear a filter.');
+    return;
+  }
+  if (a.truncated) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'kv-truncated' },
+      el('strong', {}, 'This analysis read ' + num(a.scanned) + ' of ' + num(a.total)
+        + ' matching requests. '),
+      'The newest ones were kept. Every figure on this page is over the '
+      + num(a.scanned) + ' that were read, not over the whole window — narrow the time range '
+      + 'to analyse all of it.'));
+  }
+  if (c.ttl_unknown > 0) {
+    host.appendChild(el('div', { class: 'banner', 'data-testid': 'kv-ttl-coverage' },
+      el('strong', {}, num(c.ttl_unknown) + ' of ' + num(a.scanned)
+        + ' requests did not record which cache lifetime they asked for. '),
+      'Those rows predate that column, so a blank there means NOT RECORDED, not "no cache". '
+      + 'They are taken as the provider default of five minutes so the simulation has '
+      + 'something to replay, and the observed-policy strategy below reports how much of '
+      + 'itself rested on that assumption. ' + num(c.ttl_configured) + ' recorded their own '
+      + 'tier and ' + num(c.ttl_observed) + ' could be deduced from what the provider billed.'));
+  }
+  if (c.cost_unknown > 0) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'kv-cost-coverage' },
+      el('strong', {}, num(c.cost_unknown) + ' requests have an unknown cost. '),
+      'Their token accounting was incomplete, so they are counted everywhere and valued '
+      + 'nowhere. An unpriced request is not a free one.'));
+  }
+  if (c.single_request_conversations > 0) {
+    host.appendChild(el('p', { class: 'hint', 'data-testid': 'kv-single-note' },
+      num(c.single_request_conversations) + ' of ' + num(a.cards.conversations)
+      + ' conversations have a single request in this window, so they contribute a final '
+      + 'request and no idle gap at all.'));
+  }
+}
+
+/** renderKVTiles is the summary band. */
+function renderKVTiles() {
+  const host = clear($('#kv-tiles'));
+  const a = kvc.analysis;
+  if (!a || !a.total) return;
+  const c = a.cards;
+  const costKnown = c.cost_unknown < c.requests;
+  host.appendChild(tileGroup(null, null, [
+    tile('kv-requests', 'Requests', num(c.requests),
+      num(c.scanned || a.scanned) + ' read of ' + num(a.total) + ' matched'),
+    tile('kv-conversations', 'Conversations', num(c.conversations),
+      num(c.users) + ' user' + (c.users === 1 ? '' : 's') + ' · ' + num(c.models) + ' models'),
+    tile('kv-median-idle', 'Median idle', c.with_next ? dur(c.median_idle_ms) : '—',
+      c.with_next ? 'over ' + num(c.with_next) + ' gaps' : 'no gaps in this window'),
+    tile('kv-mean-idle', 'Mean idle', c.with_next ? dur(c.mean_idle_ms) : '—',
+      c.with_next ? 'p90 ' + dur(c.p90_idle_ms) : 'no gaps'),
+    tile('kv-reuse-5m', 'Back within 5m', c.with_next ? pct(c.within_5m_pct) : '—',
+      c.with_next ? num(c.within_5m) + ' of ' + num(c.with_next) : 'no gaps', 'accent'),
+    tile('kv-reuse-1h', 'Back within 1h', c.with_next ? pct(c.within_1h_pct) : '—',
+      c.with_next ? num(c.within_1h) + ' of ' + num(c.with_next) : 'no gaps', 'accent'),
+    tile('kv-hit-rate', 'Cache-hit rate', pct(c.hit_rate_pct),
+      num(c.hits) + ' of ' + num(c.requests) + ' as the provider reported it'),
+    tile('kv-cost', 'Cost as billed', costKnown ? usd(c.cost_usd) : 'unknown',
+      costKnown ? num(c.requests - c.cost_unknown) + ' priced requests' : 'nothing priced'),
+    tile('kv-final', 'No next request', num(c.final_requests),
+      'excluded from every average above'),
+    tile('kv-prefix', 'Median cached prompt', compact(c.cached_context_p50) + ' tok',
+      'what every cost below is proportional to'),
+  ]));
+}
+
+/** renderKVIdleBands draws the histogram. */
+function renderKVIdleBands() {
+  const host = clear($('#kv-idle-bands'));
+  const a = kvc.analysis;
+  if (!a) return;
+  const bands = a.idle_bands || [];
+  const total = bands.reduce((s, b) => s + b.n, 0);
+  $('#kv-idle-note').textContent = total
+    ? 'Bands beyond five minutes are drawn in gray: a default cached prefix is already gone '
+      + 'by then. ' + num(total) + ' gaps.'
+    : '';
+  barRows(host, bands.map((b) => ({
+    label: b.label,
+    value: b.n,
+    display: num(b.n) + (total ? '  ' + pct(100 * b.n / total, 1) : ''),
+    color: b.beyond ? 'var(--s-mute)' : undefined,
+    title: b.n + ' gaps in this band' + (b.usd ? ', ' + usd(b.usd) + ' of billed cost' : ''),
+  })), { emptyDetail: 'No request in this window is followed by another in the same conversation.' });
+}
+
+/** renderKVSurvival draws the "has it come back yet" curve. */
+function renderKVSurvival() {
+  const host = $('#kv-survival');
+  const a = kvc.analysis;
+  if (!a) return;
+  const ladder = a.survival || [];
+  if (!ladder.length) {
+    emptyState(clear(host), 'No idle gaps in this window',
+      'Every request here is the last of its conversation.');
+    return;
+  }
+  // Plotted against the RUNG INDEX, not against the seconds.
+  //
+  // The ladder spans 5 s to a day, and on real traffic the entire shape is inside the first
+  // five minutes — so a linear seconds axis draws a vertical line at the left edge and a flat
+  // line across the rest, which is a chart that hides exactly what it exists to show. The rungs
+  // are chosen because they are the decision points, so spacing them evenly is the honest
+  // reading: this is a ladder, not a timeline. The labels carry the real elapsed times.
+  const pts = ladder.map((p, i) => [i, p.arrived_pct]);
+  lineChart(host, [{ name: 'Returned by', color: SERIES[0], points: pts, area: true }], {
+    yFmt: (v) => v.toFixed(0) + '%',
+    // ROUNDED, because lineChart labels the midpoint of the x range and that lands between two
+    // rungs on an even-length ladder. Without this the axis printed the raw index's neighbour
+    // as a bare number — "43202.5" — which is not an elapsed time anybody can read.
+    xFmt: (v) => (ladder[Math.round(v)] || {}).label || '',
+    tipFmt: (v) => v.toFixed(1) + '%',
+    yMax: 100,
+    label: 'share of conversations that had returned by each elapsed time',
+  });
+}
+
+/**
+ * kvGroupTable draws one grouped view.
+ *
+ * `onPick` makes a row a drill-down where one exists; a group with no successor in it shows a
+ * dash rather than 0% for its reuse columns, which is rule 2 applied to a group.
+ */
+function kvGroupTable(hostSel, groups, keyLabel, onPick, fmtKey) {
+  const host = clear($(hostSel));
+  if (!groups || !groups.length) {
+    emptyState(host, 'Nothing to group', 'No requests match these filters.');
+    return;
+  }
+  const table = el('table', { class: 'tbl compact', 'data-testid': hostSel.slice(1) + '-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, keyLabel),
+      el('th', { class: 'num' }, 'Requests'),
+      el('th', { class: 'num' }, 'Conversations'),
+      el('th', { class: 'num' }, 'With a next'),
+      el('th', { class: 'num' }, 'Final'),
+      el('th', { class: 'num' }, 'Median idle'),
+      el('th', { class: 'num' }, 'Mean idle'),
+      el('th', { class: 'num' }, 'Back in 5m'),
+      el('th', { class: 'num' }, 'Back in 1h'),
+      el('th', { class: 'num' }, 'Hit rate'),
+      el('th', { class: 'num' }, 'Cost'))));
+  const body = el('tbody');
+  table.appendChild(body);
+  for (const g of groups) {
+    const row = el('tr', onPick ? { class: 'click', onclick: () => onPick(g) } : {},
+      el('td', {}, el('span', { class: 'trunc', title: g.key },
+        (fmtKey ? fmtKey(g) : g.key) || '—')),
+      kvNum(g.requests), kvNum(g.conversations), kvNum(g.with_next), kvNum(g.final_requests),
+      el('td', { class: 'num' }, g.with_next ? dur(g.median_idle_ms) : '—'),
+      el('td', { class: 'num' }, g.with_next ? dur(g.mean_idle_ms) : '—'),
+      el('td', { class: 'num' }, g.with_next ? pct(g.within_5m_pct) : '—'),
+      el('td', { class: 'num' }, g.with_next ? pct(g.within_1h_pct) : '—'),
+      el('td', { class: 'num' }, pct(g.hit_rate_pct)),
+      el('td', { class: 'num' }, kvMoney(g.cost_usd, g.cost_unknown < g.requests)));
+    body.appendChild(row);
+  }
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
+}
+
+/** renderKVGroups draws all four grouped views. */
+function renderKVGroups() {
+  const a = kvc.analysis;
+  if (!a) return;
+  // The group key IS the filter value, including for the not-recorded group, so clicking a row
+  // narrows to exactly the rows behind it rather than to something that looks similar.
+  kvGroupTable('#kv-by-ttl', a.by_ttl, 'Observed TTL',
+    (g) => { kvc.ttl = g.key; kvReload(); }, (g) => KV_TTL_LABEL[g.key] || g.key);
+  kvGroupTable('#kv-by-user', a.by_user, 'User',
+    wideScope() ? (g) => { kvc.user = g.key; kvReload(); } : null);
+  kvGroupTable('#kv-by-model', a.by_model, 'Model', (g) => setFilter('model', g.key));
+  kvGroupTable('#kv-by-bucket', a.by_bucket, 'Time of day (UTC)',
+    (g) => { kvc.bucket = g.key; kvReload(); });
+}
+
+// ── pricing ────────────────────────────────────────────────────────────────
+
+/** The five editable rates, in table order: state key, label, price-list field. */
+const KV_RATE_FIELDS = [
+  ['in', 'Input', 'input'],
+  ['out', 'Output', 'output'],
+  ['read', 'Cache read', 'cache_read'],
+  ['w5m', 'Write 5m', 'write_5m'],
+  ['w1h', 'Write 1h', 'write_1h'],
+];
+
+/** perMTok converts a per-token rate to the per-million unit the inputs are in. */
+function perMTok(v) { return v === null || v === undefined ? '' : (v * 1e6).toFixed(4); }
+
+/**
+ * renderKVPricing draws the editable rate table and what those rates come to.
+ *
+ * The two halves are deliberate: the RATE is what a reader can change, the COST is what they
+ * are deciding about, and a per-token rate on its own is not a number anybody can act on.
+ */
+function renderKVPricing() {
+  const host = clear($('#kv-pricing'));
+  const v = kvc.prices;
+  if (!v) { loadingState(host, 2); return; }
+  const list = v.pricing || { models: [] };
+  if (!list.models.length) {
+    emptyState(host, 'No models in this window', 'Nothing to price.');
+    return;
+  }
+  host.appendChild(el('p', { class: 'hint' },
+    'Costs are on this window’s own median cached prompt of ',
+    el('strong', {}, compact(v.prefix_tokens) + ' tokens'),
+    '. “Hold” is a write plus ' + v.assumptions.schedule.max_pings
+    + ' keep-alive refreshes — the whole cost of carrying that prompt through one idle span.'));
+
+  const table = el('table', { class: 'tbl compact', 'data-testid': 'kv-pricing-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Model'),
+      ...KV_RATE_FIELDS.map(([, label]) => el('th', { class: 'num' }, label + ' $/MTok')),
+      el('th', { class: 'num' }, 'Uncached'),
+      el('th', { class: 'num' }, 'One read'),
+      el('th', { class: 'num' }, 'Write 5m'),
+      el('th', { class: 'num' }, 'Write 1h'),
+      el('th', { class: 'num' }, 'One ping'),
+      el('th', { class: 'num' }, 'Late ping'),
+      el('th', { class: 'num' }, 'Hold 5m'),
+      el('th', { class: 'num' }, 'Hold 1h'),
+      el('th', {}, 'Source'))));
+  const body = el('tbody');
+  table.appendChild(body);
+  const costs = {};
+  for (const c of v.costs || []) costs[c.model] = c;
+  for (const m of list.models) {
+    const c = costs[m.model] || {};
+    const edited = kvc.rates[m.model] || {};
+    body.appendChild(el('tr', {},
+      el('td', {}, el('span', { class: 'trunc', title: m.model }, m.model || '—')),
+      ...KV_RATE_FIELDS.map(([key, label, field]) => el('td', { class: 'num' },
+        el('input', {
+          type: 'number', step: 'any', min: '0', class: 'kv-rate' + (edited[key] ? ' kv-edited' : ''),
+          'data-testid': 'kv-rate-' + key,
+          'aria-label': label + ' rate for ' + m.model + ', USD per million tokens',
+          value: edited[key] !== undefined && edited[key] !== '' ? edited[key] : perMTok(m[field]),
+          onchange: (ev) => kvEditRate(m.model, key, ev.target.value, perMTok(m[field])),
+        }))),
+      el('td', { class: 'num' }, kvMoney(c.uncached_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.read_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.write_5m_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.write_1h_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.keep_alive_usd, m.known)),
+      el('td', { class: 'num', title: 'A keep-alive that arrived after the entry lapsed: it '
+        + 're-creates the prefix, so it is billed as a write.' },
+      kvMoney(c.late_5m_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.hold_5m_usd, m.known)),
+      el('td', { class: 'num' }, kvMoney(c.hold_1h_usd, m.known)),
+      el('td', {}, el('span', {
+        class: m.source === 'override' ? 'pill neutral' : m.known ? 'pill' : 'pill missing',
+        title: m.source === 'override' ? 'You typed this.'
+          : m.known ? 'From this deployment’s configured price list.'
+            : 'This model has no rates on the price list. Type one to price it.',
+      }, m.source || 'unpriced'))));
+  }
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
+
+  // The three multipliers and the ping overhead: deployment-wide facts rather than per-model
+  // rates, so they get their own row of controls.
+  const mult = v.assumptions.multipliers || {};
+  const sched = v.assumptions.schedule || {};
+  host.appendChild(el('div', { class: 'kv-controls', 'data-testid': 'kv-price-knobs' },
+    kvNumberInput('Cache-read × input', kvc.mult.read, mult.cache_read,
+      (val) => { kvc.mult.read = val; kvReload(); }, 'kv-mult-read'),
+    kvNumberInput('5m write × input', kvc.mult.w5m, mult.write_5m,
+      (val) => { kvc.mult.w5m = val; kvReload(); }, 'kv-mult-w5m'),
+    kvNumberInput('1h write × input', kvc.mult.w1h, mult.write_1h,
+      (val) => { kvc.mult.w1h = val; kvReload(); }, 'kv-mult-w1h'),
+    kvNumberInput('Ping input tokens', kvc.ping.in, 1,
+      (val) => { kvc.ping.in = val; kvReload(); }, 'kv-ping-in'),
+    kvNumberInput('Ping output tokens', kvc.ping.out, 1,
+      (val) => { kvc.ping.out = val; kvReload(); }, 'kv-ping-out'),
+    kvNumberInput('Ping every (s)', kvc.sched.x, sched.idle_seconds,
+      (val) => { kvc.sched.x = val; kvReload(); }, 'kv-sched-x'),
+    kvNumberInput('1h ping every (s)', kvc.sched.x1h, sched.idle_seconds_1h,
+      (val) => { kvc.sched.x1h = val; kvReload(); }, 'kv-sched-x1h'),
+    kvNumberInput('Max pings per span', kvc.sched.k, sched.max_pings,
+      (val) => { kvc.sched.k = val; kvReload(); }, 'kv-sched-k')));
+  host.appendChild(el('p', { class: 'hint' },
+    'A one-hour write rate is the one number no gateway publishes, so it is derived from the '
+    + 'multiplier above unless you type a rate for it. A keep-alive costs the same per ping at '
+    + 'either tier — it is a cache read either way — so what separates a five-minute hold from '
+    + 'a one-hour one is the write that put the entry there and how often it has to be '
+    + 'refreshed.'));
+
+  // The provider semantics, which change every result and are therefore switches rather than
+  // assumptions.
+  const sem = v.assumptions.semantics || {};
+  host.appendChild(el('div', { class: 'kv-controls', 'data-testid': 'kv-semantics' },
+    kvCheck('A cache hit refreshes the lifetime', sem.hit_refreshes_ttl,
+      (on) => { kvc.sem.hit = on; kvReload(); }, 'kv-sem-hit',
+      'Anthropic documents this: using a cached prefix refreshes it for no extra cost. Turn it '
+      + 'off for a provider where a hit does not extend the deadline.'),
+    kvCheck('A keep-alive refreshes the lifetime', sem.ping_refreshes_ttl,
+      (on) => { kvc.sem.ping = on; kvReload(); }, 'kv-sem-ping',
+      'A keep-alive is just a use of the cache, so it refreshes the entry for its own tier’s '
+      + 'lifetime.'),
+    kvCheck('Zero-generation pings allowed', sem.zero_generation,
+      (on) => { kvc.sem.zero = on; kvReload(); }, 'kv-sem-zero',
+      'Anthropic’s Messages API requires max_tokens ≥ 1, so a ping cannot generate nothing and '
+      + 'its one output token is priced. Turn this on for a provider that accepts a '
+      + 'zero-generation request.')));
+}
+
+/** kvEditRate records one typed rate, or clears it back to the configured one. */
+function kvEditRate(model, key, value, configured) {
+  const v = String(value === undefined || value === null ? '' : value).trim();
+  const row = kvc.rates[model] || {};
+  // Typing the configured value back is the way OUT of an override, so an accidental edit can
+  // be undone without a reset button.
+  if (v === '' || v === configured) delete row[key];
+  else row[key] = v;
+  if (Object.keys(row).length) kvc.rates[model] = row;
+  else delete kvc.rates[model];
+  kvReload();
+}
+
+/** kvNumberInput is one labelled numeric control with the server's value as its placeholder. */
+function kvNumberInput(label, value, fallback, onChange, testid) {
+  return el('label', {}, label,
+    el('input', {
+      type: 'number', step: 'any', min: '0', 'data-testid': testid,
+      value: value || '',
+      placeholder: fallback === undefined || fallback === null ? '' : String(fallback),
+      onchange: (ev) => onChange(ev.target.value.trim()),
+    }));
+}
+
+/** kvCheck is one labelled checkbox. */
+function kvCheck(label, on, onChange, testid, title) {
+  const box = el('input', { type: 'checkbox', 'data-testid': testid,
+    onchange: (ev) => onChange(ev.target.checked) });
+  if (on) box.setAttribute('checked', 'checked');
+  return el('label', { class: 'small', title: title || '' }, box, ' ' + label);
+}
+
+// ── the simulator ──────────────────────────────────────────────────────────
+
+/** renderKVArms draws the strategy picker and the baseline selector. */
+function renderKVArms() {
+  const host = clear($('#kv-arms'));
+  const sim = kvc.sim;
+  const specs = kvArms();
+  if (!specs.length) { loadingState(host, 2); return; }
+  const described = {};
+  if (sim) for (const r of sim.results) described[r.strategy] = r.description;
+  // What is ticked: the caller's own selection, or — on first load — exactly what the server
+  // ran, so the picker and the table below it never disagree about which arms are on screen.
+  const on = new Set(kvc.arms || (sim ? sim.results.map((r) => r.strategy) : []));
+  host.appendChild(el('div', { class: 'kv-arms', 'data-testid': 'kv-arm-picker' },
+    ...specs.map((a) => {
+      const box = el('input', {
+        type: 'checkbox', 'data-testid': 'kv-arm-' + a.name,
+        disabled: a.selectable ? null : 'disabled',
+        onchange: (ev) => {
+          const set = new Set(kvc.arms || on);
+          if (ev.target.checked) set.add(a.name); else set.delete(a.name);
+          kvc.arms = kvArmNames().filter((n) => set.has(n));
+          kvLoadSim();
+        },
+      });
+      if (on.has(a.name)) box.setAttribute('checked', 'checked');
+      return el('div', { class: 'kv-arm' + (a.unreachable ? ' kv-arm-ceiling' : ''), }, box,
+        el('div', {},
+          el('div', { class: 'kv-arm-name' }, a.name,
+            a.unreachable ? kvCeilingPill() : null,
+            a.selectable ? null : el('span', {
+              class: 'pill missing',
+              title: 'This arm is scored from an action list supplied in the process rather '
+                + 'than from a query, so it cannot be selected here. It exists so an offline '
+                + 'model\u2019s answers can be scored against the same baseline.',
+            }, 'not selectable')),
+          el('div', { class: 'kv-arm-desc', text: described[a.name] || a.description || '' })));
+    })));
+  host.appendChild(el('div', { class: 'kv-controls' },
+    kvSelect('Baseline', (sim && sim.baseline) || kvc.baseline,
+      kvBaselineArms().map((a) => [a.name, a.name]),
+      (v) => { kvc.baseline = v; kvLoadSim(); }, 'kv-baseline'),
+    kvNumberInput('P(back in 5m) \u2265', kvc.custom.p5m, 0.5,
+      (v) => { kvc.custom.p5m = v; kvLoadSim(); }, 'kv-custom-p5m'),
+    kvNumberInput('P(back in 1h) \u2265', kvc.custom.p1h, 0.5,
+      (v) => { kvc.custom.p1h = v; kvLoadSim(); }, 'kv-custom-p1h'),
+    kvNumberInput('Never cache under (tokens)', kvc.custom.min, 20000,
+      (v) => { kvc.custom.min = v; kvLoadSim(); }, 'kv-custom-min'),
+    kvCheck('Custom arm always pings', kvc.custom.always,
+      (on2) => { kvc.custom.always = on2; kvLoadSim(); }, 'kv-custom-always',
+      'Force the long hold onto the keep-alive path instead of taking whichever of a 1h write '
+      + 'and a 5m write plus refreshes is cheaper on that prefix.')));
+  host.appendChild(el('p', { class: 'hint' },
+    'The three thresholds configure the ', el('strong', {}, 'custom'), ' arm. A learned '
+    + 'predictor plugs into the same arm server-side without changing anything on this page.'));
+}
+
+/**
+ * kvCeilingPill marks an arm that reads the future.
+ *
+ * It is a bound on what any policy could achieve, never a result — so it gets its own word, its
+ * own colour, and it is not offered as a baseline. A ceiling rendered beside real arms in the
+ * same style is a promise the product cannot keep.
+ */
+function kvCeilingPill() {
+  return el('span', {
+    class: 'pill missing', 'data-testid': 'kv-ceiling-pill',
+    title: 'Unreachable. This arm is told the real next-request time, so it is the cheapest plan '
+      + 'that exists for this history \u2014 the headroom, not an option. No policy can reach it, '
+      + 'because no policy knows the future.',
+  }, 'ceiling');
+}
+
+/** renderKVSim draws the comparison table and the per-user / per-model breakdowns. */
+function renderKVSim() {
+  const host = clear($('#kv-sim'));
+  const sim = kvc.sim;
+  if (!sim) { loadingState(host, 3); return; }
+  if (sim.unknown && sim.unknown.length) {
+    host.appendChild(el('div', { class: 'banner warn' },
+      el('strong', {}, 'Not a strategy: ' + sim.unknown.join(', ') + '. '),
+      'It was skipped rather than replaced with something else.'));
+  }
+  if (!sim.results.length) {
+    emptyState(host, 'No strategy selected', 'Tick at least one arm above.');
+    return;
+  }
+  // A window where NOTHING could be priced makes every total zero and the ordering between arms
+  // meaningless — including the ceiling's, which then wears the styling of "the cheapest plan
+  // that exists" over a plan that is simply unpriced. The server states that in one field per
+  // arm rather than leaving it to be inferred from Unpriced === Requests, which is exactly the
+  // inference a consumer forgets to make.
+  if (sim.results.every((r) => r.valued === false)) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'kv-unvalued' },
+      el('strong', {}, 'None of these requests could be priced. '),
+      'Every model in this window is missing from the price list, so all of the totals below are '
+      + 'zero for want of a rate — not because nothing was spent, and not because one arm is '
+      + 'cheaper than another. Every strategy that decides by comparing costs, the ceiling '
+      + 'included, had nothing to decide with, so its actions and its hit rate are an artefact '
+      + 'rather than a policy. Add the models to the price list above, or to MODEL_PRICES, and '
+      + 'the comparison becomes meaningful.'));
+  }
+  const savings = {};
+  for (const s of sim.savings) savings[s.strategy] = s;
+
+  const table = el('table', { class: 'tbl', 'data-testid': 'kv-sim-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Strategy'),
+      el('th', { class: 'num' }, 'Total cost'),
+      el('th', { class: 'num' }, 'vs baseline'),
+      el('th', { class: 'num' }, '% vs baseline'),
+      el('th', { class: 'num' }, 'Hit rate'),
+      el('th', { class: 'num' }, 'Miss rate'),
+      el('th', { class: 'num' }, '5m writes'),
+      el('th', { class: 'num' }, '1h writes'),
+      el('th', { class: 'num' }, 'Pings'),
+      el('th', { class: 'num' }, 'Ping cost'),
+      el('th', { class: 'num' }, 'Recomputes avoided'),
+      el('th', { class: 'num' }, 'Cache held'),
+      el('th', { class: 'num' }, 'Latency avoided'))));
+  const body = el('tbody');
+  table.appendChild(body);
+  const ceiling = {};
+  for (const a of kvArms()) ceiling[a.name] = a.unreachable;
+  for (const r of sim.results) {
+    const s = savings[r.strategy] || {};
+    const isBase = r.strategy === sim.baseline;
+    const isCeiling = !!ceiling[r.strategy];
+    // The server's own field, not the same test spelled a second time: `valued` IS
+    // unpriced !== requests, and two spellings of one predicate is how they come to
+    // disagree the day one of them gains a caveat.
+    const priced = r.valued;
+    body.appendChild(el('tr', {
+      class: (isBase ? 'kv-baseline' : '') + (isCeiling ? ' kv-ceiling' : ''),
+      'data-testid': 'kv-sim-row-' + r.strategy },
+    // The name only, with the description on hover. The description is already on the picker
+    // above, and repeating it here made this column wide enough to push Total cost and
+    // vs baseline — the two figures the page exists to show — off the right edge at a normal
+    // viewport width, behind a horizontal scroll nobody would know to use.
+    el('td', { title: r.description || '' },
+      el('div', { class: 'kv-sim-name' }, r.strategy, isCeiling ? kvCeilingPill() : null)),
+    el('td', { class: 'num' }, kvMoney(r.total_usd, priced)),
+    el('td', { class: 'num' }, isBase ? document.createTextNode('—')
+      // Gated on `priced` ALONE. percent_known is false only when the baseline total is zero,
+      // and the absolute difference is perfectly well defined then — it is simply −strategy_usd.
+      // Gating this cell on it would print "unpriced" over a figure that is known, which is an
+      // absence shown where there is a measurement: the inverse of the rule this page keeps
+      // everywhere else.
+      : kvSigned(s.absolute_usd, priced)),
+    el('td', { class: 'num' }, isBase ? document.createTextNode('—')
+      : s.percent_known ? el('span', {
+        class: s.percent_usd < 0 ? 'bad-text' : 'good-text',
+        // The sign is kept here, unlike the column beside it, and it needs saying which way it
+        // points: this is a percentage OF THE BASELINE'S COST, so a negative one is an arm that
+        // costs more, not an arm that saved a negative amount.
+        title: s.percent_usd < 0 ? 'Negative: this arm costs this much MORE than the baseline.'
+          : 'Positive: this arm costs this much less than the baseline.',
+      }, pct(s.percent_usd, 2))
+        : el('span', { class: 'pill missing', title: 'The baseline cost nothing, so a '
+          + 'percentage of it is undefined rather than 0%.' }, 'undefined')),
+    el('td', { class: 'num' }, pct(r.hit_rate_pct)),
+    el('td', { class: 'num' }, pct(r.miss_rate_pct)),
+    kvNum(r.writes_5m), kvNum(r.writes_1h),
+    el('td', { class: 'num', title: kvPingNote(r) },
+      r.pings ? num(r.pings) + (r.pings_that_rewrote ? ' \u26a0' : '') : '—'),
+    el('td', { class: 'num' }, r.pings ? kvMoney(r.ping_usd, priced) : '—'),
+    el('td', { class: 'num', title: compact(r.avoided_tokens) + ' prefix tokens served from '
+      + 'cache instead of re-created' }, num(r.avoided_recomputations)),
+    el('td', { class: 'num' }, r.retained_ms ? dur(r.retained_ms) : '—'),
+    el('td', { class: 'num' }, s.latency_known
+      ? dur(Math.abs(s.latency_avoided_ms)) + (s.latency_avoided_ms < 0 ? ' worse' : '')
+      : el('span', { class: 'pill missing', title: 'Needs at least 20 real hits and 20 real '
+        + 'misses in this window to measure a difference.' }, 'not measured'))));
+  }
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
+
+  // The three things a reader has to see beside that table, or a number in it means less than
+  // it looks like it does.
+  // Reduced across the arms, like the line below it, rather than read off the first one.
+  // ForcedMisses is strategy-independent BY CONSTRUCTION — it counts rows whose recorded reason is
+  // prefix_change or cold_start, which no TTL can change — but that is an invariant of the
+  // simulator, and this page has no way to check it. Taking the max is the same answer while the
+  // invariant holds and the honest one if it ever stops holding.
+  const forced = sim.results.reduce((m, r) => Math.max(m, r.forced_misses || 0), 0);
+  const open = sim.results.reduce((m, r) => Math.max(m, r.pings_on_open_spans || 0), 0);
+  // Hit rate is on the table because an operator asks for it, NOT because it is the objective —
+  // and on this service's own traffic the two point opposite ways. Said in words, next to the
+  // number, because a reader scanning a table for the best column will otherwise pick it.
+  host.appendChild(el('div', { class: 'banner', 'data-testid': 'kv-hitrate-warning' },
+    el('strong', {}, 'Hit rate is not the objective. '),
+    'The cheapest arm is often not the one that hits most: holding every prefix for an hour '
+    + 'raises the hit rate and pays 2.0\u00d7 input to protect prompts that a 1.25\u00d7 write '
+    + 'already covered. Read the ', el('strong', {}, 'vs baseline'), ' column, not this one.'));
+  host.appendChild(el('p', { class: 'hint', 'data-testid': 'kv-sim-caveats' },
+    forced ? num(forced) + ' of these requests missed for a reason no TTL can fix (the prefix '
+      + 'changed, or there was no entry at all). Every arm misses on them, which is the '
+      + 'ceiling on all of it. ' : '',
+    open ? 'Up to ' + num(open) + ' pings are charged into idle spans whose end is not in this '
+      + 'window; they are bounded by the window and counted apart. ' : '',
+    'The cache premium below each total is what the caching machinery itself cost: a negative '
+    + 'one means the cache paid for itself.'));
+
+  // The premium, and the statistics coverage, as a small second table: these are properties of
+  // the simulation rather than of the comparison, and putting them in the table above would
+  // add four columns nobody reads across.
+  const detail = el('table', { class: 'tbl compact', 'data-testid': 'kv-sim-detail' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Strategy'),
+      el('th', { class: 'num' }, 'Uncached equivalent'),
+      el('th', { class: 'num' }, 'Cache premium'),
+      el('th', { class: 'num' }, 'Fresh input'),
+      el('th', { class: 'num' }, 'Cache read'),
+      el('th', { class: 'num' }, 'Cache write'),
+      el('th', { class: 'num' }, 'Output'),
+      el('th', { class: 'num' }, 'Unpriced'),
+      el('th', {}, 'Decisions'),
+      el('th', {}, 'Own history used')))); 
+  const dbody = el('tbody');
+  detail.appendChild(dbody);
+  for (const r of sim.results) {
+    // The server's own field, not the same test spelled a second time: `valued` IS
+    // unpriced !== requests, and two spellings of one predicate is how they come to
+    // disagree the day one of them gains a caveat.
+    const priced = r.valued;
+    dbody.appendChild(el('tr', {},
+      el('td', {}, r.strategy),
+      el('td', { class: 'num' }, kvMoney(r.uncached_usd, priced)),
+      el('td', { class: 'num' }, kvPremium(r.cache_premium_usd, priced)),
+      el('td', { class: 'num' }, kvMoney(r.fresh_input_usd, priced)),
+      el('td', { class: 'num' }, kvMoney(r.cache_read_usd, priced)),
+      el('td', { class: 'num' }, kvMoney(r.cache_write_usd, priced)),
+      el('td', { class: 'num' }, kvMoney(r.output_usd, priced)),
+      el('td', { class: 'num' }, r.unpriced ? num(r.unpriced) : '—'),
+      el('td', { class: 'small' }, kvDecisions(r.decisions)),
+      el('td', { class: 'small' }, kvLevels(r))));
+  }
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, detail));
+
+  // And the breakdowns, by user and by model, for the arms on screen.
+  host.appendChild(el('h3', {}, 'By user'));
+  host.appendChild(kvSimGroups(sim, 'by_user', 'User'));
+  host.appendChild(el('h3', {}, 'By model'));
+  host.appendChild(kvSimGroups(sim, 'by_model', 'Model'));
+}
+
+/**
+ * kvPingNote separates the two ways a keep-alive can be more than a refresh.
+ *
+ * An UPGRADE is a policy buying a hold it chose — the entry was moved to the one-hour tier
+ * because this arm decided the conversation was worth holding that long. A REWRITE is a schedule
+ * repairing damage it caused: the ping arrived after the entry had already lapsed, so the
+ * "refresh" re-created the prefix at 12.5\u00d7 a read. One is the mechanism working and the
+ * other is it misconfigured, and a single "pings that cost extra" number would make them look
+ * identical.
+ */
+function kvPingNote(r) {
+  const parts = [];
+  if (r.pings_that_upgraded) {
+    parts.push(num(r.pings_that_upgraded) + ' extended the entry to an hour with a 1h write '
+      + '(the policy choosing a longer hold)');
+  }
+  if (r.pings_that_rewrote) {
+    parts.push(num(r.pings_that_rewrote) + ' arrived after the entry had lapsed and re-created '
+      + 'it at the write rate (the schedule interval is longer than the lifetime it protects)');
+  }
+  if (r.pings_on_open_spans) {
+    parts.push(num(r.pings_on_open_spans) + ' fall in idle spans whose end is outside this '
+      + 'window, so their number depends on where the window ends');
+  }
+  return parts.join('\n');
+}
+
+/** kvDecisions renders one arm's action counts as text. */
+function kvDecisions(d) {
+  if (!d) return '—';
+  const parts = Object.keys(d).sort().filter((k) => d[k]).map((k) => k + ' ' + num(d[k]));
+  return parts.length ? parts.join(' · ') : '—';
+}
+
+/**
+ * kvLevels says how much of an arm was decided on the account's OWN history rather than on the
+ * service-wide average.
+ *
+ * "62% within five minutes over 340 of this user's gaps" and "62%, actually the service-wide
+ * average because this user is new" are different facts, and an arm that cannot tell them apart
+ * is acting confidently on nothing.
+ */
+function kvLevels(r) {
+  const l = r.stats_levels || {};
+  const total = Object.keys(l).reduce((s, k) => s + l[k], 0);
+  if (!total) return '—';
+  const own = (l['user+model+bucket'] || 0) + (l['user+model'] || 0) + (l.user || 0);
+  return el('span', {
+    title: Object.keys(l).sort().map((k) => k + ': ' + num(l[k])).join('\n'),
+  }, pct(100 * own / total, 0) + ' own history');
+}
+
+/** kvSimGroups draws one breakdown dimension for every arm on screen. */
+function kvSimGroups(sim, field, label) {
+  const table = el('table', { class: 'tbl compact', 'data-testid': 'kv-sim-' + field },
+    el('thead', {}, el('tr', {},
+      el('th', {}, label), el('th', {}, 'Strategy'),
+      el('th', { class: 'num' }, 'Requests'),
+      el('th', { class: 'num' }, 'Total cost'),
+      el('th', { class: 'num' }, 'Hit rate'),
+      el('th', { class: 'num' }, 'Pings'),
+      el('th', { class: 'num' }, 'Ping cost'),
+      el('th', { class: 'num' }, '5m writes'),
+      el('th', { class: 'num' }, '1h writes'))));
+  const body = el('tbody');
+  table.appendChild(body);
+  // Keyed by group, so a reader compares arms within one user rather than across the page.
+  const keys = [];
+  const seen = new Set();
+  for (const r of sim.results) {
+    for (const g of r[field] || []) if (!seen.has(g.key)) { seen.add(g.key); keys.push(g.key); }
+  }
+  if (!keys.length) {
+    tableMessage(body, 9, 'Nothing to break down', 'No requests in this window.');
+  }
+  for (const key of keys) {
+    for (const r of sim.results) {
+      const g = (r[field] || []).find((x) => x.key === key);
+      if (!g) continue;
+      body.appendChild(el('tr', {},
+        el('td', {}, el('span', { class: 'trunc', title: key }, key || '—')),
+        el('td', {}, r.strategy),
+        kvNum(g.requests),
+        el('td', { class: 'num' }, kvMoney(g.total_usd, g.valued)),
+        el('td', { class: 'num' }, pct(g.hit_rate_pct)),
+        el('td', { class: 'num' }, g.pings ? num(g.pings) : '—'),
+        el('td', { class: 'num' }, g.pings ? kvMoney(g.ping_usd, g.valued) : '—'),
+        kvNum(g.writes_5m), kvNum(g.writes_1h)));
+    }
+  }
+  return el('div', { class: 'tblwrap', tabindex: '0' }, table);
+}
+
+// ── the detail table ───────────────────────────────────────────────────────
+
+/** kvSortable wires the header buttons to a server-side re-sort. */
+function kvSortable(table) {
+  $$('thead th', table).forEach((th, i) => {
+    const key = KV_COLS[i];
+    if (!key) return;
+    const label = th.textContent;
+    th.setAttribute('aria-sort', key === kvc.sort
+      ? (kvc.dir === 'asc' ? 'ascending' : 'descending') : 'none');
+    clear(th).appendChild(el('button', {
+      class: 'sort', title: 'Sort by ' + label,
+      onclick: () => {
+        kvc.dir = kvc.sort === key && kvc.dir === 'desc' ? 'asc' : 'desc';
+        kvc.sort = key;
+        kvc.offset = 0;
+        kvLoadRows();
+      },
+    }, label));
+  });
+}
+
+/** renderKVTable draws one page of the derived dataset. */
+function renderKVTable() {
+  const host = clear($('#kv-table'));
+  const table = el('table', { class: 'tbl compact', 'data-testid': 'kv-rows-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'When'), el('th', {}, 'User'), el('th', {}, 'Conversation'),
+      el('th', {}, 'Model'),
+      el('th', { class: 'num' }, 'Input'), el('th', { class: 'num' }, 'Output'),
+      el('th', { class: 'num' }, 'Cache read'), el('th', { class: 'num' }, 'Cache write'),
+      el('th', { class: 'num' }, 'Cached prompt'),
+      el('th', {}, 'TTL'), el('th', {}, 'Cache'),
+      el('th', { class: 'num' }, 'Idle to next'),
+      el('th', {}, 'In 5m'), el('th', {}, 'In 1h'),
+      el('th', { class: 'num' }, 'Cost'),
+      el('th', {}, 'Next at'))));
+  const body = el('tbody', { id: 'kv-rows-body' });
+  table.appendChild(body);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, table));
+  kvSortable(table);
+
+  const page = kvc.page;
+  if (!page) { loadingRows(body, 16); return; }
+  if (!page.rows.length) {
+    tableMessage(body, 16, 'No requests match these filters',
+      'Widen the time range at the top of the page, or clear a filter.');
+    renderKVPager();
+    return;
+  }
+  const wide = wideScope();
+  for (const r of page.rows) {
+    body.appendChild(el('tr', {},
+      el('td', {}, el('a', { href: r.request_url, class: 'kv-link',
+        title: 'Open this request' }, when(r.ts))),
+      el('td', {}, wide ? el('span', { class: 'trunc', title: r.user }, r.user || '—') : '—'),
+      el('td', {}, el('a', { href: r.conversation_url, class: 'kv-link clip',
+        title: 'Open this conversation' }, r.conversation_id || '—')),
+      el('td', {}, el('span', { class: 'trunc', title: r.model }, r.model || '—')),
+      kvTok(r.input_tokens), kvTok(r.output_tokens),
+      kvTok(r.cache_read_tokens), kvTok(r.cache_write_tokens),
+      kvTok(r.cached_context_tokens),
+      el('td', {}, kvTTLPill(r)),
+      el('td', {}, kvHitPill(r)),
+      el('td', { class: 'num' }, kvIdle(r)),
+      el('td', {}, r.has_next ? (r.within_5m ? 'yes' : 'no') : '—'),
+      el('td', {}, r.has_next ? (r.within_1h ? 'yes' : 'no') : '—'),
+      el('td', { class: 'num' }, kvMoney(r.cost_usd, r.cost_known)),
+      el('td', {}, r.has_next ? when(r.next_ts) : '—')));
+  }
+  renderKVPager();
+}
+
+/** renderKVPager draws the offset pager. */
+function renderKVPager() {
+  const host = clear($('#kv-pager'));
+  const page = kvc.page;
+  if (!page) return;
+  const from = page.rows.length ? kvc.offset + 1 : 0;
+  const to = kvc.offset + page.rows.length;
+  host.appendChild(el('div', { class: 'pager' },
+    el('button', {
+      class: 'ghost', 'data-testid': 'kv-prev', disabled: kvc.offset <= 0 ? 'disabled' : null,
+      onclick: () => { kvc.offset = Math.max(0, kvc.offset - kvc.limit); kvLoadRows(); },
+    }, 'Previous'),
+    el('span', { class: 'muted small', 'data-testid': 'kv-pager-label' },
+      num(from) + '–' + num(to) + ' of ' + num(page.total)
+      + (page.truncated ? ' (analysis capped)' : '')),
+    el('button', {
+      class: 'ghost', 'data-testid': 'kv-next', disabled: to >= page.total ? 'disabled' : null,
+      onclick: () => { kvc.offset += kvc.limit; kvLoadRows(); },
+    }, 'Next')));
+}
+
+/**
+ * renderKVAssumptions prints the server's own statement of every formula and caveat.
+ *
+ * Printed, not written here. These strings arrive with the data and are checked against the
+ * functions that implement them, so the page cannot describe arithmetic the code does not do.
+ */
+function renderKVAssumptions() {
+  const host = clear($('#kv-assumptions'));
+  const a = (kvc.analysis && kvc.analysis.assumptions)
+    || (kvc.prices && kvc.prices.assumptions);
+  if (!a) { loadingState(host, 2); return; }
+  host.appendChild(el('p', { class: 'hint', 'data-testid': 'kv-units' },
+    'Times are in ', el('strong', {}, a.time_zone), '; every duration is measured in ',
+    a.time_unit, '. Reuse horizons: ', num(a.horizon_5m_seconds), ' s and ',
+    num(a.horizon_1h_seconds), ' s.'));
+  for (const f of a.formulas || []) {
+    host.appendChild(el('div', { class: 'kv-formula' },
+      el('div', { class: 'kv-formula-name', text: f.name }),
+      el('code', { text: f.formula }),
+      el('div', { class: 'kv-formula-note', text: f.note })));
+  }
+  const notes = el('ul', { 'data-testid': 'kv-notes' });
+  for (const n of a.notes || []) notes.appendChild(el('li', { class: 'small', text: n }));
+  host.appendChild(el('details', { class: 'why' },
+    el('summary', {}, 'What is assumed, and what is missing'), notes));
+}
+
+// ── loading ────────────────────────────────────────────────────────────────
+
+/** kvReload re-reads everything that depends on the filters or the prices. */
+function kvReload() {
+  kvc.offset = 0;
+  loadKVCache();
+}
+
+async function kvLoadAnalysis() {
+  try {
+    kvc.analysis = await kvFetch('kvcache');
+  } catch (err) {
+    if (aborted(err)) return;
+    errorState(clear($('#kv-tiles')), 'Could not read the KV-cache analysis', err);
+    return;
+  }
+  renderKVCoverage();
+  renderKVControls();
+  renderKVTiles();
+  renderKVIdleBands();
+  renderKVSurvival();
+  renderKVGroups();
+  renderKVAssumptions();
+}
+
+async function kvLoadPricing() {
+  try {
+    kvc.prices = await kvFetch('kvcache/pricing');
+  } catch (err) {
+    if (aborted(err)) return;
+    errorState(clear($('#kv-pricing')), 'Could not read the price list', err);
+    return;
+  }
+  renderKVPricing();
+  renderKVAssumptions();
+}
+
+async function kvLoadSim() {
+  const host = $('#kv-sim');
+  loadingState(clear(host), 3);
+  try {
+    kvc.sim = await kvFetch('kvcache/simulate', {
+      // Both OMITTED on the first load, so the server picks its own default arms and its own
+      // baseline. That is the point of driving the picker from the registry: the page does not
+      // know the roster until the server has told it, and guessing one here is what put a
+      // six-name list in this file in the first place.
+      baseline: kvc.baseline || undefined,
+      strategy: kvc.arms && kvc.arms.length ? kvc.arms.join(',') : undefined,
+    });
+  } catch (err) {
+    if (aborted(err)) return;
+    errorState(host, 'Could not replay the strategies', err);
+    return;
+  }
+  renderKVArms();
+  renderKVSim();
+}
+
+async function kvLoadRows() {
+  try {
+    kvc.page = await kvFetch('kvcache/rows',
+      { limit: kvc.limit, offset: kvc.offset, sort: kvc.sort, dir: kvc.dir });
+  } catch (err) {
+    if (aborted(err)) return;
+    kvc.page = null;
+    errorState(clear($('#kv-table')), 'Could not read the request rows', err);
+    return;
+  }
+  renderKVTable();
+}
+
+/**
+ * loadKVCache fetches the four payloads, each from its own request.
+ *
+ * Four requests and not one: the analysis is the measurement and must be on screen before any
+ * simulation runs, and one slow replay must not blank the histogram beside it. The same
+ * arrangement the keep-alive tab uses, for the same reason.
+ */
+async function loadKVCache() {
+  renderKVControls();
+  renderKVArms();
+  kvLoadAnalysis();
+  kvLoadPricing();
+  kvLoadSim();
+  kvLoadRows();
+}
+
+// Registered here, so mounting this whole view is one line in the shared page.
+Object.assign(loaders, { kvcache: loadKVCache });

--- a/dash/uikvcache_test.go
+++ b/dash/uikvcache_test.go
@@ -1,0 +1,786 @@
+package dash
+
+// Static checks over the KV-cache tab's own assets.
+//
+// Every one of them is an HONESTY property, and every one is invisible on screen when it is
+// wrong — the page looks completely fine. That is what earns a source-level assertion here,
+// exactly as TestEveryKeepAliveTileHasAnExplanation and TestEveryInventoryTileHasAnExplanation
+// do for the two tabs before it.
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Every tile on the tab has its plain-English definition, how it was derived, and its catch.
+//
+// This is the tab whose figures authorise changing a caching policy — i.e. changing somebody's
+// bill — so a number nobody can interpret is worse here than almost anywhere else.
+func TestEveryKVCacheTileHasAnExplanation(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	keys := map[string]bool{}
+	for _, m := range regexp.MustCompile(`tile\('(kv-[a-z0-9-]+)'`).FindAllStringSubmatch(src, -1) {
+		keys[m[1]] = true
+	}
+	if len(keys) == 0 {
+		t.Fatal("found no kv- tile() calls; this check needs rewriting against whatever replaced them")
+	}
+	for k := range keys {
+		if !strings.Contains(src, "'"+k+"': {") {
+			t.Errorf("tile %q has no TILE_INFO entry.\n"+
+				"Every figure on this tab needs what it means, how it was derived and its "+
+				"catch — these are the numbers somebody changes a cache policy on.", k)
+		}
+	}
+	// And the two disclosures every reader of this page needs: that a request with no successor
+	// is excluded rather than counted as zero, and that an unpriced request is not a free one.
+	for _, must := range []string{"no next request", "not zero", "not a free one"} {
+		if !strings.Contains(src, must) {
+			t.Errorf("no explanation on this tab says %q; that is the assumption every average "+
+				"on it depends on", must)
+		}
+	}
+}
+
+// NOT ONE PRICE IN THE BROWSER.
+//
+// The recorded failure this guards: app.js once carried a hardcoded 3.00/3.75/0.30 per-MTok
+// rate table, sonnet-class, on a deployment that bills opus — so every net figure derived from
+// it was ~27% wrong in a direction nobody could see. This page is entirely about prices, which
+// makes it the most likely place for that to happen again.
+//
+// Two assertions. First, no per-token rate literal: the scientific-notation forms a USD/token
+// rate takes, and the two Anthropic cache multiples, used as ARITHMETIC rather than mentioned
+// in prose (the tile explanations legitimately say "2.0x base input"). Second, no dollar field
+// is ever an operand: every *_usd on this page is displayed, never computed with.
+func TestTheKVCacheViewCarriesNoPriceOfItsOwn(t *testing.T) {
+	code := stripJSComments(readUI(t, "ui/kvcache.js"))
+	for _, bad := range []string{"e-6", "e-7", "* 1.25", "1.25 *", "* 3.75", "3.75 *",
+		"* 0.1", "0.1 *", "/ 1.25", "* 2.0", "2.0 *"} {
+		if strings.Contains(code, bad) {
+			t.Errorf("the KV-cache view computes with %q. Every rate belongs to the server: the "+
+				"browser posts inputs and renders the answers it gets back.", bad)
+		}
+	}
+	// A money field as an operand of + - * / — including a unary minus to flip a sign for a
+	// colour, which is how the first draft of this page negated the cache premium.
+	operand := regexp.MustCompile(`(?:[-+*/]\s*[A-Za-z0-9_.\[\]]*_usd\b)|(?:\b[A-Za-z0-9_.\[\]]*_usd\s*[-+*/])`)
+	for _, m := range operand.FindAllString(code, -1) {
+		t.Errorf("a dollar figure is used in arithmetic here: %q. Absolute savings, percentages "+
+			"and the cache premium are all computed server-side, in one place, from the rates "+
+			"that were actually applied.", strings.TrimSpace(m))
+	}
+}
+
+// The cost formulas are PRINTED, not retyped.
+//
+// A formula written into a JavaScript template is a second definition of the arithmetic and
+// nothing tests it against the first. They arrive in the payload, so the page shows the
+// expressions the server actually evaluated.
+func TestTheCostFormulasAreRenderedFromThePayload(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	i := strings.Index(src, "function renderKVAssumptions(")
+	if i < 0 {
+		t.Fatal("renderKVAssumptions is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 3000)]
+	for _, must := range []string{"a.formulas", "f.formula", "f.note", "a.notes", "a.time_zone"} {
+		if !strings.Contains(body, must) {
+			t.Errorf("the assumptions panel does not render %s from the payload", must)
+		}
+	}
+	// And the page states its timezone, because there is no per-user one in the store and a
+	// time-of-day analysis without a zone is not a measurement.
+	if !strings.Contains(body, "time_zone") {
+		t.Error("the page does not say which timezone its hours are in")
+	}
+}
+
+// A request with no successor is never rendered as a duration, and an unpriced model is never
+// rendered as $0. Both are one function each, and every cell goes through them.
+func TestAnAbsenceIsNeverRenderedAsAZero(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	for _, fn := range []string{"function kvIdle(", "function kvMoney(", "function kvTTLPill("} {
+		if !strings.Contains(src, fn) {
+			t.Errorf("%s is gone; this check needs rewriting", fn)
+		}
+	}
+	idle := src[strings.Index(src, "function kvIdle("):]
+	idle = idle[:min(len(idle), 900)]
+	if !strings.Contains(idle, "has_next") || !strings.Contains(idle, "no next request") {
+		t.Error("kvIdle does not distinguish a request with no successor from a zero-length gap")
+	}
+	if !strings.Contains(idle, "0 s") {
+		t.Error("kvIdle renders a genuine zero-length gap as nothing; tied timestamps are real " +
+			"(9 of 12,635 consecutive pairs on this service) and dur(0) renders an em dash, " +
+			"which is what 'no successor' looks like")
+	}
+	money := src[strings.Index(src, "function kvMoney("):]
+	money = money[:min(len(money), 600)]
+	if !strings.Contains(money, "unpriced") {
+		t.Error("kvMoney has no unpriced branch; usd(0) renders '$0', which is a claim that " +
+			"something was free")
+	}
+}
+
+// Negative savings are rendered as negative, in the status colour, and nothing clamps them.
+//
+// A strategy that costs money is the only result on this page that can stop somebody making a
+// change, so it is the one that must not be rounded away.
+func TestNegativeSavingsAreShownAsNegative(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	i := strings.Index(src, "function kvSigned(")
+	if i < 0 {
+		t.Fatal("kvSigned is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 600)]
+	if !strings.Contains(body, "bad-text") || !strings.Contains(body, "good-text") {
+		t.Error("a saving is not coloured by its sign")
+	}
+	// The DIRECTION must be in words, not only in the sign and the colour.
+	//
+	// This is the defect that shipped: a column of signed dollars was read as a saving when it
+	// was the opposite, and -$2,117.80 in a "saving" column made the worst arm look like the
+	// best. Sign plus colour was not enough, and colour must never carry a judgement alone
+	// anyway — the rule the rest of this dashboard already keeps.
+	for _, want := range []string{"cheaper", "MORE"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("kvSigned does not say %q; the direction of a difference against the "+
+				"baseline has to be a WORD beside the figure, not just its sign", want)
+		}
+	}
+
+	// No clamp on a MONEY line. Scoped to lines that mention a dollar figure or a saving,
+	// because clamping a page OFFSET at zero is correct and clamping a saving at zero is the
+	// defect: an unscoped substring check would forbid the first to catch the second.
+	//
+	// Math.abs is forbidden here for the same reason — it was how a signed figure got made
+	// unsigned — with ONE exemption, which is narrow and is the reason the check above exists:
+	// a line that emits the direction word (class "kv-dir") has already stated which way the
+	// figure points, so taking the magnitude is a rendering choice rather than a lost sign.
+	// "$2,117.80 MORE" is unambiguous where "-$2,117.80 MORE" is a double negative. Any OTHER
+	// line that reaches for Math.abs on a money figure is still a failure.
+	code := stripJSComments(src)
+	for _, line := range strings.Split(code, "\n") {
+		l := strings.ToLower(line)
+		if !strings.Contains(l, "usd") && !strings.Contains(l, "saving") &&
+			!strings.Contains(l, "percent") {
+			continue
+		}
+		statesDirection := strings.Contains(line, "kv-dir")
+		for _, bad := range []string{"math.max(0", "< 0 ? 0", "math.abs("} {
+			if bad == "math.abs(" && statesDirection {
+				continue
+			}
+			if strings.Contains(l, bad) {
+				t.Errorf("a saving is clamped or made unsigned here: %s", strings.TrimSpace(line))
+			}
+		}
+	}
+	// An undefined percentage is a pill, not a 0%.
+	if !strings.Contains(code, "percent_known") || !strings.Contains(code, "undefined") {
+		t.Error("a percentage against a zero baseline is not marked undefined; a percentage of " +
+			"nothing is not 0%")
+	}
+}
+
+// The tab respects the time-range filter, so it must NOT be in UNFILTERED_VIEWS — every figure
+// on it is "over this window", and a tab that ignored the picker above it would be answering a
+// different question from the one on screen.
+func TestTheKVCacheTabRespectsTheTimeRange(t *testing.T) {
+	app := readUI(t, "ui/app.js")
+	i := strings.Index(app, "const UNFILTERED_VIEWS")
+	if i < 0 {
+		t.Fatal("UNFILTERED_VIEWS is gone; this check needs rewriting")
+	}
+	line := app[i : i+strings.Index(app[i:], "\n")]
+	if strings.Contains(line, "kvcache") {
+		t.Errorf("the KV-cache tab is in UNFILTERED_VIEWS: %s", line)
+	}
+	src := readUI(t, "ui/kvcache.js")
+	// Wired into the loader table, or the tab renders nothing at all.
+	if !strings.Contains(src, "loaders, { kvcache: loadKVCache }") {
+		t.Error("the KV-cache view has no loader")
+	}
+	// The tab and the section mount themselves, so the shared page has one line about it.
+	if !strings.Contains(src, `'data-view': 'kvcache'`) {
+		t.Error("the KV-cache view does not mount its own tab")
+	}
+	if !strings.Contains(src, `id: 'view-kvcache'`) {
+		t.Error("the KV-cache view does not mount its own section")
+	}
+	if !strings.Contains(readUI(t, "ui/index.html"), `<script src="kvcache.js">`) {
+		t.Error("kvcache.js is not loaded by the shared page")
+	}
+}
+
+// No new hue, no pie, no gauge, no second chart library. The dashboard has a fixed four-hue
+// categorical order, a status palette, a de-emphasis gray and two chart primitives; a fifth
+// series colour means a chart needs splitting, not a new colour.
+func TestTheKVCacheTabAddsNoNewChartVocabulary(t *testing.T) {
+	code := stripJSComments(readUI(t, "ui/kvcache.js"))
+	for _, bad := range []string{"--s5", "var(--s5)", "pieChart", "treemap", "gauge", "Chart.js",
+		"d3.", "conic-gradient", "y2", "rightAxis"} {
+		if strings.Contains(code, bad) {
+			t.Errorf("the KV-cache tab introduces %q. Every panel here maps onto stat tiles, "+
+				"barRows, lineChart and a table; anything else is a new vocabulary for the "+
+				"reader to learn.", bad)
+		}
+	}
+	// It draws with the shared primitives rather than its own SVG.
+	for _, want := range []string{"barRows(", "lineChart(", "tileGroup(", "emptyState("} {
+		if !strings.Contains(code, want) {
+			t.Errorf("the KV-cache tab does not use the shared %s", want)
+		}
+	}
+	if strings.Contains(code, "svgEl(") {
+		t.Error("the KV-cache tab draws its own SVG instead of using the shared chart helpers")
+	}
+	// The stylesheet adds no hue of its own either.
+	css := readUI(t, "ui/kvcache.css")
+	for _, m := range regexp.MustCompile(`#[0-9a-fA-F]{3,8}\b`).FindAllString(css, -1) {
+		t.Errorf("kvcache.css hardcodes the colour %s; every colour on this dashboard is a "+
+			"token from style.css", m)
+	}
+}
+
+// Every row of the detail table leads back to the request and to the conversation it came from.
+// An analysis nobody can follow into the transcript is a dead end.
+func TestTheDetailTableLinksBackIntoTheDashboard(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	i := strings.Index(src, "function renderKVTable(")
+	if i < 0 {
+		t.Fatal("renderKVTable is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 4000)]
+	for _, must := range []string{"r.request_url", "r.conversation_url"} {
+		if !strings.Contains(body, must) {
+			t.Errorf("the detail table does not link with %s", must)
+		}
+	}
+	// The links come from the payload rather than being assembled here, so a route the UI
+	// spells differently cannot silently produce a dead link.
+	if strings.Contains(body, "'#requests?req='") || strings.Contains(body, `"#requests?req="`) {
+		t.Error("the detail table builds its own request URL; the server sends it")
+	}
+}
+
+// The table is sorted and paged on the SERVER, which is what makes a sorted column mean
+// anything: sorting one page client-side would label a column "Idle" and show the top of an
+// arbitrary slice. (The same distinction app.js draws between Components and Sessions.)
+func TestTheDetailTableSortsOnTheServer(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	i := strings.Index(src, "function kvSortable(")
+	if i < 0 {
+		t.Fatal("kvSortable is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 1200)]
+	if !strings.Contains(body, "kvLoadRows()") {
+		t.Error("a header click does not re-read from the server")
+	}
+	if strings.Contains(body, "sortRows(") {
+		t.Error("the KV-cache table sorts one page client-side; it is server-paged, so that " +
+			"would show the top of an arbitrary page under a column heading that claims " +
+			"otherwise")
+	}
+}
+
+// The coverage banner renders UNCONDITIONALLY, not only when the news is bad — the same rule
+// the keep-alive tab's downside panel keeps, and for the same reason: a page that tells the
+// truth only to the people who already found out is not telling the truth.
+func TestTheCoverageStatementIsNotBehindABranchOnGoodNews(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	i := strings.Index(src, "function renderKVCoverage(")
+	if i < 0 {
+		t.Fatal("renderKVCoverage is gone; this check needs rewriting")
+	}
+	body := src[i : i+min(len(src)-i, 3000)]
+	// The three states it must be able to report.
+	for _, must := range []string{"kv-truncated", "kv-ttl-coverage", "kv-cost-coverage",
+		"kv-single-note"} {
+		if !strings.Contains(body, must) {
+			t.Errorf("the coverage panel cannot report %s", must)
+		}
+	}
+	if !strings.Contains(body, "NOT RECORDED") {
+		t.Error("the coverage panel does not say that a blank tier means NOT RECORDED rather " +
+			"than 'no cache'; that is the additive-column trap this dashboard has hit before")
+	}
+	// And loadKVCache calls it before anything else renders.
+	load := src[strings.Index(src, "async function kvLoadAnalysis("):]
+	load = load[:min(len(load), 1200)]
+	cov := strings.Index(load, "renderKVCoverage()")
+	tiles := strings.Index(load, "renderKVTiles()")
+	if cov < 0 || tiles < 0 || cov > tiles {
+		t.Error("the coverage statement is not rendered before the figures it qualifies")
+	}
+}
+
+// No top-level name in a self-mounting view may collide with one in the shared script.
+//
+// The bug this caught: kvcache.js declared `const kv` and app.js already had a global
+// `function kv(k, v)` — the key-value row renderer. Two top-level declarations of the same
+// name in two classic scripts is a SyntaxError, so the whole view failed to parse and the tab
+// simply never appeared. Nothing else in this suite could see it: each file parses on its own,
+// and every static check here is a substring match within one file.
+//
+// Asserted over every appended view, not just the newest one, because the next one will have
+// the same problem.
+func TestAppendedViewsDeclareNoNameTheSharedScriptAlreadyOwns(t *testing.T) {
+	decl := regexp.MustCompile(`(?m)^(?:async\s+)?(?:function|const|let|var)\s+([A-Za-z_$][\w$]*)`)
+	top := func(name string) map[string]bool {
+		out := map[string]bool{}
+		for _, m := range decl.FindAllStringSubmatch(readUI(t, name), -1) {
+			out[m[1]] = true
+		}
+		if len(out) == 0 {
+			t.Fatalf("%s: found no top-level declarations; this check needs rewriting", name)
+		}
+		return out
+	}
+	shared := top("ui/app.js")
+	seen := map[string]string{}
+	for k := range shared {
+		seen[k] = "ui/app.js"
+	}
+	// In document order, which is the order a browser evaluates them in.
+	for _, view := range []string{"ui/tools.js", "ui/kvcache.js"} {
+		for name := range top(view) {
+			if owner, clash := seen[name]; clash {
+				t.Errorf("%s declares %q at top level, which %s already declares. Two classic "+
+					"scripts declaring the same name is a SyntaxError, so %s would not parse at "+
+					"all and its tab would silently never appear.", view, name, owner, view)
+				continue
+			}
+			seen[name] = view
+		}
+	}
+}
+
+// The arm picker is built from the SERVER's registry, and this file names no arm.
+//
+// The failure this guards actually happened here: kvcache.js carried `const KV_ARMS` with six
+// names and the API carried a matching closed list, while package kvcache had grown to ten arms.
+// Two keep-alive policies, the extend-to-1h policy and the exact cost ceiling were shipped,
+// tested, and unreachable from the dashboard — and no test on either side could see it, because
+// each list was internally consistent. A page that enumerates its own options cannot show an
+// option it was not told about.
+func TestTheArmPickerIsBuiltFromTheServersRegistry(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	code := stripJSComments(src)
+	if !strings.Contains(code, "kvc.sim && kvc.sim.arms") {
+		t.Error("the picker does not read the arms out of the simulate payload")
+	}
+	// No list of arm names in this file. Two or more known arm names quoted on one line is what a
+	// hardcoded roster looks like, whatever it is called.
+	names := []string{"'no-cache'", "'fixed-5m'", "'fixed-1h'", "'observed-policy'",
+		"'historical-probability'", "'keepalive-5m'", "'keepalive-1h'", "'optimal'"}
+	for _, line := range strings.Split(code, "\n") {
+		n := 0
+		for _, name := range names {
+			if strings.Contains(line, name) {
+				n++
+			}
+		}
+		if n >= 2 {
+			t.Errorf("this line enumerates the arms; the server does that:\n%s",
+				strings.TrimSpace(line))
+		}
+	}
+}
+
+// An UNREACHABLE arm is labelled a ceiling, in a word, and is never offered as a baseline.
+//
+// `optimal` is told the real next-request time, so it is the cheapest plan that exists for a
+// history rather than a policy anybody can run. Two ways to mislead with it, and both are shut
+// here: rendering it beside real arms in the same style, and dividing a percentage by it — every
+// figure measured against it would be a share of a number no policy can reach.
+func TestTheCeilingArmIsLabelledAndNeverABaselineOnThePage(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	code := stripJSComments(src)
+	i := strings.Index(code, "function kvBaselineArms(")
+	if i < 0 {
+		t.Fatal("kvBaselineArms is gone; the baseline picker no longer filters anything")
+	}
+	if !strings.Contains(code[i:i+min(len(code)-i, 300)], "!a.unreachable") {
+		t.Error("the baseline picker offers unreachable arms; a percentage divided by a ceiling " +
+			"is a share of a number no policy can reach")
+	}
+	// The label is a WORD, not a colour. The colour is allowed as a second statement of the same
+	// fact (see kvcache.css) but it must never be the only one.
+	if !strings.Contains(code, "'ceiling'") {
+		t.Error("nothing on the page says the word 'ceiling'; an unreachable arm rendered like a " +
+			"real one is a promise the product cannot keep")
+	}
+	if !strings.Contains(code, "kvCeilingPill()") {
+		t.Error("the ceiling marker is not applied anywhere")
+	}
+	// It is applied in BOTH places an arm appears: the picker and the comparison row.
+	if n := strings.Count(code, "kvCeilingPill()"); n < 3 {
+		t.Errorf("the ceiling marker appears %d times; it has to be on the picker entry and on "+
+			"the comparison row, or one of the two reads as an ordinary option", n)
+	}
+}
+
+// Hit rate is on the page because an operator asks for it, and the page says out loud that it is
+// not the objective.
+//
+// Measured on this service's own traffic the two point opposite ways: holding every prefix for an
+// hour gives the best hit rate on the table and is one of the most expensive arms, because it pays
+// 2.0x input to protect prompts a 1.25x write already covered. A reader scanning a table for the
+// best-looking column will pick it, so the warning is in the markup rather than left to judgement
+// — and nothing sorts or colours by it.
+func TestHitRateIsNotPresentedAsTheObjective(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	code := stripJSComments(src)
+	if !strings.Contains(code, "kv-hitrate-warning") {
+		t.Error("the page does not say that hit rate is not the objective")
+	}
+	if !strings.Contains(src, "Hit rate is not the objective") {
+		t.Error("the warning does not say it in words")
+	}
+	// No status colour and no sort on a hit-rate cell: those are the two ways a table recommends
+	// a column. Every hit_rate_pct must be a plain pct() cell.
+	for _, line := range strings.Split(code, "\n") {
+		if !strings.Contains(line, "hit_rate_pct") {
+			continue
+		}
+		for _, bad := range []string{"good-text", "bad-text", "sort", "SORT"} {
+			if strings.Contains(line, bad) {
+				t.Errorf("a hit-rate cell is coloured or sorted, which recommends it:\n%s",
+					strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// The two ways a keep-alive costs more than a refresh are two numbers, not one.
+//
+// An UPGRADE is a policy buying a hold it chose: the entry moved to the one-hour tier because the
+// arm decided the conversation was worth holding. A REWRITE is a schedule repairing damage it
+// caused: the ping arrived after the entry had lapsed, so the refresh re-created the prefix at
+// 12.5x a read. One is the mechanism working and the other is it misconfigured. Summed into a
+// single "pings that cost extra", a working arm and a broken one look identical.
+func TestTheTwoKindsOfCostlyPingAreNotOneNumber(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	code := stripJSComments(src)
+	for _, want := range []string{"pings_that_upgraded", "pings_that_rewrote"} {
+		if !strings.Contains(code, want) {
+			t.Errorf("the page never reads %s", want)
+		}
+	}
+	// And they are not added together anywhere.
+	for _, line := range strings.Split(code, "\n") {
+		if strings.Contains(line, "pings_that_upgraded") && strings.Contains(line, "pings_that_rewrote") &&
+			strings.Contains(line, "+") {
+			t.Errorf("the two are combined into one figure:\n%s", strings.TrimSpace(line))
+		}
+	}
+}
+
+// Every module-level constant an appended view REFERENCES is one that exists.
+//
+// The bug this exists for shipped and was caught by a screenshot, not by this suite: a `KV_ARMS`
+// constant was removed in favour of reading the arm roster from the server, and one reference to
+// it survived inside an async loader. The view parsed, mounted, drew its tiles, its histogram, its
+// prices and its table — and the strategy comparison, the whole point of the page, rendered
+// "Could not replay the strategies: KV_ARMS is not defined". Every other check in this file is a
+// substring match, and a substring match cannot see an identifier that is no longer declared.
+//
+// Scoped to SCREAMING_SNAKE_CASE names because that is this codebase's module-constant
+// convention, and those are exactly the ones an appended view borrows from app.js (TILE_INFO,
+// SERIES, DIMS) or declares for itself. Comments and string literals are stripped first, or the
+// direction word 'MORE' and every data-testid would read as an undefined reference.
+func TestAppendedViewsReferenceNoConstantThatDoesNotExist(t *testing.T) {
+	shared := stripJSLiterals(readUI(t, "ui/app.js"))
+	// Browser and language globals that happen to be all-caps. A NEW one appearing here should
+	// fail loudly and be added deliberately rather than silently allowed by a loose pattern.
+	globals := map[string]bool{"JSON": true, "NaN": true, "URL": true, "DOM": true}
+	declared := regexp.MustCompile(`(?:const|let|var|function|class)\s+([A-Z][A-Z0-9_]{2,})\b`)
+	word := regexp.MustCompile(`\b[A-Z][A-Z0-9_]{2,}\b`)
+
+	for _, view := range []string{"ui/kvcache.js", "ui/tools.js"} {
+		src := stripJSLiterals(readUI(t, view))
+		have := map[string]bool{}
+		for _, m := range declared.FindAllStringSubmatch(shared+"\n"+src, -1) {
+			have[m[1]] = true
+		}
+		for _, name := range word.FindAllString(src, -1) {
+			if have[name] || globals[name] {
+				continue
+			}
+			t.Errorf("%s references %s, which nothing declares in it or in app.js. A reference to "+
+				"a removed constant parses fine and throws at run time, so the panel that touches "+
+				"it renders an error while the rest of the page looks perfect.", view, name)
+			have[name] = true // report each name once
+		}
+	}
+}
+
+// stripJSLiterals removes comments AND quoted strings, so a static scan for identifiers cannot
+// be fooled by prose or by a string that happens to look like one.
+//
+// Crude on purpose — it is not a parser, and it does not need to be: it is only ever used to
+// decide whether a run of capitals is code or text. Template literals are treated as strings
+// whole, which loses any ${} interpolation inside them; that is the conservative direction for a
+// check that reports unknown names.
+func stripJSLiterals(src string) string {
+	var b strings.Builder
+	for i := 0; i < len(src); {
+		switch c := src[i]; {
+		case strings.HasPrefix(src[i:], "//"):
+			j := strings.IndexByte(src[i:], '\n')
+			if j < 0 {
+				return b.String()
+			}
+			i += j
+		case strings.HasPrefix(src[i:], "/*"):
+			j := strings.Index(src[i:], "*/")
+			if j < 0 {
+				return b.String()
+			}
+			i += j + 2
+		case c == '\'' || c == '"' || c == '`':
+			i++
+			for i < len(src) && src[i] != c {
+				if src[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			b.WriteByte(' ') // keep tokens either side from fusing
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// When nothing in the window has a rate, the page SAYS SO above the comparison — and it reads
+// the SERVER'S OWN field for it rather than re-deriving the condition.
+//
+// The state is real: the price map is fetched in the background, so the first load after a
+// restart has no rates for a few seconds, and a deployment with no price list never gets any. It
+// earns a banner rather than a row of "unpriced" pills because of what an unpriced replay does to
+// the arms that decide by comparing costs — the exact ceiling included. With no costs to compare
+// they let every entry expire and report a 0% hit rate and no writes, and on the ceiling row that
+// reads as "the cheapest possible plan is to never cache anything", the opposite of the finding
+// this page exists for. Found by rendering the page during a cold start, not by any check here.
+//
+// `valued` rather than `unpriced === requests`: the same fact, but one of them is the server's
+// answer and the other is this page's inference, and an inference is a second definition to keep
+// in step. kvcache.Result.Valued exists precisely because the derivation is the step a consumer
+// forgets.
+func TestAnEntirelyUnpricedWindowIsNamedFromTheServersOwnField(t *testing.T) {
+	src := readUI(t, "ui/kvcache.js")
+	code := stripJSComments(src)
+	if !strings.Contains(code, "kv-unvalued") {
+		t.Error("the comparison panel does not name the state where no model has a rate")
+	}
+	if !strings.Contains(code, "r.valued === false") {
+		t.Error("the panel does not read Result.valued; deriving the condition from unpriced and " +
+			"requests is a second definition of it, which is the inference the field exists to " +
+			"remove")
+	}
+	// The derivation is banned on ANY receiver, not just on a result. Groups carry `valued` too
+	// now, so `g.unpriced < g.requests` is the same second definition one level down — and it was
+	// there until a review found it, precisely because this check named a single receiver.
+	if m := regexp.MustCompile(`\w+\.unpriced\s*<\s*\w+\.requests`).FindString(code); m != "" {
+		t.Errorf("the page still derives 'nothing was priced' for itself (%s) alongside reading "+
+			"valued; two answers to one question is how they come to disagree, and both Result "+
+			"and Group state it now", m)
+	}
+	if !strings.Contains(src, "ceiling") {
+		t.Error("the banner does not say the ceiling is affected too, which is the one row an " +
+			"unpriced replay makes actively misleading")
+	}
+}
+
+// The wire contract between this package's payloads and the page that reads them.
+//
+// RECONSTRUCTED after I deleted the third session's version of this test with an unscoped
+// tail-replacement. It is written from the failure it was for, which is worth stating because the
+// failure is invisible in the most expensive way: I rebuilt KVCacheFormula with the json tags
+// {name, expression, prose} while the page read {name, formula, note}. `name` matched by luck, so
+// the assumptions panel rendered eleven formula HEADINGS above eleven EMPTY code boxes — which
+// reads as a stylesheet problem, not a missing field. Two tests passed straight through it: one
+// asserting the payload carries at least eight formulas, one asserting the page does not hardcode
+// them. Each was right about its own half of a contract neither checked ACROSS.
+//
+// Both directions matter and only one of them is cheap, so this does the cheap one generally and
+// the expensive one where the bug actually was:
+//
+//   - every snake_case property the page reads must be a key some payload emits. JS locals in this
+//     codebase are camelCase, so an underscore is a reliable signal that a read is a wire field.
+//   - the formula object, specifically, must carry exactly the keys the page reads off it — the
+//     one place a rename slipped through, and the one shape whose keys have no underscores.
+func TestThePageOnlyReadsFieldsThePayloadsEmit(t *testing.T) {
+	// Keys are collected from the TYPES by reflection, not from marshalled instances.
+	//
+	// An instance cannot answer the question: `next_ts` is tagged omitempty, so a zero-valued
+	// fixture omits it and the check would report a field the page legitimately reads as absent.
+	// Populating every field of every payload by hand is the alternative, and it is a fixture
+	// nobody would keep current. The tags are the contract; read the contract.
+	emitted := map[string]bool{}
+	var walk func(reflect.Type, int)
+	walk = func(t reflect.Type, depth int) {
+		if depth > 8 {
+			return
+		}
+		for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+			t = t.Elem()
+		}
+		if t.Kind() == reflect.Map {
+			walk(t.Elem(), depth+1)
+			return
+		}
+		if t.Kind() != reflect.Struct {
+			return
+		}
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.PkgPath != "" {
+				continue // unexported: never on the wire
+			}
+			tag := f.Tag.Get("json")
+			name, _, _ := strings.Cut(tag, ",")
+			switch {
+			case name == "-":
+				continue
+			case f.Anonymous && name == "":
+				// Embedded and untagged: its fields are inlined at this level.
+				walk(f.Type, depth+1)
+				continue
+			case name == "":
+				// An exported field with no json tag ships under its GO name, which no page reads.
+				emitted[f.Name] = true
+			default:
+				emitted[name] = true
+			}
+			walk(f.Type, depth+1)
+		}
+	}
+	for _, typ := range []any{
+		KVCacheAnalysis{}, KVCacheRowPage{}, KVCacheSimulation{}, KVCachePriceView{},
+	} {
+		walk(reflect.TypeOf(typ), 0)
+	}
+
+	code := stripJSComments(readUI(t, "ui/kvcache.js"))
+	// Reads of the form `.some_field`. An underscore is what distinguishes a wire field from a
+	// local or a DOM property in this codebase.
+	read := regexp.MustCompile(`\.([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b`)
+	// Properties that look like wire fields and are not: DOM and app.js surface.
+	notWire := map[string]bool{"last_event_id": true}
+	seen := map[string]bool{}
+	for _, m := range read.FindAllStringSubmatch(code, -1) {
+		name := m[1]
+		if emitted[name] || notWire[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		t.Errorf("the page reads .%s, which no payload emits. Either a json tag moved and this "+
+			"cell now renders blank, or the field was never added — and a blank cell reads as a "+
+			"styling problem rather than a missing field.", name)
+	}
+
+	// SINGLE-WORD wire fields, which the underscore heuristic above is blind to.
+	//
+	// That blindness was not small: `valued`, `label`, `n`, `usd`, `key`, `hits`, `strategy`,
+	// `ttl`, `seconds`, `unpriced` and thirty more carry no underscore, so more than half the
+	// wire surface this page reads was outside the check — including the one field a banner
+	// gates on, which is how a page comes to test a condition the server has stopped emitting.
+	//
+	// Covered by scoping on the RECEIVER instead of on the shape of the name. Every payload object
+	// on this page is dereferenced through a one-letter binding (a=analysis, c=cards, r=result or
+	// row, g=group, s=saving, b=band, p=point, f=formula, m=model), so `x.field` where x is one of
+	// those is a wire read; the handful of genuine non-wire reads on those bindings are named in
+	// `local` rather than pattern-matched away.
+	//
+	// WHAT THIS DOES AND DOES NOT CATCH, measured rather than assumed. `emitted` is the UNION of
+	// every payload's keys, and the receiver letter is not bound to a type — binding it would mean
+	// type-checking JavaScript. So:
+	//
+	//   - a field name that disappears from the payloads ENTIRELY is caught. Verified by renaming
+	//     KVCacheArm.Selectable's tag: the check reports `a.selectable`, which is the failure this
+	//     is for.
+	//   - a field that MOVES between shapes is NOT caught. Verified by renaming KVCacheGroup.Key's
+	//     tag while kvcache.Group still emits `key`: the check stays green. A read of `g.key` that
+	//     now resolves against a different shape's field is outside what a substring check can
+	//     see, and pretending otherwise in this comment would be worse than the gap.
+	//
+	// The bug this was written for — a rename that removed `formula` from every payload — is in the
+	// first category, and the formula object is additionally checked by name below.
+	local := map[string]bool{
+		// kvc.rates[model] keys: the page's own edit state, in USD per MILLION tokens, which is
+		// deliberately NOT the payload's per-token shape.
+		"in": true, "out": true, "read": true, "w5m": true, "w1h": true,
+	}
+	oneWord := regexp.MustCompile(`\b([abcfgmprs])\.([a-z][a-z0-9]*)\b`)
+	for _, m := range oneWord.FindAllStringSubmatch(stripJSStrings(code), -1) {
+		name := m[2]
+		if strings.Contains(name, "_") || emitted[name] || local[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		t.Errorf("the page reads %s.%s, which no payload emits. If it is this page's own state "+
+			"rather than a wire field, name it in `local` with the reason.", m[1], name)
+	}
+
+	// The formula object, by name, because its keys carry no underscore and so the check above
+	// cannot see them. This is where the rename actually shipped.
+	body := code[strings.Index(code, "function renderKVAssumptions("):]
+	body = body[:strings.Index(body, "\n}")]
+	fb, err := json.Marshal(KVCacheFormula{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var formulaKeys map[string]any
+	if err := json.Unmarshal(fb, &formulaKeys); err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range regexp.MustCompile(`\bf\.([a-z][a-z0-9_]*)\b`).FindAllStringSubmatch(body, -1) {
+		if _, ok := formulaKeys[m[1]]; !ok {
+			keys := make([]string, 0, len(formulaKeys))
+			for k := range formulaKeys {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			t.Errorf("the assumptions panel reads f.%s off a formula, which carries %v. Eleven "+
+				"headings over eleven empty code boxes is what this looks like on screen.",
+				m[1], keys)
+		}
+	}
+}
+
+// stripJSStrings removes single-quoted string literals, so a word inside a message or a CSS class
+// is not mistaken for a property read. Comments are already gone by the time this is used.
+//
+// Crude on purpose: it does not need to parse JavaScript, only to stop `'not recorded'` and
+// `'pill missing'` from looking like field accesses. A literal it fails to strip can only cause a
+// false POSITIVE, which is a test that asks a question rather than one that hides an answer.
+func stripJSStrings(src string) string {
+	var b strings.Builder
+	for i := 0; i < len(src); {
+		if src[i] != '\'' {
+			b.WriteByte(src[i])
+			i++
+			continue
+		}
+		i++
+		for i < len(src) && src[i] != '\'' {
+			if src[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		i++
+	}
+	return b.String()
+}

--- a/docs/dashboard-kvcache-page.md
+++ b/docs/dashboard-kvcache-page.md
@@ -1,0 +1,168 @@
+# The KV-cache page
+
+*The dashboard's **KV-cache** tab: how long your conversations actually stay idle, what the
+prompt cache is costing you at that idle profile, and what a different TTL policy would have
+cost on the same history.*
+
+This page documents the **UI and the read layer**. The policies, the cost model and the replay
+are package `kvcache`, which is a plain domain package the request path can import — nothing on
+this page decides or prices anything.
+
+Files: `dash/ui/kvcache.js`, `dash/ui/kvcache.css`, `dash/kvcache.go` (the derived dataset and
+its aggregates), `dash/kvcachesim.go` (name → strategy, and the comparison),
+`dash/kvcacheapi.go` (four routes). The view mounts itself — its tab, its `<section>`, its
+stylesheet and its loader registration are all in `kvcache.js`, so the shared page carries one
+line about it (`<script src="kvcache.js"></script>` in `dash/ui/index.html`). No edit to
+`app.js`, and every helper it draws with — `el()`, `tile()`, `tileGroup()`, `barRows()`,
+`lineChart()`, `emptyState()` — is `app.js`'s.
+
+## Opening it
+
+The tab sits next to **Keep-alive** — both answer "what is the prompt cache doing to my bill" —
+at `/dashboard/#kvcache`. It respects the shared filter bar above it: every figure is "over this
+window", so the time range, the model, the agent and the account selector all narrow it. Three
+narrowings exist only here (time-of-day band, observed TTL tier, and whether a request has a
+successor at all) because all three are derived rather than columns.
+
+## What is on the page, top to bottom
+
+| Section | Answers |
+|---|---|
+| **Coverage statement** | what this analysis could NOT answer: rows that recorded no TTL, rows with no cost, conversations with a single request, and whether the read was capped |
+| **Summary tiles** | requests, conversations, median and mean idle, 5-minute and 1-hour reuse probability, cache-hit rate as the provider reported it, cost as billed, requests with no successor, median cached prompt |
+| **How long until the next request** | the idle histogram, fixed edges, with everything past five minutes in the de-emphasis gray — a default cached prefix is already gone by then |
+| **Has it come back yet** | the survival curve: the cumulative share of conversations that had returned by each elapsed time. The question a TTL is actually chosen against, which a histogram does not answer |
+| **Who waits how long** | the same measurements grouped by observed TTL, by user, by model and by time-of-day band (UTC) |
+| **Prices** | every rate the simulation uses, editable, with what each comes to on this window's own median prefix |
+| **Strategies** | the arm picker, built from the server's registry, and the comparison table with each arm's cost against one baseline |
+| **Every request in the analysis** | the derived dataset, sortable on thirteen columns and paged on the server, each row linking back to the request drawer and the session diff |
+| **What every figure rests on** | the formulas and the caveats, printed from the payload |
+
+## The three things this page refuses to do
+
+**It never treats a missing measurement as a zero.** Three of them are routinely present on real
+history and each gets its own answer rather than a default:
+
+- A request with **no next request** in the same conversation has no idle time. `idle_ms` is
+  `null` on the wire, the row renders as *"no next request"*, and it is excluded from every
+  average. On the production snapshot that is 1,772 of 14,407 requests, and 1,551 of 1,772
+  conversations hold a single request — so folding them in as zero-second returns would move
+  every figure on the page.
+- `cache_ttl` arrived as an **additive column** defaulting to `''`, so a blank on an older row
+  means *not recorded*, and a request that genuinely carried no `cache_control` also reads blank.
+  The two are separated by evidence (see below) and what is left is reported as **unknown** and
+  counted, never assumed.
+- A row whose token accounting was incomplete has an **unknown** cost. It is counted everywhere
+  and valued nowhere. An unpriced request is not a free one.
+
+**It does not present the hit rate as the objective.** It is on the table because an operator
+asks for it, with a banner saying so: on this service's own traffic holding every prefix for an
+hour gives the best hit rate and costs 38% more than the five-minute tier, because it pays 2.0×
+input to protect prompts a 1.25× write already covered. Nothing sorts or colours by it.
+
+**It never clamps a comparison, and it says which way it points in words.** The column is headed
+*vs baseline* and each cell reads `$X cheaper` or `$X MORE`. A column of signed dollars headed
+"saving" was read as a saving when it was the opposite, and a reader scanning for the biggest
+number picked the worst arm.
+
+## How the observed TTL is reconstructed
+
+Three states, in `observedTTL` (`dash/kvcache.go`), with the SQL predicate that filters on them
+directly beneath it and a test asserting the two agree:
+
+| The row says | Billed at the 1h tier | Anything cached | Tier | Source |
+|---|---|---|---|---|
+| `ephemeral_5m` / `ephemeral_1h` | — | — | as recorded | **configured** |
+| blank | yes | — | 1h | **observed** — the provider's own 1h write counter is the only proof a requested `ttl:"1h"` was honoured rather than silently downgraded |
+| blank | no | yes | 5m (assumed) | **unknown** — it cached something at a tier nobody wrote down |
+| blank | no | no | none | **observed** — it really did cache nothing |
+
+An unrecognised value (`ephemeral_10m` from a future build) is treated as *not recorded* rather
+than coerced into the tier it resembles. The **observed-policy** arm reports how much of itself
+rested on the assumed default (`observed_coverage`: recorded against assumed) — on a snapshot
+that predates the column it equals the fixed-5m arm exactly, and that is not a coincidence.
+
+## The cost model
+
+Every rate is configurable per provider/model and editable in the page; nothing is hardcoded in
+a UI component, and `dash/uikvcache_test.go` asserts that no per-token rate literal and no
+arithmetic on a `*_usd` field appears in `kvcache.js`. Rates are entered in **USD per million
+tokens** — the unit every vendor's price page uses — and converted once at the HTTP boundary.
+
+```text
+uncached input        input_tokens   × input_rate
+cache read           cache_read     × cache_read_rate          (default 0.1× input)
+cache write, 5m      written_tokens × write_5m_rate             (default 1.25× input)
+cache write, 1h      written_tokens × write_1h_rate             (default 2.0× input)
+keep-alive ping      cached_tokens  × cache_read_rate + ping_input × input_rate
+                                                      + ping_output × output_rate
+keep-alive, too late cached_tokens  × write_rate(tier) + the same overhead
+request cost         uncached_input + cache_read + cache_write + output
+total cost           Σ request_cost + Σ ping_cost
+cache premium        total_cost − uncached_cost      (NEGATIVE = the cache paid for itself)
+absolute savings     baseline_cost − strategy_cost   (never clamped)
+percentage savings   absolute_savings ÷ baseline_cost × 100   (undefined, not 0%, at a zero baseline)
+```
+
+Three assumptions worth stating out loud, all of them editable:
+
+- **The 1-hour write rate is derived**, because no gateway publishes one. It is a multiplier
+  against base input, and both the multiplier and the resulting rate are on the page.
+- **A ping is a cache read**, so a five-minute and a one-hour keep-alive cost the same *per
+  ping*. What differs is the creation tier that put the entry there and how **often** a ping is
+  needed — a five-minute entry has to be touched about twelve times as often. A page that
+  charged two different per-ping rates would be inventing a price no provider publishes.
+- **A ping cannot generate nothing** where the provider requires `max_tokens ≥ 1`, so its
+  minimum output is priced and stated rather than rounded away. `zero_gen=1` models a provider
+  that accepts a zero-generation request.
+
+Cache semantics are configurable because they are not universal. The shipped defaults are
+Anthropic's documented behaviour: a cache hit refreshes the entry's lifetime for free, a
+keep-alive read is just a use and refreshes it the same way, and a refresh buys another lifetime
+*of the tier the entry was created at* — it does not upgrade a tier.
+
+## What a strategy is allowed to know
+
+A strategy sees a `kvcache.Observation`, and the whole design of that struct is what is
+**absent** from it: no next-request timestamp, no idle duration, and no field derived from
+either. The historical statistics attached to it are accumulated as gaps **close**, so a
+decision taken at time *T* can only see gaps that had ended by *T*. The real next-request time
+is used exactly once — to score the decision after it has been made.
+
+`optimal` is the exception and it is labelled one. It reads the true next-request time and
+computes the cheapest plan that exists for a history, so it is a **ceiling** on what any policy
+could achieve: it is drawn in the de-emphasis gray with the word *ceiling* beside it, and it can
+never be selected as a baseline, because a percentage measured against it would be a share of a
+number no policy can reach.
+
+## Routes
+
+Four, all `GET`, all tenant-scoped, all returning numbers, enum labels and ids only — no prompt
+text, no transcript. They are `GET` rather than `POST` for two reasons worth more than tidiness:
+both scoping tests walk the mounted route table with a `GET`, so a `POST` route would be one
+neither could check; and a simulation is a **view**, so its whole input belongs in a URL that can
+be bookmarked and pasted into an issue. See [Routes & headers](reference/routes.md).
+
+## Telemetry that is estimated, or absent
+
+- **The 1-hour write rate** is derived from a multiplier, not published. Stated above.
+- **Latency avoided** is derived from *this window's own* means — the mean upstream time of
+  requests that really missed, minus that of requests that really hit — and is reported as
+  *not measured* unless both populations reach 20 rows.
+- **`upstream_ms = 0` means not recorded**, and such rows are skipped by that differential
+  rather than averaged in as instant responses.
+- **Pings on open idle spans** are charged into a span whose end is not in the window, bounded by
+  the window's own last request, and counted apart (`pings_on_open_spans`) because their number
+  depends on where the window ends.
+- **A miss recorded as `prefix_change` or `cold_start`** cannot be rescued by any TTL. Those rows
+  force a miss in every arm and are reported as `forced_misses` — the ceiling on all of it.
+- **There is no per-user timezone anywhere in the store**, so every hour and every time-of-day
+  band on this page is **UTC** and says so.
+- **A conversation is `(account, session, model)`.** The account is in the key because a session
+  id is client-supplied and can collide between accounts. The **model** is in it because a cache
+  entry does not transfer between models — an opus request cannot read a sonnet request's entry —
+  so two requests in one session on different models are not each other's successor. Leaving the
+  model out linked them, which granted the second a hit at the read rate on an entry it could never
+  have matched; the bias was one-directional, making every arm look cheaper and hit more often than
+  it can. On this deployment's corpus the model adds 124 trajectories (1,896 against 1,772) and
+  touches the 12,035 requests that sit in a session using more than one model.

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -259,6 +259,10 @@ table above is unchanged and every path below returns 404.
 | `GET /api/benchmarks/{id}/tasks` | Per-task rows for a run (`?arm=<name>` to restrict). **Manager-only** in hosted mode. |
 | `GET /api/capture` | The capture pipeline's own health, **including its drop count**. The counters are process-wide, so in hosted mode a non-manager gets `mode` alone (with a `description` that says so, rather than one describing counters that are not in the payload). |
 | `GET /api/events` | SSE stream of captured requests (summary rows only — never content). Honors `Last-Event-ID` (or `?last_event_id=`) so a reconnect backfills the gap. |
+| `GET /api/kvcache` | The KV-cache analysis: summary cards, the idle histogram, the survival curve, the grouped views (observed TTL, user, model, time-of-day band), the price list and the **coverage statement**. One payload, so every figure shares its denominator. `scanned` / `total` / `truncated` say whether the read was capped (`kvCacheMaxRows`, 200,000) — a silent cap would read as "this is your whole history". |
+| `GET /api/kvcache/rows` | One page of the derived per-request dataset: the billed tiers, the reconstructed TTL and how well it is known, the next request in the same conversation, the idle time (**`null`**, never `0`, on a conversation's last request), and the links back to the request drawer and the session diff. Sortable on thirteen columns and paged **on the server** (`sort`, `dir`, `limit`, `offset`) — the derivation runs over the whole scoped window inside the query, so a row on page 7 carries the same successor it would on page 1. |
+| `GET /api/kvcache/simulate` | Replays the window under every requested strategy (`strategy=` repeated or comma-joined) and scores each against one `baseline=`. Returns a result and a saving per arm, the arm registry the picker is built from, and the assumptions. Savings are **never clamped** and a percentage against a zero baseline is `percent_known:false`, not `0`. An unknown arm is named in `unknown` rather than silently replaced; an unknown baseline is a `400`, because every percentage is divided by it. |
+| `GET /api/kvcache/pricing` | The editable rate table for the models in this window, plus what each rate comes to on the window's own **median** billed prefix. Its own route so editing a rate re-prices without re-running the replay. |
 
 ### The config route serves the SERVER's configuration, not yours
 
@@ -332,6 +336,7 @@ server-side.
 | `reason` | The uncompressed-reason bucket (`bypassed`, `below_trigger`, `cache_frozen`, `found_nothing`, `reverted`, `no_messages`), or `compacted` for requests we did compact. |
 | `accounting` | `complete` \| `partial` \| `missing`. |
 | `effort` · `thinking` · `stop_reason` | Captured request metadata: the reasoning effort (`low`…`max`) and thinking mode (`adaptive` \| `enabled` \| `disabled`) the client asked for, and the provider's terminal stop reason. Exact match; the drill-down from a `/api/breakdown` bar into the rows behind it. |
+| `ttl` | The prompt-cache TTL **tier** the request asked for: `ephemeral_5m` \| `ephemeral_1h`, or the sentinel `none` for a body that carried no `cache_control` at all. `none` needs a sentinel because that case's stored value is the empty string, which is also what "no filter" looks like — folding an uncached request in with the five-minute ones is the third answer disappearing. |
 | `q` | Free-text match against session id, model and agent. |
 | `limit` · `before` · `offset` | Page size; keyset cursor (`/api/requests`); offset (`/api/sessions`). |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
   - Dashboard: dashboard.md
   - Tool inventory: tool-inventory.md
   - Inventory page (UI): dashboard-inventory-page.md
+  - KV-cache page (UI): dashboard-kvcache-page.md
   - Hosted service: hosted.md
   - Results:
       - Overview: RESULTS.md


### PR DESCRIPTION
The **dashboard half** of the KV-cache work. Stacked on #99, which carries the calculation half — this branch adds no policy and no arithmetic of its own, and it targets `feat/kv-cache-ttl-cost-model` rather than `main` because `kvcache/` does not exist on `main` yet, so a PR against `main` would not compile.

## What it is

A tab answering three questions over real history: how long a conversation actually stays idle, what the prompt cache is costing at that idle profile, and what a different TTL policy would have cost on the same requests.

| Section | Answers |
|---|---|
| Coverage statement | what this analysis could **not** answer — rows with no recorded TTL, rows with no cost, single-request conversations, whether the read was capped |
| Summary tiles | requests, conversations, median/mean idle, 5-minute and 1-hour reuse probability, cache-hit rate as the provider reported it, cost as billed, requests with no successor, median cached prompt |
| Distribution | the idle histogram (everything past five minutes in the de-emphasis gray) and the survival curve beside it |
| Grouped views | the same measurement by observed TTL, user, model and time-of-day band (UTC) |
| Prices | every rate the simulation uses, editable, with what each comes to on the window's own median prefix |
| Strategies | the arm picker built from the server's registry, and the comparison table |
| Detail table | the derived dataset, sortable on 13 columns, paged on the server, each row linking back to the request drawer and the session diff |
| Formulas | printed from the payload, not retyped in the page |

## Four `GET` routes

`/api/kvcache`, `/api/kvcache/rows`, `/api/kvcache/simulate`, `/api/kvcache/pricing` — all `scopeTenant`, all returning numbers, enum labels and ids only. No prompt text, no transcript.

`GET` rather than `POST` for two reasons worth more than tidiness: both scoping tests probe the mounted route table with a `GET`, so a `POST` route would be one neither could check; and a simulation is a **view**, so its whole input belongs in a URL that can be bookmarked and pasted into an issue.

**Not manager-only.** The tab carries no `data-manager`, so every signed-in account sees it scoped to its own traffic. A manager additionally gets the service-wide view — the User filter, the drill-down on *By user*, and the User column. `TestAPIScopesEveryRouteToTheCaller`, `TestAPIIgnoresCraftedTenantParam` and `TestAPIFailsClosedWithoutAPrincipal` all walk these four routes.

## The derivation, and the one thing it would be easy to get wrong

A filter is applied in **two places**, deliberately. The predicates selecting *which conversations are in scope* — tenant, time window, session, the exclusion of ping rows — run inside the window function. Everything selecting *which requests to show* runs outside it. Running `model = X` inside the partition would make a request's successor the next request **on that model**, which is not the next request in the conversation, and on this corpus that is not a corner case: it would distort the 12,035 requests sitting in a session that uses more than one model.

The window partitions by `(tenant_id, session_id, model)`, which is exactly `kvcache.Conversation`. The model is in the key because **a cache entry does not transfer between models** — an opus request cannot read a sonnet request's entry. `TestTheSQLPartitionIsExactlyTheConversationKey` asserts the SQL grouping and the Go type agree, structurally *and* behaviourally, so they cannot drift again.

## Three things the page refuses to do

Each is enforced by a test rather than by review, because all three are invisible on screen when wrong — the page looks completely fine.

1. **An absence is never rendered as a zero.** A request with no successor has `idle_ms: null`, not `0`, and is excluded from every average — 620 of 3,391 on the demo window, and 1,551 of 1,772 conversations on the production corpus hold a single request. A tier that was never recorded reads *not recorded* in both the grouped table and the row pill, never the tier it is replayed as. A row with incomplete accounting has an **unknown** cost.
2. **Hit rate is not presented as the objective**, with a banner saying so. `fixed-1h` has a better hit rate than the baseline and costs more, so a reader scanning for the best-looking column would pick the worst arm. Nothing sorts or colours by it.
3. **A comparison is never clamped, and says which way it points in words** — `$X cheaper` / `$X MORE`. A column of signed dollars headed "saving" was read as a saving when it was the opposite.

## Evidence

Rendered in Chromium against a seeded 3,391-request window shaped like the live corpus (94.9% of gaps inside five minutes against the measured 95.3%; median cached prompt 133k tokens against 124.8k) and inspected panel by panel. **That found four defects no substring test could see:**

- the exact ceiling reporting the same total as the no-cache arm, because the price list was dropped when threading the config into `NewStrategy` — every action then cost zero and the DP chose "expire" for everything, presented as *the cheapest plan that exists*;
- the by-TTL table folding 295 not-recorded rows into the five-minute group and labelling it "configured", while the coverage banner directly above reported them as not recorded;
- the row pill printing `5m` for those same rows, with the truth only in a tooltip;
- the formulas panel rendering eleven headings above eleven **empty** boxes, because the payload emitted `{name, expression, prose}` while the page read `{name, formula, note}` — `name` matched by luck, so it read as a stylesheet problem.

Each is now guarded. The wire contract is checked in both directions from the struct tags, and its comment states what that check does **not** catch — a field moving between shapes — with the reproduction, rather than letting a green line imply coverage it does not have. Cost identities and the percentage-versus-fraction case are asserted as invariants, because every nominal check is blind to a key that keeps its name and changes its meaning.

## Also

`Filter` gains a `TTL` dimension with `"none"` as a sentinel, for the same reason `Reason` has `"compacted"`: an uncached request's stored value is the empty string, which is also what "no filter" looks like, so an empty field cannot mean it.

Docs: `docs/dashboard-kvcache-page.md`, in the mkdocs nav, with the four routes and the `ttl` filter added to `docs/reference/routes.md`.

## Verification

`gofmt -l`, `go vet ./...` and `go test ./...` clean across every package; production binary builds with `CGO_ENABLED=1`. 51 KV-cache tests in package `dash`.

## Reviewing

Open at `/dashboard/#kvcache`. Worth checking by hand: that the *not recorded* TTL group and the coverage banner agree, that `optimal` reads as a ceiling rather than an option, and that the `vs baseline` column is unambiguous about direction.