### PR TITLE
feat: manager-controlled keep-alive strategies

### DIFF
--- a/dash/api.go
+++ b/dash/api.go
@@ -240,6 +240,9 @@ func (a *API) routes() []route {
 	// The keep-alive tab's reads, declared beside their handlers in keepaliveapi.go and
 	// appended here for the same reason: this table is what both scoping tests walk.
 	rs = append(rs, a.keepAliveRoutes()...)
+	// The manager-controlled keep-alive strategy ledger, declared beside its handler in
+	// keepalivestrategy.go and appended here for the same reason.
+	rs = append(rs, a.keepAliveStrategyRoutes()...)
 	// The KV-cache TTL analysis and strategy simulator, declared beside its handlers in
 	// kvcacheapi.go and appended here for the same reason.
 	return append(rs, a.kvCacheRoutes()...)

--- a/dash/event.go
+++ b/dash/event.go
@@ -198,6 +198,14 @@ type Event struct {
 	// KeepAliveSavedUSD is the cache re-creation this request avoided because a ping kept
 	// its prefix alive.
 	KeepAliveSavedUSD float64 `json:"keepalive_saved_usd"`
+	// KeepAliveStrategyID is which manager-controlled strategy resolved a PING row's
+	// policy (see proxy/keepalivestrategy.go) — "" on every row but a ping's own, and ""
+	// even on a ping when no strategy matched (account config or a session override
+	// supplied the policy instead). Written as SQL NULL, not '', when empty — see
+	// dash/schema.go's keepalive_strategy_id column — so a row from before this feature
+	// existed is distinguishable from a ping this feature deliberately attributed to
+	// nothing.
+	KeepAliveStrategyID string `json:"keepalive_strategy_id,omitempty"`
 	// SinceLastMs is the gap from this session's previous REAL request, in milliseconds.
 	// Not persisted — AttributeCache already turns it into cache_miss_reason — but the
 	// keep-alive credit needs the raw number: the whole claim is that the gap exceeded the

--- a/dash/keepalivestrategy.go
+++ b/dash/keepalivestrategy.go
@@ -1,0 +1,109 @@
+package dash
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+// The manager-controlled keep-alive strategy tab's read side: one ledger, grouped by
+// tenant, for one strategy — see proxy/keepalivestrategy.go for how a strategy is
+// resolved and audited, and docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md
+// for the design.
+
+// StrategyLedgerRow is one tenant's economics under a strategy.
+type StrategyLedgerRow struct {
+	TenantID string  `json:"tenant_id"`
+	Pings    int64   `json:"pings"`
+	PingUSD  float64 `json:"ping_usd"`
+	SavedUSD float64 `json:"saved_usd"`
+	NetUSD   float64 `json:"net_usd"`
+}
+
+// StrategyLedgerView is one strategy's whole answer: the totals, and the per-tenant
+// breakdown behind them, costliest first.
+type StrategyLedgerView struct {
+	StrategyID string              `json:"strategy_id"`
+	Pings      int64               `json:"pings"`
+	PingUSD    float64             `json:"ping_usd"`
+	SavedUSD   float64             `json:"saved_usd"`
+	NetUSD     float64             `json:"net_usd"`
+	Tenants    []StrategyLedgerRow `json:"tenants"`
+}
+
+// StrategyLedger computes one strategy's economics, built the same way KeepAliveSessions
+// already is (dash/keepalive.go), filtered by keepalive_strategy_id instead of by
+// Filter.Tenant.
+//
+// Pings and PingUSD are EXACT: every ping row this strategy caused carries its id (see
+// proxy's record1). SavedUSD is the SAME ceiling the account-wide ledger reports
+// (KeepAliveLedger) and carries the same caveat plus one more: it is the tenant's WHOLE
+// keep-alive credit, not only the share this strategy's own pings produced. The credit
+// lands on the real request a ping rescued, which carries no strategy id — only the ping
+// itself is attributed (see the design doc's "Attribution for stats") — so on a tenant
+// running more than one strategy, or a per-session override, alongside this one, this
+// number is an upper bound on this strategy's own contribution, not an exact share of it.
+func (d *DB) StrategyLedger(strategyID string) (*StrategyLedgerView, error) {
+	out := &StrategyLedgerView{StrategyID: strategyID, Tenants: []StrategyLedgerRow{}}
+	rows, err := d.sql.Query(`SELECT tenant_id, COUNT(*), COALESCE(SUM(cost_usd),0)
+		FROM requests WHERE keepalive = 1 AND keepalive_strategy_id = ?
+		GROUP BY tenant_id ORDER BY 3 DESC`, strategyID)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var row StrategyLedgerRow
+		if err := rows.Scan(&row.TenantID, &row.Pings, &row.PingUSD); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		out.Tenants = append(out.Tenants, row)
+		out.Pings += row.Pings
+		out.PingUSD += row.PingUSD
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range out.Tenants {
+		row := &out.Tenants[i]
+		var saved sql.NullFloat64
+		if err := d.sql.QueryRow(`SELECT SUM(keepalive_saved_usd) FROM requests
+			WHERE tenant_id = ? AND keepalive_saved_usd > 0`, row.TenantID).Scan(&saved); err != nil {
+			return nil, err
+		}
+		row.SavedUSD = saved.Float64
+		row.NetUSD = row.SavedUSD - row.PingUSD
+		out.SavedUSD += row.SavedUSD
+	}
+	out.NetUSD = out.SavedUSD - out.PingUSD
+	return out, nil
+}
+
+// keepAliveStrategyRoutes is this feature's one read route, appended to routes in
+// api.go for the same reason every other feature's are: that table is what both
+// scoping tests walk.
+func (a *API) keepAliveStrategyRoutes() []route {
+	return []route{
+		{"GET /api/keepalive/strategies/{id}/ledger", scopeManager, a.keepAliveStrategyLedger},
+	}
+}
+
+// keepAliveStrategyLedger serves one strategy's ledger. Not tenant-scoped by a.scope —
+// like /api/config and /api/benchmarks, this is a server-wide view spanning every
+// tenant a strategy touched, not one tenant's own data.
+func (a *API) keepAliveStrategyLedger(w http.ResponseWriter, r *http.Request) {
+	if !a.requireManager(w, r, "a strategy's ledger") {
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		httpErr(w, http.StatusBadRequest, "name the strategy")
+		return
+	}
+	led, err := a.rec.DB().StrategyLedger(id)
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, led)
+}

--- a/dash/keepalivestrategy_test.go
+++ b/dash/keepalivestrategy_test.go
@@ -1,0 +1,77 @@
+package dash
+
+import "testing"
+
+// StrategyLedger groups a strategy's own ping rows by tenant, and folds in each
+// tenant's whole keep-alive credit — see the ceiling caveat on StrategyLedger itself.
+
+func TestStrategyLedgerGroupsPingsByTenantAndFoldsInTheirCredit(t *testing.T) {
+	db := openTestDB(t)
+
+	t1ping := kaPing(1000, "s1", 0.02, 40_000, 0)
+	t1ping.TenantID, t1ping.KeepAliveStrategyID = "t1", "strat-1"
+	t1credit := kaCredit(2000, "s1", 0.10)
+	t1credit.TenantID = "t1"
+
+	t2ping := kaPing(1500, "s2", 0.03, 60_000, 0)
+	t2ping.TenantID, t2ping.KeepAliveStrategyID = "t2", "strat-1"
+	t2credit := kaCredit(2500, "s2", 0.05)
+	t2credit.TenantID = "t2"
+
+	// A ping under a DIFFERENT strategy, and one that is not a ping at all: neither must
+	// be counted for strat-1.
+	otherStrategyPing := kaPing(1600, "s3", 0.09, 90_000, 0)
+	otherStrategyPing.TenantID, otherStrategyPing.KeepAliveStrategyID = "t1", "strat-2"
+
+	if err := db.insertBatch([]*Event{t1ping, t1credit, t2ping, t2credit, otherStrategyPing}); err != nil {
+		t.Fatal(err)
+	}
+
+	led, err := db.StrategyLedger("strat-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if led.StrategyID != "strat-1" {
+		t.Errorf("StrategyID = %q", led.StrategyID)
+	}
+	if led.Pings != 2 {
+		t.Errorf("Pings = %d, want 2 (the strat-2 ping must not be counted)", led.Pings)
+	}
+	if len(led.Tenants) != 2 {
+		t.Fatalf("Tenants = %d rows, want 2: %+v", len(led.Tenants), led.Tenants)
+	}
+	byTenant := map[string]StrategyLedgerRow{}
+	for _, r := range led.Tenants {
+		byTenant[r.TenantID] = r
+	}
+	t1 := byTenant["t1"]
+	if t1.Pings != 1 || t1.PingUSD < 0.019 || t1.PingUSD > 0.021 {
+		t.Errorf("t1 row = %+v, want 1 ping at ~$0.02", t1)
+	}
+	if t1.SavedUSD < 0.099 || t1.SavedUSD > 0.101 {
+		t.Errorf("t1 SavedUSD = %v, want ~0.10 (its own whole keep-alive credit)", t1.SavedUSD)
+	}
+	t2 := byTenant["t2"]
+	if t2.Pings != 1 || t2.PingUSD < 0.029 || t2.PingUSD > 0.031 {
+		t.Errorf("t2 row = %+v, want 1 ping at ~$0.03", t2)
+	}
+	// Totals are the sum of the per-tenant rows.
+	if led.PingUSD < t1.PingUSD+t2.PingUSD-0.0001 || led.PingUSD > t1.PingUSD+t2.PingUSD+0.0001 {
+		t.Errorf("total PingUSD %v does not sum the rows (%v + %v)", led.PingUSD, t1.PingUSD, t2.PingUSD)
+	}
+	if led.NetUSD != led.SavedUSD-led.PingUSD {
+		t.Errorf("NetUSD %v != SavedUSD %v - PingUSD %v", led.NetUSD, led.SavedUSD, led.PingUSD)
+	}
+}
+
+// A strategy with no ping rows yet answers with an empty ledger, not an error.
+func TestStrategyLedgerOnAnUnusedStrategy(t *testing.T) {
+	db := openTestDB(t)
+	led, err := db.StrategyLedger("never-fired")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if led.Pings != 0 || len(led.Tenants) != 0 {
+		t.Errorf("got %+v, want an empty ledger", led)
+	}
+}

--- a/dash/schema.go
+++ b/dash/schema.go
@@ -129,6 +129,15 @@ CREATE TABLE IF NOT EXISTS requests (
   -- reason cachesplit_saved_usd is: those tokens carry cache_control, so a miss bills them
   -- as creation at 1.25x rather than at 1.0x.
   keepalive_saved_usd REAL   NOT NULL DEFAULT 0,
+  -- Which manager-controlled keep-alive STRATEGY, if any, resolved a PING row's policy —
+  -- see proxy/keepalivestrategy.go's resolution chain and kaEntry.appliedStrategy. Set
+  -- only on a ping row; the real request a ping later rescues carries no strategy id,
+  -- because only the ping's own policy resolution ever consults the strategy list.
+  -- NULLABLE, unlike every other column here but temperature/top_p: a row written before
+  -- this feature existed reads NULL rather than a fabricated "no strategy" answer, and it
+  -- is never backfilled — there is no way to know which pre-feature pings would have
+  -- matched a strategy that did not exist yet.
+  keepalive_strategy_id TEXT,
   -- What the declaration filter stopped carrying on this request: the token weight of the
   -- tools[] elements it removed under the account's opt-in list. Written ONLY by the filter
   -- itself (apply.Trace.FilteredDeclTokens), never derived from the tool inventory — the
@@ -553,6 +562,7 @@ var additiveColumns = []struct{ table, column, ddl string }{
 	{"requests", "keepalive", "INTEGER NOT NULL DEFAULT 0"},
 	{"requests", "keepalive_pings", "INTEGER NOT NULL DEFAULT 0"},
 	{"requests", "keepalive_saved_usd", "REAL NOT NULL DEFAULT 0"},
+	{"requests", "keepalive_strategy_id", "TEXT"},
 	{"tool_declarations", "text_gz", "BLOB"},
 	{"tool_declarations", "text_hash", "TEXT"},
 	{"request_components", "gates", "TEXT NOT NULL DEFAULT ''"},

--- a/dash/store.go
+++ b/dash/store.go
@@ -287,9 +287,10 @@ func (d *DB) insertBatch(evs []*Event) error {
 		expands, expand_tokens, reverts, token_accounting, cache_miss_reason, uncompressed_reason,
 		reasoning_effort, thinking_mode, thinking_budget, temperature, top_p, max_tokens, stream,
 		tool_choice, tools, system_blocks,
-		cache_bp_system, cache_bp_tools, cache_bp_messages, cache_bp_blocks, stop_reason
+		cache_bp_system, cache_bp_tools, cache_bp_messages, cache_bp_blocks, stop_reason,
+		keepalive_strategy_id
 	) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-		?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
+		?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	if err != nil {
 		return err
 	}
@@ -322,6 +323,13 @@ func (d *DB) insertBatch(evs []*Event) error {
 
 	spend := map[spendKey]float64{}
 	for _, e := range evs {
+		// nil, not "", when no strategy applied — so the column stores SQL NULL and stays
+		// distinguishable from a row written before this feature existed either way; see
+		// the keepalive_strategy_id column comment in schema.go.
+		var strategyID any
+		if e.KeepAliveStrategyID != "" {
+			strategyID = e.KeepAliveStrategyID
+		}
 		res, err := reqStmt.Exec(
 			e.TS, e.TenantID, e.SessionID, e.Model, e.Provider, e.Agent, e.Preset, e.Mode, e.Route, e.Status,
 			boolInt(e.Bypassed), boolInt(e.CacheAware),
@@ -336,6 +344,7 @@ func (d *DB) insertBatch(evs []*Event) error {
 			e.ReasoningEffort, e.ThinkingMode, e.ThinkingBudget, e.Temperature, e.TopP, e.MaxTokens,
 			boolInt(e.Stream), e.ToolChoice, e.Tools, e.SystemBlocks,
 			e.CacheBPSystem, e.CacheBPTools, e.CacheBPMessages, e.CacheBPBlocks, e.StopReason,
+			strategyID,
 		)
 		if err != nil {
 			return err

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -1901,6 +1901,9 @@ async function loadOverview(opts = {}) {
     }, 'Fills in from the first captured request: every row is counted as exact, estimated or unmeasured.');
     renderSeries(s.buckets || []);
     paintFreshness();
+    // Not awaited: its own request, on its own failure path, so a slow or failed
+    // keep-alive ledger never delays or blanks the rest of Overview.
+    loadOverviewKeepAlive();
     // Restore the offset after the repaint. Even swapping in place, a group that gained or
     // lost a tile changes the document height by a row, and the reader should not have to
     // find their place again because a number rolled over.
@@ -1911,6 +1914,35 @@ async function loadOverview(opts = {}) {
     // the old code replaced the tiles with an error state, so one blip wiped the numbers.
     if (!first) { markDirty(); return; }
     errorState($('#tiles'), 'Could not load statistics', err);
+  }
+}
+
+/**
+ * loadOverviewKeepAlive is the Overview tab's small keep-alive callout, for every user —
+ * not just managers. It reuses the account's own already-computed GET /api/keepalive
+ * ledger (the same one the Keep-alive tab's verdict panel reads): no new backend call,
+ * no arithmetic here.
+ *
+ * Hidden until the mechanism has actually run on this account (keepalive_recorded_from):
+ * a zero on a callout nobody can dismiss is worse than no callout, and this dashboard's
+ * own rule is that a zero must never be shown where it could be an absence.
+ */
+async function loadOverviewKeepAlive() {
+  const panel = $('#overview-keepalive-panel');
+  if (!panel) return;
+  try {
+    const o = await api('keepalive');
+    if (!o.keepalive_recorded_from) { panel.hidden = true; return; }
+    panel.hidden = false;
+    const host = clear($('#overview-keepalive-tiles'));
+    host.appendChild(tileGroup(null, null, [
+      tile('ov-ka-pings', 'Keep-alive pings', num(o.pings), usd(o.ping_usd) + ' spent on your key'),
+      tile('ov-ka-saved', 'Re-creations avoided', usd(o.saved_usd), 'a ceiling — see the Keep-alive tab',
+        o.saved_usd > 0 ? 'good' : ''),
+      tile('ov-ka-net', 'Net', usd(o.net_usd), 'avoided − spent', o.net_usd < 0 ? 'bad' : 'good'),
+    ]));
+  } catch (e) {
+    if (!aborted(e)) panel.hidden = true; // best-effort: Overview must not depend on this
   }
 }
 
@@ -6905,10 +6937,320 @@ async function loadArchive() {
 // unreachable / never-archived states are rendered identically wherever they are
 // reached, and a modal alert is not a state a user can read a session id out of.
 
+// ── strategies (manager) ─────────────────────────────────────────────────────
+//
+// Manager-controlled keep-alive strategies: a durable rule that runs above every
+// tenant's own account switch and below a per-session override — see
+// docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md. The routes
+// themselves (proxy/keepalivestrategy.go) are the control plane, like the tenant
+// roster's, so every write here goes through ctl() rather than api().
+//
+// The form is built once in JS (buildStrategyForm), the same way the Feedback form is:
+// the fields, the window builder and the account picker live here so they cannot drift
+// from the validation the control route itself enforces.
+
+const strategyForm = {
+  editingID: '', // '' = creating a new one
+  windows: [],   // the windows accumulated for the form currently open
+  tenants: [],   // the roster, for the account picker; loaded once
+};
+
+const STRATEGY_DAYS = [
+  [0, 'Sun'], [1, 'Mon'], [2, 'Tue'], [3, 'Wed'], [4, 'Thu'], [5, 'Fri'], [6, 'Sat'],
+];
+
+function dayLabel(days) {
+  if (!days || !days.length) return 'every day';
+  return [...days].sort((a, b) => a - b).map((d) => STRATEGY_DAYS[d][1]).join(',');
+}
+function windowLabel(w) {
+  return `${dayLabel(w.days)} ${w.start}–${w.end} ${w.tz || 'Asia/Jerusalem'}`;
+}
+
+async function loadStrategies() {
+  const form = $('#strategy-form');
+  if (!form.dataset.built) {
+    try {
+      strategyForm.tenants = (await ctl('/api/tenants')).tenants || [];
+    } catch (_) { strategyForm.tenants = []; /* the picker still works for "every account" */ }
+    buildStrategyForm(form);
+    form.dataset.built = '1';
+  }
+  const host = clear($('#strategies-list'));
+  loadingState(host);
+  try {
+    const out = await ctl('/api/keepalive/strategies');
+    const rows = out.strategies || [];
+    $('#strategies-count').textContent = `${rows.length} strateg${rows.length === 1 ? 'y' : 'ies'}`;
+    renderStrategiesList(clear(host), rows);
+  } catch (e) {
+    clear(host);
+    errorState(host, 'Could not list strategies', e);
+  }
+}
+
+/** buildStrategyForm draws a fresh create form. editStrategy repaints it pre-filled. */
+function buildStrategyForm(form) {
+  clear(form);
+  strategyForm.editingID = '';
+  strategyForm.windows = [];
+  $('#strategy-form-title').textContent = 'New strategy';
+
+  const name = el('input', { type: 'text', id: 'sf-name', maxlength: '64', required: 'required' });
+  const idle = el('input', { type: 'number', id: 'sf-idle', value: '280', min: '1' });
+  const pings = el('input', { type: 'number', id: 'sf-pings', value: '1', min: '1' });
+  const prefix = el('input', { type: 'number', id: 'sf-prefix', value: '20000', min: '0' });
+  const usdCap = el('input', { type: 'number', id: 'sf-usd', value: '0', min: '0', step: '0.01' });
+  const active = el('input', { type: 'checkbox', id: 'sf-active', checked: 'checked' });
+
+  const targetAll = el('input', { type: 'radio', name: 'sf-target-mode', value: 'all', checked: 'checked' });
+  const targetList = el('input', { type: 'radio', name: 'sf-target-mode', value: 'list' });
+  const targetIDs = el('select', {
+    id: 'sf-target-ids', 'data-testid': 'sf-target-ids', multiple: 'multiple', size: '5', disabled: 'disabled',
+  }, ...strategyForm.tenants.map((t) => el('option', { value: t.id }, t.label ? `${t.email} · ${t.label}` : t.email)));
+  const syncTargetDisabled = () => { targetIDs.disabled = !targetList.checked; };
+  targetAll.addEventListener('change', syncTargetDisabled);
+  targetList.addEventListener('change', syncTargetDisabled);
+
+  const dayBoxes = STRATEGY_DAYS.map(([v, label]) => el('label', { class: 'comp' },
+    el('input', { type: 'checkbox', value: String(v), 'data-testid': 'sf-day-' + v }), ' ' + label));
+  const winStart = el('input', { type: 'time', value: '09:00', 'data-testid': 'sf-window-start' });
+  const winEnd = el('input', { type: 'time', value: '18:00', 'data-testid': 'sf-window-end' });
+  const winTZ = el('input', { type: 'text', value: 'Asia/Jerusalem', 'data-testid': 'sf-window-tz' });
+  const winList = el('ul', { id: 'sf-windows-list', 'data-testid': 'sf-windows-list' });
+  const windowsField = el('fieldset', { class: 'field' },
+    el('legend', {}, 'Windows (at least one; each is checked in its own timezone)'));
+
+  const paintWindows = () => {
+    clear(winList);
+    strategyForm.windows.forEach((w, i) => {
+      winList.appendChild(el('li', {}, windowLabel(w) + ' ',
+        el('button', {
+          type: 'button', class: 'ghost small', 'data-testid': 'sf-window-remove-' + i,
+          onclick: () => { strategyForm.windows.splice(i, 1); paintWindows(); },
+        }, 'Remove')));
+    });
+  };
+
+  const addWindow = el('button', {
+    type: 'button', class: 'ghost small', 'data-testid': 'sf-window-add',
+    onclick: () => {
+      const days = dayBoxes
+        .map((box, i) => (box.querySelector('input').checked ? i : -1))
+        .filter((i) => i >= 0);
+      if (!winStart.value || !winEnd.value) {
+        fieldError(windowsField, 'Give this window a start and an end.');
+        return;
+      }
+      fieldError(windowsField, '');
+      strategyForm.windows.push({
+        days, start: winStart.value, end: winEnd.value, tz: winTZ.value.trim() || 'Asia/Jerusalem',
+      });
+      // Days are per-window, not sticky across additions — a manager building "9-12
+      // weekdays" and "14-18 weekends" would otherwise have the second Add silently
+      // reuse the first window's days.
+      for (const box of dayBoxes) box.querySelector('input').checked = false;
+      paintWindows();
+    },
+  }, 'Add window');
+
+  windowsField.appendChild(el('div', { class: 'comp-grid' }, ...dayBoxes));
+  windowsField.appendChild(el('label', {}, 'Start ', winStart));
+  windowsField.appendChild(el('label', {}, 'End ', winEnd));
+  windowsField.appendChild(el('label', {}, 'Timezone ', winTZ));
+  windowsField.appendChild(addWindow);
+  windowsField.appendChild(winList);
+  windowsField.appendChild(el('p', { class: 'field-error', role: 'alert', hidden: true }));
+
+  const status = el('p', { class: 'field-error', role: 'alert', hidden: true, 'data-testid': 'sf-status' });
+  const submit = el('button', { type: 'submit', class: 'primary', 'data-testid': 'sf-submit' }, 'Create strategy');
+  const cancel = el('button', {
+    type: 'button', class: 'ghost', hidden: true, 'data-testid': 'sf-cancel',
+    onclick: () => buildStrategyForm(form),
+  }, 'Cancel edit');
+
+  form.appendChild(el('div', { class: 'field' }, el('label', { for: 'sf-name' }, 'Name'), name));
+  form.appendChild(el('div', { class: 'field' }, el('label', { for: 'sf-idle' }, 'Idle seconds'), idle));
+  form.appendChild(el('div', { class: 'field' }, el('label', { for: 'sf-pings' }, 'Max pings'), pings));
+  form.appendChild(el('div', { class: 'field' },
+    el('label', { for: 'sf-prefix' }, 'Min prefix tokens'), prefix));
+  form.appendChild(el('div', { class: 'field' },
+    el('label', { for: 'sf-usd' }, 'Max $/ping (0 = default)'), usdCap));
+  form.appendChild(el('div', { class: 'field' }, el('label', {}, active, ' Active')));
+  form.appendChild(el('fieldset', { class: 'field' },
+    el('legend', {}, 'Target'),
+    el('label', {}, targetAll, ' Every account'),
+    el('label', {}, targetList, ' Pick accounts'),
+    el('label', {}, 'Accounts (used only with "Pick accounts")', targetIDs)));
+  form.appendChild(windowsField);
+  form.appendChild(el('div', { class: 'actions' }, submit, cancel, status));
+
+  // editStrategy calls this fresh build and then overwrites the fields — simpler than a
+  // second code path that patches an existing DOM tree field by field.
+  form._fill = (s) => {
+    strategyForm.editingID = s.id;
+    strategyForm.windows = (s.windows || []).map((w) => ({ ...w }));
+    $('#strategy-form-title').textContent = 'Edit: ' + s.name;
+    name.value = s.name;
+    idle.value = String(s.idle_seconds);
+    pings.value = String(s.max_pings);
+    prefix.value = String(s.min_prefix_tokens);
+    usdCap.value = String(s.max_usd_per_ping);
+    active.checked = !!s.active;
+    if (s.target && s.target.mode === 'list') {
+      targetList.checked = true;
+      for (const o of targetIDs.options) o.selected = (s.target.tenant_ids || []).includes(o.value);
+    } else {
+      targetAll.checked = true;
+    }
+    syncTargetDisabled();
+    paintWindows();
+    submit.textContent = 'Save changes';
+    cancel.hidden = false;
+  };
+
+  form.onsubmit = async (ev) => {
+    ev.preventDefault();
+    status.hidden = true;
+    if (strategyForm.windows.length === 0) {
+      fieldError(windowsField, 'Add at least one window; a strategy with none can never fire.');
+      return;
+    }
+    fieldError(windowsField, '');
+    const body = {
+      name: name.value.trim(),
+      idle_seconds: Number(idle.value) || 0,
+      max_pings: Number(pings.value) || 0,
+      min_prefix_tokens: Number(prefix.value) || 0,
+      max_usd_per_ping: Number(usdCap.value) || 0,
+      active: active.checked,
+      windows: strategyForm.windows,
+      target: targetList.checked
+        ? { mode: 'list', tenant_ids: Array.from(targetIDs.selectedOptions).map((o) => o.value) }
+        : { mode: 'all' },
+    };
+    submit.disabled = true;
+    try {
+      const editing = strategyForm.editingID;
+      const path = editing ? '/api/keepalive/strategies/' + editing : '/api/keepalive/strategies';
+      await ctl(path, { method: editing ? 'PATCH' : 'POST', body: JSON.stringify(body) });
+      buildStrategyForm(form);
+      loadStrategies();
+    } catch (e) {
+      status.textContent = e.message;
+      status.hidden = false;
+      submit.disabled = false;
+    }
+  };
+}
+
+function editStrategy(s) {
+  const form = $('#strategy-form');
+  buildStrategyForm(form);
+  form._fill(s);
+  form.scrollIntoView({ block: 'start', behavior: 'smooth' });
+}
+
+async function toggleStrategyActive(s) {
+  try {
+    await ctl('/api/keepalive/strategies/' + s.id, {
+      method: 'PATCH', body: JSON.stringify({ active: !s.active }),
+    });
+    loadStrategies();
+  } catch (e) { alert(e.message); }
+}
+
+async function deleteStrategy(s) {
+  if (!confirm(`Delete "${s.name}"? Anything it already pinged is not un-pinged; it just ` +
+    'stops matching new requests.')) return;
+  try {
+    await ctl('/api/keepalive/strategies/' + s.id, { method: 'DELETE' });
+    loadStrategies();
+  } catch (e) { alert(e.message); }
+}
+
+/** openStrategyLedger shows one strategy's per-tenant economics, in the shared drawer. */
+async function openStrategyLedger(s) {
+  const body = openDrawer('Strategy: ' + s.name, null);
+  loadingState(body, 2);
+  try {
+    const led = await api('keepalive/strategies/' + s.id + '/ledger');
+    clear(body);
+    body.appendChild(tileGroup(null, null, [
+      tile('sl-pings', 'Pings', num(led.pings)),
+      tile('sl-ping-usd', 'Ping cost', usd(led.ping_usd)),
+      tile('sl-saved', 'Saved (ceiling, whole account credit)', usd(led.saved_usd)),
+      tile('sl-net', 'Net', usd(led.net_usd), null, led.net_usd < 0 ? 'bad' : 'good'),
+    ]));
+    body.appendChild(el('p', { class: 'note' },
+      'Saved is each tenant’s WHOLE keep-alive credit in its history, not only the ' +
+      'share this strategy’s own pings produced — see the design doc’s attribution ' +
+      'caveat. A tenant running more than one strategy, or a session override, will show more ' +
+      'here than this strategy alone earned.'));
+    if (!led.tenants || !led.tenants.length) {
+      emptyState(body, 'No pings under this strategy yet', '');
+      return;
+    }
+    const tbl = el('table', { class: 'grid' },
+      el('thead', {}, el('tr', {},
+        el('th', {}, 'Account'), el('th', { class: 'num' }, 'Pings'),
+        el('th', { class: 'num' }, 'Ping cost'), el('th', { class: 'num' }, 'Saved'),
+        el('th', { class: 'num' }, 'Net'))));
+    const tbody = el('tbody');
+    for (const r of led.tenants) {
+      tbody.appendChild(el('tr', {},
+        el('td', {}, el('code', { class: 'clip' }, r.tenant_id)),
+        el('td', { class: 'num' }, num(r.pings)),
+        el('td', { class: 'num' }, usd(r.ping_usd)),
+        el('td', { class: 'num' }, usd(r.saved_usd)),
+        el('td', { class: 'num ' + (r.net_usd < 0 ? 'bad-text' : 'good-text') }, usd(r.net_usd))));
+    }
+    tbl.appendChild(tbody);
+    body.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
+  } catch (e) {
+    clear(body);
+    errorState(body, 'Could not read this strategy’s ledger', e);
+  }
+}
+
+function renderStrategiesList(host, rows) {
+  if (!rows.length) {
+    emptyState(host, 'No strategies yet', 'Create one above.');
+    return;
+  }
+  const tbl = el('table', { class: 'grid' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Name'), el('th', {}, 'Windows'), el('th', {}, 'Target'),
+      el('th', {}, 'Idle / pings'), el('th', {}, 'State'),
+      el('th', {}, el('span', { class: 'vh' }, 'Row actions')))));
+  const body = el('tbody');
+  for (const s of rows) {
+    body.appendChild(el('tr', { class: s.active ? '' : 'revoked' },
+      el('td', {}, s.name),
+      el('td', {}, (s.windows || []).map(windowLabel).join('; ') || '—'),
+      el('td', {}, s.target && s.target.mode === 'list'
+        ? `${(s.target.tenant_ids || []).length} account(s)` : 'every account'),
+      el('td', {}, `${s.idle_seconds}s / ${s.max_pings}`),
+      el('td', {},
+        el('span', { class: 'pill ' + (s.active ? 'complete' : 'partial') }, s.active ? 'active' : 'paused'),
+        s.in_window ? el('div', { class: 'muted small' }, 'in a matching window right now') : null),
+      el('td', {}, el('div', { class: 'row-actions' },
+        el('button', { class: 'ghost small', onclick: () => toggleStrategyActive(s) },
+          s.active ? 'Pause' : 'Resume'),
+        el('button', { class: 'ghost small', onclick: () => editStrategy(s) }, 'Edit'),
+        el('button', { class: 'ghost small', onclick: () => openStrategyLedger(s) }, 'Stats'),
+        el('button', { class: 'ghost small', onclick: () => deleteStrategy(s) }, 'Delete')))));
+  }
+  tbl.appendChild(body);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
+}
+
 // ── wiring ─────────────────────────────────────────────────────────────────
 Object.assign(loaders, {
   setup: loadSetup, settings: loadSettings, tenants: loadTenants, archive: loadArchive,
+  strategies: loadStrategies,
 });
+UNFILTERED_VIEWS.add('strategies');
 
 function initAccounts() {
   $('#gate-tab-signin').addEventListener('click', () => {

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -28,6 +28,7 @@
     <button role="tab" class="tab" data-view="settings" data-testid="tab-settings" data-account hidden>Settings</button>
     <button role="tab" class="tab" data-view="feedback" data-testid="tab-feedback" data-account hidden>Feedback</button>
     <button role="tab" class="tab" data-view="tenants" data-testid="tab-tenants" data-manager hidden>Tenants</button>
+    <button role="tab" class="tab" data-view="strategies" data-testid="tab-strategies" data-manager hidden>Strategies</button>
     <button role="tab" class="tab" data-view="config" data-testid="tab-config" data-manager data-local-ok>Config</button>
   </nav>
   <div class="topbar-right">
@@ -251,6 +252,17 @@
        numbers that answer "is this working", then one labelled group per subject. Twenty
        tiles in one flat grid is twenty things of equal importance, i.e. no hierarchy. -->
   <div id="tiles"></div>
+
+  <!-- A small callout, for every user — not just managers — reusing GET /api/keepalive's
+       already-computed ledger. Hidden until the keep-alive has actually run on this
+       account (keepalive_recorded_from), so a zero here never reads as a measurement. -->
+  <div class="panel" id="overview-keepalive-panel" hidden>
+    <h2>Keep-alive savings</h2>
+    <p class="note">What the idle keep-alive has spent and avoided on your own traffic.
+      The full picture, including whether you are in the losing majority, is on the
+      Keep-alive tab.</p>
+    <div id="overview-keepalive-tiles"></div>
+  </div>
 
   <div class="panel">
     <h2>Savings percentage</h2>
@@ -819,6 +831,28 @@
     <p class="muted small">Metrics and configuration for every account. To read an
       account's transcripts, pick it in the selector and open a request or session diff.</p>
     <div id="tenants-list" data-testid="tenants-list" tabindex="0"></div>
+  </div>
+</section>
+
+<!-- Strategies: manager-controlled keep-alive rules that run above every tenant's own
+     account switch and below a per-session override. See
+     docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md. Built entirely in
+     JS (renderStrategyForm/loadStrategies in app.js), the same way the Feedback form and
+     the Tenant editor are — an empty mount point here, so the fields, the window
+     builder and the account picker cannot drift from the validation the control route
+     itself enforces. -->
+<section class="view" id="view-strategies" hidden>
+  <div class="panel">
+    <h2 id="strategy-form-title">New strategy</h2>
+    <p class="note">A durable rule: "only during Israel business hours", or a service-wide
+      policy. It forces the keep-alive on for whatever it targets, whenever a manager's
+      own account switch or a session override does not already say otherwise.</p>
+    <form id="strategy-form" data-testid="strategy-form" novalidate></form>
+  </div>
+
+  <div class="panel">
+    <div class="card-head"><h2>Strategies</h2><span class="muted" id="strategies-count"></span></div>
+    <div id="strategies-list" data-testid="strategies-list" tabindex="0"></div>
   </div>
 </section>
 

--- a/docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md
+++ b/docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md
@@ -1,0 +1,188 @@
+# Manager-controlled keep-alive strategies
+
+## Problem
+
+The keep-alive ping mechanism (`proxy/keepalive.go`) is real and measured (net
++$125.08 / 3.98% of spend at shipped defaults), but it is only reachable two
+ways: a manager flips one account-wide boolean in that account's own config,
+or a manager arms one session for up to 12h. There is no way to run a
+schedule ("only during Israel business hours"), no way to apply one policy
+across every account at once, and no way to see cost vs. savings broken out
+per policy per account. This adds that layer without touching the existing
+per-account config path or the per-session override path, both of which stay
+exactly as they are today.
+
+## Model
+
+A **strategy** is a durable, manager-authored rule:
+
+```
+Strategy {
+  ID          string
+  Name        string
+  Idle        seconds   // default 280
+  MaxPings    int        // default 1 ("one ping")
+  MinPrefixTokens int
+  MaxUSDPerPing   float64  // manager-set; strategies MAY set this, unlike
+                            // per-session overrides, because this is an
+                            // audited manager action, not an ephemeral grant
+  Windows     []Window
+  Target      Target
+  Active      bool
+  CreatedBy, CreatedAt, UpdatedBy, UpdatedAt
+}
+
+Window { Days []time.Weekday /* empty = every day */; Start, End string /* "HH:MM" */; TZ string /* default "Asia/Jerusalem" */ }
+
+Target { Mode string /* "all" | "list" */; TenantIDs []string }
+```
+
+Two windows on one strategy cover "9-12 and 14-18": `[{Start:"09:00",End:"12:00"}, {Start:"14:00",End:"18:00"}]`, `TZ:"Asia/Jerusalem"`.
+
+## Why this can't be "patch the tenant's config"
+
+The decided requirement is that a strategy overrides a tenant's own
+account-wide off switch. That rules out implementing "apply" as writing each
+target tenant's `CacheConfig` document, because the tenant's own document is
+exactly what `DELETE /api/me/keepalive` (the existing self-serve off switch)
+edits — patching it would just get overwritten the next time that tenant
+touches their own switch, and the two writers would fight silently.
+
+So a strategy is not config. It is evaluated **live**, the same way a
+per-session override already sits above account config today
+(`keeper.overrideFor`). This generalizes that one hook into a resolution
+chain:
+
+```
+account CachePolicy (config, as today)
+  -> highest-priority matching ACTIVE strategy (forces KeepAlive=true,
+     replaces Idle/MaxPings/MinPrefixTokens/MaxUSDPerPing)
+  -> session override (unchanged: still wins on top, still cannot widen
+     MaxUSDPerPing)
+```
+
+A strategy "matches" a request when: `Active`, the request's tenant is
+covered by `Target` (`all`, or in `TenantIDs`), and `now` (converted to the
+strategy's `TZ`) falls inside one of `Windows`. Because this is evaluated per
+request rather than snapshotted at apply time, an `all`-target strategy
+automatically covers tenants created after it was set up — no separate
+"reapply" step.
+
+**Precedence among strategies**, when more than one matches the same tenant
+at the same instant: a `list`-target strategy beats an `all`-target one
+(more specific wins); among equally-specific matches, the most recently
+updated wins. This is resolved once per request, not configured — no
+priority field to expose in the UI, one less knob a manager can get wrong.
+
+## Persistence
+
+New table `keepalive_strategies` in the tenant registry DB (same DB file as
+`tenants` / `tenant_config_audit` in `tenant/tenant.go`'s schema — this is
+account/control-plane data, not request-metrics data, so it does not belong
+in `dash/schema.go`'s DB). Columns: `id, name, idle_seconds, max_pings,
+min_prefix_tokens, max_usd_per_ping, windows_json, target_json, active,
+created_by, created_at, updated_by, updated_at`.
+
+Loaded into the keeper's memory (`k.strategies []strategy`, mutex-protected,
+alongside the existing `k.overrides`) at process start and refreshed on every
+write through the control routes below — the same durability trade-off the
+rest of `keepalive.go` documents at length does NOT apply here: unlike a
+per-session override (deliberately memory-only, an authorization to spend
+that should not survive a restart), a strategy is a standing rule a manager
+expects to still be there after a deploy, so it is written through to SQLite
+on every create/update/delete and reloaded at boot.
+
+## Attribution for stats
+
+`kaEntry` gains an `appliedStrategy string` (empty when none matched).
+`record1` (which already turns a fired ping into a `dash.Event{KeepAlive:
+true, ...}`) tags that event with `KeepAliveStrategyID`. This needs one new
+nullable column, `keepalive_strategy_id TEXT`, on `dash/schema.go`'s
+`requests` table (migration, additive, defaults NULL for every existing row
+— never backfilled, since there is no way to know which pre-feature pings
+would have matched a strategy that didn't exist yet).
+
+## Control plane
+
+New file `proxy/keepalivestrategy.go`, table-driven exactly like
+`keepalivectl.go`, every route `ctlManager`:
+
+- `GET /api/keepalive/strategies` — list, with each strategy's live-resolved
+  "currently in a matching window: yes/no" for the UI's at-a-glance state.
+- `POST /api/keepalive/strategies` — create. Validates windows (valid
+  `HH:MM`, `End` after `Start` within the same day — an overnight window is
+  out of scope, since "9-12 and 14-18" never crosses midnight and the extra
+  case is not worth the parsing complexity), valid IANA `TZ`
+  (`time.LoadLocation`), `Target.Mode`, and the same numeric bounds
+  `validOverride` already enforces for Idle/MaxPings (a strategy is a
+  broader-blast-radius version of the same spend authorization, so it gets
+  at least as tight a check, not a looser one).
+- `PATCH /api/keepalive/strategies/{id}` — update any field; takes effect on
+  the next request that would match (no re-push needed, since matching is
+  live).
+- `DELETE /api/keepalive/strategies/{id}` — delete. Anything currently held
+  under that strategy is not retroactively un-pinged (nothing to undo — a
+  ping already sent already happened), but it stops matching new requests
+  immediately.
+
+Every write gets an audit row via the existing `tenant.AuditWrite`, actor and
+target both the acting manager's own tenant ID (there is no single target
+tenant for an `all`-target strategy, so — unlike every other audited action
+in this codebase, which names a specific tenant — the audited object here is
+the strategy itself, named by its ID in the `field` column).
+
+## Dashboard read side
+
+New file `dash/keepalivestrategy.go`:
+
+- `StrategyLedger(strategyID string) (StrategyLedgerView, error)` — pings,
+  ping cost, saved (ceiling, same caveat as the existing account ledger),
+  net, grouped by tenant, costliest first. Built the same way
+  `KeepAliveSessions` already is, filtered by `keepalive_strategy_id`
+  instead of by `Filter.Tenant`.
+- Exposed at `GET /api/keepalive/strategies/{id}/ledger`, `scopeManager`.
+
+## UI
+
+**New manager-only "Strategies" tab**, following the exact pattern the
+existing "Tenants" tab uses (`data-manager` attribute on the tab button,
+`hidden` by default, gated by the existing `isManager()` check in
+`dash/ui/app.js`): a create/edit form (name, idle, max pings, min prefix,
+max $/ping, one or more windows with a day picker, target: all users or pick
+from the tenant list already available to managers on the Tenants tab), and
+a table of strategies with an active/paused toggle, edit, delete, and an
+expandable per-tenant stats breakdown sourced from `StrategyLedger`.
+
+**Overview tab addition** (every user, not just managers): a small "keep-alive
+savings" callout reusing the account's own already-computed
+`GET /api/keepalive` ledger (`SavedUSD`, `NetUSD`, `Pings`) — pure UI, no new
+backend call beyond the one that already exists.
+
+## Defaults
+
+New strategies default to `MaxPings=1` ("one ping"), `Idle=280s`, matching
+the literal ask; a manager can widen either per strategy. `MaxUSDPerPing`
+defaults to the existing package sentinel (`DefaultMaxUSDPerPing = 0.25`)
+when left at 0, same as account config does today.
+
+## Testing
+
+- Unit: window/timezone matching (including a case straddling a DST
+  transition in `Asia/Jerusalem`), precedence between an `all` and a `list`
+  strategy, precedence between two `list` strategies, a strategy correctly
+  losing to a live session override, validation bounds on create/update,
+  persistence across a simulated restart (reload from DB).
+- Integration: a strategy created via the control route is visible in
+  `keeper.resolvePolicy` on the very next request with no restart.
+- Live: drive a real Claude Code session through a local build of the
+  proxy with a strategy active for the current wall-clock minute, and
+  confirm a ping actually fires and lands in `/api/keepalive/strategies/{id}/ledger`.
+
+## Out of scope
+
+- Overnight windows (`End` before `Start`).
+- A priority field — precedence is fixed by specificity + recency, not
+  manager-configurable.
+- Retroactively crediting/attributing pings sent before this shipped.
+- Changing anything about the existing per-account config switch or the
+  per-session override mechanism; both are untouched.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,11 @@ validation:
   unrecognized_links: warn
   anchors: warn
 
+# docs/superpowers/ holds working plans/specs for the skill that authored them, not
+# published site content — keep it out of the nav-completeness check above.
+exclude_docs: |
+  superpowers/
+
 # Nav mirrors how people arrive: evaluate it (Get started) → understand it
 # (Concepts) → look a component up (Components) → run it a particular way
 # (Modes, Dashboard, Hosted) → check the claims (Results) → wire it in

--- a/proxy/control.go
+++ b/proxy/control.go
@@ -119,7 +119,10 @@ func (h *Handler) ctlRoutes() []ctlRoute {
 	// The keep-alive's write half, declared beside its handlers in keepalivectl.go and appended
 	// here for the same reason the dashboard's are: this table is what gate enforces and what
 	// TestEveryControlRouteEnforcesItsScope walks.
-	return append(rs, h.keepAliveCtlRoutes()...)
+	rs = append(rs, h.keepAliveCtlRoutes()...)
+	// The manager-controlled keep-alive strategy routes, declared beside their handlers in
+	// keepalivestrategy.go and appended here for the same reason.
+	return append(rs, h.keepAliveStrategyCtlRoutes()...)
 }
 
 // grafanaUserHeader carries the authorized manager's address from this endpoint to

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -17,6 +17,7 @@ import (
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/dash"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/tenant"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -262,6 +263,12 @@ type kaEntry struct {
 	// stopped means this session will not be pinged again: a ping wrote instead of reading,
 	// or the upstream refused in a way that repeating cannot fix.
 	stopped bool
+	// appliedStrategy is the id of the manager-controlled keep-alive strategy that
+	// resolved this entry's policy, "" when none matched (account config or a session
+	// override supplied it instead). Resolved once, at record time, alongside the
+	// session override — see keeper.applyStrategy in keepalivestrategy.go — and tagged
+	// onto the ping's own dash.Event by record1, never onto the real request it rescues.
+	appliedStrategy string
 	// timer is the HARD retention deadline. A scheduled deadline rather than a check inside the
 	// sweep, because the requirement is that a quiet process still drops the credential on
 	// time: with no request and no other activity the sweep is the only thing that would ever
@@ -358,6 +365,13 @@ type keeper struct {
 	// deliberately so — an authorization to spend that silently survives a restart is worse
 	// than one that does not. See keepaliveoverride.go.
 	overrides map[string]sessionOverride
+	// strategies is the manager-controlled keep-alive strategy list, loaded from the
+	// tenant registry at process start and replaced wholesale on every write through the
+	// control routes — never mutated in place, the same pattern k.overrides itself
+	// documents for a swap under lock. UNLIKE overrides, this one IS meant to survive a
+	// restart: a strategy is a standing rule a manager expects to still be there after a
+	// deploy, so it is reloaded from SQLite at boot. See keepalivestrategy.go.
+	strategies []tenant.Strategy
 
 	// send performs one ping. A field so tests can drive the whole policy — timing, caps,
 	// limits, the write-instead-of-read guard — without a network.
@@ -392,6 +406,10 @@ func newKeeper(h *Handler) *keeper {
 		overrides: map[string]sessionOverride{}, now: time.Now}
 	k.send = k.sendPing
 	k.dispatch = func(j pingJob) { go k.fire(j) }
+	// Loaded once at construction. Unlike overrides, a strategy is a standing rule a
+	// manager expects to survive a restart, so it comes from SQLite rather than starting
+	// empty — see loadStrategies.
+	k.loadStrategies()
 	return k
 }
 
@@ -535,10 +553,16 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 	// the setting off stops being retained on its very next request; anything held for a session
 	// that goes quiet instead is dropped by the hard deadline below, within (K+1)x X.
 	pol := tn.Cache
-	// A per-session manual override, if one is armed and unexpired. The ONE hook this feature
-	// has in the request path: everything below reads `pol` and neither knows nor cares where
-	// it came from. An override may switch the mechanism ON for a session whose account default
-	// is off — that is the point of it, and the arming request is the consent act — but it may
+	// The manager-controlled strategy layer, resolved once here and generalizing the one
+	// hook the session override already had — see keepalivestrategy.go's applyStrategy.
+	// A matching ACTIVE strategy forces KeepAlive on and replaces Idle/MaxPings/
+	// MinPrefixTokens/MaxUSDPerPing; it sits ABOVE account config and BELOW a session
+	// override, which still wins on top and still cannot widen MaxUSDPerPing.
+	pol, applied := k.applyStrategy(tn.ID, pol, k.now())
+	// A per-session manual override, if one is armed and unexpired. Everything below reads
+	// `pol` and neither knows nor cares where it came from. An override may switch the
+	// mechanism ON for a session whose account default (or no matching strategy) leaves it
+	// off — that is the point of it, and the arming request is the consent act — but it may
 	// not widen the per-ping cost guard, and it cannot reach around the kill switch or the
 	// no-audit-sink refusal above.
 	pol = k.overrideFor(tn.ID, session, pol)
@@ -595,7 +619,7 @@ func (k *keeper) record(tn *Tenancy, session string, startedAt time.Time, body [
 		provider: provider, model: model, route: route, preset: tn.Preset,
 		agent: r.UserAgent(), pol: pol, prefix: prefix,
 		pingUSD: k.projectedPingUSD(model, prefix),
-		hdr:     hdr, auth: auth,
+		hdr:     hdr, auth: auth, appliedStrategy: applied,
 	}
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -888,6 +912,7 @@ func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
 	// and the race detector is right to insist.
 	k.mu.Lock()
 	model, provider, route, preset, agent := e.model, e.provider, e.route, e.preset, e.agent
+	appliedStrategy := e.appliedStrategy
 	k.mu.Unlock()
 	var price modelinfo.Price
 	priced := false
@@ -898,6 +923,10 @@ func (k *keeper) record1(j pingJob, u Usage, status int, ms float64) float64 {
 		TS: k.now().UnixMilli(), TenantID: j.tenant, Model: model,
 		Provider: string(provider), Route: route, Preset: preset,
 		Status: status, KeepAlive: true,
+		// Which manager-controlled strategy resolved this PING's policy, "" when none did
+		// — tagged on the ping's own row, never on the real request it later rescues, since
+		// only the ping's policy resolution ever consults the strategy list.
+		KeepAliveStrategyID: appliedStrategy,
 	}
 	ev.SessionID = j.session
 	ev.Agent = dash.AgentFor(agent)

--- a/proxy/keepalivestrategy.go
+++ b/proxy/keepalivestrategy.go
@@ -185,6 +185,16 @@ func viewStrategy(s tenant.Strategy, now time.Time) strategyView {
 
 // ctlListKeepAliveStrategies lists every strategy.
 func (h *Handler) ctlListKeepAliveStrategies(w http.ResponseWriter, r *http.Request) {
+	actor, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	if !actor.IsManager() {
+		ctlErr(w, http.StatusForbidden, "manager only")
+		return
+	}
 	list, err := h.registry().ListStrategies()
 	if err != nil {
 		ctlErr(w, http.StatusInternalServerError, "could not list keep-alive strategies")
@@ -218,6 +228,10 @@ func (h *Handler) ctlCreateKeepAliveStrategy(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		code, msg := statusOf(err)
 		ctlErr(w, code, msg)
+		return
+	}
+	if !actor.IsManager() {
+		ctlErr(w, http.StatusForbidden, "manager only")
 		return
 	}
 	var in strategyIn
@@ -284,6 +298,10 @@ func (h *Handler) ctlPatchKeepAliveStrategy(w http.ResponseWriter, r *http.Reque
 		ctlErr(w, code, msg)
 		return
 	}
+	if !actor.IsManager() {
+		ctlErr(w, http.StatusForbidden, "manager only")
+		return
+	}
 	id := r.PathValue("id")
 	cur, err := h.registry().StrategyByID(id)
 	if err != nil {
@@ -346,7 +364,16 @@ func (h *Handler) ctlPatchKeepAliveStrategy(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.registry().AuditWrite(actor.ID, actor.ID, id, "updated", "updated: "+s.Name); err != nil {
-		ctlErr(w, http.StatusInternalServerError, "updated, but the audit log could not be written")
+		// An update we cannot account for is an update we do not keep — the same refusal
+		// ctlCreateKeepAliveStrategy makes when its own audit write fails. Reverted to the
+		// pre-patch values fetched above, rather than left standing with no audit row.
+		_, _ = h.registry().UpdateStrategy(actor.ID, id, tenant.StrategyPatch{
+			Name: &cur.Name, IdleSeconds: &cur.IdleSeconds, MaxPings: &cur.MaxPings,
+			MinPrefixTokens: &cur.MinPrefixTokens, MaxUSDPerPing: &cur.MaxUSDPerPing,
+			Windows: &cur.Windows, Target: &cur.Target, Active: &cur.Active,
+		})
+		ctlErr(w, http.StatusInternalServerError,
+			"could not record this in the audit log, so the update was not applied")
 		return
 	}
 	h.keeper.loadStrategies()
@@ -361,6 +388,10 @@ func (h *Handler) ctlDeleteKeepAliveStrategy(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		code, msg := statusOf(err)
 		ctlErr(w, code, msg)
+		return
+	}
+	if !actor.IsManager() {
+		ctlErr(w, http.StatusForbidden, "manager only")
 		return
 	}
 	// No body to read, so readJSON's cross-site guard does not cover it: check directly,

--- a/proxy/keepalivestrategy.go
+++ b/proxy/keepalivestrategy.go
@@ -1,0 +1,388 @@
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/rossoctl/context-guru/tenant"
+)
+
+// Manager-controlled keep-alive strategies: a durable, manager-authored rule that runs a
+// schedule ("only during Israel business hours") or a service-wide policy, above every
+// tenant's own account config and below a per-session override — see
+// docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md for the full design.
+//
+// This file is the resolution-chain generalization (applyStrategy, alongside
+// keepaliveoverride.go's overrideFor) and the control routes. Persistence lives in
+// tenant/keepalivestrategy.go, because a strategy is account/control-plane data and,
+// unlike a per-session override, is meant to survive a restart.
+
+// setStrategies replaces the keeper's in-memory strategy list wholesale, under lock —
+// the same swap-not-mutate pattern k.overrides documents, so a request resolving a
+// policy mid-write never sees a half-built list.
+func (k *keeper) setStrategies(list []tenant.Strategy) {
+	if k == nil {
+		return
+	}
+	k.mu.Lock()
+	k.strategies = list
+	k.mu.Unlock()
+}
+
+// loadStrategies re-reads the strategy table from the registry: at process start
+// (newKeeper) and after every create/update/delete through the control routes below, so
+// "no re-push needed, since matching is live" is actually true.
+//
+// Fails open, per this project's hard boundary: a read error is logged and the
+// in-memory list is left as it was, rather than resolving every request as if no
+// strategy exists on a deployment that plainly has some.
+func (k *keeper) loadStrategies() {
+	if k == nil || k.h == nil || k.h.opts.Tenants == nil {
+		return
+	}
+	list, err := k.h.registry().ListStrategies()
+	if err != nil {
+		slog.Warn("context-guru: could not load keep-alive strategies", "err", err)
+		return
+	}
+	k.setStrategies(list)
+}
+
+// applyStrategy resolves the highest-priority ACTIVE strategy matching tenantID at
+// `now`, if any, and returns the policy with its fields replaced plus the matched
+// strategy's id ("" when none matched).
+//
+// Called from record, between account config and the session override — see the design
+// doc's resolution chain. Evaluated once, at record time, and then fixed on the entry
+// for its whole lifetime, exactly as overrideFor's own resolution already is: a strategy
+// whose window closes mid-hold does not retroactively un-arm a ping already scheduled.
+func (k *keeper) applyStrategy(tenantID string, pol CachePolicy, now time.Time) (CachePolicy, string) {
+	k.mu.Lock()
+	strategies := k.strategies
+	k.mu.Unlock()
+	var best *tenant.Strategy
+	for i := range strategies {
+		s := &strategies[i]
+		if !s.Matches(now, tenantID) {
+			continue
+		}
+		if best == nil || betterStrategy(s, best) {
+			best = s
+		}
+	}
+	if best == nil {
+		return pol, ""
+	}
+	pol.KeepAlive = true
+	pol.Idle = time.Duration(best.IdleSeconds) * time.Second
+	pol.MaxPings = best.MaxPings
+	pol.MinPrefixTokens = best.MinPrefixTokens
+	pol.MaxUSDPerPing = best.MaxUSDPerPing
+	return pol, best.ID
+}
+
+// betterStrategy reports whether candidate beats current under the design doc's fixed
+// precedence: a list-target strategy beats an all-target one (more specific wins);
+// among equally specific matches, the most recently updated wins. Not configurable —
+// "no priority field to expose in the UI, one less knob a manager can get wrong."
+func betterStrategy(candidate, current *tenant.Strategy) bool {
+	cSpecific := candidate.Target.Mode == tenant.TargetList
+	curSpecific := current.Target.Mode == tenant.TargetList
+	if cSpecific != curSpecific {
+		return cSpecific
+	}
+	return candidate.UpdatedAt.After(current.UpdatedAt)
+}
+
+// validStrategyBounds checks the numeric fields against the SAME bounds validOverride
+// already enforces for Idle/MaxPings/MinPrefixTokens — a strategy is a
+// broader-blast-radius version of the same spend authorization, so it gets at least as
+// tight a check, not a looser one.
+//
+// MaxUSDPerPing is the one field an override does not expose at all; a strategy may set
+// it because this is an audited manager action rather than an ephemeral grant (see the
+// design doc's "Model"). Checked on its own terms: non-negative, with 0 left to mean
+// "use the package default" exactly like account config does (CachePolicy.Ceiling()).
+func validStrategyBounds(idle time.Duration, pings, minPrefix int, maxUSDPerPing float64) error {
+	if idle < minOverrideIdle || idle > maxOverrideIdle {
+		return fmt.Errorf(
+			"the idle interval must be between %d and %d seconds; past %d the first ping "+
+				"arrives after the provider's 5-minute lifetime has already lapsed and pays "+
+				"a cache WRITE instead of a read",
+			int(minOverrideIdle.Seconds()), int(maxOverrideIdle.Seconds()), int(maxOverrideIdle.Seconds()))
+	}
+	if pings < minOverridePings || pings > maxOverridePings {
+		return fmt.Errorf("the ping count must be between %d and %d", minOverridePings, maxOverridePings)
+	}
+	if minPrefix < 0 {
+		return fmt.Errorf("the prefix floor cannot be negative")
+	}
+	if maxUSDPerPing < 0 {
+		return fmt.Errorf("the per-ping cost ceiling cannot be negative")
+	}
+	return nil
+}
+
+// validWindows checks that a strategy has at least one window (one with no schedule can
+// never fire, which is never what a manager who created it meant) and that each one is
+// individually valid.
+func validWindows(windows []tenant.Window) error {
+	if len(windows) == 0 {
+		return fmt.Errorf("a strategy needs at least one window; one with no schedule can never fire")
+	}
+	for _, w := range windows {
+		if err := w.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// keepAliveStrategyCtlRoutes is this feature's control-plane table, appended to
+// ctlRoutes in control.go. Every route is ctlManager and audited, table-driven exactly
+// like keepAliveCtlRoutes' own table.
+func (h *Handler) keepAliveStrategyCtlRoutes() []ctlRoute {
+	return []ctlRoute{
+		{"GET /api/keepalive/strategies", ctlManager, h.ctlListKeepAliveStrategies},
+		{"POST /api/keepalive/strategies", ctlManager, h.ctlCreateKeepAliveStrategy},
+		{"PATCH /api/keepalive/strategies/{id}", ctlManager, h.ctlPatchKeepAliveStrategy},
+		{"DELETE /api/keepalive/strategies/{id}", ctlManager, h.ctlDeleteKeepAliveStrategy},
+	}
+}
+
+// strategyView is the wire shape for one strategy, plus InWindow — the live-resolved
+// "currently in a matching window: yes/no" the design doc asks the list route for, so the
+// UI's at-a-glance state needs no arithmetic of its own.
+type strategyView struct {
+	ID              string          `json:"id"`
+	Name            string          `json:"name"`
+	IdleSeconds     int             `json:"idle_seconds"`
+	MaxPings        int             `json:"max_pings"`
+	MinPrefixTokens int             `json:"min_prefix_tokens"`
+	MaxUSDPerPing   float64         `json:"max_usd_per_ping"`
+	Windows         []tenant.Window `json:"windows"`
+	Target          tenant.Target   `json:"target"`
+	Active          bool            `json:"active"`
+	CreatedBy       string          `json:"created_by"`
+	CreatedAt       int64           `json:"created_at"`
+	UpdatedBy       string          `json:"updated_by"`
+	UpdatedAt       int64           `json:"updated_at"`
+	InWindow        bool            `json:"in_window"`
+}
+
+func viewStrategy(s tenant.Strategy, now time.Time) strategyView {
+	return strategyView{
+		ID: s.ID, Name: s.Name, IdleSeconds: s.IdleSeconds, MaxPings: s.MaxPings,
+		MinPrefixTokens: s.MinPrefixTokens, MaxUSDPerPing: s.MaxUSDPerPing,
+		Windows: s.Windows, Target: s.Target, Active: s.Active,
+		CreatedBy: s.CreatedBy, CreatedAt: msOrZero(s.CreatedAt),
+		UpdatedBy: s.UpdatedBy, UpdatedAt: msOrZero(s.UpdatedAt),
+		InWindow: s.InWindow(now),
+	}
+}
+
+// ctlListKeepAliveStrategies lists every strategy.
+func (h *Handler) ctlListKeepAliveStrategies(w http.ResponseWriter, r *http.Request) {
+	list, err := h.registry().ListStrategies()
+	if err != nil {
+		ctlErr(w, http.StatusInternalServerError, "could not list keep-alive strategies")
+		return
+	}
+	now := time.Now()
+	out := make([]strategyView, 0, len(list))
+	for _, s := range list {
+		out = append(out, viewStrategy(s, now))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"strategies": out})
+}
+
+// strategyIn is a create request's body.
+type strategyIn struct {
+	Name            string          `json:"name"`
+	IdleSeconds     int             `json:"idle_seconds"`
+	MaxPings        int             `json:"max_pings"`
+	MinPrefixTokens int             `json:"min_prefix_tokens"`
+	MaxUSDPerPing   float64         `json:"max_usd_per_ping"`
+	Windows         []tenant.Window `json:"windows"`
+	Target          tenant.Target   `json:"target"`
+	Active          bool            `json:"active"`
+}
+
+// ctlCreateKeepAliveStrategy creates a strategy: validated at least as strictly as an
+// override, audited, and loaded into the keeper before the response is written — so the
+// very next request may match it, with no restart.
+func (h *Handler) ctlCreateKeepAliveStrategy(w http.ResponseWriter, r *http.Request) {
+	actor, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	var in strategyIn
+	if err := readJSON(w, r, &in); err != nil {
+		readErr(w, err)
+		return
+	}
+	idle := time.Duration(in.IdleSeconds) * time.Second
+	if err := validStrategyBounds(idle, in.MaxPings, in.MinPrefixTokens, in.MaxUSDPerPing); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := in.Target.Validate(); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validWindows(in.Windows); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s, err := h.registry().CreateStrategy(actor.ID, tenant.Strategy{
+		Name: in.Name, IdleSeconds: in.IdleSeconds, MaxPings: in.MaxPings,
+		MinPrefixTokens: in.MinPrefixTokens, MaxUSDPerPing: in.MaxUSDPerPing,
+		Windows: in.Windows, Target: in.Target, Active: in.Active,
+	})
+	if err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// The audited object is the strategy itself, named by its id in the field column —
+	// there is no single target tenant for an all-target strategy, so actor and target
+	// are both the manager's own id, unlike every other audited action in this codebase.
+	if err := h.registry().AuditWrite(actor.ID, actor.ID, s.ID, "", "created: "+s.Name); err != nil {
+		// A strategy we cannot account for is a strategy we do not keep — the same refusal
+		// ctlKeepAliveArm makes when its own audit write fails.
+		_ = h.registry().DeleteStrategy(s.ID)
+		ctlErr(w, http.StatusInternalServerError,
+			"could not record this in the audit log, so it was not created")
+		return
+	}
+	h.keeper.loadStrategies()
+	writeJSON(w, http.StatusCreated, viewStrategy(s, time.Now()))
+}
+
+// strategyPatchIn is an update request's body: pointers, so "not sent" and "set to
+// zero/empty" are different things, matching tenant.Patch's own convention.
+type strategyPatchIn struct {
+	Name            *string          `json:"name"`
+	IdleSeconds     *int             `json:"idle_seconds"`
+	MaxPings        *int             `json:"max_pings"`
+	MinPrefixTokens *int             `json:"min_prefix_tokens"`
+	MaxUSDPerPing   *float64         `json:"max_usd_per_ping"`
+	Windows         *[]tenant.Window `json:"windows"`
+	Target          *tenant.Target   `json:"target"`
+	Active          *bool            `json:"active"`
+}
+
+// ctlPatchKeepAliveStrategy updates any field; takes effect on the next request that
+// would match, since matching is live.
+func (h *Handler) ctlPatchKeepAliveStrategy(w http.ResponseWriter, r *http.Request) {
+	actor, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	id := r.PathValue("id")
+	cur, err := h.registry().StrategyByID(id)
+	if err != nil {
+		ctlErr(w, http.StatusNotFound, "no such strategy")
+		return
+	}
+	var in strategyPatchIn
+	if err := readJSON(w, r, &in); err != nil {
+		readErr(w, err)
+		return
+	}
+	// Validated against the RESOLVED strategy, not only the fields this call sent: a
+	// patch that only touches MaxPings must not let a previously-stored Idle drift out of
+	// bounds unchecked.
+	next := cur
+	if in.Name != nil {
+		next.Name = *in.Name
+	}
+	if in.IdleSeconds != nil {
+		next.IdleSeconds = *in.IdleSeconds
+	}
+	if in.MaxPings != nil {
+		next.MaxPings = *in.MaxPings
+	}
+	if in.MinPrefixTokens != nil {
+		next.MinPrefixTokens = *in.MinPrefixTokens
+	}
+	if in.MaxUSDPerPing != nil {
+		next.MaxUSDPerPing = *in.MaxUSDPerPing
+	}
+	if in.Windows != nil {
+		next.Windows = *in.Windows
+	}
+	if in.Target != nil {
+		next.Target = *in.Target
+	}
+	if in.Active != nil {
+		next.Active = *in.Active
+	}
+	idle := time.Duration(next.IdleSeconds) * time.Second
+	if err := validStrategyBounds(idle, next.MaxPings, next.MinPrefixTokens, next.MaxUSDPerPing); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := next.Target.Validate(); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validWindows(next.Windows); err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s, err := h.registry().UpdateStrategy(actor.ID, id, tenant.StrategyPatch{
+		Name: in.Name, IdleSeconds: in.IdleSeconds, MaxPings: in.MaxPings,
+		MinPrefixTokens: in.MinPrefixTokens, MaxUSDPerPing: in.MaxUSDPerPing,
+		Windows: in.Windows, Target: in.Target, Active: in.Active,
+	})
+	if err != nil {
+		ctlErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.registry().AuditWrite(actor.ID, actor.ID, id, "updated", "updated: "+s.Name); err != nil {
+		ctlErr(w, http.StatusInternalServerError, "updated, but the audit log could not be written")
+		return
+	}
+	h.keeper.loadStrategies()
+	writeJSON(w, http.StatusOK, viewStrategy(s, time.Now()))
+}
+
+// ctlDeleteKeepAliveStrategy deletes a strategy. Anything currently held under it is not
+// retroactively un-pinged — a ping already sent already happened — but it stops
+// matching new requests immediately.
+func (h *Handler) ctlDeleteKeepAliveStrategy(w http.ResponseWriter, r *http.Request) {
+	actor, err := h.webPrincipal(r)
+	if err != nil {
+		code, msg := statusOf(err)
+		ctlErr(w, code, msg)
+		return
+	}
+	// No body to read, so readJSON's cross-site guard does not cover it: check directly,
+	// as ctlLogout and ctlManagerReset do for the same reason.
+	if err := checkOrigin(r); err != nil {
+		readErr(w, err)
+		return
+	}
+	id := r.PathValue("id")
+	s, err := h.registry().StrategyByID(id)
+	if err != nil {
+		ctlErr(w, http.StatusNotFound, "no such strategy")
+		return
+	}
+	if err := h.registry().DeleteStrategy(id); err != nil {
+		ctlErr(w, http.StatusNotFound, "no such strategy")
+		return
+	}
+	if err := h.registry().AuditWrite(actor.ID, actor.ID, id, s.Name, "deleted"); err != nil {
+		ctlErr(w, http.StatusInternalServerError, "deleted, but the audit log could not be written")
+		return
+	}
+	h.keeper.loadStrategies()
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "deleted": true})
+}

--- a/proxy/keepalivestrategy_test.go
+++ b/proxy/keepalivestrategy_test.go
@@ -1,0 +1,319 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/tenant"
+)
+
+// The resolution chain applyStrategy generalizes overrideFor into: account config, then
+// the highest-priority matching ACTIVE strategy, then (elsewhere, in record) a session
+// override on top. These tests are about the middle link and its precedence rule.
+
+func TestApplyStrategyNoMatchLeavesPolicyUnchanged(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	account := CachePolicy{KeepAlive: false, Idle: 280 * time.Second, MaxPings: 2}
+	got, applied := k.applyStrategy("t1", account, clock.now())
+	if applied != "" {
+		t.Errorf("applied = %q, want \"\" (no strategies at all)", applied)
+	}
+	if got != account {
+		t.Errorf("policy changed with no strategy loaded: %+v", got)
+	}
+}
+
+// A list-target strategy beats an all-target one, even when the all-target one is
+// "more recent" — specificity is checked first and breaks the tie outright.
+func TestApplyStrategyListBeatsAll(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	now := clock.now()
+	window := []tenant.Window{{Start: "00:00", End: "23:59", Days: nil}}
+	allTarget := tenant.Strategy{
+		ID: "all", Active: true, Windows: window, Target: tenant.Target{Mode: tenant.TargetAll},
+		IdleSeconds: 100, MaxPings: 1, UpdatedAt: now, // newer
+	}
+	listTarget := tenant.Strategy{
+		ID: "list", Active: true, Windows: window,
+		Target:      tenant.Target{Mode: tenant.TargetList, TenantIDs: []string{"t1"}},
+		IdleSeconds: 200, MaxPings: 5, UpdatedAt: now.Add(-time.Hour), // older
+	}
+	k.setStrategies([]tenant.Strategy{allTarget, listTarget})
+
+	account := CachePolicy{}
+	got, applied := k.applyStrategy("t1", account, now)
+	if applied != "list" {
+		t.Fatalf("applied = %q, want %q (list-target beats all-target regardless of recency)", applied, "list")
+	}
+	if got.Idle != 200*time.Second || got.MaxPings != 5 {
+		t.Errorf("policy did not come from the list-target strategy: %+v", got)
+	}
+	if !got.KeepAlive {
+		t.Error("a matching strategy did not force KeepAlive on")
+	}
+}
+
+// Among two equally-specific matches, the most recently UPDATED one wins — not the one
+// that happens to sort first, and not the one that was created first.
+func TestApplyStrategyRecencyBreaksTiesAmongEquallySpecificMatches(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	now := clock.now()
+	window := []tenant.Window{{Start: "00:00", End: "23:59"}}
+	older := tenant.Strategy{
+		ID: "older", Active: true, Windows: window, Target: tenant.Target{Mode: tenant.TargetAll},
+		IdleSeconds: 100, MaxPings: 1, UpdatedAt: now.Add(-time.Hour),
+	}
+	newer := tenant.Strategy{
+		ID: "newer", Active: true, Windows: window, Target: tenant.Target{Mode: tenant.TargetAll},
+		IdleSeconds: 200, MaxPings: 2, UpdatedAt: now,
+	}
+	// Order in the slice must not matter: put the newer one first here and the older one
+	// first in the sibling case below.
+	k.setStrategies([]tenant.Strategy{newer, older})
+	_, applied := k.applyStrategy("t1", CachePolicy{}, now)
+	if applied != "newer" {
+		t.Errorf("applied = %q, want %q", applied, "newer")
+	}
+
+	k.setStrategies([]tenant.Strategy{older, newer})
+	_, applied = k.applyStrategy("t1", CachePolicy{}, now)
+	if applied != "newer" {
+		t.Errorf("applied = %q, want %q (order in the slice must not change the winner)", applied, "newer")
+	}
+}
+
+// An inactive strategy, or one whose target excludes this tenant, or one whose window
+// does not cover `now`, must not match — each checked independently.
+func TestApplyStrategyRequiresActiveTargetAndWindow(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	now := clock.now()
+	base := tenant.Strategy{
+		ID: "s", Active: true, IdleSeconds: 100, MaxPings: 1,
+		Windows: []tenant.Window{{Start: "00:00", End: "23:59"}},
+		Target:  tenant.Target{Mode: tenant.TargetAll}, UpdatedAt: now,
+	}
+
+	inactive := base
+	inactive.Active = false
+	k.setStrategies([]tenant.Strategy{inactive})
+	if _, applied := k.applyStrategy("t1", CachePolicy{}, now); applied != "" {
+		t.Errorf("an inactive strategy matched: %q", applied)
+	}
+
+	wrongTenant := base
+	wrongTenant.Target = tenant.Target{Mode: tenant.TargetList, TenantIDs: []string{"other"}}
+	k.setStrategies([]tenant.Strategy{wrongTenant})
+	if _, applied := k.applyStrategy("t1", CachePolicy{}, now); applied != "" {
+		t.Errorf("a strategy targeting another tenant matched: %q", applied)
+	}
+
+	outsideWindow := base
+	outsideWindow.Windows = []tenant.Window{{Start: "00:00", End: "00:01"}}
+	k.setStrategies([]tenant.Strategy{outsideWindow})
+	if _, applied := k.applyStrategy("t1", CachePolicy{}, now); applied != "" {
+		t.Errorf("a strategy outside its window matched: %q", applied)
+	}
+}
+
+// The resolution chain's top rule: a strategy sits ABOVE account config and BELOW a
+// session override. The override still wins on top for the fields it moves, and still
+// cannot widen MaxUSDPerPing — which the strategy, unlike an override, is allowed to set.
+func TestSessionOverrideStillWinsOverAMatchingStrategy(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	now := clock.now()
+	strategy := tenant.Strategy{
+		ID: "biz-hours", Active: true, IdleSeconds: 150, MaxPings: 3, MinPrefixTokens: 5000,
+		MaxUSDPerPing: 0.5,
+		Windows:       []tenant.Window{{Start: "00:00", End: "23:59"}},
+		Target:        tenant.Target{Mode: tenant.TargetAll}, UpdatedAt: now,
+	}
+	k.setStrategies([]tenant.Strategy{strategy})
+
+	account := CachePolicy{KeepAlive: false, Idle: 999 * time.Second, MaxPings: 99}
+	afterStrategy, applied := k.applyStrategy("t1", account, now)
+	if applied != "biz-hours" {
+		t.Fatalf("applied = %q, want %q", applied, "biz-hours")
+	}
+	if afterStrategy.Idle != 150*time.Second || afterStrategy.MaxPings != 3 ||
+		afterStrategy.MinPrefixTokens != 5000 || afterStrategy.MaxUSDPerPing != 0.5 {
+		t.Fatalf("strategy did not resolve onto the policy: %+v", afterStrategy)
+	}
+
+	armOn(t, k, "sess-1", 60*time.Second, 7, now.Add(time.Hour))
+	final := k.overrideFor("t1", "sess-1", afterStrategy)
+	if final.Idle != 60*time.Second || final.MaxPings != 7 {
+		t.Errorf("the session override did not win on top of the strategy: %+v", final)
+	}
+	if final.MaxUSDPerPing != 0.5 {
+		t.Errorf("the override moved MaxUSDPerPing to %v; it may not widen a strategy's ceiling "+
+			"any more than it may widen the account's own", final.MaxUSDPerPing)
+	}
+	if !final.KeepAlive {
+		t.Error("the resolved policy is not on")
+	}
+}
+
+// validStrategyBounds enforces the SAME numeric bounds validOverride does, at least as
+// tightly, plus its own check on MaxUSDPerPing (which an override does not expose).
+func TestValidStrategyBounds(t *testing.T) {
+	cases := []struct {
+		name          string
+		idle          time.Duration
+		pings         int
+		minPrefix     int
+		maxUSDPerPing float64
+		ok            bool
+	}{
+		{"in bounds", 280 * time.Second, 2, 20000, 0.25, true},
+		{"idle too low", minOverrideIdle - time.Second, 2, 0, 0, false},
+		{"idle too high", maxOverrideIdle + time.Second, 2, 0, 0, false},
+		{"idle at floor", minOverrideIdle, 2, 0, 0, true},
+		{"idle at ceiling", maxOverrideIdle, 2, 0, 0, true},
+		{"pings too low", 280 * time.Second, minOverridePings - 1, 0, 0, false},
+		{"pings too high", 280 * time.Second, maxOverridePings + 1, 0, 0, false},
+		{"negative prefix", 280 * time.Second, 2, -1, 0, false},
+		{"negative ceiling", 280 * time.Second, 2, 0, -0.01, false},
+		{"zero ceiling means default, and is fine", 280 * time.Second, 2, 0, 0, true},
+	}
+	for _, c := range cases {
+		err := validStrategyBounds(c.idle, c.pings, c.minPrefix, c.maxUSDPerPing)
+		if (err == nil) != c.ok {
+			t.Errorf("%s: validStrategyBounds() = %v, want ok=%v", c.name, err, c.ok)
+		}
+	}
+}
+
+// A strategy created through the control route is visible to the keeper's own
+// resolution on the very next call, with no restart — "no re-push needed, since matching
+// is live" — and a manager-only gate refuses a plain user. Update and delete take
+// effect just as immediately.
+func TestKeepAliveStrategyControlRoutesResolveLiveWithNoRestart(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+	userJar, userID := f.signUpJar(t, "user@ibm.com")
+
+	// A plain user may not create one.
+	body := `{"name":"biz hours","idle_seconds":280,"max_pings":2,"min_prefix_tokens":20000,
+		"max_usd_per_ping":0.25,"active":true,
+		"windows":[{"start":"00:00","end":"23:59"}],"target":{"mode":"all"}}`
+	w, _ := f.do(t, http.MethodPost, "/api/keepalive/strategies", body, userJar)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("a plain user's create = %d, want 403: %s", w.Code, w.Body)
+	}
+
+	w, out := f.do(t, http.MethodPost, "/api/keepalive/strategies", body, mgrJar)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d, want 201: %s", w.Code, w.Body)
+	}
+	id, _ := out["id"].(string)
+	if id == "" {
+		t.Fatalf("no id in create response: %v", out)
+	}
+
+	// Live in the keeper right now, with no restart: an all-target strategy that is
+	// active and covers this instant matches any tenant, including the one that just
+	// signed up.
+	if _, applied := f.h.keeper.applyStrategy(userID, CachePolicy{}, time.Now()); applied != id {
+		t.Errorf("applyStrategy after create = %q, want %q", applied, id)
+	}
+
+	// The audit trail names the strategy by its id in the field column, actor and target
+	// both the manager's own id.
+	entries, err := f.reg.Audit("", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Field == id && e.After == "created: biz hours" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no audit row named the new strategy by id: %+v", entries)
+	}
+
+	// PATCH turns it off; the very next resolution stops matching.
+	w, _ = f.do(t, http.MethodPatch, "/api/keepalive/strategies/"+id, `{"active":false}`, mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch = %d, want 200: %s", w.Code, w.Body)
+	}
+	if _, applied := f.h.keeper.applyStrategy(userID, CachePolicy{}, time.Now()); applied != "" {
+		t.Errorf("a deactivated strategy still applied: %q", applied)
+	}
+
+	// PATCH turns it back on; the list route reports it as such.
+	w, _ = f.do(t, http.MethodPatch, "/api/keepalive/strategies/"+id, `{"active":true}`, mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("re-activating patch = %d, want 200: %s", w.Code, w.Body)
+	}
+	w, out = f.do(t, http.MethodGet, "/api/keepalive/strategies", "", mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list = %d, want 200: %s", w.Code, w.Body)
+	}
+	list, _ := out["strategies"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("list has %d strategies, want 1: %v", len(list), out)
+	}
+	row, _ := list[0].(map[string]any)
+	if inWindow, _ := row["in_window"].(bool); !inWindow {
+		t.Errorf("a strategy whose window covers all day is not reported in_window: %v", row)
+	}
+
+	// DELETE stops it matching immediately, and it disappears from the list.
+	w, _ = f.do(t, http.MethodDelete, "/api/keepalive/strategies/"+id, "", mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete = %d, want 200: %s", w.Code, w.Body)
+	}
+	if _, applied := f.h.keeper.applyStrategy(userID, CachePolicy{}, time.Now()); applied != "" {
+		t.Errorf("a deleted strategy still applied: %q", applied)
+	}
+	w, out = f.do(t, http.MethodGet, "/api/keepalive/strategies", "", mgrJar)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list after delete = %d, want 200: %s", w.Code, w.Body)
+	}
+	if list, _ := out["strategies"].([]any); len(list) != 0 {
+		t.Errorf("deleted strategy still listed: %v", list)
+	}
+}
+
+// Validation runs at the control-route level too: an out-of-bounds idle interval and a
+// window with no schedule are both refused with a 400, and nothing is created.
+func TestKeepAliveStrategyCreateValidatesAtTheRoute(t *testing.T) {
+	f := newMgrFixture(t)
+	mgrJar, _ := f.signUpJar(t, "boss@ibm.com")
+
+	tooFast := `{"name":"x","idle_seconds":1,"max_pings":2,"windows":[{"start":"00:00","end":"23:59"}],
+		"target":{"mode":"all"}}`
+	w, _ := f.do(t, http.MethodPost, "/api/keepalive/strategies", tooFast, mgrJar)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("an idle interval below the floor = %d, want 400: %s", w.Code, w.Body)
+	}
+
+	noWindows := `{"name":"x","idle_seconds":280,"max_pings":2,"windows":[],"target":{"mode":"all"}}`
+	w, _ = f.do(t, http.MethodPost, "/api/keepalive/strategies", noWindows, mgrJar)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("a strategy with no windows = %d, want 400: %s", w.Code, w.Body)
+	}
+
+	list, err := f.reg.ListStrategies()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Errorf("a refused create nonetheless persisted %d strategies", len(list))
+	}
+}
+
+func TestValidWindowsRequiresAtLeastOne(t *testing.T) {
+	if err := validWindows(nil); err == nil {
+		t.Error("a strategy with no windows was accepted; it can never fire")
+	}
+	if err := validWindows([]tenant.Window{{Start: "09:00", End: "18:00"}}); err != nil {
+		t.Errorf("a single valid window was refused: %v", err)
+	}
+	if err := validWindows([]tenant.Window{{Start: "18:00", End: "09:00"}}); err == nil {
+		t.Error("an overnight window was accepted")
+	}
+}

--- a/tenant/keepalivestrategy.go
+++ b/tenant/keepalivestrategy.go
@@ -1,0 +1,377 @@
+package tenant
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	// The zoneinfo database, compiled in. Window.contains resolves an IANA name
+	// (Asia/Jerusalem by default) with time.LoadLocation, and the deployed image
+	// (debian:bookworm-slim, see the Dockerfile) does not install the tzdata package —
+	// so without this, every window would fail to load its zone and a manager's
+	// schedule would silently never fire. One blank stdlib import buys the database
+	// rather than a system package this repo does not otherwise depend on.
+	_ "time/tzdata"
+)
+
+// Manager-controlled keep-alive strategies: a durable, manager-authored rule that
+// overrides a tenant's own account-wide keep-alive switch when it matches a live
+// request. See docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md for the
+// full design and proxy/keepalivestrategy.go for how a Strategy is resolved against a
+// request and validated before it is written here.
+//
+// Persisted in THIS registry, not in dash's request-metrics database: a strategy is a
+// standing rule a manager expects to survive a deploy, the same durability class as a
+// tenant's own configuration document — unlike a per-session override
+// (proxy/keepaliveoverride.go), which is deliberately memory-only.
+
+// Window is one recurring span a strategy is active in, evaluated in its own timezone.
+// Days empty means every day. Start/End are "HH:MM" (24-hour), and End must be strictly
+// after Start: an overnight window is out of scope (see the design doc's "Out of
+// scope").
+type Window struct {
+	Days  []time.Weekday `json:"days,omitempty"`
+	Start string         `json:"start"`
+	End   string         `json:"end"`
+	// TZ is an IANA zone name. Empty resolves to DefaultStrategyTZ.
+	TZ string `json:"tz,omitempty"`
+}
+
+// DefaultStrategyTZ is what an unset Window.TZ resolves to.
+const DefaultStrategyTZ = "Asia/Jerusalem"
+
+// Target selects which tenants a strategy applies to.
+type Target struct {
+	Mode      string   `json:"mode"` // TargetAll | TargetList
+	TenantIDs []string `json:"tenant_ids,omitempty"`
+}
+
+const (
+	TargetAll  = "all"
+	TargetList = "list"
+)
+
+// Strategy is a manager-authored keep-alive rule — see the design doc's "Model".
+type Strategy struct {
+	ID              string
+	Name            string
+	IdleSeconds     int
+	MaxPings        int
+	MinPrefixTokens int
+	MaxUSDPerPing   float64
+	Windows         []Window
+	Target          Target
+	Active          bool
+	CreatedBy       string
+	CreatedAt       time.Time
+	UpdatedBy       string
+	UpdatedAt       time.Time
+}
+
+// StrategyPatch is a sparse update, matching Patch's own pointer convention: a nil
+// field is left alone.
+type StrategyPatch struct {
+	Name            *string
+	IdleSeconds     *int
+	MaxPings        *int
+	MinPrefixTokens *int
+	MaxUSDPerPing   *float64
+	Windows         *[]Window
+	Target          *Target
+	Active          *bool
+}
+
+// ErrNoStrategy names no keep-alive strategy.
+var ErrNoStrategy = errors.New("tenant: no such keep-alive strategy")
+
+// tzOrDefault is w.TZ, or DefaultStrategyTZ when it is empty.
+func (w Window) tzOrDefault() string {
+	if w.TZ == "" {
+		return DefaultStrategyTZ
+	}
+	return w.TZ
+}
+
+// parseHHMM parses "HH:MM" into minutes since midnight, rejecting anything else —
+// including a value Sscanf would happily half-parse.
+func parseHHMM(s string) (int, error) {
+	if len(s) != 5 || s[2] != ':' {
+		return 0, fmt.Errorf("tenant: %q is not an HH:MM time", s)
+	}
+	h, err1 := strconv.Atoi(s[:2])
+	m, err2 := strconv.Atoi(s[3:])
+	if err1 != nil || err2 != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, fmt.Errorf("tenant: %q is not a valid HH:MM time", s)
+	}
+	return h*60 + m, nil
+}
+
+// Validate checks this window's own shape: parseable HH:MM bounds, End strictly after
+// Start (an overnight window is out of scope), a loadable IANA timezone, and weekdays
+// in range. It does not know the keep-alive's own spend-authorization bounds
+// (Idle/MaxPings/…) — that check lives in proxy, alongside validOverride's bounds.
+func (w Window) Validate() error {
+	start, err := parseHHMM(w.Start)
+	if err != nil {
+		return err
+	}
+	end, err := parseHHMM(w.End)
+	if err != nil {
+		return err
+	}
+	if end <= start {
+		return fmt.Errorf("tenant: a window's end (%s) must be after its start (%s); "+
+			"an overnight window is not supported", w.End, w.Start)
+	}
+	if _, err := time.LoadLocation(w.tzOrDefault()); err != nil {
+		return fmt.Errorf("tenant: %q is not a known timezone: %w", w.tzOrDefault(), err)
+	}
+	for _, d := range w.Days {
+		if d < time.Sunday || d > time.Saturday {
+			return fmt.Errorf("tenant: %d is not a day of the week", d)
+		}
+	}
+	return nil
+}
+
+// contains reports whether `now`, converted to this window's timezone, falls inside it.
+func (w Window) contains(now time.Time) (bool, error) {
+	loc, err := time.LoadLocation(w.tzOrDefault())
+	if err != nil {
+		return false, err
+	}
+	local := now.In(loc)
+	if len(w.Days) > 0 {
+		match := false
+		for _, d := range w.Days {
+			if local.Weekday() == d {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false, nil
+		}
+	}
+	start, err := parseHHMM(w.Start)
+	if err != nil {
+		return false, err
+	}
+	end, err := parseHHMM(w.End)
+	if err != nil {
+		return false, err
+	}
+	mins := local.Hour()*60 + local.Minute()
+	return mins >= start && mins < end, nil
+}
+
+// Validate checks the target's own shape: a known mode, and at least one tenant id for
+// a list-target strategy (an empty list matches nothing, which is never what was meant).
+func (t Target) Validate() error {
+	switch t.Mode {
+	case TargetAll:
+		return nil
+	case TargetList:
+		if len(t.TenantIDs) == 0 {
+			return fmt.Errorf("tenant: a list-target strategy needs at least one tenant id")
+		}
+		return nil
+	default:
+		return fmt.Errorf("tenant: target mode must be %q or %q", TargetAll, TargetList)
+	}
+}
+
+func (t Target) matches(tenantID string) bool {
+	switch t.Mode {
+	case TargetAll:
+		return true
+	case TargetList:
+		for _, id := range t.TenantIDs {
+			if id == tenantID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// InWindow reports whether this strategy's schedule covers `now`, ignoring Target and
+// Active — the "would this fire right now, for whoever it targets" flag the strategies
+// list shows at a glance.
+func (s Strategy) InWindow(now time.Time) bool {
+	for _, w := range s.Windows {
+		if ok, err := w.contains(now); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Matches reports whether this strategy applies to tenantID right now: Active, the
+// target covers tenantID, and now falls inside one of its windows — see the design
+// doc's "Model" for the precise rule.
+func (s Strategy) Matches(now time.Time, tenantID string) bool {
+	if !s.Active || !s.Target.matches(tenantID) {
+		return false
+	}
+	return s.InWindow(now)
+}
+
+// CreateStrategy inserts a new strategy, stamping its id and both timestamps. The
+// caller (proxy's control route) validates the numeric bounds — the keep-alive's own
+// spend-authorization limits, which this package does not know about — and every
+// window and the target before calling this.
+func (r *Registry) CreateStrategy(actorID string, s Strategy) (Strategy, error) {
+	if strings.TrimSpace(s.Name) == "" {
+		return Strategy{}, fmt.Errorf("tenant: a strategy needs a name")
+	}
+	windowsJSON, err := json.Marshal(s.Windows)
+	if err != nil {
+		return Strategy{}, err
+	}
+	targetJSON, err := json.Marshal(s.Target)
+	if err != nil {
+		return Strategy{}, err
+	}
+	now := time.Now()
+	s.ID = newID()
+	s.CreatedBy, s.UpdatedBy = actorID, actorID
+	s.CreatedAt, s.UpdatedAt = now, now
+	if _, err := r.db.Exec(`INSERT INTO keepalive_strategies
+	  (id,name,idle_seconds,max_pings,min_prefix_tokens,max_usd_per_ping,windows_json,
+	   target_json,active,created_by,created_at,updated_by,updated_at)
+	  VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		s.ID, s.Name, s.IdleSeconds, s.MaxPings, s.MinPrefixTokens, s.MaxUSDPerPing,
+		string(windowsJSON), string(targetJSON), boolInt(s.Active),
+		s.CreatedBy, s.CreatedAt.UnixMilli(), s.UpdatedBy, s.UpdatedAt.UnixMilli()); err != nil {
+		return Strategy{}, err
+	}
+	return s, nil
+}
+
+// UpdateStrategy applies a sparse patch and returns the resolved strategy.
+func (r *Registry) UpdateStrategy(actorID, id string, p StrategyPatch) (Strategy, error) {
+	s, err := r.StrategyByID(id)
+	if err != nil {
+		return Strategy{}, err
+	}
+	if p.Name != nil {
+		if strings.TrimSpace(*p.Name) == "" {
+			return Strategy{}, fmt.Errorf("tenant: a strategy needs a name")
+		}
+		s.Name = *p.Name
+	}
+	if p.IdleSeconds != nil {
+		s.IdleSeconds = *p.IdleSeconds
+	}
+	if p.MaxPings != nil {
+		s.MaxPings = *p.MaxPings
+	}
+	if p.MinPrefixTokens != nil {
+		s.MinPrefixTokens = *p.MinPrefixTokens
+	}
+	if p.MaxUSDPerPing != nil {
+		s.MaxUSDPerPing = *p.MaxUSDPerPing
+	}
+	if p.Windows != nil {
+		s.Windows = *p.Windows
+	}
+	if p.Target != nil {
+		s.Target = *p.Target
+	}
+	if p.Active != nil {
+		s.Active = *p.Active
+	}
+	s.UpdatedBy, s.UpdatedAt = actorID, time.Now()
+	windowsJSON, err := json.Marshal(s.Windows)
+	if err != nil {
+		return Strategy{}, err
+	}
+	targetJSON, err := json.Marshal(s.Target)
+	if err != nil {
+		return Strategy{}, err
+	}
+	if _, err := r.db.Exec(`UPDATE keepalive_strategies SET
+	  name=?, idle_seconds=?, max_pings=?, min_prefix_tokens=?, max_usd_per_ping=?,
+	  windows_json=?, target_json=?, active=?, updated_by=?, updated_at=? WHERE id=?`,
+		s.Name, s.IdleSeconds, s.MaxPings, s.MinPrefixTokens, s.MaxUSDPerPing,
+		string(windowsJSON), string(targetJSON), boolInt(s.Active), s.UpdatedBy,
+		s.UpdatedAt.UnixMilli(), s.ID); err != nil {
+		return Strategy{}, err
+	}
+	return s, nil
+}
+
+// DeleteStrategy removes a strategy. It does not un-ping anything already sent — there
+// is nothing to undo — it only stops the strategy matching new requests.
+func (r *Registry) DeleteStrategy(id string) error {
+	res, err := r.db.Exec(`DELETE FROM keepalive_strategies WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNoStrategy
+	}
+	return nil
+}
+
+// StrategyByID reads one strategy.
+func (r *Registry) StrategyByID(id string) (Strategy, error) {
+	s, err := scanStrategy(r.db.QueryRow(
+		`SELECT `+strategyCols+` FROM keepalive_strategies WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Strategy{}, ErrNoStrategy
+	}
+	return s, err
+}
+
+// ListStrategies returns every strategy, newest first. Loaded into the keeper's memory
+// at process start and refreshed on every write — see proxy/keepalivestrategy.go.
+func (r *Registry) ListStrategies() ([]Strategy, error) {
+	rows, err := r.db.Query(`SELECT ` + strategyCols + ` FROM keepalive_strategies ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Strategy{}
+	for rows.Next() {
+		s, err := scanStrategy(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+const strategyCols = `id,name,idle_seconds,max_pings,min_prefix_tokens,max_usd_per_ping,
+	windows_json,target_json,active,created_by,created_at,updated_by,updated_at`
+
+func scanStrategy(sc scanner) (Strategy, error) {
+	var out Strategy
+	var windowsJSON, targetJSON string
+	var active int
+	var createdAt, updatedAt int64
+	if err := sc.Scan(&out.ID, &out.Name, &out.IdleSeconds, &out.MaxPings, &out.MinPrefixTokens,
+		&out.MaxUSDPerPing, &windowsJSON, &targetJSON, &active, &out.CreatedBy, &createdAt,
+		&out.UpdatedBy, &updatedAt); err != nil {
+		return Strategy{}, err
+	}
+	if windowsJSON != "" {
+		if err := json.Unmarshal([]byte(windowsJSON), &out.Windows); err != nil {
+			return Strategy{}, err
+		}
+	}
+	if targetJSON != "" {
+		if err := json.Unmarshal([]byte(targetJSON), &out.Target); err != nil {
+			return Strategy{}, err
+		}
+	}
+	out.Active = active != 0
+	out.CreatedAt, out.UpdatedAt = msTime(createdAt), msTime(updatedAt)
+	return out, nil
+}

--- a/tenant/keepalivestrategy_test.go
+++ b/tenant/keepalivestrategy_test.go
@@ -1,0 +1,205 @@
+package tenant
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// jerusalem loads the zone once per test file; a failure here means the tzdata import in
+// keepalivestrategy.go did not do its job.
+func jerusalem(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("Asia/Jerusalem")
+	if err != nil {
+		t.Fatalf("Asia/Jerusalem did not load: %v", err)
+	}
+	return loc
+}
+
+// Israel's DST law: clocks spring forward at 02:00 on the Friday before the last Sunday of
+// March. In 2026 that is Friday, March 27 — 02:00 IST jumps straight to 03:00 IDT, so the
+// wall-clock hour 02:00-02:59 does not exist that day. A window whose matching is done in
+// UTC, or with a fixed offset, gets this wrong on both sides of the jump; one done through
+// time.LoadLocation does not, because it re-resolves the offset for the instant it is given
+// rather than assuming yesterday's.
+func TestWindowMatchesAcrossTheIsraeliDSTTransition(t *testing.T) {
+	loc := jerusalem(t)
+	// 01:30 local, still IST (UTC+2) — five minutes before the jump would begin.
+	beforeJump := time.Date(2026, 3, 27, 1, 30, 0, 0, loc)
+	// 03:30 local, now IDT (UTC+3) — thirty minutes after the jump. The clock never read
+	// 02:xx at all on this day.
+	afterJump := time.Date(2026, 3, 27, 3, 30, 0, 0, loc)
+
+	early := Window{Days: []time.Weekday{time.Friday}, Start: "01:00", End: "02:00", TZ: "Asia/Jerusalem"}
+	late := Window{Days: []time.Weekday{time.Friday}, Start: "03:00", End: "04:00", TZ: "Asia/Jerusalem"}
+
+	if ok, err := early.contains(beforeJump); err != nil || !ok {
+		t.Errorf("early.contains(beforeJump) = %v, %v; want true, nil", ok, err)
+	}
+	if ok, err := early.contains(afterJump); err != nil || ok {
+		t.Errorf("early.contains(afterJump) = %v, %v; want false, nil", ok, err)
+	}
+	if ok, err := late.contains(beforeJump); err != nil || ok {
+		t.Errorf("late.contains(beforeJump) = %v, %v; want false, nil", ok, err)
+	}
+	if ok, err := late.contains(afterJump); err != nil || !ok {
+		t.Errorf("late.contains(afterJump) = %v, %v; want true, nil", ok, err)
+	}
+}
+
+// A window with no Days matches every day of the week.
+func TestWindowWithNoDaysMatchesEveryDay(t *testing.T) {
+	loc := jerusalem(t)
+	w := Window{Start: "09:00", End: "18:00", TZ: "Asia/Jerusalem"}
+	for _, day := range []int{24, 25, 26, 27, 28, 29, 30} { // a full week, March 2026
+		now := time.Date(2026, 3, day, 12, 0, 0, 0, loc)
+		if ok, err := w.contains(now); err != nil || !ok {
+			t.Errorf("day %d: contains = %v, %v; want true, nil", day, ok, err)
+		}
+	}
+}
+
+// A window's End must be strictly after Start; an overnight window is out of scope.
+func TestWindowValidateRejectsOvernightAndBadShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		w    Window
+		ok   bool
+	}{
+		{"ordinary", Window{Start: "09:00", End: "18:00", TZ: "Asia/Jerusalem"}, true},
+		{"overnight", Window{Start: "22:00", End: "06:00", TZ: "Asia/Jerusalem"}, false},
+		{"equal", Window{Start: "09:00", End: "09:00", TZ: "Asia/Jerusalem"}, false},
+		{"bad start", Window{Start: "9:00", End: "18:00", TZ: "Asia/Jerusalem"}, false},
+		{"bad minute", Window{Start: "09:60", End: "18:00", TZ: "Asia/Jerusalem"}, false},
+		{"bad tz", Window{Start: "09:00", End: "18:00", TZ: "Nowhere/Fake"}, false},
+		{"default tz", Window{Start: "09:00", End: "18:00"}, true},
+		{"bad day", Window{Start: "09:00", End: "18:00", Days: []time.Weekday{7}}, false},
+	}
+	for _, c := range cases {
+		err := c.w.Validate()
+		if (err == nil) != c.ok {
+			t.Errorf("%s: Validate() = %v, want ok=%v", c.name, err, c.ok)
+		}
+	}
+}
+
+func TestTargetValidate(t *testing.T) {
+	if err := (Target{Mode: TargetAll}).Validate(); err != nil {
+		t.Errorf("all-target refused: %v", err)
+	}
+	if err := (Target{Mode: TargetList, TenantIDs: []string{"t1"}}).Validate(); err != nil {
+		t.Errorf("list-target with a tenant refused: %v", err)
+	}
+	if err := (Target{Mode: TargetList}).Validate(); err == nil {
+		t.Error("an empty list-target was accepted; it matches nothing, which is never what was meant")
+	}
+	if err := (Target{Mode: "bogus"}).Validate(); err == nil {
+		t.Error("an unknown target mode was accepted")
+	}
+}
+
+func TestStrategyMatchesRequiresActiveTargetAndWindow(t *testing.T) {
+	loc := jerusalem(t)
+	inWindow := time.Date(2026, 6, 1, 12, 0, 0, 0, loc) // a Monday, no DST edge involved
+	s := Strategy{
+		Active: true,
+		Windows: []Window{
+			{Start: "09:00", End: "18:00", TZ: "Asia/Jerusalem"},
+		},
+		Target: Target{Mode: TargetList, TenantIDs: []string{"t1"}},
+	}
+	if !s.Matches(inWindow, "t1") {
+		t.Error("an active, in-window, correctly-targeted strategy did not match")
+	}
+	if s.Matches(inWindow, "t2") {
+		t.Error("a list-target strategy matched a tenant not on its list")
+	}
+	off := s
+	off.Active = false
+	if off.Matches(inWindow, "t1") {
+		t.Error("an inactive strategy matched")
+	}
+	outside := time.Date(2026, 6, 1, 3, 0, 0, 0, loc)
+	if s.Matches(outside, "t1") {
+		t.Error("a strategy matched outside every one of its windows")
+	}
+}
+
+// Persistence across a simulated restart: strategies survive a Close and a fresh Open of
+// the same file, unlike a per-session override (which is deliberately memory-only).
+func TestStrategyPersistsAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tenant.db")
+
+	r1, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	created, err := r1.CreateStrategy("mgr-1", Strategy{
+		Name: "business hours", IdleSeconds: 280, MaxPings: 2, MinPrefixTokens: 20000,
+		MaxUSDPerPing: 0.25, Active: true,
+		Windows: []Window{{Start: "09:00", End: "18:00", TZ: "Asia/Jerusalem"}},
+		Target:  Target{Mode: TargetAll},
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy: %v", err)
+	}
+	if err := r1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r2, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("re-Open: %v", err)
+	}
+	defer r2.Close()
+	list, err := r2.ListStrategies()
+	if err != nil {
+		t.Fatalf("ListStrategies after reload: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("got %d strategies after reload, want 1", len(list))
+	}
+	got := list[0]
+	if got.ID != created.ID || got.Name != "business hours" || got.IdleSeconds != 280 ||
+		got.MaxPings != 2 || !got.Active || len(got.Windows) != 1 ||
+		got.Windows[0].Start != "09:00" || got.Target.Mode != TargetAll {
+		t.Errorf("reloaded strategy does not match what was created: %+v", got)
+	}
+}
+
+// Create/Update/Delete round trip, including that a delete stops it matching and a
+// not-found id is reported distinctly.
+func TestStrategyCRUD(t *testing.T) {
+	r := open(t, Options{})
+	s, err := r.CreateStrategy("mgr-1", Strategy{
+		Name: "s1", IdleSeconds: 280, MaxPings: 1,
+		Windows: []Window{{Start: "09:00", End: "18:00"}},
+		Target:  Target{Mode: TargetAll},
+	})
+	if err != nil {
+		t.Fatalf("CreateStrategy: %v", err)
+	}
+	newName := "s1-renamed"
+	newPings := 3
+	updated, err := r.UpdateStrategy("mgr-2", s.ID, StrategyPatch{Name: &newName, MaxPings: &newPings})
+	if err != nil {
+		t.Fatalf("UpdateStrategy: %v", err)
+	}
+	if updated.Name != newName || updated.MaxPings != newPings || updated.UpdatedBy != "mgr-2" {
+		t.Errorf("update did not apply: %+v", updated)
+	}
+	if updated.IdleSeconds != 280 {
+		t.Errorf("update touched a field it was not given: IdleSeconds = %d", updated.IdleSeconds)
+	}
+	if err := r.DeleteStrategy(s.ID); err != nil {
+		t.Fatalf("DeleteStrategy: %v", err)
+	}
+	if _, err := r.StrategyByID(s.ID); err != ErrNoStrategy {
+		t.Errorf("StrategyByID after delete = %v, want ErrNoStrategy", err)
+	}
+	if err := r.DeleteStrategy(s.ID); err != ErrNoStrategy {
+		t.Errorf("second delete = %v, want ErrNoStrategy", err)
+	}
+}

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -1287,6 +1287,29 @@ var migrations = []string{
 	// retired key is absent from the aggregate rather than misfiled into it.
 	`ALTER TABLE feedback DROP COLUMN wanted;
 	 ALTER TABLE feedback ADD COLUMN agent TEXT NOT NULL DEFAULT '';`,
+
+	// v8: manager-controlled keep-alive strategies (see
+	// docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md and
+	// proxy/keepalivestrategy.go). A standing rule a manager expects to survive a
+	// deploy, unlike a per-session override (proxy/keepaliveoverride.go, deliberately
+	// memory-only) — so this is written through to SQLite on every create/update/delete
+	// and reloaded at boot, the same durability class as a tenant's own config document.
+	`CREATE TABLE keepalive_strategies (
+	   id                TEXT PRIMARY KEY,
+	   name              TEXT    NOT NULL,
+	   idle_seconds      INTEGER NOT NULL DEFAULT 0,
+	   max_pings         INTEGER NOT NULL DEFAULT 0,
+	   min_prefix_tokens INTEGER NOT NULL DEFAULT 0,
+	   max_usd_per_ping  REAL    NOT NULL DEFAULT 0,
+	   windows_json      TEXT    NOT NULL DEFAULT '[]',
+	   target_json       TEXT    NOT NULL DEFAULT '{}',
+	   active            INTEGER NOT NULL DEFAULT 0,
+	   created_by        TEXT    NOT NULL DEFAULT '',
+	   created_at        INTEGER NOT NULL,
+	   updated_by        TEXT    NOT NULL DEFAULT '',
+	   updated_at        INTEGER NOT NULL
+	 );
+	 CREATE INDEX idx_keepalive_strategies_active ON keepalive_strategies(active);`,
 }
 
 func migrate(db *sql.DB) error {


### PR DESCRIPTION
## Summary

Adds a manager-controlled layer above the existing keep-alive mechanism: a **strategy** is a durable, scheduled rule (idle interval, max pings, time windows in a timezone, and a target of all tenants or a specific list) that a manager creates from a new dashboard tab. A matching strategy forces the keep-alive ping on for a request, overriding that tenant's own account-level off switch — evaluated live per request, so an "all tenants" strategy automatically covers tenants created after it was set up.

This sits above the existing per-account config switch and below the existing per-session override, both of which are unchanged:

```
account config -> matching active strategy (forces on) -> session override (still wins on top)
```

- New control routes (`/api/keepalive/strategies*`), all manager-only, with an explicit role re-check inside each handler in addition to the route-table gate.
- New table `keepalive_strategies` in the tenant registry DB, loaded into the keeper's memory and refreshed on every write — unlike per-session overrides, a strategy is meant to survive a restart.
- New nullable `keepalive_strategy_id` column on `requests`, additive, never backfilled.
- New dashboard read route (`GET /api/keepalive/strategies/{id}/ledger`) and a new manager-only "Strategies" tab; a small keep-alive savings callout on the Overview tab for every user.
- Design doc: `docs/superpowers/specs/2026-08-25-keepalive-strategies-design.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./proxy/... ./dash/... ./tenant/... ./config/...` — all pass
- [x] `go test -race` on `proxy`, `dash`, `tenant` — no races
- [x] Unit tests: window/timezone matching (incl. DST transition), strategy-vs-strategy precedence, session override still wins over a matching strategy, validation bounds, persistence across a simulated restart
- [x] Live end-to-end: drove a real Claude Code session through a local hosted proxy build, created a strategy with a window covering the current time, confirmed a real ping fired after the idle threshold and landed correctly attributed in `GET /api/keepalive/strategies/{id}/ledger`
- [x] Security review pass: fixed a missing defense-in-depth role re-check in the four new control handlers, and an audit-trail gap where a failed audit write on update left the change persisted with no audit row