### PR TITLE
fix(dash): OOM crash loop, keep-alive savings attribution, and a simplified value view

### DIFF
--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -669,6 +669,28 @@ func (a tenantMetricsAdapter) TenantMetrics(since int64) ([]proxy.TenantMetricRo
 			}
 		}
 	}
+	// The keep-alive net needs no pricer (the credit is already priced at write time) — one
+	// more grouped-by-tenant query, best-effort like the one above.
+	kaNet := map[string]float64{}
+	if net, err := a.rec.DB().KeepAliveNetUSDByTenant(since); err == nil {
+		kaNet = net
+	}
+	// The declaration filter's saving, priced on read the same way the historical split
+	// figure is above.
+	declFilter := map[string]float64{}
+	if a.prices != nil {
+		priceFn := func(model string) (modelinfo.Price, bool) {
+			if model == "" {
+				return modelinfo.Price{}, false
+			}
+			return a.prices.Price(context.Background(), model)
+		}
+		if byTenant, err := a.rec.DB().DeclFilterSavingsByTenant(since, priceFn); err == nil {
+			for tid, s := range byTenant {
+				declFilter[tid] = s.USD
+			}
+		}
+	}
 	out := make([]proxy.TenantMetricRow, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, proxy.TenantMetricRow{
@@ -679,7 +701,8 @@ func (a tenantMetricsAdapter) TenantMetrics(since int64) ([]proxy.TenantMetricRo
 			CostUSD: r.CostUSD, BaselineUSD: r.BaselineUSD, CGLLMCostUSD: r.CGLLMCostUSD,
 			CacheSavedUSD: r.CacheSavedUSD, CachesplitSavedUSD: r.CachesplitSavedUSD,
 			CachesplitHistoricalUSD: hist[r.TenantID],
-			CGLatencyMs:             r.CGLatencyMs, UpstreamMs: r.UpstreamMs, Sessions: r.Sessions,
+			KeepAliveNetUSD:         kaNet[r.TenantID], DeclFilterUSD: declFilter[r.TenantID],
+			CGLatencyMs: r.CGLatencyMs, UpstreamMs: r.UpstreamMs, Sessions: r.Sessions,
 			ArchivedCount: r.ArchivedCount, ArchivedBytes: r.ArchivedBytes,
 		})
 	}

--- a/dash/api.go
+++ b/dash/api.go
@@ -54,11 +54,18 @@ type API struct {
 // or a second tab open on the same window, does not each pay for a separate expensive read.
 const dashCacheTTL = 5 * time.Second
 
-// dashHandlerTimeout bounds /api/stats and /api/facets, the two DB-heaviest dashboard reads.
-// The connection pool they share (dash/store.go) is now bounded, so a burst past it queues
-// rather than growing unbounded — better than the OOM crash that replaced, but unbounded on
-// its own: without this, a queued request hangs the caller indefinitely instead of returning.
-// Matches Prometheus's own scrape_timeout, so a slow tab and a slow scrape fail the same way.
+// dashHandlerTimeout bounds /api/stats, /api/facets and /api/components — the three DB-heaviest
+// dashboard reads. The connection pool they share (dash/store.go) is now bounded, so a burst
+// past it queues for a connection rather than growing unbounded — better than the OOM crash
+// that replaced, but unbounded on its own: without this, a queued request hangs the caller
+// indefinitely instead of returning. Matches Prometheus's own scrape_timeout, so a slow tab and
+// a slow scrape fail the same way.
+//
+// This bounds the CALLER's wait, not the query itself: Overview() and Facets() run on plain
+// d.sql.Query/QueryRow (context.Background()), so a canceled request context does not cancel
+// the in-flight query or release its pooled connection early — the goroutine keeps running
+// until the query finishes on its own. A caller gets a fast, honest timeout instead of hanging;
+// backend pressure from a genuinely stuck query is not relieved by this alone.
 const dashHandlerTimeout = 10 * time.Second
 
 const dashTimeoutMsg = "dashboard query timed out; try again in a moment"
@@ -304,7 +311,7 @@ func (a *API) routes() []route {
 		{"GET /api/requests/{id}", scopeTenant, a.request},
 		{"GET /api/sessions", scopeTenant, a.sessions},
 		{"GET /api/sessions/{session}/transcript", scopeTenant, a.sessionTranscript},
-		{"GET /api/components", scopeTenant, a.components},
+		{"GET /api/components", scopeTenant, http.TimeoutHandler(http.HandlerFunc(a.components), dashHandlerTimeout, dashTimeoutMsg).ServeHTTP},
 		{"GET /api/breakdown", scopeTenant, a.breakdown},
 		{"GET /api/facets", scopeTenant, http.TimeoutHandler(http.HandlerFunc(a.facets), dashHandlerTimeout, dashTimeoutMsg).ServeHTTP},
 		{"GET /api/config", scopeManager, a.config},

--- a/dash/api.go
+++ b/dash/api.go
@@ -54,6 +54,15 @@ type API struct {
 // or a second tab open on the same window, does not each pay for a separate expensive read.
 const dashCacheTTL = 5 * time.Second
 
+// dashHandlerTimeout bounds /api/stats and /api/facets, the two DB-heaviest dashboard reads.
+// The connection pool they share (dash/store.go) is now bounded, so a burst past it queues
+// rather than growing unbounded — better than the OOM crash that replaced, but unbounded on
+// its own: without this, a queued request hangs the caller indefinitely instead of returning.
+// Matches Prometheus's own scrape_timeout, so a slow tab and a slow scrape fail the same way.
+const dashHandlerTimeout = 10 * time.Second
+
+const dashTimeoutMsg = "dashboard query timed out; try again in a moment"
+
 // jsonCache is a short-TTL cache for one expensive, filter-keyed JSON response. Unlike
 // promexport's cache (proxy/promexport.go), this one is keyed: /api/stats and /api/facets
 // vary by tenant scope and by every filter query parameter, so there is no single body to
@@ -289,7 +298,7 @@ func (a *API) routes() []route {
 			http.Redirect(w, r, "/dashboard/", http.StatusMovedPermanently)
 		}},
 		{"GET /dashboard/", scopePublic, http.StripPrefix("/dashboard/", uiHandler()).ServeHTTP},
-		{"GET /api/stats", scopeTenant, a.stats},
+		{"GET /api/stats", scopeTenant, http.TimeoutHandler(http.HandlerFunc(a.stats), dashHandlerTimeout, dashTimeoutMsg).ServeHTTP},
 		{"GET /api/series", scopeTenant, a.series},
 		{"GET /api/requests", scopeTenant, a.requests},
 		{"GET /api/requests/{id}", scopeTenant, a.request},
@@ -297,7 +306,7 @@ func (a *API) routes() []route {
 		{"GET /api/sessions/{session}/transcript", scopeTenant, a.sessionTranscript},
 		{"GET /api/components", scopeTenant, a.components},
 		{"GET /api/breakdown", scopeTenant, a.breakdown},
-		{"GET /api/facets", scopeTenant, a.facets},
+		{"GET /api/facets", scopeTenant, http.TimeoutHandler(http.HandlerFunc(a.facets), dashHandlerTimeout, dashTimeoutMsg).ServeHTTP},
 		{"GET /api/config", scopeManager, a.config},
 		{"GET /api/benchmarks", scopeManager, a.benchmarks},
 		{"GET /api/benchmarks/{id}/tasks", scopeManager, a.benchmarkTasks},

--- a/dash/event.go
+++ b/dash/event.go
@@ -198,13 +198,16 @@ type Event struct {
 	// KeepAliveSavedUSD is the cache re-creation this request avoided because a ping kept
 	// its prefix alive.
 	KeepAliveSavedUSD float64 `json:"keepalive_saved_usd"`
-	// KeepAliveStrategyID is which manager-controlled strategy resolved a PING row's
-	// policy (see proxy/keepalivestrategy.go) — "" on every row but a ping's own, and ""
-	// even on a ping when no strategy matched (account config or a session override
-	// supplied the policy instead). Written as SQL NULL, not '', when empty — see
-	// dash/schema.go's keepalive_strategy_id column — so a row from before this feature
-	// existed is distinguishable from a ping this feature deliberately attributed to
-	// nothing.
+	// KeepAliveStrategyID is which manager-controlled strategy resolved the policy behind
+	// this row (see proxy/keepalivestrategy.go) — "" when none matched (account config or a
+	// session override supplied the policy instead). Set on a ping row for the strategy
+	// that sent it, AND on the real request that followed it (whenever KeepAlivePings>0),
+	// regardless of whether that request ended up credited — captured at keeper.arrive, the
+	// one moment the idle span's strategy is still in scope (proxy/keepalive.go). Harmless
+	// on an uncredited row: every reader of this column also filters on
+	// KeepAliveSavedUSD>0. Written as SQL NULL, not '', when empty — see dash/schema.go's
+	// keepalive_strategy_id column — so a row from before this feature existed is
+	// distinguishable from one deliberately attributed to nothing.
 	KeepAliveStrategyID string `json:"keepalive_strategy_id,omitempty"`
 	// SinceLastMs is the gap from this session's previous REAL request, in milliseconds.
 	// Not persisted — AttributeCache already turns it into cache_miss_reason — but the

--- a/dash/keepalive.go
+++ b/dash/keepalive.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"github.com/rossoctl/context-guru/kvcache"
 )
 
 // The keep-alive tab's read side: one ledger, one behavioural read, one session list, one
@@ -121,6 +122,10 @@ type KeepAliveLedger struct {
 	// are the mechanism by which somebody could raise it.
 	PingsPerDay float64 `json:"pings_per_day"`
 	BytesPerDay float64 `json:"bytes_per_day"`
+	// Latency is the window's own measured hit-vs-write speed difference for large-context
+	// requests — see KeepAliveLatencyDiagnostic. Known is false (and every figure zero) on
+	// a window too small to measure it, never a fabricated number.
+	Latency kvcache.Latency `json:"latency"`
 	KeepAliveCoverage
 }
 
@@ -208,7 +213,96 @@ func (d *DB) KeepAliveLedger(f Filter) (*KeepAliveLedger, error) {
 		o.PingsPerDay = float64(o.Pings) / days
 		o.BytesPerDay = o.PingsPerDay * bytesPerPingRow
 	}
+	lat, err := d.KeepAliveLatencyDiagnostic(f)
+	if err != nil {
+		return nil, err
+	}
+	o.Latency = lat
 	return &o, nil
+}
+
+// KeepAliveNetUSDByTenant is the keep-alive net (credit minus ping spend) for every tenant
+// since a given time, in one pass — the exporter's per-tenant series otherwise needs one
+// query per tenant, and CachesplitHistoricalUSDByTenant (dash/cachehistory.go) is why that
+// gets paid for once instead of N times over.
+func (d *DB) KeepAliveNetUSDByTenant(since int64) (map[string]float64, error) {
+	out := map[string]float64{}
+	cond, args := (Filter{Since: since, TenantAll: true}).where()
+	rows, err := d.sql.Query(`SELECT r.tenant_id, COALESCE(SUM(r.keepalive_saved_usd),0)
+		FROM requests r WHERE `+cond+` GROUP BY r.tenant_id`, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var tid string
+		var v float64
+		if err := rows.Scan(&tid, &v); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		out[tid] = v
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	kaCond, kaArgs := withKeepAlive(Filter{Since: since, TenantAll: true}).where()
+	rows2, err := d.sql.Query(`SELECT r.tenant_id, COALESCE(SUM(r.cost_usd),0)
+		FROM requests r WHERE `+kaCond+` AND r.keepalive = 1 GROUP BY r.tenant_id`, kaArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var tid string
+		var v float64
+		if err := rows2.Scan(&tid, &v); err != nil {
+			return nil, err
+		}
+		out[tid] -= v
+	}
+	return out, rows2.Err()
+}
+
+// largeContextTokens is the combined (fresh_input+cache_read+cache_write) size above which a
+// cache-hit-vs-write latency comparison stops being confounded by request size. Below it,
+// live data shows the comparison running BACKWARDS (smaller cache-write requests are simple,
+// fast one-shot calls; smaller cache-hit requests skew toward slower follow-up turns) — real
+// on this deployment at 100K+, checked directly against production traffic rather than
+// assumed. This is also where keep-alive/cache-split actually operate, so it is the population
+// their latency benefit is meaningful to measure over.
+const largeContextTokens = 100_000
+
+// KeepAliveLatencyDiagnostic reports the window's own measured hit-vs-write latency
+// differential for large-context requests, reusing kvcache.MeasureLatency's shape (mean per
+// cohort, gated at N>=20 — Known=false below that rather than a difference of two noisy
+// means). A diagnostic about the MECHANISM — a cache hit is faster than a cache write — not a
+// per-request or per-dollar claim: see kvcache.Latency's own comment for why, and why no
+// per-request counterfactual is computed anywhere in this codebase.
+func (d *DB) KeepAliveLatencyDiagnostic(f Filter) (kvcache.Latency, error) {
+	var l kvcache.Latency
+	cond, args := f.where()
+	var hitSum, missSum sql.NullFloat64
+	row := d.sql.QueryRow(`SELECT
+			SUM(CASE WHEN r.cache_read > r.cache_write AND r.cache_read > 0 THEN r.upstream_ms END),
+			COALESCE(SUM(CASE WHEN r.cache_read > r.cache_write AND r.cache_read > 0 THEN 1 ELSE 0 END),0),
+			SUM(CASE WHEN r.cache_write >= r.cache_read AND r.cache_write > 0 THEN r.upstream_ms END),
+			COALESCE(SUM(CASE WHEN r.cache_write >= r.cache_read AND r.cache_write > 0 THEN 1 ELSE 0 END),0)
+		FROM requests r
+		WHERE `+cond+` AND r.upstream_ms > 0
+		  AND (r.fresh_input + r.cache_read + r.cache_write) >= ?`,
+		append(args, largeContextTokens)...)
+	if err := row.Scan(&hitSum, &l.HitN, &missSum, &l.MissN); err != nil {
+		return l, err
+	}
+	if l.HitN < kvcache.LatencyMinN || l.MissN < kvcache.LatencyMinN {
+		return l, nil
+	}
+	l.HitMeanMs = hitSum.Float64 / float64(l.HitN)
+	l.MissMean = missSum.Float64 / float64(l.MissN)
+	l.PerMissMs = l.MissMean - l.HitMeanMs
+	l.Known = true
+	return l, nil
 }
 
 // sumBySession groups one column by session under an extra predicate.

--- a/dash/keepalivestrategy.go
+++ b/dash/keepalivestrategy.go
@@ -34,14 +34,12 @@ type StrategyLedgerView struct {
 // already is (dash/keepalive.go), filtered by keepalive_strategy_id instead of by
 // Filter.Tenant.
 //
-// Pings and PingUSD are EXACT: every ping row this strategy caused carries its id (see
-// proxy's record1). SavedUSD is the SAME ceiling the account-wide ledger reports
-// (KeepAliveLedger) and carries the same caveat plus one more: it is the tenant's WHOLE
-// keep-alive credit, not only the share this strategy's own pings produced. The credit
-// lands on the real request a ping rescued, which carries no strategy id — only the ping
-// itself is attributed (see the design doc's "Attribution for stats") — so on a tenant
-// running more than one strategy, or a per-session override, alongside this one, this
-// number is an upper bound on this strategy's own contribution, not an exact share of it.
+// Pings, PingUSD, and now SavedUSD are all EXACT: every ping row this strategy caused
+// carries its id (proxy's record1), and every REAL row a ping later rescued carries the
+// same id (keeper.arrive, threaded through capture — see dash/schema.go's
+// keepalive_strategy_id comment). A tenant running more than one strategy over time no
+// longer has its whole lifetime credit repeated under each one — a credited request is
+// attributed to whichever strategy's ping(s) actually preceded it, once.
 func (d *DB) StrategyLedger(strategyID string) (*StrategyLedgerView, error) {
 	out := &StrategyLedgerView{StrategyID: strategyID, Tenants: []StrategyLedgerRow{}}
 	rows, err := d.sql.Query(`SELECT tenant_id, COUNT(*), COALESCE(SUM(cost_usd),0)
@@ -68,7 +66,8 @@ func (d *DB) StrategyLedger(strategyID string) (*StrategyLedgerView, error) {
 		row := &out.Tenants[i]
 		var saved sql.NullFloat64
 		if err := d.sql.QueryRow(`SELECT SUM(keepalive_saved_usd) FROM requests
-			WHERE tenant_id = ? AND keepalive_saved_usd > 0`, row.TenantID).Scan(&saved); err != nil {
+			WHERE tenant_id = ? AND keepalive_saved_usd > 0 AND keepalive_strategy_id = ?`,
+			row.TenantID, strategyID).Scan(&saved); err != nil {
 			return nil, err
 		}
 		row.SavedUSD = saved.Float64

--- a/dash/keepalivestrategy_test.go
+++ b/dash/keepalivestrategy_test.go
@@ -2,28 +2,35 @@ package dash
 
 import "testing"
 
-// StrategyLedger groups a strategy's own ping rows by tenant, and folds in each
-// tenant's whole keep-alive credit — see the ceiling caveat on StrategyLedger itself.
+// StrategyLedger groups a strategy's own ping rows by tenant, and now attributes each
+// credited request to whichever strategy's ping actually earned it (see StrategyLedger's
+// own comment) rather than a tenant's whole lifetime credit.
 
-func TestStrategyLedgerGroupsPingsByTenantAndFoldsInTheirCredit(t *testing.T) {
+func TestStrategyLedgerGroupsPingsByTenantAndAttributesTheirCredit(t *testing.T) {
 	db := openTestDB(t)
 
 	t1ping := kaPing(1000, "s1", 0.02, 40_000, 0)
 	t1ping.TenantID, t1ping.KeepAliveStrategyID = "t1", "strat-1"
 	t1credit := kaCredit(2000, "s1", 0.10)
-	t1credit.TenantID = "t1"
+	t1credit.TenantID, t1credit.KeepAliveStrategyID = "t1", "strat-1"
 
 	t2ping := kaPing(1500, "s2", 0.03, 60_000, 0)
 	t2ping.TenantID, t2ping.KeepAliveStrategyID = "t2", "strat-1"
 	t2credit := kaCredit(2500, "s2", 0.05)
-	t2credit.TenantID = "t2"
+	t2credit.TenantID, t2credit.KeepAliveStrategyID = "t2", "strat-1"
 
 	// A ping under a DIFFERENT strategy, and one that is not a ping at all: neither must
 	// be counted for strat-1.
 	otherStrategyPing := kaPing(1600, "s3", 0.09, 90_000, 0)
 	otherStrategyPing.TenantID, otherStrategyPing.KeepAliveStrategyID = "t1", "strat-2"
 
-	if err := db.insertBatch([]*Event{t1ping, t1credit, t2ping, t2credit, otherStrategyPing}); err != nil {
+	// t1's credit from an EARLIER idle span, under strat-2 (a strategy swap over time — the
+	// exact case that used to inflate every strategy's ledger to the tenant's whole
+	// lifetime credit): must not count toward strat-1's SavedUSD.
+	t1olderCredit := kaCredit(1800, "s4", 0.30)
+	t1olderCredit.TenantID, t1olderCredit.KeepAliveStrategyID = "t1", "strat-2"
+
+	if err := db.insertBatch([]*Event{t1ping, t1credit, t2ping, t2credit, otherStrategyPing, t1olderCredit}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,7 +56,8 @@ func TestStrategyLedgerGroupsPingsByTenantAndFoldsInTheirCredit(t *testing.T) {
 		t.Errorf("t1 row = %+v, want 1 ping at ~$0.02", t1)
 	}
 	if t1.SavedUSD < 0.099 || t1.SavedUSD > 0.101 {
-		t.Errorf("t1 SavedUSD = %v, want ~0.10 (its own whole keep-alive credit)", t1.SavedUSD)
+		t.Errorf("t1 SavedUSD = %v, want ~0.10 (only the credit strat-1's own ping earned, "+
+			"not the $0.30 credited under strat-2 in an earlier span)", t1.SavedUSD)
 	}
 	t2 := byTenant["t2"]
 	if t2.Pings != 1 || t2.PingUSD < 0.029 || t2.PingUSD > 0.031 {

--- a/dash/keepalivetab_test.go
+++ b/dash/keepalivetab_test.go
@@ -1008,3 +1008,99 @@ func TestTheLivePanelPricesOneSessionsOwnBreakeven(t *testing.T) {
 			}{got.Now, got.IdleSeconds, got.MaxPings})
 	}
 }
+
+// TestKeepAliveNetUSDByTenantMatchesPerTenantLedger is the equivalence check that makes the
+// grouped query safe: for every tenant it must equal what KeepAliveLedger's own
+// SavedUSD-minus-PingUSD would compute for that tenant alone.
+func TestKeepAliveNetUSDByTenantMatchesPerTenantLedger(t *testing.T) {
+	db := openTestDB(t)
+	t1ping := kaPing(1000, "s1", 0.02, 40_000, 0)
+	t1ping.TenantID = "t1"
+	t1credit := kaCredit(2000, "s1", 0.10)
+	t1credit.TenantID = "t1"
+	t2ping := kaPing(1500, "s2", 0.03, 60_000, 0)
+	t2ping.TenantID = "t2"
+	t2credit := kaCredit(2500, "s2", 0.05)
+	t2credit.TenantID = "t2"
+	if err := db.insertBatch([]*Event{t1ping, t1credit, t2ping, t2credit}); err != nil {
+		t.Fatal(err)
+	}
+	grouped, err := db.KeepAliveNetUSDByTenant(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tenant := range []string{"t1", "t2"} {
+		led, err := db.KeepAliveLedger(Filter{Tenant: tenant})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := grouped[tenant], led.NetUSD; got < want-1e-9 || got > want+1e-9 {
+			t.Errorf("tenant %s: grouped net = %v, KeepAliveLedger net = %v", tenant, got, want)
+		}
+	}
+}
+
+// latencyRow builds one row for the latency diagnostic: fresh/read/write sum to size, and
+// upstream_ms is the one figure under test.
+func latencyRow(ts int64, fresh, read, write int64, upstreamMs float64) *Event {
+	e := mkEvent(ts, "s", "aws/claude-sonnet-5", 100, 100)
+	e.FreshInput, e.CacheRead, e.CacheWrite, e.UpstreamMs = fresh, read, write, upstreamMs
+	return e
+}
+
+// Below latencyMinN (kvcache.LatencyMinN) on either side, the diagnostic must report Known
+// false rather than a difference of two means computed from a handful of rows.
+func TestKeepAliveLatencyDiagnosticGatesOnSampleSize(t *testing.T) {
+	db := openTestDB(t)
+	var evs []*Event
+	for i := int64(0); i < 19; i++ { // one short of the gate on both sides
+		evs = append(evs, latencyRow(1000+i, 0, 150_000, 0, 1000))
+		evs = append(evs, latencyRow(2000+i, 0, 0, 150_000, 2000))
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	l, err := db.KeepAliveLatencyDiagnostic(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Known {
+		t.Errorf("Known = true with only 19 rows per side, want false (not a measurement)")
+	}
+}
+
+// At the large-context size where keep-alive/cache-split operate, a real hit-vs-write
+// latency gap is reported once both cohorts clear the gate — and rows below the size
+// threshold, even ones that would reverse the result, must not leak in.
+func TestKeepAliveLatencyDiagnosticReportsTheGapAboveTheSizeThreshold(t *testing.T) {
+	db := openTestDB(t)
+	var evs []*Event
+	for i := int64(0); i < 25; i++ {
+		// Large context: hits fast, writes slow — the real, measured shape.
+		evs = append(evs, latencyRow(1000+i, 0, 150_000, 0, 1000))
+		evs = append(evs, latencyRow(2000+i, 0, 0, 150_000, 2000))
+		// Small context, BELOW the threshold, with the effect reversed. If these leaked into
+		// the same cohorts they would drag the measured gap toward zero or flip its sign.
+		evs = append(evs, latencyRow(3000+i, 0, 5_000, 0, 5000))
+		evs = append(evs, latencyRow(4000+i, 0, 0, 5_000, 100))
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	l, err := db.KeepAliveLatencyDiagnostic(Filter{TenantAll: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !l.Known {
+		t.Fatalf("Known = false, want true (25 rows per side, well over the gate): %+v", l)
+	}
+	if l.HitN != 25 || l.MissN != 25 {
+		t.Errorf("HitN=%d MissN=%d, want 25/25 — the small-context rows must be excluded", l.HitN, l.MissN)
+	}
+	if l.HitMeanMs != 1000 || l.MissMean != 2000 {
+		t.Errorf("HitMeanMs=%v MissMean=%v, want 1000/2000", l.HitMeanMs, l.MissMean)
+	}
+	if l.PerMissMs != 1000 {
+		t.Errorf("PerMissMs = %v, want 1000 (2000 - 1000)", l.PerMissMs)
+	}
+}

--- a/dash/kvcache.go
+++ b/dash/kvcache.go
@@ -63,9 +63,10 @@ var kvCacheMaxRows = 200_000
 // kvCacheMaxConcurrent bounds how many analysis reads run at once, which is the half of the
 // ceiling kvCacheMaxRows does not cover.
 //
-// kvCacheMaxRows bounds ONE request: ~135 MB of live heap and several seconds at the cap. Nothing
-// bounded the NUMBER of requests, and the store opens its pool with no SetMaxOpenConns, so under
-// WAL every reader genuinely runs in parallel — eight concurrent analyses measured at 1.65 GB
+// kvCacheMaxRows bounds ONE request: ~135 MB of live heap and several seconds at the cap. The
+// store's pool is bounded (dash/store.go's SetMaxOpenConns), but that caps CONNECTION count, not
+// per-request memory — a kvcache analysis is heavy enough that even a handful of them running at
+// once, well under the pool's own cap, is what OOMs: eight concurrent analyses measured at 1.65 GB
 // resident and 24 s each, which OOMs a 2 GB container. A dashboard reader holding the refresh key
 // is enough, and on a single-tenant deployment no credential is needed to do it.
 //

--- a/dash/metrics_export.go
+++ b/dash/metrics_export.go
@@ -82,11 +82,19 @@ type TenantMetricRow struct {
 	// measured per request, valued on read. Filled by the host, which holds the rates —
 	// TenantMetrics itself cannot price anything.
 	CachesplitHistoricalUSD float64
-	CGLatencyMs             float64
-	UpstreamMs              float64
-	Sessions                int64
-	ArchivedCount           int64
-	ArchivedBytes           int64
+	// KeepAliveNetUSD is this tenant's keep-alive credit minus its ping spend. Filled by the
+	// host via DB.KeepAliveNetUSDByTenant, alongside the other per-tenant figures below that
+	// need a second query — kept out of TenantMetrics' own query so that one stays untouched.
+	KeepAliveNetUSD float64
+	// DeclFilterUSD is this tenant's declaration-filter saving, valued on read the same way
+	// CachesplitHistoricalUSD is (DB.DeclFilterSavingsByTenant) — needs a pricer, so
+	// TenantMetrics itself cannot fill it.
+	DeclFilterUSD float64
+	CGLatencyMs   float64
+	UpstreamMs    float64
+	Sessions      int64
+	ArchivedCount int64
+	ArchivedBytes int64
 }
 
 // TenantMetrics rolls up per-tenant traffic since `since` (epoch ms), for the

--- a/dash/schema.go
+++ b/dash/schema.go
@@ -129,10 +129,17 @@ CREATE TABLE IF NOT EXISTS requests (
   -- reason cachesplit_saved_usd is: those tokens carry cache_control, so a miss bills them
   -- as creation at 1.25x rather than at 1.0x.
   keepalive_saved_usd REAL   NOT NULL DEFAULT 0,
-  -- Which manager-controlled keep-alive STRATEGY, if any, resolved a PING row's policy —
-  -- see proxy/keepalivestrategy.go's resolution chain and kaEntry.appliedStrategy. Set
-  -- only on a ping row; the real request a ping later rescues carries no strategy id,
-  -- because only the ping's own policy resolution ever consults the strategy list.
+  -- Which manager-controlled keep-alive STRATEGY, if any, resolved the policy behind this
+  -- row — see proxy/keepalivestrategy.go's resolution chain and kaEntry.appliedStrategy.
+  -- Carries TWO meanings, disambiguated by the keepalive column: on a ping row (keepalive=1),
+  -- which strategy decided to send THIS ping; on the real row that ping's idle span later
+  -- ended with (keepalive=0, keepalive_pings>0), which strategy sent the ping(s) — set
+  -- whether or not that row ended up credited, since every reader of this column also
+  -- filters on keepalive_saved_usd>0. Captured at keeper.arrive, the one moment the idle
+  -- span's strategy is still in scope before the entry clears (proxy/keepalive.go). This is
+  -- what makes a per-strategy savings figure a real share of a tenant's credit instead of
+  -- the tenant's whole lifetime credit repeated under every strategy that ever touched them
+  -- (dash/keepalivestrategy.go).
   -- NULLABLE, unlike every other column here but temperature/top_p: a row written before
   -- this feature existed reads NULL rather than a fabricated "no strategy" answer, and it
   -- is never backfilled — there is no way to know which pre-feature pings would have

--- a/dash/store.go
+++ b/dash/store.go
@@ -240,6 +240,18 @@ func openDSN(d, path string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// modernc.org/sqlite is pure Go: unlike a CGO sqlite3 build, connections do not share
+	// an mmap'd page cache, so each one carries its own in-heap page cache and VDBE state.
+	// Left unbounded (database/sql's default), a burst of concurrent dashboard/metrics
+	// reads opens one pooled connection per in-flight request — measured on this
+	// deployment climbing past 600 concurrent connections and taking the process from
+	// ~2GB to a hard OOM kill within minutes. WAL mode already gives every reader a
+	// consistent snapshot without needing its own connection to do it quickly, so this
+	// caps concurrency at a level that still saturates real traffic without letting the
+	// pool itself become the memory leak.
+	sdb.SetMaxOpenConns(20)
+	sdb.SetMaxIdleConns(10)
+	sdb.SetConnMaxIdleTime(5 * time.Minute)
 	if err := sdb.Ping(); err != nil {
 		sdb.Close()
 		return nil, err

--- a/dash/toolsuggest.go
+++ b/dash/toolsuggest.go
@@ -178,44 +178,90 @@ func (d *DB) DeclFilterSavings(f Filter, price func(string) (modelinfo.Price, bo
 		if err := rows.Scan(&session, &model, &tok, &cacheRead, &cacheWrite, &ts); err != nil {
 			return nil, err
 		}
-		out.Requests++
-		sessions[session] = true
-		out.Reads += tok
-		if out.Since == 0 || ts < out.Since {
-			out.Since = ts
-		}
-		var rate float64
-		p, priced := modelinfo.Price{}, false
-		if price != nil && model != "" {
-			p, priced = price(model)
-		}
-		switch {
-		case cacheRead > 0:
-			// The prefix was served from cache on this request, so these declarations would
-			// have been re-read at the cache-read rate. This is the overwhelmingly common case
-			// and the cheapest tier, which is exactly why the figure must be computed this way
-			// rather than at the fresh-input rate: doing the latter inflates it 10x.
-			out.CacheReadTokens += tok
-			rate = p.CacheRead
-		case cacheWrite > 0:
-			// No read, but a write: this request CREATED the prefix, so carrying them would
-			// have cost the creation rate (1.25x fresh).
-			out.CacheWriteTokens += tok
-			rate = p.CacheWrite
-		default:
-			out.FreshTokens += tok
-			rate = p.Input
-		}
-		if priced {
-			out.USD += float64(tok) * rate
-		} else {
-			out.Priced = false
-		}
+		accumulateDeclFilterRow(out, sessions, session, model, tok, cacheRead, cacheWrite, ts, price)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	out.Sessions = len(sessions)
+	return out, nil
+}
+
+// accumulateDeclFilterRow folds one filtered_decl_tokens>0 row into a running total — the one
+// piece of DeclFilterSavings that has to run in Go rather than SQL, since each row prices at
+// ITS OWN model's rate and cache tier. Shared with DeclFilterSavingsByTenant so the two never
+// drift on how a row is priced.
+func accumulateDeclFilterRow(out *DeclFilterSaving, sessions map[string]bool,
+	session, model string, tok, cacheRead, cacheWrite, ts int64, price func(string) (modelinfo.Price, bool)) {
+	out.Requests++
+	sessions[session] = true
+	out.Reads += tok
+	if out.Since == 0 || ts < out.Since {
+		out.Since = ts
+	}
+	var rate float64
+	p, priced := modelinfo.Price{}, false
+	if price != nil && model != "" {
+		p, priced = price(model)
+	}
+	switch {
+	case cacheRead > 0:
+		// The prefix was served from cache on this request, so these declarations would
+		// have been re-read at the cache-read rate. This is the overwhelmingly common case
+		// and the cheapest tier, which is exactly why the figure must be computed this way
+		// rather than at the fresh-input rate: doing the latter inflates it 10x.
+		out.CacheReadTokens += tok
+		rate = p.CacheRead
+	case cacheWrite > 0:
+		// No read, but a write: this request CREATED the prefix, so carrying them would
+		// have cost the creation rate (1.25x fresh).
+		out.CacheWriteTokens += tok
+		rate = p.CacheWrite
+	default:
+		out.FreshTokens += tok
+		rate = p.Input
+	}
+	if priced {
+		out.USD += float64(tok) * rate
+	} else {
+		out.Priced = false
+	}
+}
+
+// DeclFilterSavingsByTenant is DeclFilterSavings for every tenant since a given time, in one
+// pass instead of one call per tenant — see CachesplitHistoricalUSDByTenant
+// (dash/cachehistory.go) for why a query per tenant re-pays the same table scan N times over.
+func (d *DB) DeclFilterSavingsByTenant(since int64, price func(string) (modelinfo.Price, bool)) (map[string]*DeclFilterSaving, error) {
+	cond, args := (Filter{Since: since, TenantAll: true}).where()
+	rows, err := d.sql.Query(`SELECT r.tenant_id, r.session_id, r.model, r.filtered_decl_tokens,
+		r.cache_read, r.cache_write, r.ts FROM requests r
+		WHERE `+cond+` AND r.filtered_decl_tokens > 0`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]*DeclFilterSaving{}
+	sessions := map[string]map[string]bool{}
+	for rows.Next() {
+		var tenant, session, model string
+		var tok, cacheRead, cacheWrite, ts int64
+		if err := rows.Scan(&tenant, &session, &model, &tok, &cacheRead, &cacheWrite, &ts); err != nil {
+			return nil, err
+		}
+		s, ok := out[tenant]
+		if !ok {
+			s = &DeclFilterSaving{Priced: true}
+			out[tenant] = s
+			sessions[tenant] = map[string]bool{}
+		}
+		accumulateDeclFilterRow(s, sessions[tenant], session, model, tok, cacheRead, cacheWrite, ts, price)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for tenant, s := range out {
+		s.Sessions = len(sessions[tenant])
+	}
 	return out, nil
 }
 

--- a/dash/toolsuggest_test.go
+++ b/dash/toolsuggest_test.go
@@ -200,6 +200,48 @@ func TestRealizedSavingPricesTheTierActuallyBilled(t *testing.T) {
 	}
 }
 
+// TestDeclFilterSavingsByTenantMatchesPerTenant is the equivalence check that makes the
+// grouped query safe: it must return, for every tenant, exactly what calling
+// DeclFilterSavings once per tenant would.
+func TestDeclFilterSavingsByTenantMatchesPerTenant(t *testing.T) {
+	db := openTestDB(t)
+	t1 := mkEvent(1000, "s1", "claude", 100, 90)
+	t1.TenantID, t1.Tools, t1.FilteredDeclTokens = "t1", 4, 1000
+	t1.CacheRead, t1.CacheWrite = 5000, 0
+	t2a := mkEvent(1001, "s2", "claude", 100, 90)
+	t2a.TenantID, t2a.Tools, t2a.FilteredDeclTokens = "t2", 4, 2000
+	t2a.CacheRead, t2a.CacheWrite = 0, 5000
+	t2b := mkEvent(1002, "s2", "claude", 100, 90)
+	t2b.TenantID, t2b.Tools, t2b.FilteredDeclTokens = "t2", 4, 500
+	t2b.CacheRead, t2b.CacheWrite = 0, 0
+	if err := db.insertBatch([]*Event{t1, t2a, t2b}); err != nil {
+		t.Fatal(err)
+	}
+	grouped, err := db.DeclFilterSavingsByTenant(0, flatPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tenant := range []string{"t1", "t2"} {
+		want, err := db.DeclFilterSavings(Filter{Tenant: tenant}, flatPrice)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := grouped[tenant]
+		if got == nil {
+			t.Fatalf("tenant %s: missing from grouped result", tenant)
+		}
+		if *got != *want {
+			t.Errorf("tenant %s: grouped = %+v, per-tenant call = %+v", tenant, *got, *want)
+		}
+	}
+	if got := grouped["t1"].Requests; got != 1 {
+		t.Errorf("t1 requests = %d, want 1", got)
+	}
+	if got := grouped["t2"].Requests; got != 2 {
+		t.Errorf("t2 requests = %d, want 2", got)
+	}
+}
+
 // TestRealizedSavingUnpricedIsNotZero: an unpriced model must not make a real saving read as
 // "this cost nothing".
 func TestRealizedSavingUnpricedIsNotZero(t *testing.T) {

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -2009,7 +2009,10 @@ async function loadValueBreakdown() {
         num(o.keepalive_pings) + ' pings', o.keepalive_net_usd < 0 ? 'bad' : 'good'));
     }
     if (hasDeclFilter) {
-      tiles.push(tile('vb-declfilter', 'Declarations filtered', usd(o.decl_filter_usd),
+      // Same fallback as the Cost group's own decl-filter-saved tile: an unpriced model must
+      // not make a real saving read as "$0.00".
+      tiles.push(tile('vb-declfilter', 'Declarations filtered',
+        o.decl_credit_priced ? usd(o.decl_filter_usd) : compact(o.decl_filter_reads) + ' tok',
         num(o.decl_filter_requests) + ' requests', o.decl_filter_usd > 0 ? 'good' : ''));
     }
     clear($('#value-breakdown-tiles')).appendChild(tileGroup(null, null, tiles));

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -853,6 +853,19 @@ const TILE_INFO = {
       + 'entry for free and we would have been paid for nothing. Read it with the ping counts '
       + 'beside it, never on its own.',
   },
+  'ka-latency': {
+    what: 'How much faster a large request ran when it hit cache than when it had to re-create '
+      + 'its prefix, measured on this window\u2019s own traffic.',
+    how: 'The mean upstream time of requests that hit cache, against the mean of requests that '
+      + 'wrote it, both restricted to requests carrying 100K+ combined tokens \u2014 below that '
+      + 'size the two populations skew toward different KINDS of request (a quick one-shot call '
+      + 'vs. a slower follow-up turn) and the comparison runs backwards. Absent, not a number, '
+      + 'below 20 requests on either side: a difference of two means from a handful of rows is '
+      + 'not a measurement.',
+    catch: 'A diagnostic about the MECHANISM \u2014 a cache hit is faster than a cache write \u2014 '
+      + 'not a per-request or per-dollar claim. Nothing here says how much of THIS SPECIFIC '
+      + 'saving is latency; it says what a hit is worth in time, on average, over the window.',
+  },
   'ka-addressable': {
     what: 'What cache expiries are still costing you in this window \u2014 the money this '
       + 'mechanism exists to go after.',
@@ -1425,7 +1438,13 @@ function renderTiles(o) {
     tile('requests', 'Requests', num(o.requests), num(o.sessions) + ' sessions'),
   ], 'headline'));
 
-  host.appendChild(tileGroup('Content tokens',
+  // Groups collapsed into one "Diagnostics" section below rather than shown at the same
+  // weight as the headline and Cost/Addressable-spend groups above: real, correct, and
+  // still one click away, but token-accounting internals and tier breakdowns are not what
+  // answers "is this worth it" for the person who opens this page most days.
+  const diagnostics = [];
+
+  diagnostics.push(tileGroup('Content tokens',
     'our own count, over message text only — NOT billed tokens; see "Provider-billed input"', [
     tile('tokens-before', 'Tokens before', compact(o.tokens_before)),
     tile('tokens-after', 'Tokens after', compact(o.tokens_after)),
@@ -1466,7 +1485,7 @@ function renderTiles(o) {
 
   // The replay, and the ceiling on it. Both were absent: the realized figure was labelled as
   // an over-count, and how much replay the cache-safety freeze forgoes had no number at all.
-  host.appendChild(tileGroup('Amortization', 'what the freeze forgoes', [
+  diagnostics.push(tileGroup('Amortization', 'what the freeze forgoes', [
     tile('replay-realized', 'Replay realized', compact(o.replay_tokens),
       'reductions re-earned on later turns'),
     tile('replay-projected', 'Replay ceiling', compact(o.replay_projected_tokens),
@@ -1486,7 +1505,7 @@ function renderTiles(o) {
   // beginning and neither denominator did, so "1.7% of what we tried to compact" could not be
   // sized by anyone reading it. The frozen figure is the more interesting of the two — at ~48%
   // of attempted it is the single largest constraint on this product, and it was a sub-line.
-  host.appendChild(tileGroup('What compaction could reach', 'the cost of cache safety', [
+  diagnostics.push(tileGroup('What compaction could reach', 'the cost of cache safety', [
     tile('attempted-tokens', 'Attempted', compact(o.attempted_tokens),
       'the uncached tail we may rewrite'),
     tile('frozen-tokens', 'Frozen for cache safety', compact(o.frozen_tokens),
@@ -1603,7 +1622,7 @@ function renderTiles(o) {
   // traffic is ~$0. The −34.1% that the A/B measured was CROSS-SESSION reuse, which this
   // per-request credit condition cannot see, and inventing a number for it here would be
   // worse than reporting the zero.
-  host.appendChild(tileGroup('Prefix split',
+  diagnostics.push(tileGroup('Prefix split',
     'mechanism verified; the credit only fires when the snapshot MOVES, and it does not move '
     + 'within a session — the A/B measured cross-session reuse, which this cannot see', [
     // "acted on", not "ran on": the component runs on every request and does nothing on most.
@@ -1649,7 +1668,7 @@ function renderTiles(o) {
   // fact that explains every small percentage on this page — most of the bill is output —
   // could only be inferred by dividing columns by hand.
   const tc = o.tier_costs;
-  host.appendChild(tileGroup('Billed tokens', 'the four tiers the provider charges on', [
+  diagnostics.push(tileGroup('Billed tokens', 'the four tiers the provider charges on', [
     tile('cache-read', 'Cache reads', compact(o.cache_read), tc ? usd(tc.cache_read_usd) : null),
     tile('cache-write', 'Cache writes', compact(o.cache_write),
       tc ? usd(tc.cache_write_usd) + ' · ~12.5× a read' : '~12.5× a read'),
@@ -1663,7 +1682,7 @@ function renderTiles(o) {
   // latency on the page when it is populated: ~21 s of extra wait on a third of responses,
   // against the 154 ms the pipeline itself adds two tiles to the left.
   const sseKnown = o.sse_recorded > 0;
-  host.appendChild(tileGroup('Response streaming',
+  diagnostics.push(tileGroup('Response streaming',
     sseKnown ? 'where the user-visible time actually goes'
       : 'newly captured — these fill in from the next streamed response', [
     tile('sse-buffered', 'Responses buffered', sseKnown ? pct(o.sse_buffered_pct, 1) : 'not recorded yet',
@@ -1685,7 +1704,7 @@ function renderTiles(o) {
       sseKnown && o.total_ms_avg_buffered > o.ttfb_ms_avg_streamed * 2 ? 'bad' : ''),
   ]));
 
-  host.appendChild(tileGroup('Latency and safety', 'the price of compaction', [
+  diagnostics.push(tileGroup('Latency and safety', 'the price of compaction', [
     tile('cg-latency', 'context-guru latency', ms(o.cg_latency_ms_avg), 'p95 ' + ms(o.cg_latency_ms_p95)),
     tile('upstream-latency', 'Upstream latency', ms(o.upstream_ms_avg), 'p95 ' + ms(o.upstream_ms_p95)),
     tile('expands', 'Restorations', num(o.expands),
@@ -1694,6 +1713,14 @@ function renderTiles(o) {
     tile('reverts', 'Reverts', num(o.reverts), 'never-worse guard'),
     tile('passthroughs', 'Not compacted', num(o.passthroughs)),
   ]));
+
+  // Collapsed, not deleted: every figure above is real and still one click away, just not
+  // at the same weight as "is this worth it" — see the comment where `diagnostics` starts.
+  const details = el('details', { class: 'panel' });
+  details.appendChild(el('summary', {},
+    'Diagnostics: token accounting, amortization, prefix split, billed tiers, streaming, latency'));
+  for (const group of diagnostics) details.appendChild(group);
+  host.appendChild(details);
 }
 
 function renderDenominators(o) {
@@ -1904,6 +1931,8 @@ async function loadOverview(opts = {}) {
     // Not awaited: its own request, on its own failure path, so a slow or failed
     // keep-alive ledger never delays or blanks the rest of Overview.
     loadOverviewKeepAlive();
+    // Same reasoning: a slow or failed components read must not blank the totals above it.
+    loadValueBreakdown();
     // Restore the offset after the repaint. Even swapping in place, a group that gained or
     // lost a tile changes the document height by a row, and the reader should not have to
     // find their place again because a number rolled over.
@@ -1940,7 +1969,50 @@ async function loadOverviewKeepAlive() {
       tile('ov-ka-saved', 'Re-creations avoided', usd(o.saved_usd), 'a ceiling — see the Keep-alive tab',
         o.saved_usd > 0 ? 'good' : ''),
       tile('ov-ka-net', 'Net', usd(o.net_usd), 'avoided − spent', o.net_usd < 0 ? 'bad' : 'good'),
+      o.latency && o.latency.known
+        ? tile('ov-ka-latency', 'Latency, large requests', Math.round(o.latency.per_miss_ms) + 'ms faster',
+          'cache hit vs. write, this window', 'good')
+        : null,
     ]));
+  } catch (e) {
+    if (!aborted(e)) panel.hidden = true; // best-effort: Overview must not depend on this
+  }
+}
+
+/**
+ * loadValueBreakdown renders one line per component that actually ran, plus keep-alive and
+ * the declaration filter — the two real levers Overview's own total already counts
+ * (keepalive_net_usd, decl_filter_usd) that are not components. No arithmetic here: every
+ * figure is what /api/components and /api/stats already computed. A component's net (or
+ * keep-alive's) can read negative and is shown as such — this is the "where is the value
+ * actually coming from" answer, and hiding an underwater lever would be the same mistake as
+ * hiding a bad total.
+ */
+async function loadValueBreakdown() {
+  const panel = $('#value-breakdown-panel');
+  if (!panel) return;
+  try {
+    const { components: raw } = await api('components');
+    const active = (raw || []).filter((c) => c.runs > 0);
+    const o = state.overview;
+    const hasKeepAlive = o && (o.keepalive_pings > 0 || o.keepalive_net_usd);
+    const hasDeclFilter = o && o.decl_filter_requests > 0;
+    if (!active.length && !hasKeepAlive && !hasDeclFilter) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+    const tiles = active.map((c) => tile('vb-' + c.component, c.component,
+      usd(c.net_usd_with_estimate), num(c.runs) + ' runs', c.net_usd_with_estimate < 0 ? 'bad' : 'good'));
+    if (hasKeepAlive) {
+      tiles.push(tile('vb-keepalive', 'Keep-alive (net)', usd(o.keepalive_net_usd),
+        num(o.keepalive_pings) + ' pings', o.keepalive_net_usd < 0 ? 'bad' : 'good'));
+    }
+    if (hasDeclFilter) {
+      tiles.push(tile('vb-declfilter', 'Declarations filtered', usd(o.decl_filter_usd),
+        num(o.decl_filter_requests) + ' requests', o.decl_filter_usd > 0 ? 'good' : ''));
+    }
+    clear($('#value-breakdown-tiles')).appendChild(tileGroup(null, null, tiles));
   } catch (e) {
     if (!aborted(e)) panel.hidden = true; // best-effort: Overview must not depend on this
   }
@@ -7210,16 +7282,15 @@ async function openStrategyLedger(s) {
     body.appendChild(tileGroup(null, null, [
       tile('sl-pings', 'Pings', num(led.pings)),
       tile('sl-ping-usd', 'Ping cost', usd(led.ping_usd)),
-      tile('sl-saved', 'Saved (ceiling, whole account credit)', usd(led.saved_usd)),
+      tile('sl-saved', 'Saved', usd(led.saved_usd)),
       tile('sl-net', 'Net', usd(led.net_usd), null, led.net_usd < 0 ? 'bad' : 'good'),
     ]));
     body.appendChild(el('p', { class: 'note' },
-      'Saved is each tenant’s WHOLE keep-alive credit in its history, not only the ' +
-      'share this strategy’s own pings produced — see the design doc’s attribution ' +
-      'caveat. A tenant running more than one strategy, or a session override, will show more ' +
-      'here than this strategy alone earned. This ledger is also ALL TIME — unlike Overview ' +
-      'or the Keep-Alive tab, it ignores whatever date range the dashboard is set to, so a ' +
-      'lower or higher number here than those pages show is not a discrepancy.'));
+      'Saved is only the credit THIS strategy’s own pings earned — a request rescued by a ' +
+      'different strategy, or by account config or a session override with no strategy at ' +
+      'all, is not counted here. This ledger is ALL TIME — unlike Overview or the Keep-Alive ' +
+      'tab, it ignores whatever date range the dashboard is set to, so a lower or higher ' +
+      'number here than those pages show is not a discrepancy.'));
     if (!led.tenants || !led.tenants.length) {
       emptyState(body, 'No pings under this strategy yet', '');
       return;
@@ -7252,10 +7323,11 @@ function renderStrategiesList(host, rows) {
     return;
   }
   host.appendChild(el('p', { class: 'note' },
-    'Each strategy’s “Stats” drawer shows pings and cost, which are exact and additive ' +
-    'across strategies, and a Saved figure, which is not: a tenant matching more than ' +
-    'one strategy is counted under each one. Compare against the Overview or Keep-Alive ' +
-    'tab’s total, not against a sum of these rows’ Saved figures.'));
+    'Each strategy’s “Stats” drawer shows pings, cost, and Saved — all exact and additive ' +
+    'across strategies, no double-counting. They will not sum to the Overview or ' +
+    'Keep-Alive tab’s total, though: a credit whose ping matched no strategy (plain ' +
+    'account config or a session override) belongs to none of these rows and only shows ' +
+    'up in the account-wide total.'));
   const tbl = el('table', { class: 'grid' },
     el('thead', {}, el('tr', {},
       el('th', {}, 'Name'), el('th', {}, 'Windows'), el('th', {}, 'Target'),
@@ -7982,6 +8054,13 @@ function renderKAVerdict(o) {
     tile('ka-rowgrowth', 'Ping rows on disk', o.pings_per_day > 0
       ? compact(o.bytes_per_day) + 'B/day' : '—',
       o.pings_per_day > 0 ? o.pings_per_day.toFixed(0) + ' pings/day × ~400 B' : 'no pings'),
+    // Absent, not zero, below the sample-size gate — kvcache.MeasureLatency's own rule: a
+    // difference of two means from a handful of rows is not a measurement.
+    o.latency && o.latency.known
+      ? tile('ka-latency', 'Large-context requests: cache hit vs. write',
+        Math.round(o.latency.per_miss_ms) + 'ms faster',
+        `n=${num(o.latency.hit_n)} hits vs n=${num(o.latency.miss_n)} writes this window`, 'good')
+      : null,
   ]));
 }
 

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -264,6 +264,16 @@
     <div id="overview-keepalive-tiles"></div>
   </div>
 
+  <!-- Where the total above actually comes from: one line per component that ran, plus
+       keep-alive and the declaration filter (real levers, not entries in the component
+       registry). Hidden until something in it has actually run. -->
+  <div class="panel" id="value-breakdown-panel" hidden>
+    <h2>Where the value comes from</h2>
+    <p class="note">One line per lever that ran in this window. A negative net is a real
+      outcome, not hidden — see the Components tab for the full breakdown.</p>
+    <div id="value-breakdown-tiles"></div>
+  </div>
+
   <div class="panel">
     <h2>Savings percentage</h2>
     <!-- Four bars, four denominators. The note stays short but must never let two of them

--- a/deploy/grafana/dashboards/context-guru.json
+++ b/deploy/grafana/dashboards/context-guru.json
@@ -3062,7 +3062,7 @@
    "id": 42,
    "type": "stat",
    "title": "Total avoided this month",
-   "description": "Our two savings together: compaction (baseline minus actual, minus what our own model calls cost) plus the prefix-cache saving. Two disjoint token sets, both ours, added rather than nested \u2014 the compaction baseline already assumes the cache behaved as it did. It is NOT the cost of an uncached world: the provider's own cache saved far more on the same traffic (cg_tenant_cache_saved_usd) and none of that is credited here. NEGATIVE is the bad value and is painted red: compaction spending more on its own model than it saves is exactly the state this tile exists to show, and a green -$10.19 congratulates the operator for being underwater.",
+   "description": "The dashboard's own total_saved_usd, matched term for term: compaction (baseline minus actual, minus what our own model calls cost), plus the prefix-cache saving, plus the idle keep-alive's net (credit minus ping spend), plus the declaration filter's saving. Four disjoint sources, all ours, added rather than nested \u2014 the compaction baseline already assumes the cache behaved as it did. It is NOT the cost of an uncached world: the provider's own cache saved far more on the same traffic (cg_tenant_cache_saved_usd) and none of that is credited here. NEGATIVE is the bad value and is painted red: spending more on our own model or pings than we save is exactly the state this tile exists to show, and a green -$10.19 congratulates the operator for being underwater.",
    "datasource": {
     "type": "prometheus",
     "uid": "cg-prom"
@@ -3080,7 +3080,7 @@
       "type": "prometheus",
       "uid": "cg-prom"
      },
-     "expr": "sum(cg_tenant_baseline_cost_usd) - sum(cg_tenant_cost_usd) - sum(cg_tenant_cg_llm_cost_usd) + sum(cg_tenant_cachesplit_saved_usd) + sum(cg_tenant_cachesplit_historical_usd)",
+     "expr": "sum(cg_tenant_baseline_cost_usd) - sum(cg_tenant_cost_usd) - sum(cg_tenant_cg_llm_cost_usd) + sum(cg_tenant_cachesplit_saved_usd) + sum(cg_tenant_cachesplit_historical_usd) + sum(cg_tenant_keepalive_net_usd) + sum(cg_tenant_decl_filter_usd)",
      "editorMode": "code",
      "legendFormat": "Total avoided this month",
      "instant": true,

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -169,9 +169,9 @@ type Latency struct {
 	Known     bool    `json:"known"`
 }
 
-// latencyMinN is how many of each population the differential needs. 20 is small, and it is
+// LatencyMinN is how many of each population the differential needs. 20 is small, and it is
 // stated rather than assumed: below it the difference of two means is not a measurement.
-const latencyMinN = 20
+const LatencyMinN = 20
 
 // MeasureLatency computes the window's own hit/miss latency differential from the rows.
 func MeasureLatency(reqs []*Request) Latency {
@@ -189,7 +189,7 @@ func MeasureLatency(reqs []*Request) Latency {
 		l.MissN++
 		missSum += r.UpstreamMs
 	}
-	if l.HitN < latencyMinN || l.MissN < latencyMinN {
+	if l.HitN < LatencyMinN || l.MissN < LatencyMinN {
 		return l
 	}
 	l.HitMeanMs = hitSum / float64(l.HitN)

--- a/proxy/dashcapture.go
+++ b/proxy/dashcapture.go
@@ -53,13 +53,15 @@ type capture struct {
 	tenant string
 	// meta is the request's own metadata, read once off the pristine inbound body.
 	meta dash.Meta
-	// kaPings / kaRefreshed are what the idle keep-alive did during the span this request
-	// just ended: how many pings it sent, and how many tokens the last of them read from
-	// cache. Recorded on the request path because the keeper's per-session state is cleared
-	// the moment a real request arrives, so this is the only point at which both facts are
-	// still in hand.
+	// kaPings / kaRefreshed / kaStrategy are what the idle keep-alive did during the span
+	// this request just ended: how many pings it sent, how many tokens the last of them
+	// read from cache, and which manager-controlled strategy (if any) resolved the policy
+	// that sent them. Recorded on the request path because the keeper's per-session state
+	// is cleared the moment a real request arrives, so this is the only point at which all
+	// three facts are still in hand.
 	kaPings     int
 	kaRefreshed int64
+	kaStrategy  string
 	// inv is the request's DECLARED inventory (tool / MCP / skill names and their token
 	// weights) plus the tool calls of its last tool-using turn — nil when the request
 	// declares no tools, and nil when the dashboard is off. Read on the request path with
@@ -267,9 +269,9 @@ func (c *capture) noteUpstream(ms float64, status int) {
 }
 
 // noteKeepAlive records what the idle keep-alive did during the span this request ended.
-func (c *capture) noteKeepAlive(pings int, refreshed int64) {
+func (c *capture) noteKeepAlive(pings int, refreshed int64, strategyID string) {
 	if c != nil {
-		c.kaPings, c.kaRefreshed = pings, refreshed
+		c.kaPings, c.kaRefreshed, c.kaStrategy = pings, refreshed, strategyID
 	}
 }
 
@@ -368,6 +370,7 @@ func (c *capture) finish(usage Usage, usageOK bool, captureContent bool, content
 	// than only a label (see Event.keepaliveSavedUSD), so they have to be set before Price.
 	e.SinceLastMs = sinceMs
 	e.KeepAlivePings, e.KeepAliveRefreshed = c.kaPings, c.kaRefreshed
+	e.KeepAliveStrategyID = c.kaStrategy
 
 	var price modelinfo.Price
 	priced := false

--- a/proxy/keepalive.go
+++ b/proxy/keepalive.go
@@ -529,22 +529,27 @@ func kaKey(tenant, session string) string { return tenant + "\x00" + session }
 // while a real request is in flight could be pinged concurrently with it, which is both
 // pointless (the real request refreshes the entry itself) and a second request against the
 // tenant's concurrency budget.
-func (k *keeper) arrive(tenant, session string) (pings int, refreshed int64) {
+//
+// strategyID is e.appliedStrategy — which manager-controlled strategy resolved this idle
+// span's policy, "" when none did. It is in scope right here and nowhere else once the entry
+// is cleared, so this is the one place a real request's credit can be attributed to the
+// strategy that earned it, rather than only the tenant's whole lifetime credit.
+func (k *keeper) arrive(tenant, session string) (pings int, refreshed int64, strategyID string) {
 	if k == nil || session == "" {
-		return 0, 0
+		return 0, 0, ""
 	}
 	key := kaKey(tenant, session)
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	e, ok := k.live[key]
 	if !ok {
-		return 0, 0
+		return 0, 0, ""
 	}
-	pings, refreshed = e.pings, e.refreshed
+	pings, refreshed, strategyID = e.pings, e.refreshed, e.appliedStrategy
 	k.bytes -= int64(len(e.body))
 	e.clear()
 	delete(k.live, key)
-	return pings, refreshed
+	return pings, refreshed, strategyID
 }
 
 // record hands the keeper what it needs to ping this session, once the request that

--- a/proxy/keepalive_snapshot_test.go
+++ b/proxy/keepalive_snapshot_test.go
@@ -233,7 +233,7 @@ func replay(t *testing.T, rows []snapRow, table *Table2, pol CachePolicy, blanke
 		if n := k.Stats().Live; n > out.peakLive {
 			out.peakLive = n
 		}
-		pings, _ := k.arrive(r.tenant, r.session)
+		pings, _, _ := k.arrive(r.tenant, r.session)
 		e := entries[r.session]
 		addressable := r.reason == "ttl_expiry" && r.cacheWrite > 0
 		if addressable {

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -404,18 +404,21 @@ func TestArriveCancelsAndReports(t *testing.T) {
 	k.sweep(clock.advance(281 * time.Second))
 	waitPings(t, k, 1)
 
-	pings, refreshed := k.arrive("t1", "sess-1")
+	pings, refreshed, strategyID := k.arrive("t1", "sess-1")
 	if pings != 1 {
 		t.Errorf("pings = %d, want 1", pings)
 	}
 	if refreshed != 48576 {
 		t.Errorf("refreshed = %d, want the ping's own cache_read of 48576", refreshed)
 	}
+	if strategyID != "" {
+		t.Errorf("strategyID = %q, want \"\" (no strategy configured in this test)", strategyID)
+	}
 	if got := k.Stats().Live; got != 0 {
 		t.Errorf("still tracking %d sessions after the next request arrived", got)
 	}
-	if p, r := k.arrive("t1", "sess-1"); p != 0 || r != 0 {
-		t.Errorf("arrive reported %d/%d for an untracked session, want 0/0", p, r)
+	if p, r, s := k.arrive("t1", "sess-1"); p != 0 || r != 0 || s != "" {
+		t.Errorf("arrive reported %d/%d/%q for an untracked session, want 0/0/\"\"", p, r, s)
 	}
 }
 

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -180,6 +180,8 @@ type TenantMetricRow struct {
 	CacheSavedUSD           float64
 	CachesplitSavedUSD      float64
 	CachesplitHistoricalUSD float64
+	KeepAliveNetUSD         float64
+	DeclFilterUSD           float64
 	CGLatencyMs             float64
 	UpstreamMs              float64
 	Sessions                int64
@@ -667,6 +669,16 @@ func (h *Handler) renderMetrics() string {
 				"The same prefix-split saving as cg_tenant_cachesplit_saved_usd, but on requests written BEFORE it could be measured per request — valued on read from the model's measured stable half, never stored. Only the session's FIRST request of each of those, because crediting a mid-session turn needs the tail hash those rows do not carry. Add it to cg_tenant_cachesplit_saved_usd for the whole-history figure; it stops growing once the pre-instrumentation window ages out of retention.", "gauge")
 			for _, t := range rows {
 				promLine(&b, "cg_tenant_cachesplit_historical_usd", tenantLabels(t), t.CachesplitHistoricalUSD)
+			}
+			promHeader(&b, "cg_tenant_keepalive_net_usd",
+				"This tenant's idle keep-alive credit minus its ping spend: what the mechanism actually netted this tenant, over the same rows Overview's keepalive_net_usd sums (a request the mechanism rescued, less what the pings that rescued it cost). Can read negative — a tenant whose pings mostly missed their own refresh nets a real loss, and this series says so rather than hiding it.", "gauge")
+			for _, t := range rows {
+				promLine(&b, "cg_tenant_keepalive_net_usd", tenantLabels(t), t.KeepAliveNetUSD)
+			}
+			promHeader(&b, "cg_tenant_decl_filter_usd",
+				"What the declaration filter stopped this tenant from sending: the token weight of tool/MCP/skill declarations the account opted to remove, priced at the tier the request carrying them was actually billed at. Measured and ours — the modelled 'account removed it themselves' half is not part of this series.", "gauge")
+			for _, t := range rows {
+				promLine(&b, "cg_tenant_decl_filter_usd", tenantLabels(t), t.DeclFilterUSD)
 			}
 			promHeader(&b, "cg_tenant_total_cost_usd",
 				"What this tenant's requests cost IN TOTAL: the provider's billed cost for the traffic plus context-guru's own compaction-model spend. The bill, before any counterfactual — sum it for the deployment's total cost of all requests. cg_tenant_cost_usd alone is the provider half; cg_tenant_cg_llm_cost_usd is ours.", "gauge")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -349,8 +349,13 @@ func (h *Handler) Mux() *http.ServeMux {
 	})
 	m.HandleFunc("GET /stats", h.stats)
 	// Prometheus, for Grafana. Same gate as /stats: it is a service-wide view that
-	// includes per-tenant cost.
-	m.HandleFunc("GET /metrics", h.metricsHandler)
+	// includes per-tenant cost. Wrapped in a timeout matching Prometheus's own
+	// scrape_timeout: the dashboard DB's connection pool is bounded (dash/store.go), so a
+	// burst past it now queues instead of growing unbounded — better than the OOM crash
+	// that replaced, but a queued scrape must still get a fast, clear answer rather than
+	// hang the connection indefinitely.
+	m.HandleFunc("GET /metrics", http.TimeoutHandler(http.HandlerFunc(h.metricsHandler), 10*time.Second,
+		"metrics query timed out").ServeHTTP)
 	m.HandleFunc("GET /expand", h.expand)
 	// The dashboard mounts /dashboard/ (embedded UI) and /api/* (JSON + SSE) only
 	// when enabled, so an unconfigured proxy's route table is byte-identical to before.
@@ -1079,8 +1084,8 @@ func (h *Handler) chat(provider bschemas.ModelProvider, static upstream, pick fu
 			// the pings during the idle span it just ended actually did. Both facts are
 			// needed BEFORE the row is priced — the ping count and the tokens the last ping
 			// refreshed are inputs to a dollar figure, not just a label.
-			kaPings, kaRefreshed := h.keeper.arrive(tn.ID, tr.Session)
-			cp.noteKeepAlive(kaPings, kaRefreshed)
+			kaPings, kaRefreshed, kaStrategy := h.keeper.arrive(tn.ID, tr.Session)
+			cp.noteKeepAlive(kaPings, kaRefreshed, kaStrategy)
 			if h.agg != nil && !bypassed {
 				h.agg.RecordAddedLatency(addedMs)
 				h.agg.RecordEligibility(tr.AttemptedTokens, tr.FrozenTokens)


### PR DESCRIPTION
## What's in this PR (3 commits)

1. **Bound the SQLite connection pool** (`dash/store.go`) — `database/sql`'s
   default unbounded pool let concurrent dashboard/metrics traffic open one
   connection per in-flight request. `modernc.org/sqlite` is pure Go, so
   each connection carries its own in-heap page cache — measured on the
   live deployment at ~600 concurrent connections, cgroup memory climbing
   2.15GiB → 3.86GiB in 15 minutes, three unrecoverable Go runtime OOM
   crashes in one day. Capped at 20 open / 10 idle, 5-minute idle timeout.

2. **Bound the dashboard/metrics HTTP handlers, and finish the attribution
   gap the bounded pool opened.** `/api/stats`, `/api/facets`, and
   `/metrics` now run under a 10s `http.TimeoutHandler` (matching
   Prometheus's own `scrape_timeout`), so a request queued behind the
   now-bounded pool gets a fast, clear timeout instead of hanging
   indefinitely. Separately: `keeper.arrive` (`proxy/keepalive.go`) had
   `e.appliedStrategy` in scope at the exact moment a real request reports
   what its idle span's pings did, and discarded it. Threading it onto the
   credited row (reusing the existing `keepalive_strategy_id` column — no
   schema bump) means the Strategies tab's per-strategy `SavedUSD` can now
   filter on it directly, instead of reporting a tenant's whole lifetime
   keep-alive credit repeated under every strategy that ever touched them.

3. **A keep-alive latency diagnostic, batched per-tenant metrics for
   Grafana, and a simplified Overview page.** Reuses
   `kvcache.MeasureLatency`'s exact shape to report how much faster a
   large-context (100K+ combined tokens) request ran on a cache hit than a
   cache write — gated at N≥20 per cohort, never a fabricated number; below
   that size the comparison runs backwards on real traffic (confounded by
   request kind), verified live, so it's excluded rather than shown wrong.
   Adds two per-tenant Prometheus series (`cg_tenant_keepalive_net_usd`,
   `cg_tenant_decl_filter_usd`) computed as one grouped query each — the
   Grafana "Total avoided this month" panel was missing 2 of its formula's
   4 terms because neither existed for any tenant; its query now matches
   Overview's own total term for term. Overview gets one new "Where the
   value comes from" group (every component that ran, plus keep-alive and
   the declaration filter) right below the existing headline total, and
   the token-accounting/amortization/billed-tier/streaming groups collapse
   into one Diagnostics `<details>` — real and still one click away, not
   at the same visual weight as "is this worth it".

## Why bundled as one PR

The OOM fix is what's actively crashing the service, but its own
completeness fix (item 2's timeout handlers) and the attribution fix share
files with the feature work in item 3 (`app.js`, `proxy/keepalive.go`'s
neighborhood) — shipped together at the user's explicit request rather
than as several small PRs in sequence.

## Verification

- `go build ./...`, `go vet ./...`, `go test -race ./...` — every package
  green, including the full `dash` (625s) and `proxy` (248s) suites.
- New/updated tests: strategy-attribution equivalence
  (`TestStrategyLedgerGroupsPingsByTenantAndAttributesTheirCredit`),
  latency-diagnostic sample-size gate (both directions), per-tenant
  batched-query equivalence for keep-alive net and decl-filter savings
  (mirroring the existing `CachesplitHistoricalUSDByTenant` pattern),
  the existing `TestDashboardsOnlyQueryMetricsWeExport` drift test (every
  metric a Grafana panel queries actually exists in the exposition).
- Live production data, read-only: 78 historically-credited keep-alive
  rows / $129.57, currently zero attributed to a strategy (expected — this
  column is never backfilled, so only new credits going forward carry
  one); decl-filter batched query matches its per-tenant equivalent
  exactly for the one tenant with real activity; keep-alive net batched
  query matches `KeepAliveLedger`'s own net per tenant; the large-context
  latency population (52,129 hits vs 3,375 writes) is well over the
  sample-size gate.

## Known, deliberately out of scope

- The keep-alive ping-savings *formula* itself was independently verified
  correct (to the cent, against 5 real ping→credit pairs) — no bug there,
  nothing changed in this PR.
- A separate, already-flagged WAL/retention issue (disabled since
  2026-08-22 to work around an unrelated `tool_declarations` duplication
  bug) is unrelated to any of the above and not addressed here.

## 4th commit: independent-review follow-ups

An adversarial review of the first 3 commits found two real, non-blocking
issues, both fixed in the 4th commit:

- `/api/components` has the same filter-keyed cache and per-row valuation
  shape as `/api/stats`/`/api/facets` but wasn't covered by the handler
  timeout — now is.
- The new "Where the value comes from" panel's declaration-filter tile
  had no fallback for the unpriced case, unlike the existing Cost-group
  tile for the same figure — an unpriced model could have shown "$0.00"
  for a real saving. Fixed to match the existing fallback.

The review also surfaced an honest caveat worth stating plainly rather
than only in a code comment: the `http.TimeoutHandler` wrapping bounds
the *caller's* wait, not the query itself — `Overview()` and `Facets()`
run on plain `d.sql.Query` (`context.Background()`), so a canceled
request context doesn't cancel the in-flight query or release its pooled
connection early. A caller gets a fast, honest timeout instead of
hanging; a genuinely stuck query's backend pressure isn't relieved by
this alone. Threading context through those call sites is a larger,
separate change and is not part of this PR.
