### PR TITLE
fix(config): housellm configured extract_llm into a no-op

### DIFF
--- a/components/all/xglobal_test.go
+++ b/components/all/xglobal_test.go
@@ -2,13 +2,16 @@ package all_test
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/config"
 	"github.com/rossoctl/context-guru/schema"
 	"github.com/rossoctl/context-guru/store"
+	"gopkg.in/yaml.v3"
 )
 
 // TestExtractResultCacheHitsAcrossSessions is the headline acceptance criterion for issue
@@ -112,18 +115,14 @@ func TestNoDefaultConfigRunsExtractLLMOnCachingBackend(t *testing.T) {
 		"defaults": "strategy: code\nmodel:\n  source: config\n",
 		"codesmart": "strategy: code\nmodel:\n  source: config\nmin_tokens: 3000\n" +
 			"trigger:\n  min_request_tokens: 3000\nllm_every_n_requests: 1\nllm_max_per_request: 4\n",
-		// housellm sets allow_on_caching_backend: TRUE, and passes anyway — which is the
-		// reason to have it here. The flag lifts exactly one check, and with per_output:false
-		// the only path into the gate is the cold sweep, whose branch returns cached:false by
-		// construction. So `per_output: false` is the brake, not the flag and not the economic
-		// gate. If a future edit turns per_output on while leaving the flag set, this case
-		// fails and names the combination our own numbers price as net-negative.
-		"housellm": "strategy: code\nper_output: false\nallow_on_caching_backend: true\n" +
-			"economic_gate: true\nmodel:\n  source: config\nmin_tokens: 3000\n" +
-			"aggressiveness: medium\ncontext: recent\ncontext_messages: 2\n" +
-			"trigger:\n  min_request_tokens: 20000\nllm_every_n_requests: 1\n" +
-			"llm_max_per_request: 4\nllm_max_per_session: 0\n" +
-			"cold_cache:\n  enabled: true\n  max_calls: 20\n  min_tokens: 3000\n",
+		// housellm is read from config.presetConfigs rather than copied here, because a copy
+		// cannot catch the drift this test exists to catch. The preset now ships
+		// per_output: TRUE, which makes `val.cached && !allowCached` live on every warm turn;
+		// the only thing keeping this case green is that allow_on_caching_backend is absent
+		// from the preset. Re-add it there and this fails, naming the combination our own
+		// numbers price as net-negative (extract_econ.go:333, break-even ~30,500 tokens per
+		// output against a largest-observed 2,053).
+		"housellm": housellmExtractLLM(t),
 	}
 	for name, cfg := range cfgs {
 		t.Run(name, func(t *testing.T) {
@@ -264,5 +263,70 @@ func TestGlobalCacheHitIsNotSplicedAtDepth(t *testing.T) {
 	}
 	if cmC.calls != 0 {
 		t.Fatalf("a global hit must avoid the model call, got %d", cmC.calls)
+	}
+}
+
+// housellmExtractLLM returns the extract_llm block EXACTLY as the housellm preset ships it,
+// so the guard above tests the shipped configuration instead of a transcription of it.
+func housellmExtractLLM(t *testing.T) string {
+	t.Helper()
+	cfg, err := config.LoadBytes([]byte("preset: housellm\n"))
+	if err != nil {
+		t.Fatalf("load housellm preset: %v", err)
+	}
+	node, ok := cfg.Components["extract_llm"]
+	if !ok {
+		t.Fatal("housellm preset no longer configures extract_llm; this guard is testing nothing")
+	}
+	raw, err := yaml.Marshal(&node)
+	if err != nil {
+		t.Fatalf("marshal extract_llm block: %v", err)
+	}
+	return string(raw)
+}
+
+// TestHousellmColdSweepActuallyFires is the other half of
+// TestNoDefaultConfigRunsExtractLLMOnCachingBackend, and it exists because the preset
+// shipped for a day in a state where BOTH halves were silent.
+//
+// Every extraction call this service has ever made was a cold one, so cold_cache.min_tokens
+// is the single knob deciding whether extract_llm does anything at all. It was 3000, and at
+// 3000 production recorded `below_output_floor` on all 36 sweeping turns and zero
+// extractions across 3,437 requests — the component was configured into a no-op while
+// looking fully enabled. A candidate of ~1,500 tokens is the size that regression turned
+// away, so that is what this asserts on: the preset, not a copy of it, must call the model
+// on a cold turn.
+//
+// Raising the preset's cold floor above ~1,500 fails this; re-adding
+// allow_on_caching_backend fails the warm guard above. The pair pins the economics from
+// both sides.
+func TestHousellmColdSweepActuallyFires(t *testing.T) {
+	off := newComp(t, "extract_llm", housellmExtractLLM(t))
+	// ~1,500 tokens of the noise the sweep is meant to reduce, with a filterable shape.
+	body := `[`
+	for i := 0; i < 120; i++ {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"id":` + strconv.Itoa(i) + `,"name":"record ` + strings.Repeat("payload ", 6) + `"}`
+	}
+	body += `]`
+	cm := &countingModel{resp: "data = json.decode(INPUT)\nOUTPUT = json.encode(data[:2])\n"}
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("summarize the records"), toolMsg(body),
+	}}
+	// ColdCache is what makes this a sweep: the prefix TTL has expired, so the whole
+	// transcript is about to be re-billed at the write rate and savedTokenValue reports
+	// cached:false — which is why the warm guard's decline does not apply here.
+	c := &components.Ctx{Ctx: context.Background(), Session: "cold1",
+		Store: store.NewMemory(store.Options{}), Model: components.ModelSpec{Static: cm},
+		CacheAware: true, ColdCache: true, MaxCachedIdx: -1, CtxWindow: 1_000_000}
+	var rep components.Report
+	if _, err := off.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	if cm.calls == 0 {
+		t.Fatalf("the housellm preset made NO model call on a cold turn with a ~1.5k-token "+
+			"candidate — the component is configured into a no-op. gates=%v", rep.Gates)
 	}
 }

--- a/components/all/xglobal_test.go
+++ b/components/all/xglobal_test.go
@@ -341,27 +341,32 @@ func TestHousellmColdSweepActuallyFires(t *testing.T) {
 }
 
 // TestHousellmDoesNotAttemptTheTailBelowBreakEven pins the floor that makes the warm/tail
-// path safe, from the loss side. TestDefaultConfigsSpendOnlyOnTheUncachedTail shows a huge
-// tail candidate IS worth a call now; this shows a realistically-sized one is not, and that
-// the preset refuses it before spending anything.
+// path safe, from the loss side. TestDefaultConfigsSpendOnlyOnTheUncachedTail shows a large
+// tail candidate IS worth a call now; this shows a small one is not, and that the preset
+// refuses it before spending anything.
 //
-// The number is measured, not chosen. On real warm sessions through a local proxy an
-// extraction call cost ~$0.0193 per ACCEPTED result — output-dominated, and including the
-// 1-in-5 rejected outright that pays full price for nothing. At the cache-write rate that
-// needs ~4,060 saved tokens, and the observed reduction on accepted tail calls was ~65%, so
-// the candidate must be ~6,250 tokens before a call can repay itself. The preset's floor is
-// 8,000.
+// The floor is derived. A call costs ~$0.0193 per ACCEPTED result — output-dominated, and
+// including the 1-in-5 rejected outright that pays full price for nothing. At the cache-write
+// rate plus the corrected amortization (reuses 12 on a long transcript) a saved token is worth
+// ~$9.31/MTok, so a call needs ~2,073 saved tokens, which at the observed ~65% reduction needs
+// a ~3,190-token candidate. The preset's floor is 3000.
 //
-// At a 1,000 floor the same sessions made 5 warm calls, accepted 4, saved 8,718 tokens for
-// $0.0771 — net -$0.036 — and every one of those calls was permitted by the EXPLORATION
-// budget rather than by the arithmetic. That is what this floor exists to prevent, and it is
-// why the assertion is on below_output_floor specifically: the floor must refuse the
-// candidate BEFORE the exploration allowance can spend on it.
+// It is NOT 8000, which an earlier revision of this change used: tool outputs on this workload
+// top out near 7,399 tokens (see TestContentClassesGateOnExpectedYield) and only 1 of 132
+// production candidates reached 8000, so that floor disabled the path rather than bounding it.
+//
+// The assertion is on below_output_floor specifically because the floor must refuse the
+// candidate BEFORE the exploration allowance can spend on it: exploration bypasses the
+// arithmetic, and at a 1000 floor every warm call real sessions made was an exploration call,
+// for a measured net of -$0.036.
 func TestHousellmDoesNotAttemptTheTailBelowBreakEven(t *testing.T) {
 	off := newComp(t, "extract_llm", housellmExtractLLM(t))
-	// ~4,000 tokens of log lines: comfortably above the OLD 1,000 floor, below break-even,
-	// and in the tail. This is the shape that lost money.
-	body := strings.Repeat("2024-01-01 GET /users/42 200 12ms handler=src/api/users.py\n", 330)
+	// 1,495 tokens of log lines (measured with schema.TextTokens, not estimated — 23 tokens
+	// per line, and guessing 12 put an earlier version of this fixture ABOVE the floor it was
+	// meant to sit under). Above the old 1,000 floor, below the 3,000 one, and in the tail:
+	// this is literally the size that lost money, since the two smallest calls real sessions
+	// made were 1,357 and 1,536 tokens, saving 290 and 0 for $0.0133 and $0.0124.
+	body := strings.Repeat("2024-01-01 GET /users/42 200 12ms handler=src/api/users.py\n", 65)
 	cm := &countingModel{resp: "data = json.decode(INPUT)\nOUTPUT = json.encode(data[:1])\n"}
 	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
 		userMsg("find the slow handler"), toolMsg(body),
@@ -374,9 +379,9 @@ func TestHousellmDoesNotAttemptTheTailBelowBreakEven(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cm.calls != 0 {
-		t.Fatalf("the preset spent a call on a ~4k-token tail candidate, which measured a "+
-			"net LOSS of $0.036 across five such calls; the hot floor must refuse it. "+
-			"calls=%d gates=%v", cm.calls, rep.Gates)
+		t.Fatalf("the preset spent a call on a 1,495-token tail candidate; candidates this "+
+			"size saved 0-290 tokens for $0.012-0.013 each in real sessions, so the hot "+
+			"floor must refuse it. calls=%d gates=%v", cm.calls, rep.Gates)
 	}
 	if rep.Gates["below_output_floor"] == 0 {
 		t.Fatalf("expected below_output_floor to be what refused it — anything else means the "+

--- a/components/all/xglobal_test.go
+++ b/components/all/xglobal_test.go
@@ -96,76 +96,6 @@ func TestExtractGateSuppressesInPipelineWhenCacheAware(t *testing.T) {
 	}
 }
 
-// The shipping guard, end to end and through the PRESETS: no default configuration may
-// run extract_llm on a prompt-caching backend. The unit test in components/offload covers
-// evaluateGate's hard decline directly; this one covers the wiring, so a rebase that drops
-// `allow_on_caching_backend` from the config struct or forgets to thread `allowCached`
-// into the gate fails here rather than shipping silently.
-//
-// The output is deliberately HUGE (far above the ~30,500-token cached break-even), so the
-// economics alone would permit the call — only the hard decline can suppress it.
-func TestNoDefaultConfigRunsExtractLLMOnCachingBackend(t *testing.T) {
-	filter := "data = json.decode(INPUT)\nOUTPUT = json.encode([r for r in data if \"keep\" in r[\"name\"]])\n"
-	pad := strings.Repeat("padding ", 30_000) // ~240k tokens: economics pass on their own
-	body := `[{"id":1,"name":"keep this ` + pad + `"},{"id":2,"name":"drop this ` + pad + `"}]`
-
-	// Every default that reaches extract_llm: the bare component, plus each preset's tuned
-	// config. None of them may spend on caching traffic.
-	cfgs := map[string]string{
-		"defaults": "strategy: code\nmodel:\n  source: config\n",
-		"codesmart": "strategy: code\nmodel:\n  source: config\nmin_tokens: 3000\n" +
-			"trigger:\n  min_request_tokens: 3000\nllm_every_n_requests: 1\nllm_max_per_request: 4\n",
-		// housellm is read from config.presetConfigs rather than copied here, because a copy
-		// cannot catch the drift this test exists to catch. The preset now ships
-		// per_output: TRUE, which makes `val.cached && !allowCached` live on every warm turn;
-		// the only thing keeping this case green is that allow_on_caching_backend is absent
-		// from the preset. Re-add it there and this fails, naming the combination our own
-		// numbers price as net-negative (extract_econ.go:333, break-even ~30,500 tokens per
-		// output against a largest-observed 2,053).
-		"housellm": housellmExtractLLM(t),
-	}
-	for name, cfg := range cfgs {
-		t.Run(name, func(t *testing.T) {
-			off := newComp(t, "extract_llm", cfg)
-			cm := &countingModel{resp: filter}
-			req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
-				userMsg("find the keep records"), toolMsg(body),
-			}}
-			c := &components.Ctx{Ctx: context.Background(), Session: "s1",
-				Store: store.NewMemory(store.Options{}), Model: components.ModelSpec{Static: cm},
-				CacheAware: true, MaxCachedIdx: -1, CtxWindow: 1_000_000}
-			var rep components.Report
-			if _, err := off.Offload(req, &rep, c); err != nil {
-				t.Fatal(err)
-			}
-			if cm.calls != 0 {
-				t.Fatalf("a default config must NOT call the LLM on a caching backend "+
-					"(measured net-negative), calls=%d", cm.calls)
-			}
-			if schema.MessageText(req.Input[1]) != body {
-				t.Fatal("a declined candidate must be left verbatim (fail open)")
-			}
-		})
-	}
-
-	// And the escape hatch still works, so the guard is a default and not a wall.
-	off := newComp(t, "extract_llm", "strategy: code\nmodel:\n  source: config\n"+
-		"allow_on_caching_backend: true\ntrigger:\n  min_request_tokens: 1\n")
-	cm := &countingModel{resp: filter}
-	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
-		userMsg("find the keep records"), toolMsg(body),
-	}}
-	if _, err := off.Offload(req, &components.Report{}, &components.Ctx{
-		Ctx: context.Background(), Session: "s2", Store: store.NewMemory(store.Options{}),
-		Model: components.ModelSpec{Static: cm}, CacheAware: true, MaxCachedIdx: -1,
-		CtxWindow: 1_000_000}); err != nil {
-		t.Fatal(err)
-	}
-	if cm.calls == 0 {
-		t.Fatal("allow_on_caching_backend: true must hand control back to the economics")
-	}
-}
-
 // Backward compatibility: an existing config that pins min_tokens must keep working
 // unchanged — the smarter trigger is the DEFAULT only when nothing was configured.
 func TestExplicitMinTokensConfigStillReduces(t *testing.T) {
@@ -286,6 +216,85 @@ func housellmExtractLLM(t *testing.T) string {
 }
 
 // TestHousellmColdSweepActuallyFires is the other half of
+// TestDefaultConfigsSpendOnlyOnTheUncachedTail replaces
+// TestNoDefaultConfigRunsExtractLLMOnCachingBackend, whose premise this change deliberately
+// reverses. That test asserted a default config makes NO call on a caching backend even for a
+// candidate its own comment identified as being in the tail. The reason it could assert that
+// was a mis-pricing, not a measurement: savedTokenValue reported `cached: true` for the whole
+// request, so a tail candidate — content being written INTO the cache on this very turn, at
+// 1.25x fresh — was valued at the cache-READ rate, 12.5x too low. The ~30,500-token
+// break-even quoted alongside it is explicitly the CACHED break-even. Together they read as
+// "extraction cannot pay on a caching backend", which is true at depth and was never
+// established for the tail.
+//
+// So the decision this pins is now positional, which is the honest form of it:
+//
+//	at DEPTH — inside the live cached prefix — a default must still not spend. Removing
+//	  cached content saves the read rate and forces a suffix re-write on top.
+//	in the TAIL, a default MAY spend, and must, when the economics pass.
+//
+// What is NOT relaxed is the economic gate itself: see
+// TestTheTailIsStillGatedOnItsOwnEconomics, which is the other half of this and the reason
+// this is a re-pricing rather than an opening of the floodgates.
+func TestDefaultConfigsSpendOnlyOnTheUncachedTail(t *testing.T) {
+	filter := "data = json.decode(INPUT)\nOUTPUT = json.encode([r for r in data if \"keep\" in r[\"name\"]])\n"
+	pad := strings.Repeat("padding ", 30_000) // ~240k tokens: economics pass on their own
+	body := `[{"id":1,"name":"keep this ` + pad + `"},{"id":2,"name":"drop this ` + pad + `"}]`
+
+	cfgs := map[string]string{
+		"defaults": "strategy: code\nmodel:\n  source: config\n",
+		"codesmart": "strategy: code\nmodel:\n  source: config\nmin_tokens: 3000\n" +
+			"trigger:\n  min_request_tokens: 3000\nllm_every_n_requests: 1\nllm_max_per_request: 4\n",
+		// Read from config.presetConfigs rather than copied, because a copy cannot catch the
+		// drift this test exists to catch.
+		"housellm": housellmExtractLLM(t),
+	}
+	// The tool output sits at index 1, so MaxCachedIdx 1 puts it inside the cached prefix and
+	// MaxCachedIdx 0 leaves it in the tail. One number is the whole difference.
+	for _, pos := range []struct {
+		name         string
+		maxCachedIdx int
+		wantCall     bool
+	}{
+		{"at depth, inside the cached prefix", 1, false},
+		{"in the uncached tail", 0, true},
+	} {
+		for name, cfg := range cfgs {
+			t.Run(pos.name+"/"+name, func(t *testing.T) {
+				off := newComp(t, "extract_llm", cfg)
+				cm := &countingModel{resp: filter}
+				req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+					userMsg("find the keep records"), toolMsg(body),
+				}}
+				c := &components.Ctx{Ctx: context.Background(), Session: "s1",
+					Store: store.NewMemory(store.Options{}), Model: components.ModelSpec{Static: cm},
+					// 75k, not 1M, and the number is measured rather than picked: this request is
+					// 60,026 tokens (schema.MessagesTokens). With no explicit min_tokens the
+					// `defaults` config decides on context PRESSURE, and against a 1M window
+					// 60k is 0.06 — far under the 0.25 bar — so it declined for a reason with
+					// nothing to do with caching, and the depth case passed without exercising
+					// anything. 75k puts pressure at 0.80, past the 0.60 bar that fires on
+					// pressure alone, so position is the only variable left.
+					CacheAware: true, MaxCachedIdx: pos.maxCachedIdx, CtxWindow: 75_000}
+				var rep components.Report
+				if _, err := off.Offload(req, &rep, c); err != nil {
+					t.Fatal(err)
+				}
+				if got := cm.calls > 0; got != pos.wantCall {
+					if pos.wantCall {
+						t.Fatalf("a 240k-token candidate in the UNCACHED tail must be worth a "+
+							"call — it is billed at the cache-write rate, not the read rate. "+
+							"calls=%d gates=%v", cm.calls, rep.Gates)
+					}
+					t.Fatalf("a default config must NOT spend on content inside the live cached "+
+						"prefix (read-rate saving, plus a forced suffix re-write), calls=%d", cm.calls)
+				}
+			})
+		}
+	}
+}
+
+// TestHousellmColdSweepActuallyFires is the other half of
 // TestNoDefaultConfigRunsExtractLLMOnCachingBackend, and it exists because the preset
 // shipped for a day in a state where BOTH halves were silent.
 //
@@ -328,5 +337,49 @@ func TestHousellmColdSweepActuallyFires(t *testing.T) {
 	if cm.calls == 0 {
 		t.Fatalf("the housellm preset made NO model call on a cold turn with a ~1.5k-token "+
 			"candidate — the component is configured into a no-op. gates=%v", rep.Gates)
+	}
+}
+
+// TestHousellmDoesNotAttemptTheTailBelowBreakEven pins the floor that makes the warm/tail
+// path safe, from the loss side. TestDefaultConfigsSpendOnlyOnTheUncachedTail shows a huge
+// tail candidate IS worth a call now; this shows a realistically-sized one is not, and that
+// the preset refuses it before spending anything.
+//
+// The number is measured, not chosen. On real warm sessions through a local proxy an
+// extraction call cost ~$0.0193 per ACCEPTED result — output-dominated, and including the
+// 1-in-5 rejected outright that pays full price for nothing. At the cache-write rate that
+// needs ~4,060 saved tokens, and the observed reduction on accepted tail calls was ~65%, so
+// the candidate must be ~6,250 tokens before a call can repay itself. The preset's floor is
+// 8,000.
+//
+// At a 1,000 floor the same sessions made 5 warm calls, accepted 4, saved 8,718 tokens for
+// $0.0771 — net -$0.036 — and every one of those calls was permitted by the EXPLORATION
+// budget rather than by the arithmetic. That is what this floor exists to prevent, and it is
+// why the assertion is on below_output_floor specifically: the floor must refuse the
+// candidate BEFORE the exploration allowance can spend on it.
+func TestHousellmDoesNotAttemptTheTailBelowBreakEven(t *testing.T) {
+	off := newComp(t, "extract_llm", housellmExtractLLM(t))
+	// ~4,000 tokens of log lines: comfortably above the OLD 1,000 floor, below break-even,
+	// and in the tail. This is the shape that lost money.
+	body := strings.Repeat("2024-01-01 GET /users/42 200 12ms handler=src/api/users.py\n", 330)
+	cm := &countingModel{resp: "data = json.decode(INPUT)\nOUTPUT = json.encode(data[:1])\n"}
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("find the slow handler"), toolMsg(body),
+	}}
+	c := &components.Ctx{Ctx: context.Background(), Session: "warm-tail",
+		Store: store.NewMemory(store.Options{}), Model: components.ModelSpec{Static: cm},
+		CacheAware: true, MaxCachedIdx: 0, CtxWindow: 1_000_000}
+	var rep components.Report
+	if _, err := off.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	if cm.calls != 0 {
+		t.Fatalf("the preset spent a call on a ~4k-token tail candidate, which measured a "+
+			"net LOSS of $0.036 across five such calls; the hot floor must refuse it. "+
+			"calls=%d gates=%v", cm.calls, rep.Gates)
+	}
+	if rep.Gates["below_output_floor"] == 0 {
+		t.Fatalf("expected below_output_floor to be what refused it — anything else means the "+
+			"exploration budget could still spend here. gates=%v", rep.Gates)
 	}
 }

--- a/components/offload/extract_econ.go
+++ b/components/offload/extract_econ.go
@@ -111,12 +111,10 @@ const (
 	agentCacheWritePerMTok = 3.75
 )
 
-// savedTokenValue prices one saved token for THIS request. When the request goes to a
-// prompt-caching backend, content the agent re-sends every turn is already in the cached
-// prefix, so removing it saves the cache-read rate — the 10x haircut that sinks the
-// component's economics.
-func savedTokenValue(c *components.Ctx) tokenValue {
-	fresh, read, write := agentFreshPerMTok/1e6, agentCacheReadPerMTok/1e6, agentCacheWritePerMTok/1e6
+// agentRates resolves the three billing tiers for this request, preferring the deployment's
+// own price table over the built-in constants.
+func agentRates(c *components.Ctx) (fresh, read, write float64) {
+	fresh, read, write = agentFreshPerMTok/1e6, agentCacheReadPerMTok/1e6, agentCacheWritePerMTok/1e6
 	// The request's own model, at the rates this deployment is actually billed, beats any
 	// constant. Ctx.SelfRates comes from the same provider price table the dashboard prices
 	// requests with, so the gate's numerator and the operator's bill can no longer disagree.
@@ -134,6 +132,14 @@ func savedTokenValue(c *components.Ctx) tokenValue {
 			write = fresh * 1.25
 		}
 	}
+	return fresh, read, write
+}
+
+// savedTokenValue prices one saved token for THIS request, ignoring where in the transcript
+// it sits. It is the REQUEST-level answer and it is correct only for content in the cached
+// prefix; use savedTokenValueAt for a decision about a specific candidate.
+func savedTokenValue(c *components.Ctx) tokenValue {
+	fresh, read, write := agentRates(c)
 	if c != nil && c.CacheAware {
 		// A cache-aware turn whose cache has EXPIRED is the opposite case to a warm one: the
 		// whole prefix is about to be re-written at 1.25x fresh, so a token removed here is
@@ -150,6 +156,39 @@ func savedTokenValue(c *components.Ctx) tokenValue {
 	// No caching backend: every turn re-sends at the fresh rate, so a replay is worth as
 	// much as the first removal.
 	return tokenValue{perToken: fresh, repeatPerToken: fresh, cached: false}
+}
+
+// savedTokenValueAt prices a saved token for ONE candidate, at message index i.
+//
+// `cached` is a property of the CANDIDATE, not of the request, and conflating the two was a
+// real mis-pricing rather than a rounding choice. On a warm turn the tail — everything past
+// the provider's last cached index — is NOT in the cache: it is being written into it on this
+// very turn. MEASURED on this deployment across 4,384 warm requests, the tail is billed as
+// cache_creation, not as fresh input (17.2M cache_write tokens against 9.4M fresh_input,
+// averaging 4,124 written tokens per warm turn). So a token removed from the tail saves
+// 1.25x fresh, which is 12.5x what savedTokenValue reported for it.
+//
+// That understatement is what silenced the hot path. The `val.cached && !allowCached` decline
+// in evaluateGate was refusing tail candidates on the strength of a value computed as though
+// they were already cached, and the ~30,500-token break-even quoted against it is explicitly
+// the CACHED break-even — the two facts compounded into "extraction cannot pay on a caching
+// backend", which is true at depth and was never established for the tail.
+//
+// Depth is unchanged: a candidate inside the live cached prefix really is worth the read rate,
+// and removing it additionally forces a suffix re-write, which is why the tail gate stops it
+// before this function is ever consulted.
+func savedTokenValueAt(c *components.Ctx, i int) tokenValue {
+	v := savedTokenValue(c)
+	// A cold sweep already prices at the write rate, and a non-caching backend at fresh;
+	// neither has a cached prefix to be inside, so position cannot change the answer.
+	if v.cold || c == nil || !c.CacheAware {
+		return v
+	}
+	if !c.TailOnly(i) {
+		return v // inside the live cached prefix: the read rate is the honest one
+	}
+	_, read, write := agentRates(c)
+	return tokenValue{perToken: write, repeatPerToken: read, cached: false}
 }
 
 // priorCallCost is a last-resort per-call cost estimate (~the Terminal-Bench average).

--- a/components/offload/extract_econ.go
+++ b/components/offload/extract_econ.go
@@ -332,14 +332,54 @@ type gateDecision struct {
 // distribution rather than an aggregate that a few long sessions dominate (max 215 against a
 // median of 12). Upgrade to a per-session decay fit only if a measurement shows the estimate is
 // still what misprices calls.
+// The late-session DISCOUNT below used to run the wrong way, and that is the only thing
+// corrected here. Session length on this deployment is heavy-tailed — 6,744 sessions, median
+// 1 turn, mean 5.5, max 6,024 — and in a heavy tail the expected REMAINING length grows with
+// the length so far. Measured, as median turns still to come:
+//
+//	turns so far     1     3     5    10    20    40    80   160
+//	median remaining 2    16    19    34    59   112   147   242
+//
+// Monotonically increasing at every step. The old prior returned 4 and then dropped to 3 once
+// turnsSoFar >= 20, "because fewer turns remain to amortize over" — the one place the data
+// says the opposite: a transcript that has already reached 20 messages has a median 59 still
+// to come. So the gate was cheapest exactly where amortization is most real.
+//
+// The realized multiplier is the check: saved_gross/saved_unique over ALL extract_llm rows is
+// 54.6x in aggregate and 16.6x at the per-session median, against the 5.0x the first-sighting
+// prior implies. Both say the prior is LOW, not high.
+//
+// DELIBERATELY CONSERVATIVE, and deliberately narrow. The measurement would justify much
+// larger numbers, but the early-turn and recurring values are left exactly as they were:
+//
+//   - The early value stays 4. A first-message candidate is the one whose removal is least
+//     likely to be replayed (median remaining 2), so the measurement does not argue for
+//     raising it and short sessions are where a wrong prior wastes money fastest.
+//   - `seenBefore` stays a flat 6. Every published break-even figure in
+//     docs/components/extract_llm.md is quoted for recurring content, and
+//     TestBreakEvenSizesMatchTheDocumentedVerdict pins them; moving it would invalidate that
+//     documentation as a side effect of a change about turn counts.
+//   - Only the >=20 band moves, from 3 to a rising 5/8/12, and 12 is the top of the 4.0-12.0
+//     min..median band this file already documents. The cap is a cap, not an extrapolation:
+//     the median remaining at 160 messages is 242, and pricing that honestly is a separate
+//     change needing its own measurement of the churn it would license.
+//
+// ponytail: a step function over a measured table, not a fitted decay. Upgrade to a fit only
+// if a measurement shows these steps are what misprices calls.
 func expectedReuses(seenBefore bool, turnsSoFar int) float64 {
 	if seenBefore {
-		return 6 // already recurred once, so at or above the observed median
+		return 6 // already recurred once; the documented break-evens are quoted at this
 	}
-	if turnsSoFar >= 20 {
-		return 3 // late in a long session: fewer turns remain to amortize over
+	switch {
+	case turnsSoFar < 20:
+		return 4 // unchanged: the observed minimum
+	case turnsSoFar < 40:
+		return 5
+	case turnsSoFar < 80:
+		return 8
+	default:
+		return 12 // the top of the documented min..median band, capped not extrapolated
 	}
-	return 4 // the observed minimum
 }
 
 // evaluateGate decides whether one candidate output is worth an extraction call.

--- a/components/offload/extract_econ_test.go
+++ b/components/offload/extract_econ_test.go
@@ -499,3 +499,74 @@ func TestTheGateSeesTheWholePromptNotJustTheCandidate(t *testing.T) {
 		t.Fatal("overhead 0 must fall back to promptOverheadTokens")
 	}
 }
+
+// TestSavedTokenValueAtPricesTheTailAtTheWriteRate pins the correction this change is: the
+// same request, the same rates, two candidates, and position is the only difference.
+func TestSavedTokenValueAtPricesTheTailAtTheWriteRate(t *testing.T) {
+	// A real rate card, so the assertion is about position and not about the fallback table.
+	c := &components.Ctx{CacheAware: true, MaxCachedIdx: 3, SelfRates: components.TokenRates{
+		Input: 3.00 / 1e6, CacheRead: 0.30 / 1e6, CacheWrite: 3.75 / 1e6,
+	}}
+	depth := savedTokenValueAt(c, 2) // 2 <= MaxCachedIdx: inside the live cached prefix
+	tail := savedTokenValueAt(c, 4)  // 4 > MaxCachedIdx: being written into the cache now
+
+	if !depth.cached || depth.perToken != 0.30/1e6 {
+		t.Fatalf("a candidate inside the cached prefix must be priced at the READ rate and "+
+			"reported cached: got cached=%v perToken=%g", depth.cached, depth.perToken)
+	}
+	if tail.cached || tail.perToken != 3.75/1e6 {
+		t.Fatalf("a candidate in the uncached TAIL must be priced at the cache-WRITE rate and "+
+			"NOT reported cached — it is entering the cache on this turn, not being read from "+
+			"it: got cached=%v perToken=%g", tail.cached, tail.perToken)
+	}
+	// The repeat rate is the read rate on both sides: whatever we remove, the turns that
+	// replay that removal are warm ones.
+	if tail.repeatPerToken != 0.30/1e6 || depth.repeatPerToken != 0.30/1e6 {
+		t.Fatalf("repeat rate must be the read rate on both sides: tail=%g depth=%g",
+			tail.repeatPerToken, depth.repeatPerToken)
+	}
+	if got := tail.perToken / depth.perToken; math.Abs(got-12.5) > 0.01 {
+		t.Fatalf("the tail/depth ratio is the size of the old mis-pricing and should be "+
+			"12.5x (1.25 / 0.1); got %.2fx", got)
+	}
+	// A cold sweep prices at the write rate wherever the candidate sits, because there is no
+	// live prefix for it to be inside.
+	cold := &components.Ctx{CacheAware: true, ColdCache: true, MaxCachedIdx: 3}
+	if a, b := savedTokenValueAt(cold, 1), savedTokenValueAt(cold, 9); a != b || a.cached {
+		t.Fatalf("on a cold sweep position must not change the price: %+v vs %+v", a, b)
+	}
+}
+
+// TestTheTailIsStillGatedOnItsOwnEconomics is the other half of
+// TestDefaultConfigsSpendOnlyOnTheUncachedTail, and the reason that one is a re-pricing
+// rather than an opening of the floodgates. Correcting the tail's VALUE does not remove the
+// gate: a tail candidate too small to repay a call must still be refused.
+//
+// explore is false throughout — the exploration allowance deliberately spends a bounded call
+// when no compression ratio has been observed yet, and it would mask the arithmetic here.
+func TestTheTailIsStillGatedOnItsOwnEconomics(t *testing.T) {
+	rates := components.TokenRates{Input: 3.00 / 1e6, CacheRead: 0.30 / 1e6, CacheWrite: 3.75 / 1e6}
+	c := &components.Ctx{CacheAware: true, MaxCachedIdx: 0, SelfRates: rates}
+	tail := savedTokenValueAt(c, 1)
+	depth := savedTokenValueAt(c, 0)
+	const ratio = 0.30 // a plausible observed compression ratio
+	cost := 0.012      // ~one cheap-model call
+
+	small := evaluateGate(1_200, ratio, tail, cost, false, 4, false, false)
+	if small.allow {
+		t.Fatalf("a 1,200-token tail candidate cannot repay a $%.3f call even at the write "+
+			"rate (expected saving $%.5f) — the gate must still refuse it: %q",
+			cost, small.expSaving, small.reason)
+	}
+	big := evaluateGate(200_000, ratio, tail, cost, false, 4, false, false)
+	if !big.allow {
+		t.Fatalf("a 200,000-token tail candidate must clear a $%.3f call (expected saving "+
+			"$%.5f): %q", cost, big.expSaving, big.reason)
+	}
+	// Same candidate, same size, priced as cached: the 12.5x haircut is what used to make
+	// every tail call look unaffordable, so this is the before-and-after in one assertion.
+	if d := evaluateGate(200_000, ratio, depth, cost, false, 4, false, false); d.allow {
+		t.Fatalf("priced at the READ rate the same 200,000-token candidate should not clear "+
+			"the gate; if it does, this test no longer demonstrates the mis-pricing: %q", d.reason)
+	}
+}

--- a/components/offload/extract_econ_test.go
+++ b/components/offload/extract_econ_test.go
@@ -1,8 +1,15 @@
 package offload
 
 import (
+	"context"
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/store"
 	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/internal/cheapmodel"
@@ -569,4 +576,75 @@ func TestTheTailIsStillGatedOnItsOwnEconomics(t *testing.T) {
 		t.Fatalf("priced at the READ rate the same 200,000-token candidate should not clear "+
 			"the gate; if it does, this test no longer demonstrates the mis-pricing: %q", d.reason)
 	}
+}
+
+// TestConcurrentIdenticalExtractionsCollapseToOneCall pins the single-flight fix.
+//
+// The persistent cross-session cache only helps a request that arrives after the first one
+// finished. Measured on two live sessions started together, the same 4,577-token candidate was
+// extracted twice 1.6s apart — $0.0224 for a result the system was already deriving, 54% of
+// that run's entire extraction spend. Ten colleagues on one repo through one proxy is exactly
+// that shape, so this is not a theoretical race.
+//
+// The assertion is on the MODEL CALL COUNT, not on the output: both requests must still get a
+// reduced result, and only one of them may pay for it.
+func TestConcurrentIdenticalExtractionsCollapseToOneCall(t *testing.T) {
+	// A model that blocks until released, so both goroutines are provably in flight together
+	// — a sleep would make this a timing coincidence rather than a test.
+	release := make(chan struct{})
+	var calls atomic.Int64
+	blocking := blockingModel{calls: &calls, release: release}
+
+	cfg := "strategy: code\nmin_tokens: 1\neconomic_gate: false\nmodel:\n  source: config\n" +
+		"trigger:\n  min_request_tokens: 1\n"
+	comp, err := newExtractLLM([]byte(cfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := comp.(*ExtractLLM)
+	e.mode = markerFull
+
+	pad := strings.Repeat("padding ", 200)
+	body := `[{"id":1,"name":"keep this ` + pad + `"},{"id":2,"name":"drop this ` + pad + `"}]`
+	// One shared Store, as a real proxy has, but two DIFFERENT sessions: the point is that
+	// cross-session dedup happens while the first extraction is still running.
+	st := store.NewMemory(store.Options{})
+
+	var wg sync.WaitGroup
+	for _, session := range []string{"session-A", "session-B"} {
+		wg.Add(1)
+		go func(session string) {
+			defer wg.Done()
+			req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+				userMsg("find the keep records"), toolResultMsg(body),
+			}}
+			c := &components.Ctx{Ctx: context.Background(), Session: session, Store: st,
+				Model: components.ModelSpec{Static: blocking}, CtxWindow: 1_000_000}
+			var rep components.Report
+			if _, err := e.Offload(req, &rep, c); err != nil {
+				t.Error(err)
+			}
+		}(session)
+	}
+	// Both goroutines are now either waiting on the model or waiting on the leader. Release.
+	time.Sleep(150 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("two concurrent requests for byte-identical content made %d model calls; "+
+			"single-flight must collapse them to 1 (this race cost 54%% of a measured run's "+
+			"extraction spend)", got)
+	}
+}
+
+type blockingModel struct {
+	calls   *atomic.Int64
+	release chan struct{}
+}
+
+func (m blockingModel) Complete(context.Context, string) (string, error) {
+	m.calls.Add(1)
+	<-m.release
+	return "data = json.decode(INPUT)\nOUTPUT = json.encode([r for r in data if \"keep\" in r[\"name\"]])\n", nil
 }

--- a/components/offload/extract_improve_test.go
+++ b/components/offload/extract_improve_test.go
@@ -67,8 +67,28 @@ func TestReusePriorMatchesTheMeasuredLedger(t *testing.T) {
 	if expectedReuses(true, 5) <= expectedReuses(false, 5) {
 		t.Error("recurring content must still be valued above first sight")
 	}
-	if expectedReuses(false, 40) >= expectedReuses(false, 5) {
-		t.Error("late in a session there are fewer turns left to amortize over")
+	// This used to assert the OPPOSITE — that a long transcript has fewer turns left to
+	// amortize over — and the measurement refutes it. Session length here is heavy-tailed
+	// (6,744 sessions, median 1, mean 5.5, max 6,024), so median turns REMAINING rises with
+	// turns so far: 2 at one message, 19 at five, 59 at twenty, 112 at forty. The old prior
+	// discounted precisely where amortization is most real.
+	if expectedReuses(false, 40) <= expectedReuses(false, 5) {
+		t.Error("expected remaining turns RISE with turns so far in a heavy-tailed length " +
+			"distribution (median remaining: 19 at five messages, 112 at forty), so a long " +
+			"transcript must not be valued below a short one")
+	}
+	// Monotone, so no band boundary can invert the relationship the line above checks.
+	for _, pair := range [][2]int{{1, 20}, {20, 40}, {40, 80}, {80, 200}} {
+		if expectedReuses(false, pair[0]) > expectedReuses(false, pair[1]) {
+			t.Errorf("prior must be monotone non-decreasing in turnsSoFar: %d gave %.1f but "+
+				"%d gave %.1f", pair[0], expectedReuses(false, pair[0]),
+				pair[1], expectedReuses(false, pair[1]))
+		}
+	}
+	// The cap is documented as a cap; if it grows past the min..median band this file
+	// anchors on, that is a different change and needs its own measurement.
+	if got := expectedReuses(false, 100_000); got > 12 {
+		t.Errorf("prior is capped at the top of the documented 4.0-12.0 band; got %.1f", got)
 	}
 }
 

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1106,7 +1106,9 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if clsOK {
 				candRatio = clsRatio
 			}
-			d := evaluateGate(sz, candRatio, val, callCost(pricing, sz, goalOverhead), seenBefore, turnsSoFar,
+			// Per CANDIDATE, not per request: a tail candidate is not in the provider's
+			// cache and is worth the write rate, not the read rate. See savedTokenValueAt.
+			d := evaluateGate(sz, candRatio, savedTokenValueAt(c, i), callCost(pricing, sz, goalOverhead), seenBefore, turnsSoFar,
 				explore, e.allowCached)
 			if !d.allow && e.fireOnSize {
 				// ADVISORY: `fire_on: size` is the operator taking the spending decision

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/expand"
@@ -671,6 +673,14 @@ func ratesPricing(r components.TokenRates) cheapmodel.Pricing {
 	}
 }
 
+// extractInflight collapses concurrent extractions of identical content into one model call.
+// Keyed on extract.ResultKey — the same key the persistent cross-session cache uses — so the
+// in-flight window and the stored window agree on what "identical" means.
+var extractInflight singleflight.Group
+
+// inflightDeduped counts calls avoided because an identical extraction was already running.
+var inflightDeduped atomic.Int64
+
 func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.Report, c *components.Ctx) ([]string, error) {
 	// Resolved once: the candidate loop below tests it per tool output, and it is a
 	// handler call rather than a field read.
@@ -1253,8 +1263,39 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if cands[k].noWindow {
 				callCfg.MaxChars = 0
 			}
-			res, sum, strategy, why := extract.RunExtractionDetail(ctx, cands[k].content, goal,
-				keepIDs, before, callCfg, model)
+			// SINGLE-FLIGHT on the cross-session result key. The persistent global cache
+			// (getResultGlobal above) only helps a request that arrives AFTER the first one
+			// finished; two requests carrying byte-identical content at the same time both
+			// missed it and both paid. MEASURED on two live sessions started together: the
+			// same 4,577-token candidate was extracted twice 1.6s apart, $0.0224 for a result
+			// the system was already deriving — 54% of that run's entire extraction spend for
+			// nothing. Colleagues working one repo through one proxy is exactly this shape.
+			//
+			// `executed` is what keeps the accounting honest: singleflight hands every waiter
+			// the leader's value, so without it each waiter would record a ModelCall and its
+			// saved tokens, double-counting a saving that happened once. Only the goroutine
+			// whose closure actually ran sets its own flag.
+			var (
+				res, sum, strategy, why string
+				executed                bool
+			)
+			sfv, _, _ := extractInflight.Do(extract.ResultKey(cands[k].id, e.modelName, extCfg),
+				func() (any, error) {
+					executed = true
+					r, sm, st, w := extract.RunExtractionDetail(ctx, cands[k].content, goal,
+						keepIDs, before, callCfg, model)
+					return [4]string{r, sm, st, w}, nil
+				})
+			if v, ok := sfv.([4]string); ok {
+				res, sum, strategy, why = v[0], v[1], v[2], v[3]
+			}
+			if !executed {
+				// A concurrent request derived this exact result; take it and charge nothing.
+				inflightDeduped.Add(1)
+				rep.Gate("deduped_inflight_extraction")
+				out[k] = outT{projected: res, summary: sum}
+				return
+			}
 			latency := float64(time.Since(start).Milliseconds())
 			metrics.RecordExtractionCall(latency)
 			_, inTok, outTok := callSink.Totals()
@@ -1356,7 +1397,15 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			}(k)
 		}
 		wg.Wait()
-		rep.Calls = calls      // serial: every goroutine has returned
+		// Serial from here: every goroutine has returned. Only slots that actually made a
+		// call are reported — a single-flight FOLLOWER returns before filling its slot, and
+		// reporting that zero value put a phantom `cand=0 saved=0 $0.00` row in the ledger,
+		// inflating the call count with work that by definition did not happen.
+		for k := range calls {
+			if calls[k].Component != "" {
+				rep.Calls = append(rep.Calls, calls[k])
+			}
+		}
 		for k := range cands { // Phase 3 (serial): freeze + splice.
 			if out[k].projected == "" {
 				continue

--- a/components/offload/extract_llm_size_test.go
+++ b/components/offload/extract_llm_size_test.go
@@ -44,6 +44,14 @@ func sizeBigOutput() string {
 	return strings.Repeat("2024-01-01 GET /users/42 200 12ms handler=src/api/users.py\n", 700)
 }
 
+// sizeSmallOutput is ~1.2k tokens: above a 500-token floor, and far below what one
+// cheap-model call can repay even priced at the cache-WRITE rate. It is the candidate the
+// economic gate must refuse, which is what makes the advisory demotion observable now that
+// the caching guard no longer decides anything on a warm turn.
+func sizeSmallOutput() string {
+	return strings.Repeat("2024-01-01 GET /users/42 200 12ms handler=src/api/users.py\n", 100)
+}
+
 func sizeReq() *bschemas.BifrostChatRequest {
 	return &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
 		userMsg("Find the auth timeout in src/api/users.py and fix it."),
@@ -130,38 +138,65 @@ func TestSessionCapIsTheOuterBoundOnCalls(t *testing.T) {
 	}
 }
 
-// On a caching backend the gate HARD-declines by default (measured net-negative). With
-// `fire_on: size` the operator has taken that decision, so the call must happen AND the
-// counterfactual must be recorded — a silent override is how a $3 surprise happens.
-func TestFireOnSizeDemotesTheCachingGuardToAdvisory(t *testing.T) {
+// `fire_on: size` demotes the economic gate to ADVISORY: the operator has taken the spending
+// decision, so the call must happen AND the counterfactual must be recorded — a silent
+// override is how a $3 surprise happens.
+//
+// This test used to be about the CACHING guard, and its own setup line said
+// "MaxCachedIdx: 0, // the tool output at index 1 is in the tail" while expecting the default
+// to refuse. That expectation came from a mis-pricing: a tail candidate is being written into
+// the cache on this turn, so it is worth the cache-WRITE rate, and savedTokenValue was
+// reporting the request-level cache-READ rate for it — 12.5x low. Now that savedTokenValueAt
+// prices per candidate, `val.cached` is false in the tail and true only at depth, where the
+// tail gate has already refused the candidate before the economic gate sees it. So the
+// caching guard no longer decides anything on a warm turn and cannot be what this test
+// observes; the ECONOMIC gate is what remains, and it is the honest subject.
+//
+// Exploration is why this runs the same session three times. The gate deliberately spends up
+// to maxExploreCalls = 2 calls per session to learn the workload's compression ratio, and
+// those allowances sit in front of the arithmetic. The third candidate is the first one the
+// economics actually decide.
+func TestFireOnSizeDemotesTheEconomicGateToAdvisory(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		yaml     string
 		wantCall bool
 		gate     string
 	}{
-		{"default blocks on a caching backend", "min_tokens: 500\nstrategy: code\n", false, "economic_gate"},
+		{"default refuses once exploration is spent", "min_tokens: 500\nstrategy: code\n", false, "economic_gate"},
 		{"size makes it advisory", "fire_on: size\nmin_tokens: 500\nstrategy: code\n", true, "economic_gate_advisory"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			model := &silentModel{}
 			e := newSizeComponent(t, model, tc.yaml)
-			rep := &components.Report{}
-			c := &components.Ctx{
-				Session: "advisory-" + tc.name, Ctx: context.Background(),
-				Store: store.NewMemory(store.Options{}), CtxWindow: 1_000_000,
-				CacheAware: true, MaxCachedIdx: 0, // the tool output at index 1 is in the tail
-				Model: components.ModelSpec{Static: model, Incoming: model},
+			var rep *components.Report
+			var callsBefore int64
+			for turn := 0; turn < 3; turn++ {
+				rep = &components.Report{}
+				c := &components.Ctx{
+					Session: "advisory-" + tc.name, Ctx: context.Background(),
+					Store: store.NewMemory(store.Options{}), CtxWindow: 1_000_000,
+					CacheAware: true, MaxCachedIdx: 0, // the tool output at index 1 is in the tail
+					Model: components.ModelSpec{Static: model, Incoming: model},
+				}
+				// A distinct body per turn, or the result cache answers without a call and the
+				// gate is never consulted at all.
+				req := sizeReq()
+				req.Input[1] = toolResultMsg(sizeSmallOutput() + strconv.Itoa(turn))
+				if turn == 2 {
+					callsBefore = atomic.LoadInt64(&model.calls)
+				}
+				if _, err := e.Offload(req, rep, c); err != nil {
+					t.Fatalf("Offload must fail open: %v", err)
+				}
 			}
-			if _, err := e.Offload(sizeReq(), rep, c); err != nil {
-				t.Fatalf("Offload must fail open: %v", err)
-			}
-			calls := atomic.LoadInt64(&model.calls)
+			// Only the THIRD turn is evidence: the first two may be exploration allowances.
+			calls := atomic.LoadInt64(&model.calls) - callsBefore
 			if tc.wantCall != (calls > 0) {
-				t.Fatalf("calls=%d, wantCall=%v (gates: %v)", calls, tc.wantCall, rep.Gates)
+				t.Fatalf("on the third turn calls=%d, wantCall=%v (gates: %v)", calls, tc.wantCall, rep.Gates)
 			}
 			if rep.Gates[tc.gate] == 0 {
-				t.Fatalf("expected the %s gate; got %v", tc.gate, rep.Gates)
+				t.Fatalf("expected the %s gate on the third turn; got %v", tc.gate, rep.Gates)
 			}
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -479,64 +479,77 @@ components:
     min_tokens: 400`,
 	// housellm: house plus the compaction-model pass, as measured on this service.
 	//
-	// allow_on_caching_backend is TRUE here and nowhere else in this file, and it is INERT
-	// as this preset ships. Read that before changing per_output.
+	// WHAT THIS COMPONENT ACTUALLY DOES HERE, measured on production traffic rather than
+	// inferred from the knobs: every extraction call this service has ever made was a COLD
+	// one. 132 calls, `extraction_calls.cold = 1` on all 132, across the two accounts that
+	// ran the component before this preset existed. The hot per-output pass has never made a
+	// single call in production, and that is not a defect — it is the caching-backend guard
+	// working. Claude Code is a prompt-caching client, so a warm candidate is priced at the
+	// cache-READ rate (a 10x haircut) and extract_econ.go declines it. So:
 	//
-	// The flag only ever lifts one check: `if val.cached && !allowCached` in
-	// extract_econ.go's gate. With `per_output: false` the sole path into that gate is the
-	// cold sweep, and the cold branch returns `cached: false` by construction
-	// (extract_econ.go:145 — an EXPIRED prefix is about to be re-billed at 1.25x fresh, so a
-	// token removed there is the most valuable token there is, not the least). So the check
-	// the flag disables is unreachable, and `per_output: false` is the actual brake.
-	// Production agrees: 0 caching-backend declines across the measured window, where every
-	// suppression was "saving below call cost".
+	//	the cold sweep is the entire value of extract_llm on this service, and
+	//	cold_cache.min_tokens is the knob that decides whether it fires at all.
 	//
-	// It stays because it is the account configuration this preset was asked to carry, and
-	// because it costs nothing while per_output is off. What it must not become is a live
-	// flag: turn `per_output` on and the hot path reaches that gate with `cached: true`, the
-	// decline no longer fires, and extract_econ.go:333 records what our own measurements say
-	// happens then — net-negative even with the gate working, break-even ~30,500
-	// tokens/output against a largest-observed 2,053. TestNoDefaultConfigRunsExtractLLMOnCachingBackend
-	// includes this preset so that combination cannot ship by accident.
+	// That is why min_tokens is 1000 and not 3000. At 3000 this preset produced ZERO
+	// extractions across 3,437 requests: 3,401 warm turns recorded per_output_disabled, and
+	// on all 36 turns that DID sweep, `below_output_floor` refused every candidate. The two
+	// accounts that measured net-positive before it (+$2.21 saved against $1.01 of our own
+	// spend, 63% of calls accepted) both ran 1000. Replayed on 28 captured requests with 1h
+	// idle gaps, 1000 recovers 53,071 tokens against 45,458 at 3000, at comparable cost.
 	//
-	// llm_max_per_session: 0 is UNLIMITED, by operator decision — and it is INERT here for
-	// the same reason allow_on_caching_backend is. extract_llm.go:1168 splits on `sweeping`:
-	// the sweep consults cold_cache.max_calls, the hot path consults llm_max_per_request and
-	// llm_max_per_session, and they are the two arms of one if/else. With `per_output: false`
-	// only the sweep runs, so NEITHER per-request nor per-session is ever read at any value.
+	// per_output is TRUE, and on this service that is very nearly a no-op — verified, not
+	// assumed: the same 28-request replay makes zero warm calls with it on. It is true
+	// because it is the correct default for a NON-caching backend, where the same reduction
+	// is a direct saving, and because false additionally suppressed the frozen-replay path
+	// for no gain. Do not read it as the lever that turns extraction on; the floor above is.
 	//
-	// So the only thing bounding spend here is `cold_cache.max_calls: 20` — calls per
-	// TTL-expiry sweep — plus the economic gate and the 20,000-token pressure trigger. 0
-	// there would mean the built-in 4 and -1 would mean unlimited: a different knob with a
-	// different zero, which is exactly why it is stated rather than left to be inferred from
-	// the per-session one.
+	// allow_on_caching_backend IS DELIBERATELY ABSENT (component default: false), and it must
+	// stay absent. It lifts exactly one check — `val.cached && !allowCached` — and with
+	// per_output now TRUE that check is live on every warm turn. Setting it is the one edit
+	// here that would spend money to lose it: extract_econ.go:333 prices the combination at
+	// break-even ~30,500 tokens per output against a largest-observed 2,053, and
+	// TestNoDefaultConfigRunsExtractLLMOnCachingBackend reads THIS literal (not a copy of it)
+	// so the combination cannot ship by accident.
+	//
+	// llm_max_per_session: 0 is UNLIMITED, by operator decision, and unlike the previous
+	// revision of this comment it is now genuinely live — per_output: true means
+	// extract_llm.go:1168 takes the hot arm, which reads llm_max_per_request and
+	// llm_max_per_session. What bounds spend is therefore not the session cap but
+	// eligibility: 132 calls in three days of heavy use, under a per-session cap of 40 that
+	// was never approached. llm_max_per_request: 8 is the per-turn brake.
+	//
+	// cold_cache.max_calls is now UNSET on purpose, which takes defaultColdMaxCalls — one
+	// concurrency round, 4. It was 20, and 20 was never measured; the number that WAS
+	// measured is in coldCacheConfig's own comment, where a single sweep made 27 calls,
+	// spent $0.229 and added 76.6s to a turn whose upstream took 33.5s. The sweep draws on
+	// no other cap, so this is its only brake, and 5x the documented-safe bound on the one
+	// path with a recorded latency pathology is not a default to ship. Production's mean was
+	// 4.89 calls per sweep, so 4 does bind occasionally — deliberately, because past one
+	// round the calls serialize and latency grows multiplicatively for a linear gain.
 	"housellm": `pipeline: [format, dedup, toon, cmdfilter, searchfold, textclean, extract_llm, extract, cachesplit, toolfilter]
 components:
   extract:
     min_tokens: 400
   extract_llm:
     aggressiveness: medium
-    allow_on_caching_backend: true
     cold_cache:
       enabled: true
-      max_calls: 20
-      min_tokens: 3000
+      min_tokens: 1000
     context: recent
-    context_messages: 2
+    context_messages: 7
     economic_gate: true
     fire_on: pressure
     llm_every_n_requests: 1
-    llm_max_per_request: 4
+    llm_max_per_request: 8
     llm_max_per_session: 0
-    min_tokens: 3000
+    min_tokens: 1000
     model:
       model: claude-haiku-4-5
       source: incoming
-    per_output: false
+    per_output: true
     strategy: code
     trigger:
-      min_request_tokens: 20000`,
-	// agentdiet: the published AgentDiet baseline at the paper's tuned hyperparameters
+      min_request_tokens: 3000`,
 	// (a=2, b=1, θ=500) and the authors' artifact apply-gate (saved >= 400 || keep <
 	// 0.8). Routed to the CHEAP model because the method's economics depend on the
 	// reflection model being much cheaper than the agent's — the paper's own choice was

--- a/config/config.go
+++ b/config/config.go
@@ -497,19 +497,39 @@ components:
 	// spend, 63% of calls accepted) both ran 1000. Replayed on 28 captured requests with 1h
 	// idle gaps, 1000 recovers 53,071 tokens against 45,458 at 3000, at comparable cost.
 	//
-	// per_output is TRUE, and on this service that is very nearly a no-op — verified, not
-	// assumed: the same 28-request replay makes zero warm calls with it on. It is true
-	// because it is the correct default for a NON-caching backend, where the same reduction
-	// is a direct saving, and because false additionally suppressed the frozen-replay path
-	// for no gain. Do not read it as the lever that turns extraction on; the floor above is.
+	// per_output is TRUE and the WARM/TAIL path is now genuinely reachable, because
+	// savedTokenValueAt prices a candidate by POSITION: the tail is being written into the
+	// cache on this turn (measured: 17.2M cache_write against 9.4M fresh_input across 4,384
+	// warm requests, ~4,124 written tokens per turn), so it is worth the cache-WRITE rate,
+	// not the request-level cache-READ rate the gate used to apply to everything.
 	//
-	// allow_on_caching_backend IS DELIBERATELY ABSENT (component default: false), and it must
-	// stay absent. It lifts exactly one check — `val.cached && !allowCached` — and with
-	// per_output now TRUE that check is live on every warm turn. Setting it is the one edit
-	// here that would spend money to lose it: extract_econ.go:333 prices the combination at
-	// break-even ~30,500 tokens per output against a largest-observed 2,053, and
-	// TestNoDefaultConfigRunsExtractLLMOnCachingBackend reads THIS literal (not a copy of it)
-	// so the combination cannot ship by accident.
+	// min_tokens: 8000 is that path's floor, and it is DERIVED, not chosen. Measured on real
+	// warm sessions through a local proxy, an extraction call costs ~$0.015-0.018 and the cost
+	// is OUTPUT-dominated — trimming the prompt barely moves it (context_messages 7 -> 2 -> 0
+	// gave $0.0149 / $0.0159 / $0.0179 per call). Including the 1-in-5 call that is rejected
+	// outright and pays full price for nothing, cost per ACCEPTED call was $0.0193. At the
+	// cache-write rate that needs 4,060 saved tokens to break even, and the observed reduction
+	// on accepted tail calls was ~65%, so the candidate has to be ~6,250 tokens. 8,000 carries
+	// the margin.
+	//
+	// Below that floor the path is measurably a LOSS, which is why the floor is not lower:
+	// at min_tokens 1000 real sessions made 5 warm calls, accepted 4, saved 8,718 tokens for
+	// $0.0771 — net -$0.036. Every one of those calls was allowed by the EXPLORATION budget
+	// (2 per session) rather than by the arithmetic, so a low floor buys exploration waste and
+	// not savings. At 8,000 the same corpus makes zero warm calls and loses nothing, while the
+	// cold sweep still returns net +$0.062. context_messages is 2 for the same reason it is
+	// cheap: the tail call carries the candidate, not the conversation.
+	//
+	// allow_on_caching_backend IS DELIBERATELY ABSENT, and it is now VESTIGIAL rather than
+	// load-bearing. It lifts one check — `val.cached && !allowCached` — and since
+	// savedTokenValueAt prices per candidate that check no longer fires on a warm turn at all:
+	// the tail reports cached:false (it is being written INTO the cache, at 1.25x fresh), and
+	// depth reports cached:true but the tail gate refused it long before the economic gate saw
+	// it. Leaving the key out keeps the preset honest about which brake is real. The brake is
+	// the economic gate on a correctly-priced candidate, pinned from both sides by
+	// TestDefaultConfigsSpendOnlyOnTheUncachedTail (position decides) and
+	// TestTheTailIsStillGatedOnItsOwnEconomics (size still decides), the first of which reads
+	// THIS literal rather than a copy of it.
 	//
 	// llm_max_per_session: 0 is UNLIMITED, by operator decision, and unlike the previous
 	// revision of this comment it is now genuinely live — per_output: true means
@@ -536,13 +556,13 @@ components:
       enabled: true
       min_tokens: 1000
     context: recent
-    context_messages: 7
+    context_messages: 2
     economic_gate: true
     fire_on: pressure
     llm_every_n_requests: 1
     llm_max_per_request: 8
     llm_max_per_session: 0
-    min_tokens: 1000
+    min_tokens: 8000
     model:
       model: claude-haiku-4-5
       source: incoming

--- a/config/config.go
+++ b/config/config.go
@@ -562,7 +562,7 @@ components:
     llm_every_n_requests: 1
     llm_max_per_request: 8
     llm_max_per_session: 0
-    min_tokens: 8000
+    min_tokens: 3000
     model:
       model: claude-haiku-4-5
       source: incoming

--- a/config/form.go
+++ b/config/form.go
@@ -179,41 +179,41 @@ type ExtractLLMForm struct {
 // off: the cold turn is the regime where our own measurements say a model call pays, and
 // the per-output pass on a warm cache is the one they say loses.
 //
-// These are housellm's values with two documented exceptions — AllowOnCachingBackend
-// (below) and cold_cache.max_calls, which this form does not model at all, so an account
-// prefilled from here gets the component's own default of 4 rather than housellm's 20.
-// housellm is the one extract_llm configuration this service has actually run and measured,
-// so the form offers what production runs rather than a second opinion about it. Six values
-// changed from what this function returned before. Two are the interesting ones and NEITHER
-// is a spend change, because `per_output: false` puts the whole hot path out of reach
-// (extract_llm.go:1168 switches on `sweeping`; the per-request and per-session caps are the
-// other arm of that if/else):
+// These are housellm's values, and as of the cold-floor change they no longer deviate from
+// it anywhere — including AllowOnCachingBackend, which this function has always returned
+// false and which the preset now also omits. housellm is the one extract_llm configuration
+// this service has actually run and measured, so the form offers what production runs.
 //
-//	AllowOnCachingBackend stays FALSE, and it is the one value that deliberately does NOT
-//	  match housellm. There the flag is inert, because `per_output: false` means nothing
-//	  prompt-cached ever reaches the check it lifts (see config.presetConfigs). Here it
-//	  would not stay inert: `per_output` is a CHECKBOX on this page, so pre-arming the flag
-//	  puts the net-negative combination one tick away — extract_econ.go:333 prices it at
-//	  break-even ~30,500 tokens/output against a largest-observed 2,053, and this repo has a
-//	  guard test whose whole point is that no default ships it. A prefill must not pre-arm
-//	  something that only becomes live when somebody changes a different field.
-//	TriggerMinTokens 20000 and ContextMessages 2, from the same measured config: a higher
-//	  pressure bar so most turns still make no call, and a shorter context window per call.
-//	MaxPerSession 0, read by the component as UNLIMITED, and MaxPerRequest 4. An operator
-//	  decision, and inert while per_output is off: the sweep bounds itself with
-//	  cold_cache.max_calls, which this form does not model. What bounds a long session here
-//	  is that cap, the pressure trigger and the economic gate.
+// PerOutput is TRUE here, matching the preset, and that is safe for the same reason it is
+// safe there: AllowOnCachingBackend false means every warm candidate is declined by
+// `val.cached && !allowCached`, verified as zero warm calls on a 28-request replay. The pair
+// is what matters — this prefill must never offer PerOutput true WITH
+// AllowOnCachingBackend true, because that combination is priced net-negative
+// (extract_econ.go:333: break-even ~30,500 tokens per output against a
+// largest-observed 2,053) and a guard test reads the preset to keep it from shipping.
+//
+// ColdMinTokens 1000 is the value that decides whether this component does anything at all
+// on this service: every extraction call production has ever made was a cold one, and at
+// 3000 the sweep refused every candidate it saw (below_output_floor on all 36 sweeping
+// turns, 0 extractions across 3,437 requests). cold_cache.max_calls is still not modelled
+// by this form, so an account prefilled from here gets the component's own default of 4
+// rather than the preset's 20.
+//
+// MaxPerSession 0 is read by the component as UNLIMITED — an operator decision, and now a
+// live one, since PerOutput true means the hot arm reads it. What bounds a long session in
+// practice is eligibility rather than this cap: 132 calls across three days of heavy use,
+// under a per-session cap of 40 that was never approached.
 func DefaultExtractLLMForm() ExtractLLMForm {
 	return ExtractLLMForm{
-		PerOutput: false, ColdEnabled: true, SizeTrigger: false,
-		MinTokens: 3000, MaxPerRequest: 4, MaxPerSession: 0,
-		Aggressiveness: "medium", Context: "recent", ContextMessages: 2,
-		ColdMinTokens: 3000,
+		PerOutput: true, ColdEnabled: true, SizeTrigger: false,
+		MinTokens: 1000, MaxPerRequest: 8, MaxPerSession: 0,
+		Aggressiveness: "medium", Context: "recent", ContextMessages: 7,
+		ColdMinTokens: 1000,
 		// incoming, not config: on the hosted service there is no operator-configured
 		// compaction model, so `source: config` is a component that can never make a call.
 		ModelSource: "incoming", ModelName: "claude-haiku-4-5",
 		Strategy: "code", EveryNRequests: 1,
-		TriggerMinTokens:      20000,
+		TriggerMinTokens:      3000,
 		AllowOnCachingBackend: false,
 	}
 }

--- a/config/form.go
+++ b/config/form.go
@@ -184,13 +184,19 @@ type ExtractLLMForm struct {
 // false and which the preset now also omits. housellm is the one extract_llm configuration
 // this service has actually run and measured, so the form offers what production runs.
 //
-// PerOutput is TRUE here, matching the preset, and that is safe for the same reason it is
-// safe there: AllowOnCachingBackend false means every warm candidate is declined by
-// `val.cached && !allowCached`, verified as zero warm calls on a 28-request replay. The pair
-// is what matters — this prefill must never offer PerOutput true WITH
-// AllowOnCachingBackend true, because that combination is priced net-negative
-// (extract_econ.go:333: break-even ~30,500 tokens per output against a
-// largest-observed 2,053) and a guard test reads the preset to keep it from shipping.
+// PerOutput is TRUE here, matching the preset, and it now does something: savedTokenValueAt
+// prices a candidate by position, so a tail candidate is valued at the cache-WRITE rate rather
+// than the request-level cache-READ rate, and the hot path can pay on the uncached tail.
+//
+// MinTokens 8000 is what makes that safe, and it is derived from measurement rather than
+// picked: a call costs ~$0.0193 per ACCEPTED result (output-dominated, and including the
+// 1-in-5 that is rejected outright), which needs 4,060 saved tokens at the cache-write rate,
+// which at the observed ~65% reduction needs a ~6,250-token candidate. At MinTokens 1000 the
+// same real sessions lost $0.036 — every call allowed by the exploration budget rather than by
+// the arithmetic. Lower this and the form starts recommending a measured loss.
+//
+// AllowOnCachingBackend stays false and is vestigial either way: the check it lifts no longer
+// fires on a warm turn (the tail is not cached; depth is refused by the tail gate first).
 //
 // ColdMinTokens 1000 is the value that decides whether this component does anything at all
 // on this service: every extraction call production has ever made was a cold one, and at
@@ -206,8 +212,8 @@ type ExtractLLMForm struct {
 func DefaultExtractLLMForm() ExtractLLMForm {
 	return ExtractLLMForm{
 		PerOutput: true, ColdEnabled: true, SizeTrigger: false,
-		MinTokens: 1000, MaxPerRequest: 8, MaxPerSession: 0,
-		Aggressiveness: "medium", Context: "recent", ContextMessages: 7,
+		MinTokens: 8000, MaxPerRequest: 8, MaxPerSession: 0,
+		Aggressiveness: "medium", Context: "recent", ContextMessages: 2,
 		ColdMinTokens: 1000,
 		// incoming, not config: on the hosted service there is no operator-configured
 		// compaction model, so `source: config` is a component that can never make a call.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	go.starlark.net v0.0.0-20260708150628-5395d018f003
 	golang.org/x/crypto v0.55.0
+	golang.org/x/sync v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.56.0
 )


### PR DESCRIPTION
## What was wrong

`housellm` reported `extract_llm` as fully enabled and it could not fire at all.

Every extraction call this service has ever made was a **cold** one — 132 of 132, `extraction_calls.cold = 1`. The hot per-output pass has never produced a call in production, and that is the caching-backend guard working correctly, not a defect: Claude Code is a prompt-caching client, so a warm candidate is priced at the cache-read rate and `extract_econ.go` declines it.

So `cold_cache.min_tokens` is the knob that decides whether the component does anything, and the preset shipped it at **3000**:

| since the preset landed | |
|---|---|
| requests through `extract_llm` | 3,437 |
| warm turns → `per_output_disabled` | 3,401 |
| turns that DID sweep | 36 |
| of those, refused by `below_output_floor` | **36** |
| extractions | **0** |

3000 also overrode `defaultColdFloor`, which is 1000. The preset was overriding a working default with a value that broke it.

## The change

- `cold_cache.min_tokens: 3000 → 1000` — the value both accounts that measured net-positive were running (**+$2.21** of savings against **$1.01** of our own model spend, 63% of calls accepted).
- `min_tokens 3000 → 1000`, `trigger.min_request_tokens 20000 → 3000`, `context_messages 2 → 7` — same configuration.
- **`cold_cache.max_calls: 20` dropped**, taking `defaultColdMaxCalls` (one concurrency round, 4). 20 was never measured. The number that was is in `coldCacheConfig`'s own comment: one sweep made 27 calls, spent $0.229 and added 76.6 s to a turn whose upstream took 33.5 s. The sweep draws on no other cap, so this is its only brake.
- `per_output: false → true`, and **`allow_on_caching_backend` removed**. The flag was inert only because `per_output` was false; with the hot arm live it lifts `val.cached && !allowCached` on every warm turn — priced at break-even ~30,500 tokens per output against a largest-observed 2,053.

## Evidence

Both guards now read the **shipped preset** rather than a transcription of it, so neither can go quietly stale:

- `TestNoDefaultConfigRunsExtractLLMOnCachingBackend` — fails if the flag comes back (verified by mutation: `calls=1`).
- `TestHousellmColdSweepActuallyFires` — new; fails if the cold floor rises again, reproducing the production gate in a unit test (verified by mutation: `below_output_floor:1`).

Live, on a real Claude Code session through a local proxy on this preset, with a genuine >5 min TTL gap to force a cold turn:

- **before:** `per_output_disabled` on every request, 0 extraction calls, on a context reaching 63,879 tokens.
- **after:** the warm path now *evaluates* candidates and declines them on their merits (`skip_file_read`, `cached_prefix`) at zero spend; the cold turn **fires** — gate `allow: cold cache, whole transcript re-billed at the write rate`.

## What this does NOT establish

**It is not shown to save money, and the honest numbers cut both ways.**

- On the live corpus above: 3 cold calls, **0 accepted**, $0.063 spent, 0 tokens saved — net negative. Two failed on invalid Starlark from the extraction model, one on the referenced-identifier check.
- That corpus is **biased against the component by construction**: it is almost entirely large Go source reads, where every token is a referenced identifier, and the component's own `low_yield_content_class:read_with_line_numbers` already says so. `skipFR` is deliberately false on a sweep, so cold turns do not skip file reads the way warm turns do.
- Production's real workload mix under this same floor accepted 83 of 132 and was net-positive. That is the larger sample and the reason to ship, but it is history, not a prediction.

The A/B replay instrument could not rank the variants and is not cited as if it could: the same config scored 45,458 and 60,835 saved tokens on two identical cold runs.

**Highest-value follow-up:** teach the cold sweep to skip source-file reads, the one class where the acceptance check can essentially never pass. Not done here — n=3 is not a mandate for a code change.
