### PR TITLE
feat(dash): suggest the cheapest KV-cache strategy per user, per hour of day

### DIFF
--- a/dash/kvcache_test.go
+++ b/dash/kvcache_test.go
@@ -590,7 +590,7 @@ func TestPingScheduleMatchesTheKeepAliveTab(t *testing.T) {
 func TestKVCacheRoutesAnswerOnAnEmptyDatabase(t *testing.T) {
 	a, _ := newTestAPI(t, Options{})
 	for _, path := range []string{"/api/kvcache", "/api/kvcache/rows",
-		"/api/kvcache/simulate", "/api/kvcache/pricing"} {
+		"/api/kvcache/simulate", "/api/kvcache/pricing", "/api/kvcache/suggest"} {
 		w, body := get(t, a, path, "")
 		if w.Code != http.StatusOK {
 			t.Errorf("%s -> %d: %s", path, w.Code, w.Body.String())

--- a/dash/kvcacheapi.go
+++ b/dash/kvcacheapi.go
@@ -35,6 +35,7 @@ func (a *API) kvCacheRoutes() []route {
 		{"GET /api/kvcache/rows", scopeTenant, a.kvCacheRows},
 		{"GET /api/kvcache/simulate", scopeTenant, a.kvCacheSimulate},
 		{"GET /api/kvcache/pricing", scopeTenant, a.kvCachePricing},
+		{"GET /api/kvcache/suggest", scopeTenant, a.kvCacheSuggest},
 	}
 }
 
@@ -92,6 +93,33 @@ func (a *API) kvCacheSimulate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// An unknown arm or baseline is the caller's mistake; anything else came from the store.
 		// Reporting a database failure as 400 means no 5xx alert ever fires for it.
+		code := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "unknown baseline strategy") {
+			code = http.StatusBadRequest
+		}
+		httpErr(w, code, err.Error())
+		return
+	}
+	writeJSON(w, out)
+}
+
+// kvCacheSuggest serves the per-user, per-hour strategy suggestion: for each account's own
+// Sunday–Thursday history in each hour of the day, which arm would have cost the least.
+func (a *API) kvCacheSuggest(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	// Reads the whole dataset, same as kvCache and kvCacheSimulate — same slot, same reason.
+	if err := acquireKVCache(r.Context()); err != nil {
+		return
+	}
+	defer releaseKVCache()
+	out, err := a.rec.DB().WithContext(r.Context()).
+		KVCacheSuggest(f, kvCacheOptionsFrom(r), a.pricer, kvCacheConfigFrom(r))
+	if err != nil {
+		// An unknown baseline is the caller's mistake, same as on /api/kvcache/simulate.
 		code := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "unknown baseline strategy") {
 			code = http.StatusBadRequest

--- a/dash/kvcachesuggest.go
+++ b/dash/kvcachesuggest.go
@@ -1,0 +1,295 @@
+package dash
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// The KV-cache page's per-user, per-hour strategy suggester.
+//
+// It answers a narrower question than the simulator above: not "how did every arm do over the
+// whole window", but "for THIS account, in THIS hour of the day, which arm would have cost the
+// least" — one answer per (user, hour-of-day) cell, deterministic and reproducible from exactly
+// the history that already drives the rest of this page.
+//
+// # Why Friday and Saturday are simply not read
+//
+// This deployment's work week is Sunday through Thursday. A cell built from a work-week hour
+// must not be informed by weekend traffic, whose shape (who is active, how long a gap runs) is
+// a different population. So the weekday check below is a FILTER on which rows even enter the
+// candidate pool — not a down-weighting, not a separate "weekend" group reported alongside —
+// because a policy chosen from a blend of the two describes neither.
+//
+// # Why a cell can be simulated with nothing more than the rows already at hand
+//
+// kvcache.Simulate derives each conversation's own gaps FROM THE SLICE IT IS GIVEN, walking it
+// in (ts, id) order and tracking state per Conversation key — it does not read Request.HasNext,
+// .IdleMs or .NextTS, which are dataset/display fields filled in elsewhere. So handing it a
+// cell's own rows (one user, one hour-of-day, Sunday–Thursday only) is not an approximation
+// bolted onto the real simulator; it IS the real simulator, replaying exactly the population the
+// cell claims to describe. Two rows from the same conversation that land in the same hour on two
+// different days are treated as consecutive turns with a multi-day gap, which is the honest
+// reading of "this is what this account's traffic in this hour looks like" rather than a defect
+// to be worked around.
+//
+// # Why the candidate list is not written down here
+//
+// It is KVCacheArms() filtered to what an unattended sweep can actually run — see
+// kvSuggestCandidates. A strategy added to the registry becomes a candidate the day it lands,
+// with nothing here to update; the alternative is a second, driftable list of arm names, which
+// is the exact defect that made four shipped arms invisible to the simulator's own picker.
+
+// kvSuggestMinRequests is how many requests a (user, hour) cell needs before its winner is
+// reported as a recommendation rather than a guess.
+//
+// 5, one below kvcache's own minCell of 6: minCell governs a STRATEGY's internal fallback
+// (whether HistoricalProbability trusts a cell's own history over its parent's), and this
+// governs whether THIS page trusts the cell's REPLAY at all. A cell below the floor still
+// simulates — every candidate's own numbers are on the wire — but InsufficientData is set so a
+// caller does not act on three requests as though they were a pattern.
+const kvSuggestMinRequests = 5
+
+// kvSuggestWeekdays is the work week this suggester reads, in the order a reader expects.
+var kvSuggestWeekdays = []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday"}
+
+// kvInWorkWeek reports whether ts's UTC weekday is Sunday..Thursday. Friday and Saturday are
+// excluded, not reclassified: see the file doc comment.
+func kvInWorkWeek(ts int64) bool {
+	switch time.UnixMilli(ts).UTC().Weekday() {
+	case time.Sunday, time.Monday, time.Tuesday, time.Wednesday, time.Thursday:
+		return true
+	}
+	return false
+}
+
+// kvSuggestCandidates is every arm an unattended sweep may pick as a cell's winner: every
+// REACHABLE, name-buildable registry arm. `optimal` is excluded because it reads the true
+// next-request time (Unreachable), `replay` because it carries no action list here
+// (unbuildable), and `custom` because there is no operator present to configure its
+// thresholds or hand it a predictor.
+func kvSuggestCandidates() []string {
+	out := []string{}
+	for _, a := range KVCacheArms() {
+		if a.Selectable && !a.Unreachable && a.Name != KVStrategyCustom {
+			out = append(out, a.Name)
+		}
+	}
+	return out
+}
+
+// KVCacheSuggestion is one (user, hour-of-day) cell's winner, decided from exactly that
+// account's own Sunday–Thursday requests in that hour — nothing else.
+type KVCacheSuggestion struct {
+	User    string `json:"user"`
+	HourUTC int    `json:"hour_utc"`
+	// Requests is how many Sunday–Thursday requests fall in this cell. It is the population
+	// every figure below was decided from — Friday and Saturday requests, if this account has
+	// any in this hour, are not in it.
+	Requests int64 `json:"requests"`
+	// InsufficientData is true below kvSuggestMinRequests. Every candidate is still simulated
+	// and reported — a floor on trusting the answer is not a reason to hide the arithmetic.
+	InsufficientData bool `json:"insufficient_data"`
+
+	// Baseline is the arm every saving below is measured against — the same honest denominator
+	// the page-wide simulator uses, not a second definition of it.
+	Baseline    string  `json:"baseline"`
+	BaselineUSD float64 `json:"baseline_usd"`
+
+	// BestStrategy is the argmax by absolute dollar saving against Baseline, over every valued
+	// candidate. Baseline is itself always a candidate, so BestStrategy is never worse than
+	// changing nothing: the floor of this field is "keep doing what you already do".
+	BestStrategy    string  `json:"best_strategy"`
+	BestDescription string  `json:"best_description,omitempty"`
+	BestUSD         float64 `json:"best_usd"`
+	// SavingUSD and SavingPct are Baseline's cost minus the winner's, absolute and as a share of
+	// Baseline. Never negative — see BestStrategy — and never clamped either; a cell with no
+	// arm beating the baseline simply reports 0.
+	SavingUSD   float64 `json:"saving_usd"`
+	SavingPct   float64 `json:"saving_pct"`
+	SavingKnown bool    `json:"saving_known"`
+	// Valued is false where neither the baseline nor the winner could be priced — every dollar
+	// figure on this cell is then 0.00 for want of a rate, not because nothing was spent.
+	Valued bool `json:"valued"`
+
+	// Candidates is every arm's own saving over this cell's own rows, baseline included, so the
+	// winner is checkable rather than asserted.
+	Candidates []kvcache.Savings `json:"candidates"`
+}
+
+// KVCacheSuggestions is the whole /api/kvcache/suggest payload.
+type KVCacheSuggestions struct {
+	Baseline string   `json:"baseline"`
+	Weekdays []string `json:"weekdays_included"`
+	TimeZone string   `json:"time_zone"`
+	// MinRequests is kvSuggestMinRequests, echoed so a reader of the JSON does not have to find
+	// it in the code that produced it.
+	MinRequests int      `json:"min_requests"`
+	Users       []string `json:"users"`
+	// Cells is one entry per (user, hour) that had any Sunday–Thursday traffic at all, ordered
+	// by user then hour so the same window renders the same list twice.
+	Cells []KVCacheSuggestion `json:"cells"`
+	// TotalSavingUSD sums SavingUSD over the cells that both cleared MinRequests and were
+	// priced — the aggregate this deployment would have kept had every cell run its own winner
+	// instead of the baseline, over exactly the history read.
+	TotalSavingUSD float64 `json:"total_saving_usd"`
+
+	Scanned   int64 `json:"scanned"`
+	Total     int64 `json:"total"`
+	Truncated bool  `json:"truncated"`
+
+	Notes []string `json:"notes"`
+}
+
+// KVCacheSuggest builds the per-user, per-hour strategy suggestion.
+func (d *DB) KVCacheSuggest(f Filter, o KVCacheOptions, p modelinfo.Pricer,
+	cfg KVCacheSimConfig) (*KVCacheSuggestions, error) {
+	baseName := cfg.Baseline
+	if baseName == "" {
+		baseName = kvCacheDefaultBaseline()
+	}
+	// Validated up front, against an empty probe dataset — the same probe KVCacheArms() itself
+	// uses to decide Selectable. A caller's typo must fail the WHOLE request, the same way it
+	// fails /api/kvcache/simulate (see KVCacheSimulate's identical check), rather than reaching
+	// every cell and rendering a silent, all-empty 200.
+	if buildStrategy(baseName, nil, cfg, kvcache.Config{}) == nil {
+		return nil, fmt.Errorf("dash: unknown baseline strategy %q", cfg.Baseline)
+	}
+
+	rows, total, err := d.KVCacheDataset(f, o)
+	if err != nil {
+		return nil, err
+	}
+
+	inWeek := make([]*kvcache.Request, 0, len(rows))
+	for _, r := range rows {
+		if kvInWorkWeek(r.TS) {
+			inWeek = append(inWeek, r)
+		}
+	}
+
+	// candidates ALWAYS includes the baseline, even one an operator picked that
+	// kvSuggestCandidates() would not itself offer — `optimal`, say, to see the headroom
+	// against the true ceiling. Without this a cell could report a "best" that costs MORE than
+	// a baseline that was never in its own comparison, which is the one thing SavingUSD must
+	// never do.
+	candidates := kvSuggestCandidates()
+	if !slices.Contains(candidates, baseName) {
+		candidates = append(candidates, baseName)
+	}
+	prices := kvcache.NewPriceList(context.Background(), modelsOf(inWeek), p,
+		cfg.Multipliers, cfg.Overrides)
+
+	type cellKey struct {
+		user string
+		hour int
+	}
+	groups := map[cellKey][]*kvcache.Request{}
+	userSet := map[string]bool{}
+	for _, r := range inWeek {
+		k := cellKey{r.User, r.HourUTC}
+		groups[k] = append(groups[k], r)
+		userSet[r.User] = true
+	}
+
+	out := &KVCacheSuggestions{Baseline: baseName, Weekdays: kvSuggestWeekdays, TimeZone: "UTC",
+		MinRequests: kvSuggestMinRequests, Cells: []KVCacheSuggestion{},
+		Scanned: int64(len(rows)), Total: total, Truncated: int64(len(rows)) < total}
+	for u := range userSet {
+		out.Users = append(out.Users, u)
+	}
+	sort.Strings(out.Users)
+
+	for _, u := range out.Users {
+		for h := 0; h < 24; h++ {
+			grp := groups[cellKey{u, h}]
+			if len(grp) == 0 {
+				continue
+			}
+			cell := kvSuggestCell(u, h, grp, candidates, baseName, prices, cfg)
+			out.Cells = append(out.Cells, cell)
+			if cell.Valued && !cell.InsufficientData {
+				out.TotalSavingUSD += cell.SavingUSD
+			}
+		}
+	}
+
+	out.Notes = []string{
+		"Every timestamp and hour is UTC, matching the rest of this page. Friday and Saturday " +
+			"requests are not read at all, not down-weighted and not shown in a separate group.",
+		"Each cell is replayed on ONLY its own rows: this account's Sunday–Thursday requests in " +
+			"this one hour of the day, nothing else. Two requests from the same conversation that " +
+			"land in the same hour on different days are treated as consecutive turns with a " +
+			"multi-day gap, which is what this account's traffic in this hour actually looks like.",
+		"BestStrategy is never worse than Baseline: Baseline is itself always a candidate, so a " +
+			"cell where nothing beats it simply recommends keeping it.",
+		"A cell below min_requests still reports every candidate's own numbers; " +
+			"insufficient_data says not to act on it as a pattern.",
+	}
+	return out, nil
+}
+
+// kvSuggestCell replays one (user, hour) cell under every candidate and picks the winner.
+func kvSuggestCell(user string, hour int, rows []*kvcache.Request, candidates []string,
+	baseName string, prices *kvcache.PriceList, cfg KVCacheSimConfig) KVCacheSuggestion {
+	sim := kvcache.Config{Prices: prices, Semantics: cfg.Semantics, PingIdle: cfg.PingIdle,
+		PingIdle1h: cfg.PingIdle1h, MaxPings: cfg.MaxPings}
+
+	byName := map[string]*kvcache.Result{}
+	for _, name := range candidates {
+		s := buildStrategy(name, rows, cfg, sim)
+		if s == nil {
+			continue
+		}
+		byName[name] = kvcache.Simulate(rows, s, sim)
+	}
+	baseline := byName[baseName]
+	if baseline == nil {
+		if s := buildStrategy(baseName, rows, cfg, sim); s != nil {
+			baseline = kvcache.Simulate(rows, s, sim)
+			byName[baseName] = baseline
+		}
+	}
+
+	cell := KVCacheSuggestion{User: user, HourUTC: hour, Requests: int64(len(rows)),
+		InsufficientData: int64(len(rows)) < kvSuggestMinRequests,
+		Baseline:         baseName, Candidates: []kvcache.Savings{}}
+	if baseline == nil {
+		return cell
+	}
+	cell.BaselineUSD = baseline.TotalUSD
+
+	var best kvcache.Savings
+	var bestResult *kvcache.Result
+	haveBest := false
+	for _, name := range candidates {
+		r := byName[name]
+		if r == nil {
+			continue
+		}
+		s := kvcache.Compare(baseline, r)
+		cell.Candidates = append(cell.Candidates, s)
+		if !r.Valued {
+			continue
+		}
+		if !haveBest || s.AbsoluteUSD > best.AbsoluteUSD {
+			best, bestResult, haveBest = s, r, true
+		}
+	}
+	if !haveBest {
+		return cell
+	}
+	cell.BestStrategy = best.Strategy
+	cell.BestDescription = bestResult.Description
+	cell.BestUSD = bestResult.TotalUSD
+	cell.SavingUSD = best.AbsoluteUSD
+	cell.SavingPct = best.PercentUSD
+	cell.SavingKnown = best.Known
+	cell.Valued = baseline.Valued && bestResult.Valued
+	return cell
+}

--- a/dash/kvcachesuggest_test.go
+++ b/dash/kvcachesuggest_test.go
@@ -1,0 +1,242 @@
+package dash
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// findSuggestCell returns the cell for one (user, hour), or nil.
+func findSuggestCell(out *KVCacheSuggestions, user string, hour int) *KVCacheSuggestion {
+	for i := range out.Cells {
+		if out.Cells[i].User == user && out.Cells[i].HourUTC == hour {
+			return &out.Cells[i]
+		}
+	}
+	return nil
+}
+
+// 2023-01-01 is a Sunday, 2023-01-06 a Friday and 2023-01-07 a Saturday — the fixed points every
+// test below is built from, so a reader can check the weekday without running `date` themselves.
+
+// A user whose ENTIRE history in this window is Friday and Saturday must not be read at all:
+// not shown with a lower confidence, not folded into a neighbouring cell, simply absent.
+func TestKVCacheSuggestExcludesFridayAndSaturday(t *testing.T) {
+	sunday10 := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
+	friday10 := time.Date(2023, 1, 6, 10, 0, 0, 0, time.UTC).UnixMilli()
+	saturday11 := time.Date(2023, 1, 7, 11, 0, 0, 0, time.UTC).UnixMilli()
+	db := seedKV(t,
+		kvEvent("weekday-user", "s1", "m", sunday10, 0, 100_000),
+		kvEvent("weekend-user", "s2", "m", friday10, 0, 100_000),
+		kvEvent("weekend-user", "s2", "m", saturday11, 0, 100_000),
+	)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, u := range out.Users {
+		if u == "weekend-user" {
+			t.Fatalf("weekend-user has only Friday/Saturday requests; must not appear: %v", out.Users)
+		}
+	}
+	for _, c := range out.Cells {
+		if c.User == "weekend-user" {
+			t.Errorf("a cell attributes requests to weekend-user: %+v", c)
+		}
+	}
+	c := findSuggestCell(out, "weekday-user", 10)
+	if c == nil {
+		t.Fatal("weekday-user's Sunday request produced no cell")
+	}
+	if c.Requests != 1 {
+		t.Errorf("weekday-user hour 10 requests = %d, want 1", c.Requests)
+	}
+}
+
+// A cell below the request floor still reports every candidate's own numbers — it is not
+// hidden — but is flagged so a caller does not act on a couple of requests as a pattern.
+func TestKVCacheSuggestFlagsInsufficientData(t *testing.T) {
+	base := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli() // Sunday 09:00
+	db := seedKV(t,
+		kvEvent("sparse", "s1", "m", base, 0, 100_000),
+		kvEvent("sparse", "s1", "m", base+120_000, 0, 100_000),
+	)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := findSuggestCell(out, "sparse", 9)
+	if c == nil {
+		t.Fatal("no cell for sparse user, hour 9")
+	}
+	if !c.InsufficientData {
+		t.Errorf("2 requests is below min_requests (%d); got %+v", out.MinRequests, c)
+	}
+	if len(c.Candidates) == 0 {
+		t.Error("a below-floor cell must still report every candidate's own numbers")
+	}
+}
+
+// On gaps that consistently outlive the 5-minute tier's own lifetime, holding the entry with
+// keep-alives (or some other arm) is cheaper than the naive fixed-5m default, which pays a full
+// re-creation on every turn for nothing: this is the case the suggester exists to catch.
+func TestKVCacheSuggestPicksACheaperArmThanTheNaiveBaseline(t *testing.T) {
+	start := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli() // Sunday 09:00
+	var evs []*Event
+	for i := int64(0); i < 6; i++ {
+		evs = append(evs, kvEvent("heavy", "s1", "m", start+i*600_000, 0, 100_000)) // 10 min apart
+	}
+	db := seedKV(t, evs...)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := findSuggestCell(out, "heavy", 9)
+	if c == nil {
+		t.Fatal("no cell for heavy user, hour 9")
+	}
+	if c.InsufficientData {
+		t.Fatalf("6 requests should clear the floor: %+v", c)
+	}
+	if c.Baseline != KVStrategyFixed5m {
+		t.Fatalf("baseline = %q, want the registry's own default %q", c.Baseline, KVStrategyFixed5m)
+	}
+	if c.SavingUSD <= 0 || !c.SavingKnown {
+		t.Errorf("expected some arm to beat fixed-5m on 10-minute gaps over a 100k prefix; "+
+			"saving = %.6f known=%v best=%s", c.SavingUSD, c.SavingKnown, c.BestStrategy)
+	}
+	if c.BestStrategy == KVStrategyFixed5m {
+		t.Error("fixed-5m cannot be the cheapest arm when every gap outlives its own lifetime")
+	}
+	// The winner must be checkable: its own Savings entry is in Candidates, and it agrees with
+	// the top-level fields rather than being a second, driftable copy of them.
+	found := false
+	for _, s := range c.Candidates {
+		if s.Strategy == c.BestStrategy {
+			found = true
+			if s.AbsoluteUSD != c.SavingUSD {
+				t.Errorf("candidate saving %.6f disagrees with the reported best %.6f",
+					s.AbsoluteUSD, c.SavingUSD)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("best strategy %q is not among its own cell's candidates", c.BestStrategy)
+	}
+}
+
+// The suggestion is never worse than doing nothing: on gaps that never come back within any
+// horizon this simulator knows, nothing beats the baseline, and the cell says so rather than
+// picking an arm at random among equally-bad options.
+func TestKVCacheSuggestFallsBackToBaselineWhenNothingWins(t *testing.T) {
+	start := time.Date(2023, 1, 1, 8, 0, 0, 0, time.UTC).UnixMilli() // Sunday 08:00
+	// One request per user per week, same hour: every gap is days long, far past any tier's
+	// lifetime or keep-alive schedule, so caching never pays for itself.
+	var evs []*Event
+	for i := int64(0); i < 5; i++ {
+		evs = append(evs, kvEvent("cold", "s1", "m", start+i*7*24*3600_000, 0, 50_000))
+	}
+	db := seedKV(t, evs...)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := findSuggestCell(out, "cold", 8)
+	if c == nil {
+		t.Fatal("no cell for cold user, hour 8")
+	}
+	if c.BestStrategy != KVStrategyNoCache && c.SavingUSD > 1e-9 {
+		t.Errorf("with no reuse at all, no-cache (or the baseline itself) should win; got "+
+			"best=%s saving=%.6f", c.BestStrategy, c.SavingUSD)
+	}
+}
+
+// A baseline that is a real, buildable arm but not one kvSuggestCandidates() would ever offer
+// on its own — `optimal`, the exact ceiling — must still be IN the comparison, or a cell can
+// report a "best" that costs more than a baseline nothing was ever measured against.
+func TestKVCacheSuggestNeverBeatsAnUnofferedBaseline(t *testing.T) {
+	start := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli() // Sunday 09:00
+	var evs []*Event
+	for i := int64(0); i < 6; i++ {
+		evs = append(evs, kvEvent("heavy", "s1", "m", start+i*600_000, 0, 100_000))
+	}
+	db := seedKV(t, evs...)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{Baseline: KVStrategyOptimal})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Baseline != KVStrategyOptimal {
+		t.Fatalf("baseline = %q, want %q", out.Baseline, KVStrategyOptimal)
+	}
+	c := findSuggestCell(out, "heavy", 9)
+	if c == nil {
+		t.Fatal("no cell for heavy user, hour 9")
+	}
+	if c.SavingUSD < 0 {
+		t.Errorf("nothing can beat the exact ceiling; saving must be 0, got %.6f (best=%s)",
+			c.SavingUSD, c.BestStrategy)
+	}
+	foundBaseline := false
+	for _, s := range c.Candidates {
+		if s.Strategy == KVStrategyOptimal {
+			foundBaseline = true
+			if s.AbsoluteUSD != 0 {
+				t.Errorf("the baseline's own saving against itself must be exactly 0, got %.6f",
+					s.AbsoluteUSD)
+			}
+		}
+	}
+	if !foundBaseline {
+		t.Error("the baseline itself is not among its own cell's candidates")
+	}
+}
+
+// An unresolvable baseline must fail the whole request, the same way it fails
+// /api/kvcache/simulate — not degrade into a 200 full of empty cells.
+func TestKVCacheSuggestRejectsAnUnknownBaseline(t *testing.T) {
+	db := seedKV(t, kvEvent("t", "s", "m", kvBase, 0, 100_000))
+	_, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{Baseline: "not-a-real-strategy"})
+	if err == nil {
+		t.Fatal("an unknown baseline must be an error, not a silently-empty result")
+	}
+	if !strings.Contains(err.Error(), "unknown baseline strategy") {
+		t.Errorf("error = %q, want it to name the baseline as unknown (matching KVCacheSimulate's "+
+			"own wording, which kvCacheSuggest's handler string-matches for its 400)", err.Error())
+	}
+}
+
+// The HTTP route must map that same error to 400, exactly as /api/kvcache/simulate does.
+func TestKVCacheSuggestRouteRejectsAnUnknownBaselineAs400(t *testing.T) {
+	a, rec := newTestAPI(t, Options{})
+	seed(t, rec, kvEvent("", "s", "m", kvBase, 0, 100_000))
+	w, _ := get(t, a, "/api/kvcache/suggest?baseline=not-a-real-strategy", "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("/api/kvcache/suggest?baseline=bogus = %d, want %d: %s",
+			w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// Every route this page mounts must answer, and this one specifically must not regress into
+// panicking on the empty-candidate or empty-window path.
+func TestKVCacheSuggestRouteAnswersOnRealData(t *testing.T) {
+	a, rec := newTestAPI(t, Options{})
+	sunday9 := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli()
+	seed(t, rec, kvEvent("", "s", "m", sunday9, 0, 100_000))
+	w, body := get(t, a, "/api/kvcache/suggest", "")
+	if w.Code != 200 {
+		t.Fatalf("/api/kvcache/suggest = %d: %s", w.Code, w.Body.String())
+	}
+	if body == nil {
+		t.Fatal("/api/kvcache/suggest served no JSON object")
+	}
+	if _, ok := body["cells"]; !ok {
+		t.Errorf("response has no \"cells\" key: %v", body)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new read, `KVCacheSuggest` (mounted at `GET /api/kvcache/suggest`), that sweeps the
KV-cache page's own strategy registry per **(user, hour-of-day)** cell and reports which arm
would have cost the least, replaying only that account's own **Sunday-Thursday** history in
that one hour.

This is a first cut at turning the KV-cache page's simulator into a per-account recommendation
rather than a whole-window comparison - one entry per user per hour of the day, with the
possible dollar saving against the baseline for that specific slice of history.

## How it works

- **Candidates are derived, not hardcoded.** `kvSuggestCandidates()` reuses `KVCacheArms()` -
  the same probe the picker already uses - filtered to arms that are both reachable and
  buildable from a name (drops `optimal`, `replay`, and `custom`). A strategy added to the
  registry becomes a candidate the day it lands, with nothing here to update - the same reason
  the picker itself is registry-driven rather than a second, driftable list of arm names.
- **Friday and Saturday requests are excluded outright**, not down-weighted and not folded into
  a separate group: the work week's traffic shape should not be informed by the weekend's.
- **Each (user, hour) cell replays `kvcache.Simulate` on only its own rows.** `Simulate` derives
  a conversation's gaps from whatever slice of requests it is handed (it does not read the
  dataset's own precomputed `HasNext`/`IdleMs`/`NextTS`), so handing it one cell's own rows is a
  real replay of exactly that population, not an approximation bolted onto the simulator.
- **A 5-request floor** flags a cell as `insufficient_data` rather than hiding it - every
  candidate's own numbers are still reported below the floor, so nothing is silently withheld.
- **The baseline is always folded into the comparison set**, even one an operator names
  explicitly that the picker would not offer on its own (e.g. `optimal`, to see the exact
  ceiling) - otherwise a cell could report a "best" that costs more than a baseline it was
  never measured against. An unresolvable baseline now fails the whole request up front with
  the same `"unknown baseline strategy"` error `/api/kvcache/simulate` uses, mapped to 400 by
  the route the same way.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./dash/... ./kvcache/...`
- [x] `gofmt -l` clean on all touched files
- [x] `go test ./dash/... ./kvcache/...` - full suite green
- [x] New tests cover: Friday/Saturday exclusion, the insufficient-data floor, a case where a
      keep-alive arm beats the naive fixed-5m default (verified by hand-tracing the ping
      schedule), a case where the baseline is already optimal, cross-checking the winner
      against its own candidate row, an operator-chosen baseline the picker wouldn't offer on
      its own (`optimal`) never being beaten, an unknown baseline being rejected end to end
      (`KVCacheSuggest` error -> HTTP 400), and the route answering on both an empty and a
      populated database.
- [x] Ran ad hoc against a live snapshot of production traffic (67.8k requests / 17 users over
      ~9 days) to sanity-check the output shape and magnitude before opening this PR.