### PR TITLE
feat(extract_llm): never ask the model to transport text while sweeping history

### DIFF
--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -226,6 +226,27 @@ const (
 	unknownModelInputLimit = 32768
 )
 
+// nonTransportingStrategies are the strategies that never hand tool-output text back THROUGH the
+// model: `code` has it write a Starlark program executed against the real text, and
+// `deterministic` makes no model call at all. `single` (returns the selected JSON) and `rlm`
+// (returns selected content per chunk) are the transporting ones, and are what a sweep excludes.
+//
+// `auto` is deliberately absent rather than filtered: it is a strategy ORDER, and
+// extract.intersectAllowed narrows the order it produces, so an `auto` configuration still resolves
+// — to code, then deterministic — instead of being emptied.
+var nonTransportingStrategies = []string{"code", "deterministic"}
+
+// transportsText reports whether a configured strategy would have asked the model to reproduce
+// content, so narrowing it can be counted rather than applied silently. `auto` counts, because its
+// first pick on a large body — the sweep case — is `rlm`.
+func transportsText(strategy string) bool {
+	switch strategy {
+	case "single", "rlm", "auto":
+		return true
+	}
+	return false
+}
+
 // staticWindows is the last-resort model→window table modelinfo already maintains. Held as
 // a package var because DefaultStatic allocates.
 var staticWindows = modelinfo.DefaultStatic()
@@ -823,6 +844,37 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 	extCfg.Aggressiveness = e.aggro
 	if e.maxChars > 0 {
 		extCfg.MaxChars = e.maxChars
+	}
+	// NEVER ASK THE MODEL TO TRANSPORT TEXT WHILE SWEEPING HISTORY.
+	//
+	// This is the per-output form of removing the merged design's `trim` verdict, and it rests on
+	// the same measurement: trim was chosen zero times in 21 probe opportunities, metrics were
+	// identical without it, and in production it was accepted ONCE against EIGHT rejected as
+	// invented. It was the only verdict that asked the model to transport text, which is what it
+	// is worst at.
+	//
+	// The strategies divide the same way. `code` and `deterministic` produce a PROGRAM (or a
+	// deterministic projection) that is executed against the real text, so nothing is transported
+	// and nothing can be invented. `single` returns the selected JSON and `rlm` returns selected
+	// content per chunk — both hand the content back through the model, which is the transporting
+	// shape trim was removed for.
+	//
+	// Restricted on the SWEEP specifically, for two compounding reasons. `strategy: auto` orders
+	// `rlm` ahead of `code` once a body is large, and large bodies are exactly what a sweep works
+	// on — so the transporting mode is not a corner case here, it is the default pick. And a sweep
+	// rewrites content DEEP IN HISTORY that the model has already reasoned about, so an invention
+	// contradicts the transcript rather than just degrading one recent tool result.
+	//
+	// The exclusion is COUNTED, not silent, which is the half of the trim change that is easy to
+	// lose: there a model answering `trim` degraded to `keep` and was counted, because an unjudged
+	// output is otherwise indistinguishable from silence. Here a configuration whose strategy was
+	// narrowed is recorded, so "the operator asked for rlm and got code" never looks like "the
+	// operator asked for code".
+	if sweeping {
+		extCfg.AllowedStrategies = nonTransportingStrategies
+		if transportsText(e.strategy) {
+			rep.Gate("sweep_strategy_narrowed")
+		}
 	}
 
 	// Keep-ids are harvested from the AGENT's OWN WORDS, never from the tool outputs — even

--- a/components/offload/extract_sweep_strategy_test.go
+++ b/components/offload/extract_sweep_strategy_test.go
@@ -1,0 +1,110 @@
+package offload
+
+import (
+	"testing"
+
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/internal/extract"
+)
+
+// The narrowing must apply on a SWEEP and not on a warm turn, and it must be COUNTED rather than
+// silent — the half of the trim change that is easy to lose, since there a model answering `trim`
+// degraded to `keep` and was counted, because an unjudged output is otherwise indistinguishable
+// from silence. Here, "the operator asked for rlm and got code" must not look like "the operator
+// asked for code".
+//
+// Both arms use the SAME `strategy: rlm` config and differ only in whether the prompt cache is
+// cold, so this asserts the sweep condition rather than something general about rlm.
+func TestSweepNarrowsATransportingStrategyAndCountsIt(t *testing.T) {
+	const yaml = "strategy: rlm\neconomic_gate: false\nmin_tokens: 1\n" +
+		"cold_cache:\n  enabled: true\n  min_tokens: 1\n"
+	for _, cold := range []bool{false, true} {
+		name := "warm"
+		if cold {
+			name = "cold sweep"
+		}
+		t.Run(name, func(t *testing.T) {
+			comp, err := newExtractLLM([]byte(yaml))
+			if err != nil {
+				t.Fatalf("config: %v", err)
+			}
+			e := comp.(*ExtractLLM)
+			rep := components.Report{}
+			if _, err := e.Offload(coldReq(), &rep,
+				coldCtx("s", cold, 600_000, &silentModel{})); err != nil {
+				t.Fatalf("offload: %v", err)
+			}
+			got := rep.Gates["sweep_strategy_narrowed"]
+			if cold && got == 0 {
+				t.Errorf("a sweep configured with a transporting strategy must record "+
+					"sweep_strategy_narrowed; gates=%v", rep.Gates)
+			}
+			if !cold && got != 0 {
+				t.Errorf("a warm turn must not narrow the strategy, got %d; gates=%v",
+					got, rep.Gates)
+			}
+		})
+	}
+}
+
+// The strategy split that makes the restriction meaningful: a sweep must never select a strategy
+// that hands tool-output text back THROUGH the model.
+//
+// This is the per-output form of removing the merged design's `trim` verdict, and rests on the same
+// measurement — trim was chosen zero times in 21 probe opportunities, metrics were identical
+// without it, and in production it was accepted once against eight rejected as invented, because it
+// was the only verdict that asked the model to transport text.
+func TestNonTransportingStrategiesExcludeTheReproducingOnes(t *testing.T) {
+	transporting := map[string]bool{"single": true, "rlm": true}
+	for _, s := range nonTransportingStrategies {
+		if transporting[s] {
+			t.Errorf("%q transports text and must not be allowed while sweeping", s)
+		}
+	}
+	// The list must not be empty of the one strategy that can actually compact with a model:
+	// narrowing to deterministic alone would silently turn a sweep into a no-LLM projection.
+	var hasCode bool
+	for _, s := range nonTransportingStrategies {
+		if s == "code" {
+			hasCode = true
+		}
+	}
+	if !hasCode {
+		t.Error("`code` must remain allowed: it is the only model-driven strategy that does not " +
+			"transport text, and without it a sweep degrades to a deterministic projection")
+	}
+	// `auto` must be absent rather than filtered: it is an ORDER, and intersectAllowed narrows the
+	// order it produces. Listing it would allow the transporting modes back in.
+	for _, s := range nonTransportingStrategies {
+		if s == "auto" {
+			t.Error("`auto` must not appear in the allow-list: it resolves to an order that " +
+				"includes rlm and single")
+		}
+	}
+}
+
+// transportsText decides whether narrowing gets COUNTED, so it must classify `auto` as
+// transporting: auto's first pick on a large body is `rlm`, and large bodies are the sweep case.
+// Getting this wrong makes the narrowing silent for the configuration where it matters most.
+func TestTransportsTextClassifiesEveryStrategy(t *testing.T) {
+	want := map[string]bool{
+		"code": false, "deterministic": false,
+		"single": true, "rlm": true, "auto": true,
+	}
+	// Every strategy the engine accepts must be classified, or a new one silently defaults to
+	// "does not transport" and its narrowing goes uncounted.
+	for _, m := range extract.Modes {
+		w, ok := want[m]
+		if !ok {
+			t.Fatalf("strategy %q is accepted by the engine but unclassified here; decide "+
+				"whether it transports text", m)
+		}
+		if got := transportsText(m); got != w {
+			t.Errorf("transportsText(%q) = %v, want %v", m, got, w)
+		}
+	}
+	if len(want) != len(extract.Modes) {
+		t.Errorf("classification covers %d strategies, engine accepts %d — the two must agree",
+			len(want), len(extract.Modes))
+	}
+}


### PR DESCRIPTION
Ports the reasoning behind removing the merged design's `trim` verdict (`cc1aa9f`, on
`feat/coref-compaction`) to the per-output path that `main` actually ships, and applies it where
it matters most: the cold-cache sweep.

## The principle, transferred

`cc1aa9f` removed `trim` because it was **the only verdict that asked the model to transport
text**, on this evidence: chosen zero times in 21 probe opportunities, metrics identical without
it, and in production accepted **once against eight rejected as invented**.

There is no `trim` verdict on `main` — it belongs to the merged contract, where one call disposes
of many outputs and needs a word per output. But the same division exists in the per-output
strategies, and nothing had drawn the line:

| Strategy | What the model returns | Transports text |
|---|---|---|
| `code` | a Starlark program, executed against the real text | no |
| `deterministic` | nothing — no model call | no |
| `single` | the selected JSON | **yes** |
| `rlm` | selected content, per chunk | **yes** |

A sweep now allows only the first group.

## Why the sweep specifically

Two reasons that compound:

- **`strategy: auto` orders `rlm` ahead of `code` once a body is large**, and large bodies are
  precisely what a sweep works on. So on a sweep the transporting mode is not a corner case, it is
  the default pick.
- **A sweep rewrites content deep in history** that the model has already reasoned about. An
  invention there contradicts the transcript, rather than degrading one recent tool result.

## Two details taken from the original rather than invented

**The narrowing is counted** (`sweep_strategy_narrowed`). This is the half of the trim change
that is easy to lose: there, a model answering `trim` degraded to `keep` *and was counted*,
because an unjudged output is otherwise indistinguishable from silence. Here, "the operator asked
for `rlm` and got `code`" must not read as "the operator asked for `code`".

**`auto` is excluded by absence, not by filtering.** It is a strategy *order*, and
`extract.intersectAllowed` narrows the order it produces — so an `auto` configuration still
resolves, to `code` then `deterministic`, instead of being emptied and failing open to no
compaction at all.

## Verification

Three tests. Two pin the classification against `extract.Modes`, the engine's own list of accepted
strategies, so a strategy added later cannot silently default to "does not transport" and have its
narrowing go uncounted. The third runs **one** `strategy: rlm` config over two turns that differ
*only* in whether the prompt cache is cold, so it asserts the sweep condition rather than
something general about `rlm`.

Verified by removing the narrowing: the cold arm fails with `gates=map[]`, the warm arm still
passes. Full suite: 27 packages, 0 failures, `gofmt` clean. No benchmarks run.

## Intentionally not in this PR

**Splitting `extract_llm` into `extract_llm` + `extract_llm_sweep`.** Agreed as the better design
and scoped, but it is a config-surface migration and belongs in its own PR. The sweep already
diverges from the tail path in nine places — its own floor (`cold_cache.min_tokens` replaces
`min_tokens`), its own call cap, cadence gate exempted, pressure trigger exempted, request trigger
exempted, cached-prefix tail gate bypassed, `skip_file_reads` auto-mode inverted, model escalation
on prompt overflow, and serialised cache-write ordering. That is two components sharing one config
struct, and `per_output: false` plus the *"leaves the component with nothing to do"* error is the
seam showing.

When that lands, a transporting `strategy` under `extract_llm_sweep` should become a **config-time
error** rather than a runtime narrowing — strictly better feedback. The narrowing here then
becomes defence-in-depth, following the precedent set in `2d6902d`, which kept
`dropOrphanedToolResults` "as a defensive net rather than the primary mechanism."

**Whether the sweep's `rewrite` should default to `false`** (verified deletion-only containment
rather than the `derivationRatio` backstop). It is the adjacent question — proof *strength* rather
than text *transport* — and it would reduce sweep savings by an amount only measurement can
establish, so it is deliberately unchanged here.
