### PR TITLE
fix(dash): stop /metrics hanging on an unchecked WAL backlog

### DIFF
--- a/dash/janitor.go
+++ b/dash/janitor.go
@@ -50,6 +50,18 @@ func (r *Recorder) janitorPass() {
 		slog.Info("dash: pruned old dashboard rows", "requests", n)
 	}
 	r.relieveDiskPressure()
+	// Checkpoint on every pass, not only as reclaim()'s side effect of an actual
+	// deletion above: a deployment comfortably inside its retention budget never
+	// deletes anything, so without this the WAL was left to grow until SQLite's own
+	// default wal_autocheckpoint (1000 pages) forced an inline checkpoint on an
+	// ordinary writer commit — paying off the WHOLE accumulated backlog inside that
+	// one commit. Measured against a WAL bloated to the production scale (~40k
+	// pages): that single commit took 5.5s, and a concurrent reader sharing this
+	// *sql.DB (e.g. /metrics) blocked for the same 5.2s — this driver does not give
+	// non-blocking WAL reads across a commit. Checkpointing here, every
+	// pruneInterval, keeps the backlog small enough that neither this call nor
+	// SQLite's own auto-checkpoint in between is ever slow.
+	r.db.checkpoint()
 }
 
 // diskWatermarks resolves the configured watermarks, applying defaults and

--- a/dash/janitor_checkpoint_test.go
+++ b/dash/janitor_checkpoint_test.go
@@ -1,0 +1,161 @@
+package dash
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestJanitorPassCheckpointsWAL guards the /metrics hang: janitorPass must checkpoint
+// the WAL on every pass, not only as a side effect of an actual retention deletion.
+// A deployment comfortably inside its retention budget never deletes anything, so
+// without an unconditional checkpoint here the WAL is left to grow until SQLite's own
+// default wal_autocheckpoint (1000 pages) forces an inline checkpoint on an ordinary
+// writer commit — which pays off the whole accumulated backlog inside that commit and
+// blocks any reader sharing this *sql.DB (this driver gives no non-blocking WAL reads
+// across it) for as long as that checkpoint takes.
+func TestJanitorPassCheckpointsWAL(t *testing.T) {
+	path := t.TempDir() + "/janitor.db"
+	rec, err := NewRecorder(Options{
+		DBPath: path,
+		// Generous retention on purpose: this reproduces a healthy deployment that
+		// never hits Prune's delete path, the case the old code silently depended on
+		// reclaim() for and never got.
+		RetentionAge:   365 * 24 * time.Hour,
+		RetentionBytes: 10 << 30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close()
+
+	// Build up a non-trivial WAL directly against the store, bypassing the async
+	// writer so the test controls exactly how much has accumulated before checking.
+	if _, err := rec.db.sql.Exec(`PRAGMA wal_autocheckpoint=0`); err != nil {
+		t.Fatal(err)
+	}
+	blob := make([]byte, 4096)
+	for b := 0; b < 40; b++ {
+		tx, err := rec.db.sql.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt, err := tx.Prepare(`INSERT INTO requests(ts, tenant_id, session_id, model) VALUES (?,?,?,?)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 100; i++ {
+			if _, err := stmt.Exec(time.Now().UnixMilli(), "t1", "s1", string(blob[:8])); err != nil {
+				t.Fatal(err)
+			}
+		}
+		stmt.Close()
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := rec.db.sql.Exec(`PRAGMA wal_autocheckpoint=1000`); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.Stat(path + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const bloatFloor = 200 << 10 // 200KB: proves the setup actually built up a WAL worth checkpointing
+	if before.Size() < bloatFloor {
+		t.Fatalf("test setup did not bloat the WAL enough to be meaningful: %d bytes", before.Size())
+	}
+
+	rec.janitorPass()
+
+	after, err := os.Stat(path + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("WAL size before janitorPass: %d bytes, after: %d bytes", before.Size(), after.Size())
+	const wantMax = 64 << 10 // small: a checkpoint just ran and truncated it
+	if after.Size() > wantMax {
+		t.Fatalf("janitorPass left the WAL at %d bytes (want <= %d): it did not checkpoint on a pass with nothing to prune",
+			after.Size(), wantMax)
+	}
+}
+
+// TestOpenCheckpointsInheritedWAL guards the other half of the /metrics hang: a
+// process that inherits an already-bloated WAL from a PREVIOUS run (a restart, not a
+// clean shutdown -- SQLite's own auto-checkpoint-on-close never got a chance to run)
+// must not leave that backlog sitting unpaid, silently, for whatever query or commit
+// happens to touch it first. Open must checkpoint it proactively.
+func TestOpenCheckpointsInheritedWAL(t *testing.T) {
+	path := t.TempDir() + "/inherited.db"
+
+	// Simulate the previous process: open plainly (bypassing Open/NewRecorder),
+	// disable autocheckpoint, write enough to build a non-trivial WAL, then close
+	// WITHOUT letting SQLite's own close-time auto-checkpoint run -- Close() on a
+	// clean *sql.DB does exactly that, which is not what an abrupt restart leaves
+	// behind, so a bare low-level connection is used instead and simply abandoned.
+	sdb, err := sql.Open("sqlite", dsn(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An unrelated table, not "requests": this connection is deliberately opened
+	// without going through Open/migrate, so it must not collide with the schema
+	// migrate() expects to find once the real Open below runs against this file.
+	if _, err := sdb.Exec(`CREATE TABLE bloat_probe(id INTEGER PRIMARY KEY, tenant_id TEXT, ts INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sdb.Exec(`PRAGMA wal_autocheckpoint=0`); err != nil {
+		t.Fatal(err)
+	}
+	for b := 0; b < 30; b++ {
+		tx, err := sdb.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt, err := tx.Prepare(`INSERT INTO bloat_probe(tenant_id, ts) VALUES (?, ?)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 200; i++ {
+			if _, err := stmt.Exec("t1", time.Now().UnixMilli()); err != nil {
+				t.Fatal(err)
+			}
+		}
+		stmt.Close()
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Deliberately never sdb.Close(): SQLite auto-checkpoints when the LAST
+	// connection to a WAL database closes cleanly, which is exactly what an abrupt
+	// process restart (systemd SIGTERM/SIGKILL) does not get a chance to do. The
+	// leaked connection is harmless -- this process exits at the end of the test.
+
+	before, err := os.Stat(path + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const bloatFloor = 200 << 10
+	if before.Size() < bloatFloor {
+		t.Skipf("test setup did not bloat the WAL enough to be meaningful (%d bytes); SQLite's own close-time checkpoint likely folded it in, which is exactly the case this test cannot exercise", before.Size())
+	}
+
+	// The fresh open a restarted process performs.
+	db, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	after, err := os.Stat(path + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("WAL size before Open: %d bytes, after: %d bytes", before.Size(), after.Size())
+	const wantMax = 64 << 10
+	if after.Size() > wantMax {
+		t.Fatalf("Open left an inherited WAL at %d bytes (want <= %d): it did not checkpoint the backlog left by the previous process",
+			after.Size(), wantMax)
+	}
+}

--- a/dash/store.go
+++ b/dash/store.go
@@ -105,6 +105,20 @@ func Open(path string) (*DB, error) {
 		}
 	}
 	db, err := openDSN(dsn(path), path)
+	if err == nil {
+		// A fresh boot inherits whatever WAL the PREVIOUS process left on disk, and
+		// nothing before this point ever checkpoints it: reclaim() only runs from the
+		// byte-budget path, which a deployment inside its retention budget never
+		// takes. Left alone, the first ordinary write past SQLite's own
+		// wal_autocheckpoint threshold (1000 pages) checkpoints the WHOLE inherited
+		// backlog inline, on the writer's own commit — measured against a WAL bloated
+		// to production scale, that single commit took 5.5s, and every reader sharing
+		// this *sql.DB (e.g. /metrics) blocked for the same span, reproducing on a
+		// cold restart with no other traffic at all. Checkpointing once here, before
+		// any traffic is served, pays that backlog down up front instead of on the
+		// first request that happens to land on it.
+		db.checkpoint()
+	}
 	var mismatch *versionMismatch
 	if errors.As(err, &mismatch) {
 		aside := fmt.Sprintf("%s.v%s.bak", path, sanitizeVersion(mismatch.have))


### PR DESCRIPTION
## Summary

/metrics has been hanging for 15s+ with zero bytes returned, reproducing cold
on a fresh restart with no other traffic. PR #108 fixed the promCache mutex
and two slow queries (`CompactionResets`, `SelfRemovals`), but a third
mechanism was still live:

`dash/store.go` only ever checkpoints the WAL from `reclaim()`, which only
runs as a side effect of `Prune()` actually deleting rows on the byte-budget
path. A deployment comfortably inside its retention budget — this one —
never takes that path, so nothing checkpoints the WAL during ordinary
operation.

Left alone, the WAL grows until SQLite's own default `wal_autocheckpoint`
(1000 pages) forces an inline checkpoint on an ordinary writer commit, paying
off the *whole* accumulated backlog inside that one commit. `modernc.org/sqlite`
gives no non-blocking WAL reads across it, so every reader sharing that
`*sql.DB` — including /metrics's per-tenant query — blocks for the same span.
Measured against a WAL bloated to the live scale (~40k pages / ~160MB, the
same order of magnitude observed on `cg.db-wal`): that single commit took
5.5s, and a concurrent reader blocked for 5.2s.

A restart inherits whatever WAL the previous process left on disk (SQLite's
close-time auto-checkpoint never gets a chance to run against a systemd
SIGTERM/SIGKILL), so the same cost lands again on the very first write after
a cold start — which is why this reproduced on two separate fresh restarts
with zero concurrent traffic. Reproduced end-to-end with a real binary and
curl: a fresh process opening a synthetically bloated WAL (matching
production's ~150k-row scale) returned zero bytes after a 15s timeout before
this fix, and answered in under a second after it.

## Fix

Two checkpoints close the gap, both best-effort like the existing one in
`reclaim()`:

- Once in `Open()`, so a restart pays down whatever backlog it inherited
  before serving any traffic, instead of deferring that cost to the first
  request or commit that happens to land on it.
- Once every `janitorPass` (every `pruneInterval`, unconditionally — not only
  when `Prune` found something to delete), so the WAL never re-accumulates to
  this size while the process stays up between `reclaim()` runs.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes across the whole repo
- [x] Added `TestOpenCheckpointsInheritedWAL` and
      `TestJanitorPassCheckpointsWAL` — both fail against the pre-fix code
      (WAL stays large) and pass against the fix (checkpointed to near zero)
- [x] Built the proxy binary in an isolated worktree, pointed it at a
      synthetic (never production) database bloated to production scale,
      and confirmed with `curl -m 15`:
      - before this fix: `http_code=000 size=0` after the full 15s timeout
      - after this fix: `http_code=200` in well under a second