### PR TITLE
fix(dash): cache /api/components like /api/stats and /api/facets

### DIFF
--- a/dash/api.go
+++ b/dash/api.go
@@ -38,12 +38,15 @@ type API struct {
 	tenantCapture func(tenantID string) bool
 	// pricer values the pre-instrumentation split figure on read. nil = that figure is omitted.
 	pricer modelinfo.Pricer
-	// statsCache and facetsCache hold the last rendered body per (principal, query), briefly.
-	// Overview alone measured 25s under real production write load (many sequential queries,
-	// each one a chance to queue behind the writer), and this endpoint has NO other cache — a
-	// dashboard tab left auto-refreshing, or two managers looking at the same window, each cost
-	// another full 25s+ read rather than getting the answer the last one just computed.
-	statsCache, facetsCache jsonCache
+	// statsCache, facetsCache and componentsCache hold the last rendered body per
+	// (principal, query), briefly. Overview alone measured 25s under real production write
+	// load (many sequential queries, each one a chance to queue behind the writer), and
+	// these endpoints had NO other cache — a dashboard tab left auto-refreshing, or two
+	// managers looking at the same window, each cost another full read rather than getting
+	// the answer the last one just computed. components was missed by the original fix:
+	// its own 5 queries (Components, DecomposeComponentSavedUSD, EstimateComponentSavedUSD)
+	// measured ~4.4s cold on a comparable corpus, uncached, on the dashboard's most-read tab.
+	statsCache, facetsCache, componentsCache jsonCache
 }
 
 // dashCacheTTL bounds how stale a cached /api/stats or /api/facets body may be. Short enough
@@ -864,9 +867,15 @@ func (a *API) sessions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) components(w http.ResponseWriter, r *http.Request) {
-	f, _, ok := a.scope(r)
+	f, p, ok := a.scope(r)
 	if !ok {
 		unauthorized(w)
+		return
+	}
+	key := cacheKey(p, r)
+	if body, ok := a.componentsCache.get(key); ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
 		return
 	}
 	rows, err := a.rec.DB().Components(f)
@@ -892,7 +901,14 @@ func (a *API) components(w http.ResponseWriter, r *http.Request) {
 				"err", err)
 		}
 	}
-	writeJSON(w, map[string]any{"components": rows})
+	body, err := json.Marshal(map[string]any{"components": rows})
+	if err != nil {
+		httpErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	a.componentsCache.set(key, body)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(body)
 }
 
 // breakdown serves spent-vs-saved and usage aggregated by ONE dimension — per model, per

--- a/dash/componentscache_test.go
+++ b/dash/componentscache_test.go
@@ -1,0 +1,57 @@
+package dash
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestComponentsCached guards the fix: /api/components had no cache at all (unlike
+// /api/stats and /api/facets), so every load re-ran all five of its queries cold —
+// measured ~4.4s on a corpus matching production scale. A second call within
+// dashCacheTTL must be served from cache, not re-run against the store: seed one
+// component row, read it, seed a second, and confirm the immediate re-read still
+// reports only the first (the cached body), while a read past the TTL sees both.
+func TestComponentsCached(t *testing.T) {
+	a, rec := newTestAPI(t, Options{})
+	e := mkEvent(time.Now().UnixMilli(), "sess-1", "aws/claude-sonnet-5", 1000, 800)
+	e.Components = []CompRow{{Component: "toon", Kind: "reformat", Acted: true}}
+	seed(t, rec, e)
+
+	w, body := get(t, a, "/api/components", "127.0.0.1:1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("first call: %d %s", w.Code, w.Body.String())
+	}
+	rows, _ := body["components"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("first call: got %d component rows, want 1", len(rows))
+	}
+
+	// Seed a second, distinct component. A cache HIT must not see it yet.
+	e2 := mkEvent(time.Now().UnixMilli(), "sess-2", "aws/claude-sonnet-5", 1000, 800)
+	e2.Components = []CompRow{{Component: "cachesplit", Kind: "reformat", Acted: true}}
+	seed(t, rec, e2)
+
+	_, body = get(t, a, "/api/components", "127.0.0.1:1")
+	rows, _ = body["components"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("second call within the TTL: got %d component rows, want 1 (cached) -- the cache did not hit", len(rows))
+	}
+
+	// Past the TTL, the same call must see the fresh data. Single-tenant scope() always
+	// returns Principal{Manager: true} (see API.scope), so cacheKey's own rule gives a
+	// deterministic key to backdate.
+	key := cacheKey(Principal{Manager: true}, httptest.NewRequest(http.MethodGet, "/api/components", nil))
+	a.componentsCache.mu.Lock()
+	entry := a.componentsCache.entries[key]
+	entry.at = time.Now().Add(-dashCacheTTL - time.Second)
+	a.componentsCache.entries[key] = entry
+	a.componentsCache.mu.Unlock()
+
+	_, body = get(t, a, "/api/components", "127.0.0.1:1")
+	rows, _ = body["components"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("call past the TTL: got %d component rows, want 2 (fresh)", len(rows))
+	}
+}


### PR DESCRIPTION
## Summary

The Components page has been "loading forever." `/api/components` had no
cache at all — PR #108 added the 5s TTL `jsonCache` to `/api/stats` and
`/api/facets`, but missed this one, so the dashboard's most-read tab re-ran
all five of its queries (`Components`, `DecomposeComponentSavedUSD`,
`EstimateComponentSavedUSD`) cold on every single load.

Measured on a corpus matching production scale (70k requests x 7
components, 490k `request_components` rows, all properly indexed — this is
not a missing-index or N+1 bug):

```
Components():                    1.36s
DecomposeComponentSavedUSD():    2.21s
EstimateComponentSavedUSD():     0.87s
TOTAL, cold, every load:         4.44s
```

A tab left auto-refreshing, or two managers on the same window, each paid
that ~4.4s independently — the exact "piling up under load" pattern #108
already fixed everywhere else on this endpoint's neighbors.

(The Overview page's "sometimes a few minutes" report is the WAL-checkpoint
mechanism fixed separately in #115 — Overview shares the same `*sql.DB` with
the writer that /metrics does. Not re-fixed here.)

## Fix

Added `componentsCache` alongside the existing `statsCache`/`facetsCache`
and wrapped `a.components` the same way `a.stats` already wraps `Overview`.
No new abstraction, no query changes.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes across the whole repo
- [x] Added `TestComponentsCached` — does not even compile against the
      pre-fix code (no `componentsCache` field) and passes against the fix