### PR TITLE
fix(dash): compute CachesplitHistoricalUSD once for every tenant, not once per tenant

### DIFF
--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -657,18 +657,16 @@ func (a tenantMetricsAdapter) TenantMetrics(since int64) ([]proxy.TenantMetricRo
 		return nil, err
 	}
 	// The pre-instrumentation split figure, per tenant, priced here because this is the layer
-	// that holds the rates. One query per tenant rather than one for all of them: the figure is
-	// scoped by tenant everywhere else it appears, and a shared query would have to be
-	// re-grouped anyway. Best-effort — a tenant it cannot value reports 0 for that metric only.
+	// that holds the rates. One query for every tenant, not one per tenant — see
+	// DB.CachesplitHistoricalUSDByTenant for why a query per tenant re-paid the same
+	// whole-table sort N times over. Best-effort — a query failure here zeroes this metric
+	// for every tenant rather than failing the whole scrape.
 	hist := map[string]float64{}
 	if a.prices != nil {
-		for _, r := range rows {
-			h, err := a.rec.DB().CachesplitHistoricalUSD(
-				dash.Filter{Since: since, Tenant: r.TenantID}, a.prices)
-			if err != nil {
-				continue // per tenant, as the comment above promises: break zeroed every tenant after this one
+		if byTenant, err := a.rec.DB().CachesplitHistoricalUSDByTenant(since, a.prices); err == nil {
+			for tid, h := range byTenant {
+				hist[tid] = h.USD
 			}
-			hist[r.TenantID] = h.USD
 		}
 	}
 	out := make([]proxy.TenantMetricRow, 0, len(rows))

--- a/dash/cachecost_test.go
+++ b/dash/cachecost_test.go
@@ -599,6 +599,56 @@ func TestHistoricalSplitValuationIsReadOnlyAndConservative(t *testing.T) {
 	}
 }
 
+// TestHistoricalSplitValuationByTenantMatchesPerTenant is the equivalence check that makes
+// the grouped query safe: it must return, for every tenant, exactly what calling
+// CachesplitHistoricalUSD once per tenant would — the whole point of computing the
+// session-first ranking once is that grouping it afterward changes nothing about the
+// answer. Two tenants, each with a multi-request session, so a bug that let a mid-session
+// row through (or leaked one tenant's rows into another's total) would show up here.
+func TestHistoricalSplitValuationByTenantMatchesPerTenant(t *testing.T) {
+	db := openTestDB(t)
+	const stable = 5697
+	mk := func(tenant, sess string, ts int64, read, write int64, stableTok int) *Event {
+		e := &Event{TS: ts, TenantID: tenant, SessionID: sess, Model: "aws/claude-sonnet-5",
+			TokensBefore: 100, TokensAfter: 100, FreshInput: 10, CacheRead: read, CacheWrite: write,
+			OutputTokens: 20, SplitStableTokens: stableTok}
+		e.Price(ibmSonnet, true)
+		return e
+	}
+	evs := []*Event{
+		mk("t-x", "s-new", 5000, 54_304, 1_000, stable), // teaches the stable half
+		// t-x: session-first qualifies, second request in the same session must not.
+		mk("t-x", "s-a", 1000, 54_304, 1_000, 0),
+		mk("t-x", "s-a", 1100, 55_000, 900, 0),
+		// t-y: a single session-first request of its own — must not be counted against t-x.
+		mk("t-y", "s-b", 1200, 54_304, 1_000, 0),
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	pricer := staticPricer{ibmSonnet}
+	grouped, err := db.CachesplitHistoricalUSDByTenant(0, pricer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tenant := range []string{"t-x", "t-y"} {
+		want, err := db.CachesplitHistoricalUSD(Filter{Tenant: tenant}, pricer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := grouped[tenant]
+		if got != want {
+			t.Errorf("tenant %s: grouped = %+v, per-tenant call = %+v", tenant, got, want)
+		}
+	}
+	if got := grouped["t-x"].Requests; got != 1 {
+		t.Errorf("t-x requests = %d, want 1 (only the session-first row)", got)
+	}
+	if got := grouped["t-y"].Requests; got != 1 {
+		t.Errorf("t-y requests = %d, want 1", got)
+	}
+}
+
 // staticPricer prices every model the same, which is what a test wants and what production must
 // never do.
 type staticPricer struct{ p modelinfo.Price }

--- a/dash/cachehistory.go
+++ b/dash/cachehistory.go
@@ -124,6 +124,92 @@ func (d *DB) CachesplitHistoricalUSD(f Filter, p modelinfo.Pricer) (CachesplitHi
 	return out, rows.Err()
 }
 
+// CachesplitHistoricalUSDByTenant is CachesplitHistoricalUSD for every tenant since a given
+// time, in one pass instead of one call per tenant.
+//
+// The Prometheus exporter used to call CachesplitHistoricalUSD once per tenant. Each call's
+// ROW_NUMBER ranks the WHOLE unfiltered requests table (that's what makes it correct — see
+// CachesplitHistoricalUSD's comment), so calling it N times re-sorted that same table N
+// times over: on this deployment, 19 tenants at ~0.8s a sort, every single scrape. Tenant is
+// only ever the outer filter here, never part of the session-first ranking itself, so it is
+// safe to compute the ranking once and group the qualifying rows by tenant afterward.
+func (d *DB) CachesplitHistoricalUSDByTenant(since int64, p modelinfo.Pricer) (map[string]CachesplitHistorical, error) {
+	out := map[string]CachesplitHistorical{}
+	if d == nil || p == nil {
+		return out, nil
+	}
+	sizes, err := d.CachesplitSizeSpread()
+	if err != nil {
+		return out, err
+	}
+	cond, args := (Filter{Since: since, TenantAll: true}).where()
+	rows, err := d.sql.Query(`WITH s AS (
+		SELECT r.*, ROW_NUMBER() OVER (PARTITION BY r.session_id ORDER BY r.ts, r.id) AS rn
+		FROM requests r
+	) SELECT r.tenant_id, r.model, r.cache_read, r.cache_write FROM s r
+		WHERE `+cond+` AND r.split_stable_tokens = 0 AND r.cache_read > 0 AND r.rn = 1`, args...)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+	acc := map[string]*CachesplitHistorical{}
+	seen := map[string]map[string]bool{}
+	priced := map[string]float64{} // model -> value of one qualifying request, shared across tenants
+	for rows.Next() {
+		var tenant, model string
+		var read, write int64
+		if err := rows.Scan(&tenant, &model, &read, &write); err != nil {
+			return out, err
+		}
+		h, ok := acc[tenant]
+		if !ok {
+			h = &CachesplitHistorical{}
+			acc[tenant] = h
+			seen[tenant] = map[string]bool{}
+		}
+		sp, ok := sizes[model]
+		if !ok {
+			h.Uncovered++
+			continue
+		}
+		stable := int64(sp[1])
+		if read < stable || write >= stable {
+			continue // the stable half was not what the provider served from cache
+		}
+		v, done := priced[model]
+		if !done {
+			price, ok := p.Price(context.Background(), model)
+			if !ok || price.Zero() {
+				h.Uncovered++
+				continue
+			}
+			miss := price.CacheWrite
+			if miss < price.Input {
+				miss = price.Input
+			}
+			if delta := miss - price.CacheRead; delta > 0 {
+				v = float64(stable) * delta
+			}
+			priced[model] = v
+		}
+		if v <= 0 {
+			h.Uncovered++
+			continue
+		}
+		h.USD += v
+		h.Requests++
+		seen[tenant][model] = true
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+	for tenant, h := range acc {
+		h.Models = len(seen[tenant])
+		out[tenant] = *h
+	}
+	return out, nil
+}
+
 // CachesplitSizeSpread reports the recorded minimum and maximum stable half per model. The
 // estimate above rests on those being equal; this is how that gets checked instead of assumed.
 func (d *DB) CachesplitSizeSpread() (map[string][2]int, error) {


### PR DESCRIPTION
## What

Follow-up to #127. That PR fixed `CachesplitHistoricalUSD`'s correlated
subquery for the `/api/stats` (whole-deployment) case, but the Prometheus
exporter (`/metrics`) calls it once *per tenant* in a loop
(`cmd/context-guru-proxy/main.go`'s `tenantMetricsAdapter.TenantMetrics`).
Each call's `ROW_NUMBER()` window ranks the whole unfiltered `requests`
table to stay correct — necessary, not a bug — so calling it 19 times
(one per tenant on this deployment) re-sorted that same table 19 times
over, every single scrape.

Adds `CachesplitHistoricalUSDByTenant`: one query, `tenant_id` kept only
as an outer grouping key. It's never part of the session-first ranking
itself, so grouping the qualifying rows by tenant afterward changes
nothing about the answer for any individual tenant — that equivalence is
exactly what the new test asserts (grouped result vs. calling the
existing single-tenant `CachesplitHistoricalUSD` per tenant).
`tenantMetricsAdapter.TenantMetrics` now calls it once instead of
looping.

## Why this matters in production

After #127 deployed, `/metrics` was still timing out (confirmed live:
calls ran 90+ seconds with zero bytes returned). Restructuring the
per-tenant loop into one query cuts this specific cost from ~14.5s (19
sequential full-table sorts) to ~0.81s (one sort). This does not by
itself explain the full observed hang — there is a separate, larger,
already-flagged contributor (WAL checkpoint starvation under concurrent
load, from retention having been disabled since 2026-08-22) that this PR
does not address — but it removes a real, measured, redundant cost from
the hot path every 15s scrape pays.

## Verification

- New test `TestHistoricalSplitValuationByTenantMatchesPerTenant`:
  asserts the grouped call returns, per tenant, exactly what the
  existing single-tenant call would, across two tenants with a
  multi-request session each (the exact case that would break if
  grouping leaked one tenant's rows into another's, or let a
  mid-session row through).
- `go test ./dash/...` and `go vet ./...` clean.
- Ran the batched query against the live production DB, read-only,
  compared against the old per-tenant-call query for every tenant with
  qualifying rows: identical result sets. Timed: ~14.5s (per-tenant
  loop) -> ~0.81s (batched).