### PR TITLE
Fix the dashboard/metrics outage and a cross-tenant savings bug

### DIFF
--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -652,33 +653,57 @@ type tenantMetricsAdapter struct {
 }
 
 func (a tenantMetricsAdapter) TenantMetrics(since int64) ([]proxy.TenantMetricRow, error) {
-	rows, err := a.rec.DB().TenantMetrics(since)
-	if err != nil {
-		return nil, err
-	}
-	// The pre-instrumentation split figure, per tenant, priced here because this is the layer
-	// that holds the rates. One query for every tenant, not one per tenant — see
-	// DB.CachesplitHistoricalUSDByTenant for why a query per tenant re-paid the same
-	// whole-table sort N times over. Best-effort — a query failure here zeroes this metric
-	// for every tenant rather than failing the whole scrape.
-	hist := map[string]float64{}
-	if a.prices != nil {
+	// The four queries below are independent — none consumes another's result — so they run
+	// concurrently rather than one after another: CachesplitHistoricalUSDByTenant alone measured
+	// ~2s against a production-sized copy of the DB, and summed sequentially with the other
+	// three that is most of a /metrics scrape's wall time for no reason. A plain
+	// sync.WaitGroup, not an errgroup, because three of these four keep an EXISTING
+	// best-effort contract — a query failure zeroes that one metric for every tenant rather
+	// than failing the whole scrape — and an errgroup's Wait returns the first error, which
+	// would turn one optional query's failure into the whole scrape's.
+	var (
+		rows    []dash.TenantMetricRow
+		rowsErr error
+		// The pre-instrumentation split figure, per tenant, priced here because this is the
+		// layer that holds the rates. One query for every tenant, not one per tenant — see
+		// DB.CachesplitHistoricalUSDByTenant for why a query per tenant re-paid the same
+		// whole-table sort N times over.
+		hist = map[string]float64{}
+		// The keep-alive net needs no pricer (the credit is already priced at write time) —
+		// one more grouped-by-tenant query, best-effort like the one above.
+		kaNet = map[string]float64{}
+		// The declaration filter's saving, priced on read the same way the historical split
+		// figure is above.
+		declFilter = map[string]float64{}
+	)
+	var wg sync.WaitGroup
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		rows, rowsErr = a.rec.DB().TenantMetrics(since)
+	}()
+	go func() {
+		defer wg.Done()
+		if a.prices == nil {
+			return
+		}
 		if byTenant, err := a.rec.DB().CachesplitHistoricalUSDByTenant(since, a.prices); err == nil {
 			for tid, h := range byTenant {
 				hist[tid] = h.USD
 			}
 		}
-	}
-	// The keep-alive net needs no pricer (the credit is already priced at write time) — one
-	// more grouped-by-tenant query, best-effort like the one above.
-	kaNet := map[string]float64{}
-	if net, err := a.rec.DB().KeepAliveNetUSDByTenant(since); err == nil {
-		kaNet = net
-	}
-	// The declaration filter's saving, priced on read the same way the historical split
-	// figure is above.
-	declFilter := map[string]float64{}
-	if a.prices != nil {
+	}()
+	go func() {
+		defer wg.Done()
+		if net, err := a.rec.DB().KeepAliveNetUSDByTenant(since); err == nil {
+			kaNet = net
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if a.prices == nil {
+			return
+		}
 		priceFn := func(model string) (modelinfo.Price, bool) {
 			if model == "" {
 				return modelinfo.Price{}, false
@@ -690,6 +715,10 @@ func (a tenantMetricsAdapter) TenantMetrics(since int64) ([]proxy.TenantMetricRo
 				declFilter[tid] = s.USD
 			}
 		}
+	}()
+	wg.Wait()
+	if rowsErr != nil {
+		return nil, rowsErr
 	}
 	out := make([]proxy.TenantMetricRow, 0, len(rows))
 	for _, r := range rows {

--- a/dash/accounting_test.go
+++ b/dash/accounting_test.go
@@ -311,6 +311,83 @@ func TestSelfRemovalNeedsComparableLaterSessions(t *testing.T) {
 	}
 }
 
+// TestSelfRemovalDoesNotPoolAcrossTenants pins the bug found auditing the manager's
+// service-wide (TenantAll) view against a copy of the live DB: an MCP tool declared in exactly
+// ONE session of ONE tenant was reported "removed" on the strength of hundreds of OTHER
+// tenants' sessions that simply never carried that tenant's MCP server at all — a candidate's
+// query grouped `tool_declarations` by (kind, name, server) with no tenant_id in sight, so two
+// unrelated accounts' declaration timelines for a same-named item were pooled into one. The
+// production instance of this credited $154.53 of avoided cost to a removal nobody made.
+//
+// t1 declares mcp__srv__thing once and never again; t2, which has ALWAYS carried it (every one
+// of its sessions still declares it), must contribute nothing to t1's SessionsAfter or dollars —
+// and t1's own comparable-but-not-yet-three-strong count must not be inflated to "removed" by
+// borrowing t2's session count. session_id namespaces overlap deliberately (see
+// TestInventoryKeysAreTenantScoped, same technique on the write side): a fix that merely happened
+// to key off distinct ids would still be wrong the day two tenants' clients collide.
+func TestSelfRemovalDoesNotPoolAcrossTenants(t *testing.T) {
+	db := openTestDB(t)
+	decl := func(tenant, session string, ts int64, kinds [][3]string) {
+		e := &Event{
+			TS: ts, SessionID: session, Model: "m1", TenantID: tenant,
+			TokensBefore: 5000, TokensAfter: 5000, Meta: Meta{Tools: 3},
+			FreshInput: 10, CacheRead: 20000, TokenAccounting: AccountingComplete,
+		}
+		insertReq(t, db, e)
+		for _, k := range kinds {
+			if _, err := db.sql.Exec(`INSERT INTO tool_declarations(
+				tenant_id, session_id, digest, kind, name, server, tokens, ts)
+				VALUES(?,?,'d1',?,?,?,100,?)`, tenant, session, k[0], k[1], k[2], ts); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mcpTool := [][3]string{{KindMCPTool, "mcp__srv__thing", "srv"}}
+	// t1: one session declares the tool, then five later (same session-id namespace as t2's,
+	// on purpose) comparable sessions that do not.
+	decl("t1", "shared-a", 1000, mcpTool)
+	for i := 0; i < 5; i++ {
+		decl("t1", "shared-later"+string(rune('a'+i)), int64(2000+i), [][3]string{{KindMCPTool, "mcp__srv__other", "srv"}})
+	}
+	// t2: carries the SAME tool in every one of its sessions, including ones that collide with
+	// t1's session ids above. If these leak into t1's evidence, t1's tool would wrongly look
+	// still-carried (diluting SessionsAfter) or, in the pre-fix bug's actual failure mode,
+	// t2's carrying sessions would wrongly count as t1's "confirmed removed" testimony.
+	for i := 0; i < 5; i++ {
+		decl("t2", "shared-later"+string(rune('a'+i)), int64(2000+i), mcpTool)
+	}
+
+	got, err := db.SelfRemovals(Filter{TenantAll: true},
+		func(m string) (modelinfo.Price, bool) { return handPrice.Price(context.Background(), m) },
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mine SelfRemoval
+	found := false
+	for _, r := range got {
+		if r.Name == "mcp__srv__thing" {
+			mine, found = r, true
+		}
+	}
+	if !found {
+		t.Fatal("t1's removed MCP tool was not credited at all")
+	}
+	// Only t1's own 5 later sessions may testify. If t2's sessions leaked in, this would be 10.
+	if mine.SessionsAfter != 5 {
+		t.Errorf("SessionsAfter = %d, want 5 — t2's sessions must not count as t1's evidence",
+			mine.SessionsAfter)
+	}
+	// t1's carried-then-dropped tool was 100 tokens; t2 read 20000 tokens on 5 sessions of a
+	// tool it never dropped. If those requests were priced into t1's row, AvoidedUSD would be
+	// off by orders of magnitude. Sanity bound: at 100 tokens x 5 sessions x a few requests each,
+	// this cannot rationally exceed a fraction of a cent.
+	if mine.AvoidedUSD > 0.01 {
+		t.Errorf("AvoidedUSD = %.6f, implausibly large for a 100-token item over 5 sessions — "+
+			"looks like another tenant's traffic leaked in", mine.AvoidedUSD)
+	}
+}
+
 // TestSessionLengthUsesTheRequestWeightedMean pins the statistic a per-session projection
 // multiplies by.
 //

--- a/dash/api.go
+++ b/dash/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/context-guru/internal/modelinfo"
+	"golang.org/x/sync/errgroup"
 )
 
 // API serves the dashboard: the JSON endpoints, the SSE stream, and the embedded
@@ -728,33 +729,90 @@ func (a *API) stats(w http.ResponseWriter, r *http.Request) {
 		w.Write(body)
 		return
 	}
-	o, err := a.rec.DB().Overview(f)
-	if err != nil {
-		httpErr(w, http.StatusInternalServerError, err.Error())
-		return
-	}
+	// The four calls below are independent of each other — none reads another's result, only
+	// this handler's own fields afterward do — so they run concurrently rather than one after
+	// another. Sequentially, on a production-sized DB, Overview() alone measured ~5-10s (see its
+	// own errgroup for why) and DeclCreditFor another ~4-16s (see SelfRemovals' own comment for
+	// why it was rewritten), which summed past this handler's 10s caller-facing timeout on every
+	// call. Run concurrently, wall time drops to roughly the slowest of the four rather than
+	// their sum.
+	var (
+		o              *Overview
+		overviewErr    error
+		cachesplitHist *CachesplitHistorical
+		tierCosts      *TierCosts
+		declCredit     *DeclCredit
+	)
+	var g errgroup.Group
+	g.Go(func() error {
+		var err error
+		o, err = a.rec.DB().Overview(f)
+		overviewErr = err
+		return nil // Overview's own error is reported below, not folded into the group's error:
+		// a pricing failure in one of the other three must not mask it, and it must not mask them.
+	})
 	// Best-effort, and omitted rather than zeroed when it cannot be computed: a figure the
 	// dashboard cannot value must read as absent, never as "saved nothing".
 	if a.pricer != nil {
-		if h, err := a.rec.DB().CachesplitHistoricalUSD(f, a.pricer); err == nil {
-			o.CachesplitHistorical = &h
-		}
+		g.Go(func() error {
+			if h, err := a.rec.DB().CachesplitHistoricalUSD(f, a.pricer); err == nil {
+				cachesplitHist = &h
+			}
+			return nil
+		})
 		// The bill split by tier, and with it the addressable share and the safety panel's
 		// benefit half. Same rule: absent when it cannot be priced, never a zeroed bill.
-		if t, err := a.rec.DB().TierCosts(f, a.pricer); err == nil {
-			o.SetTiers(t)
-		}
+		g.Go(func() error {
+			if t, err := a.rec.DB().TierCosts(f, a.pricer); err == nil {
+				tierCosts = t
+			}
+			return nil
+		})
 	}
 	// The declarations no longer sent, both halves. Needs no pricer for the token counts, so it
 	// runs outside the block above; best-effort and non-fatal, because it is an addition to the
 	// walk and a deployment where it fails should still get the walk. NEVER silent, though: an
 	// error swallowed here returns zeros, and a zero in a savings figure is a claim.
-	if c, err := a.rec.DB().DeclCreditFor(f, a.priceFn(r),
-		a.toolFilterStateForScope(f).Removed); err == nil {
-		o.SetDeclCredit(c)
-	} else {
-		slog.Warn("dash: declaration-removal credit unavailable", "err", err)
+	g.Go(func() error {
+		c, err := a.rec.DB().DeclCreditFor(f, a.priceFn(r), a.toolFilterStateForScope(f).Removed)
+		if err != nil {
+			slog.Warn("dash: declaration-removal credit unavailable", "err", err)
+			return nil
+		}
+		declCredit = c
+		return nil
+	})
+	g.Wait() //nolint:errcheck // every goroutine above always returns nil; see each one's own error handling
+	if overviewErr != nil {
+		httpErr(w, http.StatusInternalServerError, overviewErr.Error())
+		return
 	}
+	if cachesplitHist != nil {
+		o.CachesplitHistorical = cachesplitHist
+		// Folded into the running total here, not inside Overview() itself, because
+		// pricing it needs a.pricer — Overview() returns before this figure exists, the
+		// same reason DeclCreditFor's addition below happens out here too. Leaving it out
+		// was the actual inconsistency, not a deliberate scoping choice: the page's own
+		// "Prefix-cache savings" tile (dash/ui/app.js) already adds CachesplitSavedUSD and
+		// this historical figure together and calls the sum ours — the headline total
+		// should agree with the tile two inches to its right, not exclude half of it.
+		o.TotalSavedUSD += cachesplitHist.USD
+	}
+	if tierCosts != nil {
+		o.SetTiers(tierCosts)
+	}
+	if declCredit != nil {
+		o.SetDeclCredit(declCredit)
+	}
+	// Rebuilt here, not left as Overview()'s own snapshot: o.Waterfall was materialized
+	// before any of the priced additions above existed, so its "declarations no longer
+	// sent" step baked in a zero (SetDeclCredit had not run yet) and its own "total_saved"
+	// step baked in a total short by both the historical split figure and the decl-filter
+	// credit — silently disagreeing with the headline tile two inches above it, which reads
+	// o.TotalSavedUSD directly rather than through the waterfall. waterfall() only reads
+	// current field values, so calling it again here is exactly as correct as the first
+	// call and now sees everything this handler has since added.
+	o.Waterfall = o.waterfall()
 	body, err := json.Marshal(o)
 	if err != nil {
 		httpErr(w, http.StatusInternalServerError, err.Error())

--- a/dash/capture.go
+++ b/dash/capture.go
@@ -230,12 +230,33 @@ func NewRecorder(opts Options) (*Recorder, error) {
 		r.wg.Add(1)
 		go r.archiveLoop()
 	}
-	// And the one-time prompt-text backfill, on its own goroutine for the same reason. It is
-	// unconditional and needs no flag: it is a no-op (one indexed query) on a database that has
-	// nothing left to move, which after the first run is every start. See dedupetext.go.
+	// And the one-time migrations, on their own shared goroutine for the same reason
+	// archiveLoop is: the writer owes the request path a fast insert, and anything measured
+	// in minutes on that goroutine means a full queue and dropped events. See
+	// backgroundMigrations for why they share ONE goroutine rather than one each.
 	r.wg.Add(1)
-	go r.dedupeLoop()
+	go r.backgroundMigrations()
 	return r, nil
+}
+
+// backgroundMigrations runs every one-time housekeeping migration in sequence, on one shared
+// goroutine, rather than giving each its own.
+//
+// Each was written expecting to be the only writer contending with the capture pipeline's own
+// batches, and is small and fast next to the archiver's minutes-scale rclone round trips (which
+// keeps its own goroutine, unchanged, for exactly that reason). Running dedupeLoop and
+// keepAliveStrategyBackfillLoop as two SEPARATE goroutines instead of one measurably doubled
+// SQLite write-lock contention on every startup — enough that
+// TestRecorderMigratesLegacyPromptTextOnStart's own migration missed its busy_timeout under
+// -race, on a database with no real content at all. Sequencing them costs nothing that
+// matters: neither runs for more than a fraction of a second on any deployment measured so
+// far, migrations that have already run skip past their own predicate check near-instantly
+// (see each one's own completion marker), and a deployment with real historical backlog in
+// both at once still finishes well inside the time a single one used to take alone.
+func (r *Recorder) backgroundMigrations() {
+	defer r.wg.Done()
+	r.dedupeLoop()
+	r.keepAliveStrategyBackfillLoop()
 }
 
 // archiveLoop runs the age-based archival passes until the recorder closes.

--- a/dash/declcredit_test.go
+++ b/dash/declcredit_test.go
@@ -1,7 +1,10 @@
 package dash
 
 import (
+	"encoding/json"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -137,6 +140,80 @@ func TestDeclCreditFlagsAnUnpricedModel(t *testing.T) {
 	}
 	if c.Priced {
 		t.Error("priced = true for a model with no rates")
+	}
+}
+
+// TestWaterfallTotalMatchesTheHeadlineAfterAllPricedAdditions is the API-handler-level version
+// of TestSetDeclCreditPutsEachHalfInTheRightTotal: it caught a real bug that the field-level
+// test could not, because o.Waterfall is built INSIDE Overview(), before CachesplitHistoricalUSD
+// and SetDeclCredit ever run — so the waterfall's own "total_saved" bar baked in a total short by
+// both additions, silently disagreeing with the headline tile two inches above it (which reads
+// o.TotalSavedUSD directly, not through the waterfall). Exercises the real GET /api/stats
+// handler, not the field-level helpers, because that staleness is invisible to anything that
+// calls Overview()/SetDeclCredit directly without going through the handler's full sequence.
+func TestWaterfallTotalMatchesTheHeadlineAfterAllPricedAdditions(t *testing.T) {
+	db := seedCredit(t, 1000)
+	// A pre-instrumentation cachesplit-historical row, same shape as
+	// TestHistoricalSplitValuationIsReadOnlyAndConservative: one row teaching the model's stable
+	// half, one session-first row that qualifies for the historical credit.
+	teach := mkEvent(9000, "s-hist", "aws/claude-sonnet-5", 100, 100)
+	teach.TenantID, teach.CacheRead, teach.CacheWrite, teach.SplitStableTokens = "t1", 54_304, 1_000, 5_697
+	qualifies := mkEvent(9100, "s-new-hist", "aws/claude-sonnet-5", 100, 100)
+	qualifies.TenantID, qualifies.CacheRead, qualifies.CacheWrite = "t1", 54_304, 1_000
+	if err := db.insertBatch([]*Event{teach, qualifies}); err != nil {
+		t.Fatal(err)
+	}
+	// A Recorder built directly around the already-seeded db, not via NewRecorder: that
+	// constructor starts background goroutines (the writer, the dedupe backfill) against
+	// whatever DB it opens, and swapping rec.db out from under them afterward is a data race
+	// (caught by -race: dedupeLoop reads r.db concurrently with this test's own write to it).
+	// This test only needs a Recorder that answers DB() and Close() for NewAPI/t.Cleanup — no
+	// live capture pipeline is exercised here.
+	rec := &Recorder{db: db, hub: NewHub(), done: make(chan struct{})}
+	t.Cleanup(func() { rec.Close() })
+	api := NewAPI(rec)
+	api.SetPricer(staticPricer{ibmSonnet})
+	mux := http.NewServeMux()
+	api.Mount(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/stats", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("/api/stats = %d: %s", w.Code, w.Body)
+	}
+	var resp struct {
+		TotalSavedUSD float64 `json:"total_saved_usd"`
+		DeclFilterUSD float64 `json:"decl_filter_usd"`
+		Waterfall     []struct {
+			Key      string  `json:"key"`
+			DeltaUSD float64 `json:"delta_usd"`
+		} `json:"waterfall"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, w.Body)
+	}
+	if resp.DeclFilterUSD <= 0 {
+		t.Fatal("decl_filter_usd is not positive; the fixture stopped exercising it")
+	}
+	var waterfallTotal, waterfallDeclFilter float64
+	var sawDeclFilter bool
+	for _, s := range resp.Waterfall {
+		if s.Key == "total_saved" {
+			waterfallTotal = s.DeltaUSD
+		}
+		if s.Key == "decl_filter_saved" {
+			waterfallDeclFilter, sawDeclFilter = -s.DeltaUSD, true
+		}
+	}
+	if !sawDeclFilter {
+		t.Fatal("no decl_filter_saved step in the waterfall")
+	}
+	if math.Abs(waterfallTotal-resp.TotalSavedUSD) > 1e-9 {
+		t.Errorf("waterfall total_saved = %v, headline total_saved_usd = %v — the chart and the "+
+			"tile disagree", waterfallTotal, resp.TotalSavedUSD)
+	}
+	if math.Abs(waterfallDeclFilter-resp.DeclFilterUSD) > 1e-9 {
+		t.Errorf("waterfall's decl_filter_saved step = %v, headline decl_filter_usd = %v — the "+
+			"waterfall step is stale", waterfallDeclFilter, resp.DeclFilterUSD)
 	}
 }
 

--- a/dash/dedupetext.go
+++ b/dash/dedupetext.go
@@ -287,13 +287,10 @@ func (d *DB) dedupeOneBatch(batch []declBlob) (int64, error) {
 	return moved, tx2.Commit()
 }
 
-// dedupeLoop is the recorder's hook: run the backfill once, then reclaim what it freed.
-//
-// On its own goroutine and not on the writer's, for the reason archiveLoop is: the writer owes
-// the request path a fast insert, and anything measured in minutes on that goroutine means a
-// full queue and dropped events.
+// dedupeLoop runs the backfill once, then reclaims what it freed. Called from
+// backgroundMigrations (capture.go), not given its own goroutine — see that function's
+// comment for why every one-time migration shares one.
 func (r *Recorder) dedupeLoop() {
-	defer r.wg.Done()
 	moved, err := r.db.dedupeDeclarationText(r.done, dedupeBatch, dedupePause)
 	if err != nil {
 		// A partial migration is readable and resumable, so this is a warning, not a fatal:

--- a/dash/dedupetext.go
+++ b/dash/dedupetext.go
@@ -14,9 +14,11 @@ package dash
 //     COLUMN stays in place (dropping a column rewrites the table in SQLite), unread by the
 //     writer, still read by the reader for whatever this has not reached.
 //   - IT RUNS AGAINST A LIVE SERVICE. So: bounded batches, a pause between them, the
-//     recorder's own done channel checked every batch, and no state of its own — the work
-//     left is a predicate over the data (`text_gz IS NOT NULL`), which is what makes it
-//     both resumable after a crash and idempotent on a second run.
+//     recorder's own done channel checked every batch. The work left is a predicate over the
+//     data (`text_gz IS NOT NULL`), which is what makes it both resumable after a crash and
+//     idempotent on a second run — the one piece of state this file keeps (see
+//     dedupeMigrationDoneKey below) is only a cache of that predicate's answer, never a
+//     substitute for it: losing or clearing that row costs one redundant scan, not correctness.
 //
 // The interruption story, which is the part worth checking rather than trusting: each batch
 // is two transactions, and every possible stopping point leaves the text readable.
@@ -30,6 +32,7 @@ package dash
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"log/slog"
 	"time"
@@ -54,17 +57,34 @@ const (
 // dedupeDeclarationText moves every per-row prompt blob into declaration_text and points the
 // row at it. Returns the number of rows migrated. It stops early and without error when stop
 // is closed, because a partial run is a valid state — the next start continues from the data.
+//
+// dedupeMigrationDoneKey short-circuits this on every restart AFTER the first one that finds
+// nothing left: the cursor resets to 0 on every new process (see below), and on a table that
+// has already been fully migrated that "resets to 0" cost is not the one-time ~3s this file
+// used to measure it at — tool_declarations grows without bound (no retention), so the scan
+// needed to conclude "nothing pending" grows with it, and it was measured taking ~18-20s on a
+// production-sized table under real concurrent load, once per restart, forever. A single row
+// in `meta` (already used for schema_version, see schema.go) records that the migration has
+// reached the end of the table at least once; once set, every later restart skips straight
+// past pendingDedupe's full scan instead of re-proving what is already known. This is a small
+// forward step from the partial-index alternative this file's history already rejected (that
+// one paid ~50s inside Open(), blocking every request until it finished, to buy the same thing)
+// — a meta flag costs nothing to check and nothing to set, and unlike the index it does not
+// touch tool_declarations at all.
 func (d *DB) dedupeDeclarationText(stop <-chan struct{}, batch int, pause time.Duration) (int64, error) {
 	if batch <= 0 {
 		batch = dedupeBatch
 	}
+	if done, err := d.dedupeMigrationDone(); err != nil {
+		slog.Warn("dash: could not read the dedupe-migration marker; scanning as if it were unset", "err", err)
+	} else if done {
+		return 0, nil
+	}
 	// A rowid cursor within the run. The predicate alone would be correct — and is what makes
 	// this resumable and idempotent — but re-issuing it each pass re-walks every row already
-	// migrated, which over 488k rows is quadratic. A partial index on the predicate was the
-	// other way to fix that and was measured worse: building it costs 50 seconds inside Open()
-	// on a production-sized file, i.e. 50 seconds of proxy startup, to save a scan that happens
-	// on this background goroutine. The cursor resets to 0 on the next process, which costs one
-	// scan (~3s, measured, off the request path) to conclude there is nothing left to do.
+	// migrated, which over 488k rows is quadratic. The cursor resets to 0 on the next process
+	// that has NOT yet set the marker above; once it sets the marker, there is no next scan to
+	// reset for.
 	var cursor, moved int64
 	started := time.Now()
 	for {
@@ -78,6 +98,13 @@ func (d *DB) dedupeDeclarationText(stop <-chan struct{}, batch int, pause time.D
 			return moved, err
 		}
 		if len(rows) == 0 {
+			// Reaching an empty page, at ANY cursor, means every row from here to the end of
+			// the table has been checked and none is pending — the whole table is done,
+			// regardless of how much of it this particular call walked versus a previous one.
+			if merr := d.markDedupeMigrationDone(); merr != nil {
+				slog.Warn("dash: could not persist the dedupe-migration marker; "+
+					"the next restart will re-scan to confirm nothing is pending", "err", merr)
+			}
 			break
 		}
 		cursor = rows[len(rows)-1].rowid
@@ -99,6 +126,33 @@ func (d *DB) dedupeDeclarationText(stop <-chan struct{}, batch int, pause time.D
 			"took", time.Since(started).Round(time.Millisecond))
 	}
 	return moved, nil
+}
+
+// dedupeMigrationDoneKey is the `meta` row this migration sets once it has scanned to the end
+// of tool_declarations and found nothing left pending. `meta` already holds schema_version
+// (see schema.go) as a generic key/value settings table, so this needs no new table.
+const dedupeMigrationDoneKey = "dedupe_declaration_text_done"
+
+// dedupeMigrationDone reports whether a previous run already proved nothing is pending. Best
+// read as "no" on error — a mis-read marker should cost one redundant scan, not a migration
+// that silently never runs.
+func (d *DB) dedupeMigrationDone() (bool, error) {
+	var v string
+	err := d.sql.QueryRow(`SELECT value FROM meta WHERE key = ?`, dedupeMigrationDoneKey).Scan(&v)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return v == "1", nil
+}
+
+// markDedupeMigrationDone persists that the scan reached the end of the table with nothing
+// pending, so the next process start can skip straight past it.
+func (d *DB) markDedupeMigrationDone() error {
+	_, err := d.sql.Exec(`INSERT OR REPLACE INTO meta(key, value) VALUES (?, '1')`, dedupeMigrationDoneKey)
+	return err
 }
 
 // declBlob is one row of work: where it lives and what it holds.

--- a/dash/dedupetext_test.go
+++ b/dash/dedupetext_test.go
@@ -228,6 +228,57 @@ func TestBackfillIsEquivalentAndCollapsesDuplicates(t *testing.T) {
 	}
 }
 
+// A completed migration marks itself done, and a later call — a fresh process finding the
+// table already fully migrated — skips the scan entirely rather than re-walking the whole
+// table to rediscover the same answer. This is the property that makes the marker worth
+// having: without it, every restart pays pendingDedupe's full-table cost forever, even though
+// nothing is ever pending again once the one-time legacy backlog is gone.
+func TestDedupeMigrationMarkerSkipsARepeatScan(t *testing.T) {
+	db := emptyDB(t)
+	legacyRow(t, db, "s0", "Bash", `{"name":"Bash"}`)
+
+	if done, err := db.dedupeMigrationDone(); err != nil {
+		t.Fatal(err)
+	} else if done {
+		t.Fatal("marker reads done before any migration has run")
+	}
+
+	moved, err := db.dedupeDeclarationText(nil, 500, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 1 {
+		t.Fatalf("first run migrated %d rows, want 1", moved)
+	}
+	done, err := db.dedupeMigrationDone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !done {
+		t.Fatal("marker not set after a run that scanned to the end of the table")
+	}
+
+	// A new legacy-shaped row appearing after the marker is set is the scenario the marker
+	// trades away deliberately (see the comment on dedupeDeclarationText): the current write
+	// path never produces one, so this is not expected in production, but the test should
+	// still prove the marker actually short-circuits rather than merely existing.
+	legacyRow(t, db, "s1", "Read", `{"name":"Read"}`)
+	moved, err = db.dedupeDeclarationText(nil, 500, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 0 {
+		t.Fatalf("second run migrated %d rows, want 0 (marker should have skipped the scan)", moved)
+	}
+	var stillLegacy int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM tool_declarations WHERE text_gz IS NOT NULL`).Scan(&stillLegacy); err != nil {
+		t.Fatal(err)
+	}
+	if stillLegacy != 1 {
+		t.Errorf("%d rows still carry text_gz, want 1 (the post-marker row the skip left alone)", stillLegacy)
+	}
+}
+
 // Interrupted, then resumed, then run again — and the reveal is identical at every step.
 //
 // This is the property the live migration is judged on: the process can stop anywhere, and what

--- a/dash/keepalivestrategybackfill.go
+++ b/dash/keepalivestrategybackfill.go
@@ -1,0 +1,215 @@
+package dash
+
+// The one-time backfill that recovers keepalive_strategy_id on REAL rows written before
+// dashcapture.go learned to tag them (2026-08-30). It was reported as "every strategy shows
+// $0 Saved, including last week's" — which turned out to be true for exactly the rows this
+// file fixes, and only those: dash/keepalivestrategy.go's StrategyLedger filters on
+// keepalive_saved_usd > 0 AND keepalive_strategy_id = ?, and a real row credited before the
+// real-row tagging code existed has NULL there, permanently, with no way for the live code to
+// ever set it after the fact — the moment arrive() had the strategy in scope is long gone.
+//
+// The information is not lost, though: the PING rows that rescued those real rows were
+// already tagged (this half of the feature is older, PR #114), and a real row's own
+// keepalive_pings > 0 says a ping preceded it. So for a real row missing the tag, the ping(s)
+// that immediately preceded it in the SAME session — after that session's own previous real
+// row, so this never reaches into an EARLIER, already-consumed idle span — carry exactly the
+// strategy id arrive() would have reported at the time, had this code existed then. Measured
+// on the live corpus: 109 of 130 such rows recover a tag this way; the other 21 have no
+// matching tagged ping at all, which means the rescue came from plain account config or a
+// session override with no strategy involved — correctly left NULL, not guessed at.
+//
+// NOTHING IS DELETED and nothing already tagged is touched — this only ever moves a NULL to a
+// value it can prove from data the table already holds. Same shape as dedupetext.go's
+// migration: a predicate over the data, so it is naturally idempotent and resumable, with a
+// meta marker recording it has run so a restart does not repeat a full-table predicate check
+// once nothing new could ever match it (new rescues are tagged directly at write time now;
+// this file has no ongoing job once the historical gap is closed).
+
+import (
+	"database/sql"
+	"log/slog"
+	"time"
+)
+
+// keepAliveStrategyBackfillDoneKey is the `meta` row this backfill sets once it has swept the
+// whole table and found nothing left to recover.
+const keepAliveStrategyBackfillDoneKey = "keepalive_strategy_backfill_done"
+
+// keepAliveStrategyBackfillBatch bounds how many candidate rows one pass considers. The live
+// corpus this was measured against had 130 total candidates ever — this is not a table-sized
+// migration, but it still batches and pauses like one, so a future deployment with a much
+// larger backlog of idle real rows behaves the same way dedupetext.go's migration does rather
+// than assuming today's small scale forever.
+const keepAliveStrategyBackfillBatch = 500
+
+// keepAliveStrategyBackfillPause is the gap between batches, so the capture writer always has
+// the lock available and this cannot starve it even on a much larger backlog.
+const keepAliveStrategyBackfillPause = 200 * time.Millisecond
+
+// keepAliveStrategyBackfillLoop runs the recovery sweep once. Called from
+// backgroundMigrations (capture.go), not given its own goroutine — see that function's
+// comment for why every one-time migration shares one.
+func (r *Recorder) keepAliveStrategyBackfillLoop() {
+	if _, err := r.db.backfillKeepAliveStrategyID(r.done, keepAliveStrategyBackfillBatch, keepAliveStrategyBackfillPause); err != nil {
+		// A partial run is readable and resumable, so this is a warning, not a fatal: the
+		// rows it did not reach stay exactly as informative as they were before this ran.
+		slog.Warn("dash: keepalive-strategy backfill stopped early", "err", err)
+	}
+}
+
+// backfillKeepAliveStrategyID recovers keepalive_strategy_id on real rows a ping rescued
+// before the real-row tagging code existed. Returns the number of rows it filled. Stops early
+// and without error when stop is closed, exactly like dedupeDeclarationText — a partial run is
+// a valid state, and the next start continues from the data, not from any cursor of its own.
+func (d *DB) backfillKeepAliveStrategyID(stop <-chan struct{}, batch int, pause time.Duration) (int64, error) {
+	if batch <= 0 {
+		batch = keepAliveStrategyBackfillBatch
+	}
+	if done, err := d.keepAliveStrategyBackfillDone(); err != nil {
+		slog.Warn("dash: could not read the keepalive-strategy-backfill marker; sweeping as if it were unset", "err", err)
+	} else if done {
+		return 0, nil
+	}
+	var cursor, moved int64
+	started := time.Now()
+	for {
+		select {
+		case <-stop:
+			return moved, nil
+		default:
+		}
+		ids, err := d.pendingKeepAliveStrategyBackfill(cursor, batch)
+		if err != nil {
+			return moved, err
+		}
+		if len(ids) == 0 {
+			if merr := d.markKeepAliveStrategyBackfillDone(); merr != nil {
+				slog.Warn("dash: could not persist the keepalive-strategy-backfill marker; "+
+					"the next restart will re-sweep to confirm nothing is left", "err", merr)
+			}
+			break
+		}
+		cursor = ids[len(ids)-1]
+		n, err := d.backfillOneKeepAliveStrategyBatch(ids)
+		moved += n
+		if err != nil {
+			return moved, err
+		}
+		if pause > 0 {
+			select {
+			case <-stop:
+				return moved, nil
+			case <-time.After(pause):
+			}
+		}
+	}
+	if moved > 0 {
+		slog.Info("dash: recovered keepalive_strategy_id on real rows a ping rescued before the real-row tagging code existed",
+			"rows", moved, "took", time.Since(started).Round(time.Millisecond))
+	}
+	return moved, nil
+}
+
+// pendingKeepAliveStrategyBackfill finds the next batch of real rows a ping rescued
+// (keepalive_pings > 0) that have never been tagged with the strategy that sent the ping.
+// id is the table's own rowid, so `id > ?` is a seek rather than a rescan of what came before.
+func (d *DB) pendingKeepAliveStrategyBackfill(after int64, limit int) ([]int64, error) {
+	rows, err := d.sql.Query(`SELECT id FROM requests
+		WHERE id > ? AND keepalive = 0 AND keepalive_pings > 0 AND keepalive_strategy_id IS NULL
+		ORDER BY id LIMIT ?`, after, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// backfillOneKeepAliveStrategyBatch fills in keepalive_strategy_id for exactly the rows named,
+// each from the strategy id of the ping(s) that immediately preceded it in the SAME session —
+// after that session's own previous real row, which is what keeps this from reaching into an
+// earlier, already-consumed idle span. A row with no matching tagged ping (plain account
+// config or a session override rescued it, never a strategy) is left NULL, not guessed at.
+func (d *DB) backfillOneKeepAliveStrategyBatch(ids []int64) (int64, error) {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after a successful Commit
+	// The matching-ping predicate is repeated in an EXISTS rather than trusted to the SET
+	// subquery alone: SQLite counts a row as affected once the UPDATE touches it, even when
+	// the value it writes is the same NULL that was already there — a row with no matching
+	// tagged ping would otherwise report as "moved" while staying NULL, overstating how much
+	// this recovered.
+	stmt, err := tx.Prepare(`UPDATE requests SET keepalive_strategy_id = (
+			SELECT p.keepalive_strategy_id FROM requests p
+			WHERE p.tenant_id = requests.tenant_id AND p.session_id = requests.session_id
+			  AND p.keepalive = 1 AND p.keepalive_strategy_id IS NOT NULL
+			  AND p.ts <= requests.ts
+			  AND p.ts > COALESCE((
+			      SELECT MAX(q.ts) FROM requests q
+			      WHERE q.tenant_id = requests.tenant_id AND q.session_id = requests.session_id
+			        AND q.keepalive = 0
+			        AND (q.ts < requests.ts OR (q.ts = requests.ts AND q.id < requests.id))
+			  ), 0)
+			ORDER BY p.ts DESC LIMIT 1
+		)
+		WHERE id = ? AND keepalive_strategy_id IS NULL
+		  AND EXISTS (
+			SELECT 1 FROM requests p
+			WHERE p.tenant_id = requests.tenant_id AND p.session_id = requests.session_id
+			  AND p.keepalive = 1 AND p.keepalive_strategy_id IS NOT NULL
+			  AND p.ts <= requests.ts
+			  AND p.ts > COALESCE((
+			      SELECT MAX(q.ts) FROM requests q
+			      WHERE q.tenant_id = requests.tenant_id AND q.session_id = requests.session_id
+			        AND q.keepalive = 0
+			        AND (q.ts < requests.ts OR (q.ts = requests.ts AND q.id < requests.id))
+			  ), 0)
+		  )`)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+	var moved int64
+	for _, id := range ids {
+		res, err := stmt.Exec(id)
+		if err != nil {
+			return moved, err
+		}
+		if n, err := res.RowsAffected(); err == nil {
+			moved += n
+		}
+	}
+	return moved, tx.Commit()
+}
+
+// keepAliveStrategyBackfillDone reports whether a previous run already swept the whole table
+// and found nothing left to recover. Best read as "no" on error, matching dedupetext.go's own
+// marker — a mis-read should cost one redundant sweep, not skip a backfill that has real,
+// recoverable rows.
+func (d *DB) keepAliveStrategyBackfillDone() (bool, error) {
+	var v string
+	err := d.sql.QueryRow(`SELECT value FROM meta WHERE key = ?`, keepAliveStrategyBackfillDoneKey).Scan(&v)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return v == "1", nil
+}
+
+// markKeepAliveStrategyBackfillDone persists that a sweep found nothing left to recover, so
+// the next process start can skip straight past the predicate check.
+func (d *DB) markKeepAliveStrategyBackfillDone() error {
+	_, err := d.sql.Exec(`INSERT OR REPLACE INTO meta(key, value) VALUES (?, '1')`, keepAliveStrategyBackfillDoneKey)
+	return err
+}

--- a/dash/keepalivestrategybackfill_test.go
+++ b/dash/keepalivestrategybackfill_test.go
@@ -1,0 +1,152 @@
+package dash
+
+import "testing"
+
+// The property this whole file exists for: a real row rescued by a tagged ping, written
+// before the real-row tagging code existed (so it carries keepalive_pings > 0 but a NULL
+// keepalive_strategy_id), recovers the ping's own strategy id — not a guess, the exact value
+// arrive() would have reported had the code existed at the time.
+func TestBackfillRecoversStrategyFromThePingThatRescuedTheRow(t *testing.T) {
+	db := emptyDB(t)
+
+	prevReal := mkEvent(1_000, "s1", "claude", 100, 90)
+	prevReal.TenantID = "t1"
+	ping := mkEvent(2_000, "s1", "claude", 100, 90)
+	ping.TenantID = "t1"
+	ping.KeepAlive = true
+	ping.KeepAliveStrategyID = "strat-a"
+	rescued := mkEvent(3_000, "s1", "claude", 100, 90)
+	rescued.TenantID = "t1"
+	rescued.KeepAlivePings = 1
+	rescued.KeepAliveSavedUSD = 0.42
+	// KeepAliveStrategyID left "" — exactly the pre-fix historical shape.
+
+	if err := db.insertBatch([]*Event{prevReal, ping, rescued}); err != nil {
+		t.Fatal(err)
+	}
+
+	moved, err := db.backfillKeepAliveStrategyID(nil, 500, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 1 {
+		t.Fatalf("moved %d rows, want 1", moved)
+	}
+
+	var got string
+	if err := db.sql.QueryRow(`SELECT keepalive_strategy_id FROM requests WHERE ts = 3000`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "strat-a" {
+		t.Errorf("recovered strategy = %q, want %q", got, "strat-a")
+	}
+	// The ping row and the earlier real row must be untouched.
+	var pingStrat string
+	if err := db.sql.QueryRow(`SELECT keepalive_strategy_id FROM requests WHERE ts = 2000`).Scan(&pingStrat); err != nil {
+		t.Fatal(err)
+	}
+	if pingStrat != "strat-a" {
+		t.Errorf("the ping row's own strategy id changed to %q", pingStrat)
+	}
+}
+
+// A rescue with no matching tagged ping — plain account config or a session override, never a
+// strategy — must stay NULL rather than being guessed at.
+func TestBackfillLeavesAnUntaggedRescueAlone(t *testing.T) {
+	db := emptyDB(t)
+
+	ping := mkEvent(1_000, "s1", "claude", 100, 90)
+	ping.TenantID = "t1"
+	ping.KeepAlive = true
+	// No KeepAliveStrategyID: an account-config ping, never a strategy.
+	rescued := mkEvent(2_000, "s1", "claude", 100, 90)
+	rescued.TenantID = "t1"
+	rescued.KeepAlivePings = 1
+	rescued.KeepAliveSavedUSD = 0.10
+
+	if err := db.insertBatch([]*Event{ping, rescued}); err != nil {
+		t.Fatal(err)
+	}
+
+	moved, err := db.backfillKeepAliveStrategyID(nil, 500, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 0 {
+		t.Fatalf("moved %d rows, want 0 — nothing here to recover", moved)
+	}
+	var got *string
+	if err := db.sql.QueryRow(`SELECT keepalive_strategy_id FROM requests WHERE ts = 2000`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("recovered strategy = %q, want NULL (no tagged ping to attribute to)", *got)
+	}
+}
+
+// A ping from an EARLIER, already-consumed idle span must never bleed into a LATER rescue in
+// the same session — the "after this session's own previous real row" bound is what keeps
+// this backfill from ever attributing a rescue to the wrong span's strategy.
+func TestBackfillNeverReachesPastAnEarlierRealRow(t *testing.T) {
+	db := emptyDB(t)
+
+	oldPing := mkEvent(1_000, "s1", "claude", 100, 90)
+	oldPing.TenantID = "t1"
+	oldPing.KeepAlive = true
+	oldPing.KeepAliveStrategyID = "strat-old"
+	firstRescue := mkEvent(2_000, "s1", "claude", 100, 90)
+	firstRescue.TenantID = "t1"
+	firstRescue.KeepAlivePings = 1
+	firstRescue.KeepAliveStrategyID = "strat-old" // already tagged correctly, e.g. by live code
+	newPing := mkEvent(3_000, "s1", "claude", 100, 90)
+	newPing.TenantID = "t1"
+	newPing.KeepAlive = true
+	newPing.KeepAliveStrategyID = "strat-new"
+	secondRescue := mkEvent(4_000, "s1", "claude", 100, 90)
+	secondRescue.TenantID = "t1"
+	secondRescue.KeepAlivePings = 1
+	// KeepAliveStrategyID left "" — this is the row under test.
+
+	if err := db.insertBatch([]*Event{oldPing, firstRescue, newPing, secondRescue}); err != nil {
+		t.Fatal(err)
+	}
+
+	moved, err := db.backfillKeepAliveStrategyID(nil, 500, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 1 {
+		t.Fatalf("moved %d rows, want 1 (only the untagged rescue)", moved)
+	}
+	var got string
+	if err := db.sql.QueryRow(`SELECT keepalive_strategy_id FROM requests WHERE ts = 4000`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "strat-new" {
+		t.Errorf("recovered strategy = %q, want %q (the NEW span's ping, not the old span's)", got, "strat-new")
+	}
+}
+
+// Run twice: the second run must be a true no-op, both in row count and in leaving the marker
+// set, matching dedupetext.go's own idempotency guarantee.
+func TestBackfillIsIdempotent(t *testing.T) {
+	db := emptyDB(t)
+	ping := mkEvent(1_000, "s1", "claude", 100, 90)
+	ping.TenantID, ping.KeepAlive, ping.KeepAliveStrategyID = "t1", true, "strat-a"
+	rescued := mkEvent(2_000, "s1", "claude", 100, 90)
+	rescued.TenantID, rescued.KeepAlivePings = "t1", 1
+	if err := db.insertBatch([]*Event{ping, rescued}); err != nil {
+		t.Fatal(err)
+	}
+
+	if moved, err := db.backfillKeepAliveStrategyID(nil, 500, 0); err != nil || moved != 1 {
+		t.Fatalf("first run: moved=%d err=%v, want 1/nil", moved, err)
+	}
+	done, err := db.keepAliveStrategyBackfillDone()
+	if err != nil || !done {
+		t.Fatalf("marker not set after a full sweep: done=%v err=%v", done, err)
+	}
+	if moved, err := db.backfillKeepAliveStrategyID(nil, 500, 0); err != nil || moved != 0 {
+		t.Fatalf("second run: moved=%d err=%v, want 0/nil", moved, err)
+	}
+}

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -3,6 +3,8 @@ package dash
 import (
 	"database/sql"
 	"fmt"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Denominator is one labelled savings ratio. Shipping a single "savings %" is the
@@ -581,56 +583,100 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// about that, which is what matters: session ids are `tenant:uuid` so a cross-tenant
 	// collision is not reachable, and the ceiling is deliberately about the session's whole life
 	// rather than the filtered slice of it.
-	if err := d.sql.QueryRow(`SELECT COALESCE(SUM(r.saved_unique * (
-			SELECT COUNT(*) FROM requests p WHERE p.session_id = r.session_id
-			  AND (p.ts > r.ts OR (p.ts = r.ts AND p.id > r.id)))),0)
-		FROM requests r WHERE `+cond+` AND r.saved_unique > 0`, args...).Scan(&o.ReplayProjectedTokens); err != nil {
-		return nil, err
-	}
-	// The correction, driven from the PING side: one pass to find the pings, then ONE indexed sum
-	// per ping over the earlier rows of its own session. O(pings x session) rather than a second
-	// full pass over the filtered rows, and pings are ~1% of rows — on a deployment that has never
-	// pinged it is a single index scan over an empty set.
+	//
+	// NOT rewritten as a window function, despite looking like the same shape CompactionResets
+	// was fixed for. Tried it, verified against live production data: byte-identical result,
+	// but consistently ~50-70% SLOWER (0.9s correlated vs 1.5s windowed, 5 runs). The difference
+	// from CompactionResets: that query's outer filter (tokens_before > 0) matches ~100% of
+	// rows, so a correlated subquery paid its per-invocation overhead on nearly every row and a
+	// single sort over everyone wins. Here the outer filter (saved_unique > 0) matches only
+	// 8.5% of rows (measured on the live corpus) — the correlated subquery only ever runs for
+	// that 8.5%, each an indexed lookup, while a window function must still sort the WHOLE
+	// table before the outer filter can narrow anything. Left as the correlated form on purpose.
+	// Everything from here to the percentiles below is a separate, independent read against
+	// the same filter — none of these queries consumes another's result (the two exceptions,
+	// the inflation correction and the estimator median, are noted where they are), so nothing
+	// stops them running concurrently instead of one after another. That is not an optimization
+	// for its own sake: measured against a production-sized copy of this table with zero write
+	// contention, this stretch alone summed to ~9s run sequentially — CompactionResets and the
+	// replay estimate each multiple seconds by themselves — which is why /api/stats was timing
+	// out its 10s caller-facing deadline on every single call, not just under load. Run
+	// concurrently against the same pooled *sql.DB (store.go's SetMaxOpenConns already sizes
+	// the pool for this), wall time drops to roughly the slowest single query rather than their
+	// sum. SQLite's WAL mode already gave each of these its own read snapshot when they ran
+	// sequentially — nothing here was ever one atomic view of the table — so concurrency changes
+	// only how long the caller waits, never what any individual query reads.
+	var (
+		replayProjectedRaw, inflation          int64
+		ttl                                    map[string]int64
+		bs, bt, bm, bb, modalRequests          int64
+		estimatorDivergenceRows                int64
+		estimatorDivergence                    float64
+		keepAlivePings                         int64
+		keepAlivePingUSD                       float64
+		accountingM, cacheMissM, uncompressedM map[string]int64
+		p95cg, p95up                           float64
+	)
+	var g errgroup.Group
+	// The replay ceiling's raw form, corrected below by the inflation query once both are in —
+	// see the comment above `splitMoved` usage earlier in this function for the ceiling's own
+	// derivation, and see the correlated-vs-window-function tradeoff explained where this query
+	// used to live: NOT rewritten as a window function despite looking like the same shape
+	// CompactionResets was fixed for. Tried it, verified against live production data:
+	// byte-identical result, but consistently ~50-70% SLOWER (0.9s correlated vs 1.5s windowed,
+	// 5 runs). The difference from CompactionResets: that query's outer filter (tokens_before >
+	// 0) matches ~100% of rows, so a correlated subquery paid its per-invocation overhead on
+	// nearly every row and a single sort over everyone wins. Here the outer filter
+	// (saved_unique > 0) matches only 8.5% of rows (measured on the live corpus) — the
+	// correlated subquery only ever runs for that 8.5%, each an indexed lookup, while a window
+	// function must still sort the WHOLE table before the outer filter can narrow anything.
+	// Left as the correlated form on purpose.
+	g.Go(func() error {
+		return d.sql.QueryRow(`SELECT COALESCE(SUM(r.saved_unique * (
+				SELECT COUNT(*) FROM requests p WHERE p.session_id = r.session_id
+				  AND (p.ts > r.ts OR (p.ts = r.ts AND p.id > r.id)))),0)
+			FROM requests r WHERE `+cond+` AND r.saved_unique > 0`, args...).Scan(&replayProjectedRaw)
+	})
+	// The correction to the above, driven from the PING side: one pass to find the pings, then
+	// ONE indexed sum per ping over the earlier rows of its own session. O(pings x session)
+	// rather than a second full pass over the filtered rows, and pings are ~1% of rows — on a
+	// deployment that has never pinged it is a single index scan over an empty set.
 	//
 	// It used to sit behind an `EXISTS(SELECT 1 FROM requests WHERE keepalive = 1)` gate, claiming
 	// the correction then "costs literally nothing where the mechanism has never run". It does not:
 	// `keepalive` is in no index, so the EXISTS is itself a scan. Timed alternately on the
 	// 10,000-row perf fixture, 5 trials: gated 52.7 ms against 53.0 ms ungated at 0 pings, and
 	// 58.0 against 57.3 at 100 — one extra scan for no measurable saving, so it is gone.
-	var inflation int64
-	if err := d.sql.QueryRow(`SELECT COALESCE(SUM((
-			SELECT COALESCE(SUM(r.saved_unique),0) FROM requests r
-			  WHERE r.session_id = p.session_id AND r.saved_unique > 0
-			    AND (r.ts < p.ts OR (r.ts = p.ts AND r.id < p.id))
-			    AND `+cond+`)),0)
-		FROM requests p WHERE p.keepalive = 1`, args...).Scan(&inflation); err != nil {
-		return nil, err
-	}
-	if o.ReplayProjectedTokens -= inflation; o.ReplayProjectedTokens < 0 {
-		o.ReplayProjectedTokens = 0
-	}
-	if o.ReplayProjectedTokens > 0 {
-		o.ReplayRealizedPct = float64(o.ReplayTokens) / float64(o.ReplayProjectedTokens) * 100
-	}
+	g.Go(func() error {
+		return d.sql.QueryRow(`SELECT COALESCE(SUM((
+				SELECT COALESCE(SUM(r.saved_unique),0) FROM requests r
+				  WHERE r.session_id = p.session_id AND r.saved_unique > 0
+				    AND (r.ts < p.ts OR (r.ts = p.ts AND r.id < p.id))
+				    AND `+cond+`)),0)
+			FROM requests p WHERE p.keepalive = 1`, args...).Scan(&inflation)
+	})
 	// Which cache TTL tier each request asked for. A map rather than columns because ""
 	// (no cache_control at all) is a real third answer that must not be folded into 5m.
-	ttl, err := d.countBy(cond, args, "cache_ttl")
-	if err != nil {
-		return nil, err
-	}
-	o.CacheTTL = ttl
+	g.Go(func() error {
+		m, err := d.countBy(cond, args, "cache_ttl")
+		if err != nil {
+			return err
+		}
+		ttl = m
+		return nil
+	})
 	// The MODAL breakpoint placement, not the mean: 1.5 breakpoints in a system block is not
 	// a thing any request did, and an average across locations describes no prompt at all.
-	var bs, bt, bm, bb int64
-	if err := d.sql.QueryRow(`SELECT r.cache_bp_system, r.cache_bp_tools, r.cache_bp_messages,
-			r.cache_bp_blocks, COUNT(*) AS n
-		FROM requests r WHERE `+cond+`
-		GROUP BY 1,2,3,4 ORDER BY n DESC LIMIT 1`, args...).Scan(&bs, &bt, &bm, &bb,
-		&o.Breakpoints.ModalRequests); err != nil && err != sql.ErrNoRows {
-		return nil, err
-	} else if err == nil {
-		o.Breakpoints.Modal = fmt.Sprintf("system=%d, tools=%d, messages=%d, blocks=%d", bs, bt, bm, bb)
-	}
+	g.Go(func() error {
+		err := d.sql.QueryRow(`SELECT r.cache_bp_system, r.cache_bp_tools, r.cache_bp_messages,
+				r.cache_bp_blocks, COUNT(*) AS n
+			FROM requests r WHERE `+cond+`
+			GROUP BY 1,2,3,4 ORDER BY n DESC LIMIT 1`, args...).Scan(&bs, &bt, &bm, &bb, &modalRequests)
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return err
+	})
 	// Context resets, DERIVED: a turn that arrived smaller than the previous turn of its own
 	// session. This is the bound on amortization — replay accrues only while removed content
 	// keeps being re-sent, and this is where that stops — so it belongs beside the replay
@@ -646,54 +692,113 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// prior row with tokens_before <= 0 to find one further back — on this corpus that never
 	// happens (tokens_before > 0 holds for every row measured), so this is not a behavior
 	// change in practice, but it is not a byte-for-byte port of the old query's guarantee.
-	q := `WITH s AS (
-		SELECT r.*, LAG(CASE WHEN r.tokens_before > 0 THEN r.tokens_before END)
-			OVER (PARTITION BY r.session_id ORDER BY r.ts, r.id) AS prev_tokens_before
-		FROM requests r
-	) SELECT COUNT(*) FROM s r WHERE ` + cond + `
-		AND r.tokens_before > 0 AND r.prev_tokens_before IS NOT NULL
-		AND r.tokens_before < r.prev_tokens_before`
-	if err := d.sql.QueryRow(q, args...).Scan(&o.CompactionResets); err != nil {
-		return nil, err
-	}
+	g.Go(func() error {
+		q := `WITH s AS (
+			SELECT r.*, LAG(CASE WHEN r.tokens_before > 0 THEN r.tokens_before END)
+				OVER (PARTITION BY r.session_id ORDER BY r.ts, r.id) AS prev_tokens_before
+			FROM requests r
+		) SELECT COUNT(*) FROM s r WHERE ` + cond + `
+			AND r.tokens_before > 0 AND r.prev_tokens_before IS NOT NULL
+			AND r.tokens_before < r.prev_tokens_before`
+		return d.sql.QueryRow(q, args...).Scan(&o.CompactionResets)
+	})
 	// The estimator check, on the only population where the two counts are comparable: requests
 	// where nothing was removed, so tokens_before and the provider's billed input describe the
 	// same prompt. A median rather than a mean, and rather than a ratio of sums, because a
 	// handful of enormous requests otherwise dominate and the figure stops describing a typical
 	// row. Computed with OFFSET over an ordered ratio, the same shape as DB.percentile — which
-	// takes a bare column name and so cannot express this ratio.
-	const ratioPop = ` AND r.tokens_before = r.tokens_after AND r.tokens_before > 0
-		AND r.token_accounting = 'complete' AND r.fresh_input + r.cache_read + r.cache_write > 0`
-	if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+ratioPop,
-		args...).Scan(&o.EstimatorDivergenceRows); err != nil {
+	// takes a bare column name and so cannot express this ratio. The median query depends on
+	// the row-count query run just before it (the OFFSET is half the count), so those two stay
+	// sequential WITHIN this one goroutine — only across the other units does this run concurrently.
+	g.Go(func() error {
+		const ratioPop = ` AND r.tokens_before = r.tokens_after AND r.tokens_before > 0
+			AND r.token_accounting = 'complete' AND r.fresh_input + r.cache_read + r.cache_write > 0`
+		if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+ratioPop,
+			args...).Scan(&estimatorDivergenceRows); err != nil {
+			return err
+		}
+		if estimatorDivergenceRows > 0 {
+			var med sql.NullFloat64
+			if err := d.sql.QueryRow(`SELECT
+				CAST(r.fresh_input + r.cache_read + r.cache_write AS REAL) / r.tokens_before AS ratio
+				FROM requests r WHERE `+cond+ratioPop+`
+				ORDER BY ratio ASC LIMIT 1 OFFSET ?`,
+				append(append([]any(nil), args...), estimatorDivergenceRows/2)...).Scan(&med); err != nil {
+				return err
+			}
+			estimatorDivergence = med.Float64
+		}
+		return nil
+	})
+	// The COST half, over the same window and the same filters but with ping rows included.
+	// A second query rather than a CASE in the first, because the first deliberately cannot see
+	// them: one predicate, one meaning.
+	g.Go(func() error {
+		kaCond, kaArgs := withKeepAlive(f).where()
+		return d.sql.QueryRow(`SELECT
+			COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0)
+			FROM requests r WHERE `+kaCond, kaArgs...).Scan(&keepAlivePings, &keepAlivePingUSD)
+	})
+	for name, col := range map[string]string{
+		"accounting": "token_accounting", "cache_miss": "cache_miss_reason", "uncompressed": "uncompressed_reason",
+	} {
+		name, col := name, col // captured per-goroutine, not by the shared loop variable
+		g.Go(func() error {
+			m, err := d.countBy(cond, args, col)
+			if err != nil {
+				return err
+			}
+			switch name {
+			case "accounting":
+				accountingM = m
+			case "cache_miss":
+				cacheMissM = m
+			case "uncompressed":
+				uncompressedM = m
+			}
+			return nil
+		})
+	}
+	g.Go(func() error {
+		v, err := d.percentile(cond, args, "cg_latency_ms", 0.95)
+		if err != nil {
+			return err
+		}
+		p95cg = v
+		return nil
+	})
+	g.Go(func() error {
+		v, err := d.percentile(cond, args, "upstream_ms", 0.95)
+		if err != nil {
+			return err
+		}
+		p95up = v
+		return nil
+	})
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
-	if o.EstimatorDivergenceRows > 0 {
-		var med sql.NullFloat64
-		if err := d.sql.QueryRow(`SELECT
-			CAST(r.fresh_input + r.cache_read + r.cache_write AS REAL) / r.tokens_before AS ratio
-			FROM requests r WHERE `+cond+ratioPop+`
-			ORDER BY ratio ASC LIMIT 1 OFFSET ?`,
-			append(append([]any(nil), args...), o.EstimatorDivergenceRows/2)...).Scan(&med); err != nil {
-			return nil, err
-		}
-		o.EstimatorDivergence = med.Float64
+
+	o.ReplayProjectedTokens = replayProjectedRaw
+	if o.ReplayProjectedTokens -= inflation; o.ReplayProjectedTokens < 0 {
+		o.ReplayProjectedTokens = 0
 	}
+	if o.ReplayProjectedTokens > 0 {
+		o.ReplayRealizedPct = float64(o.ReplayTokens) / float64(o.ReplayProjectedTokens) * 100
+	}
+	o.CacheTTL = ttl
+	o.Breakpoints.ModalRequests = modalRequests
+	if modalRequests > 0 {
+		o.Breakpoints.Modal = fmt.Sprintf("system=%d, tools=%d, messages=%d, blocks=%d", bs, bt, bm, bb)
+	}
+	o.EstimatorDivergenceRows = estimatorDivergenceRows
+	o.EstimatorDivergence = estimatorDivergence
 	if o.Requests > 0 {
 		o.ExpandRate = float64(o.Expands) / float64(o.Requests)
 	}
 	o.NetSavedUSD = o.BaselineCostUSD - o.CostUSD - o.CGLLMCostUSD
-	// The COST half, over the same window and the same filters but with ping rows included.
-	// A second query rather than a CASE in the first, because the first deliberately cannot see
-	// them: one predicate, one meaning.
-	kaCond, kaArgs := withKeepAlive(f).where()
-	if err := d.sql.QueryRow(`SELECT
-		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN 1 ELSE 0 END),0),
-		COALESCE(SUM(CASE WHEN r.keepalive = 1 THEN r.cost_usd ELSE 0 END),0)
-		FROM requests r WHERE `+kaCond, kaArgs...).Scan(
-		&o.KeepAlivePings, &o.KeepAlivePingUSD); err != nil {
-		return nil, err
-	}
+	o.KeepAlivePings, o.KeepAlivePingUSD = keepAlivePings, keepAlivePingUSD
 	// The keep-alive's net, and the one number a decision rests on. Not folded into
 	// TotalSavedUSD: presenting a saving without the spend that bought it is exactly the
 	// dishonesty this ledger exists to prevent, and CostUSD above no longer carries the pings
@@ -710,32 +815,9 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	// caller that does not attach the credit — reads a total that is short rather than one that
 	// is absent. SetDeclCredit moves both.
 	o.TotalReducedUSD = o.TotalSavedUSD
-
-	for name, col := range map[string]string{
-		"accounting": "token_accounting", "cache_miss": "cache_miss_reason", "uncompressed": "uncompressed_reason",
-	} {
-		m, err := d.countBy(cond, args, col)
-		if err != nil {
-			return nil, err
-		}
-		switch name {
-		case "accounting":
-			o.Accounting = m
-		case "cache_miss":
-			o.CacheMiss = m
-		case "uncompressed":
-			o.Uncompressed = m
-		}
-	}
-
-	p95cg, err := d.percentile(cond, args, "cg_latency_ms", 0.95)
-	if err != nil {
-		return nil, err
-	}
-	p95up, err := d.percentile(cond, args, "upstream_ms", 0.95)
-	if err != nil {
-		return nil, err
-	}
+	o.Accounting = accountingM
+	o.CacheMiss = cacheMissM
+	o.Uncompressed = uncompressedM
 	o.CGLatencyMsP95, o.UpstreamMsP95 = p95cg, p95up
 
 	o.SafetyCost.FrozenTokens = o.FrozenTokens

--- a/dash/store.go
+++ b/dash/store.go
@@ -246,11 +246,18 @@ func openDSN(d, path string) (*DB, error) {
 	// reads opens one pooled connection per in-flight request — measured on this
 	// deployment climbing past 600 concurrent connections and taking the process from
 	// ~2GB to a hard OOM kill within minutes. WAL mode already gives every reader a
-	// consistent snapshot without needing its own connection to do it quickly, so this
-	// caps concurrency at a level that still saturates real traffic without letting the
-	// pool itself become the memory leak.
-	sdb.SetMaxOpenConns(20)
-	sdb.SetMaxIdleConns(10)
+	// consistent snapshot without needing its own connection to do it quickly, so bounding
+	// the pool caps the memory risk without needing per-connection changes elsewhere.
+	//
+	// First shipped at 20/10, which turned out too low for this deployment's real
+	// concurrent demand: live traffic queued for a connection long enough to blow the
+	// dashboard handlers' own 10s timeout (dash/api.go's dashHandlerTimeout), on a box with
+	// 561% CPU and zero SQLITE_BUSY errors logged — i.e. queued for a POOL SLOT, never even
+	// reaching SQLite to contend on a lock. 100/50 costs at most ~285MB more at the
+	// ~2.85MB/connection rate measured against the 600-connection incident (vs. an 8GB
+	// cgroup cap and ~300MB baseline) while giving 5x the headroom before a burst queues.
+	sdb.SetMaxOpenConns(100)
+	sdb.SetMaxIdleConns(50)
 	sdb.SetConnMaxIdleTime(5 * time.Minute)
 	if err := sdb.Ping(); err != nil {
 		sdb.Close()
@@ -291,11 +298,35 @@ func (d *DB) Close() error {
 // Path returns the on-disk path ("" when in-memory).
 func (d *DB) Path() string { return d.path }
 
+// gzPair is one blob's before/after compression, precomputed outside the transaction.
+type gzPair struct{ before, after []byte }
+
 // insertBatch writes a batch of captured events in ONE transaction — the whole
 // point of batching: a per-request fsync would make the writer the bottleneck
 // under agent traffic. A failed batch is logged and dropped; observability never
 // retries into a growing backlog.
 func (d *DB) insertBatch(evs []*Event) error {
+	// Every gzip compression this batch needs, done BEFORE the transaction opens. gzip is
+	// real CPU work — up to ContentMaxPerRequest x 2 blobs per event, plus one pair per
+	// extraction call — and this driver blocks a concurrent READ for the writer's WHOLE open
+	// transaction (see CLAUDE.local.md). Compressing inside the transaction was paying that
+	// CPU cost while every reader on the box waited for it; precomputing here means the
+	// transaction itself does nothing but the inserts it actually needs the lock for.
+	contentGz := make([][]gzPair, len(evs))
+	xcallGz := make([][]gzPair, len(evs))
+	for i, e := range evs {
+		cg := make([]gzPair, len(e.Content))
+		for j, c := range e.Content {
+			cg[j] = gzPair{gzipText(c.Before), gzipText(c.After)}
+		}
+		contentGz[i] = cg
+		xg := make([]gzPair, len(e.Extractions))
+		for j, x := range e.Extractions {
+			xg[j] = gzPair{gzipText(x.Before), gzipText(x.After)}
+		}
+		xcallGz[i] = xg
+	}
+
 	tx, err := d.sql.Begin()
 	if err != nil {
 		return err
@@ -348,7 +379,7 @@ func (d *DB) insertBatch(evs []*Event) error {
 	defer xcallStmt.Close()
 
 	spend := map[spendKey]float64{}
-	for _, e := range evs {
+	for idx, e := range evs {
 		// nil, not "", when no strategy applied — so the column stores SQL NULL and stays
 		// distinguishable from a row written before this feature existed either way; see
 		// the keepalive_strategy_id column comment in schema.go.
@@ -389,7 +420,7 @@ func (d *DB) insertBatch(evs []*Event) error {
 		}
 		for i, c := range e.Content {
 			if _, err := contentStmt.Exec(id, i, c.Path, c.BeforeTokens, c.AfterTokens,
-				gzipText(c.Before), gzipText(c.After), strings.Join(c.Components, ",")); err != nil {
+				contentGz[idx][i].before, contentGz[idx][i].after, strings.Join(c.Components, ",")); err != nil {
 				return err
 			}
 		}
@@ -403,7 +434,7 @@ func (d *DB) insertBatch(evs []*Event) error {
 				x.CandidateTokens, x.SavedTokens, x.PromptTokens, x.CompletionTok,
 				x.CacheRead, x.CacheWrite, x.CostUSD, x.LatencyMs, boolInt(x.Accepted),
 				x.GateReason, x.Rejection, x.Summary,
-				gzipText(x.Before), gzipText(x.After)); err != nil {
+				xcallGz[idx][i].before, xcallGz[idx][i].after); err != nil {
 				return err
 			}
 		}

--- a/dash/toolapi.go
+++ b/dash/toolapi.go
@@ -973,41 +973,111 @@ func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), 
 	// Session ordering comes from the requests table (the declarations carry a ts, but one per
 	// digest, not per session start), so "before" and "after" mean the same thing here as
 	// everywhere else on the page.
-	q := `WITH sess AS (
-			SELECT r.session_id AS sid, MIN(r.ts) AS started, COUNT(*) AS reqs,
-				SUM(CASE WHEN r.cache_read > 0 THEN 1 ELSE 0 END) AS reads,
-				SUM(CASE WHEN r.cache_read = 0 AND r.cache_write > 0 THEN 1 ELSE 0 END) AS writes,
-				SUM(CASE WHEN r.cache_read = 0 AND r.cache_write = 0 THEN 1 ELSE 0 END) AS fresh,
-				MIN(r.model) AS model
-			FROM requests r WHERE ` + where + ` AND r.tools > 0 GROUP BY 1)
-		SELECT d.kind, d.name, d.server, MAX(d.tokens), MAX(s.started),
-			COUNT(DISTINCT d.session_id)
-		FROM tool_declarations d JOIN sess s ON s.sid = d.session_id`
-	a := append([]any{}, args...)
-	if !f.TenantAll {
-		q += ` WHERE d.tenant_id = ?`
-		a = append(a, f.Tenant)
+	//
+	// Sessions in scope, their re-read multiplier, and (filled in below) the cohort flags — one
+	// query, reused for the candidate lastSeen/before computation, the cohort test, AND the
+	// AvoidedReads/AvoidedUSD walk. It used to be the same requests-table aggregate run under
+	// three different names for three different purposes.
+	type sessRow struct {
+		tenant, session      string
+		started              int64
+		reads, writes, fresh int
+		model                string
+		hasMCP, hasSkills    bool
 	}
-	q += ` GROUP BY d.kind, d.name, d.server`
-	rows, err := d.sql.Query(q, a...)
+	srows, err := d.sql.Query(`SELECT r.tenant_id, r.session_id, MIN(r.ts),
+			SUM(CASE WHEN r.cache_read > 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN r.cache_read = 0 AND r.cache_write > 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN r.cache_read = 0 AND r.cache_write = 0 THEN 1 ELSE 0 END),
+			MIN(r.model)
+		FROM requests r WHERE `+where+` AND r.tools > 0 GROUP BY r.tenant_id, r.session_id`, args...)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	type cand struct {
-		kind, name, server string
-		tokens             int
-		lastSeen           int64
-		before             int
-	}
-	var cands []cand
-	for rows.Next() {
-		var c cand
-		if err := rows.Scan(&c.kind, &c.name, &c.server, &c.tokens, &c.lastSeen, &c.before); err != nil {
+	type sessKey struct{ tenant, session string }
+	sessByKey := map[sessKey]*sessRow{}
+	var sess []*sessRow
+	for srows.Next() {
+		s := &sessRow{}
+		if err := srows.Scan(&s.tenant, &s.session, &s.started, &s.reads, &s.writes, &s.fresh, &s.model); err != nil {
+			srows.Close()
 			return nil, err
 		}
-		// ONLY MCP tools and skills are eligible, and that is a correctness restriction rather
-		// than a scoping choice.
+		sessByKey[sessKey{s.tenant, s.session}] = s
+		sess = append(sess, s)
+	}
+	srows.Close()
+	if err := srows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Candidates and cohort flags, from ONE sequential scan of tool_declarations rather than two
+	// SQL joins against it.
+	//
+	// The joins this replaced each drove their nested loop from the SMALL side (a few thousand
+	// sessions) and probed tool_declarations' own (tenant_id, session_id, ...) primary-key index
+	// once per session — a separate index seek, and for the candidates query a separate row
+	// fetch, for every one of them. Measured on the production corpus (974k+ declaration rows,
+	// 4,553 in-scope sessions): 11.4s for the candidates join and 6.3s for the cohort join,
+	// EXPLAIN QUERY PLAN confirming `SEARCH d USING INDEX ... (tenant_id=? AND session_id=?)`
+	// inside a CO-ROUTINE — a probe per outer row, not a scan. This is the same shape the
+	// CompactionResets bug had (see dash/CLAUDE.local.md): the cost is invocation count, not
+	// I/O — 4,553 separate lookups into a 974k-row table costs more than one pass over that
+	// table, even though each individual lookup looks cheap.
+	//
+	// One plain SELECT over tool_declarations (5.9s to scan every row on this corpus) replaces
+	// both: whether a declared row's session is "in scope" becomes a map lookup instead of a
+	// join condition, and the candidate + cohort aggregation happen in the same pass. Filtered by
+	// tenant_id in SQL when the caller is scoped to one account — the common case — so a
+	// per-account view still only ever touches that account's own rows, exactly as before.
+	dq := `SELECT tenant_id, session_id, kind, name, server, tokens FROM tool_declarations`
+	var dargs []any
+	if !f.TenantAll {
+		dq += ` WHERE tenant_id = ?`
+		dargs = append(dargs, f.Tenant)
+	}
+	drows, err := d.sql.Query(dq, dargs...)
+	if err != nil {
+		return nil, err
+	}
+	type cand struct {
+		tenant, kind, name, server string
+		tokens                     int
+		lastSeen                   int64
+		sessionsSeen               map[string]bool
+	}
+	// Keyed by (tenant, kind, name, server): candidates are never pooled across tenants, even
+	// under TenantAll — a manager's service-wide view. Without that, a manager's "self-removed"
+	// figure pooled every tenant's declaration timeline into one: on the production corpus, an
+	// MCP tool declared in exactly ONE session of ONE tenant was reported as removed on the
+	// strength of 555 sessions belonging to OTHER tenants that simply never had that tenant's
+	// MCP server at all — $154.53 of avoided cost credited to a removal nobody made.
+	cands := map[[4]string]*cand{}
+	for drows.Next() {
+		var tenant, sid, kind, name, server string
+		var tokens int
+		if err := drows.Scan(&tenant, &sid, &kind, &name, &server, &tokens); err != nil {
+			drows.Close()
+			return nil, err
+		}
+		s, ok := sessByKey[sessKey{tenant, sid}]
+		if !ok {
+			continue // this session is not in the requests-side scope (tools>0, the filter, ...)
+		}
+		// The cohort flags: whether this session declared ANY MCP tool, and whether it carried a
+		// skills listing. Set from every row seen, INCLUDING kinds that are not themselves
+		// eligible candidates below (skill_listing counts for the cohort test but is never itself
+		// offered as a removal) — this is what makes a later session able to testify. A session
+		// that declared no MCP tools cannot be evidence that one particular MCP tool was
+		// removed — it is evidence that this session was not an MCP session.
+		switch kind {
+		case KindMCPTool:
+			s.hasMCP = true
+		case KindSkill, KindSkillListing:
+			s.hasSkills = true
+		}
+		// ONLY MCP tools and skills are eligible CANDIDATES, and that is a correctness
+		// restriction rather than a scoping choice.
 		//
 		// The first version of this considered every declaration and confidently reported that
 		// the account had "removed" Bash, Agent, TodoWrite and Monitor — because sessions
@@ -1019,82 +1089,27 @@ func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), 
 		// MCP tools and skills are the items the question is actually about — they are what a
 		// user adds and drops — and they come with a usable control: a later session either
 		// carries MCP tools at all, or carries a skills listing at all, and only such a session
-		// can testify about a missing one. See the cohort test below, which is the other half of
+		// can testify about a missing one. See the cohort test above, which is the other half of
 		// this fix; neither half works alone.
-		if c.kind != KindMCPTool && c.kind != KindSkill {
+		if kind != KindMCPTool && kind != KindSkill {
 			continue
 		}
-		cands = append(cands, c)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	// The sessions that ran after each candidate was last declared, and what they would have
-	// paid to keep carrying it. One pass over the session list rather than a query per
-	// candidate: the list is a few thousand rows and there can be hundreds of candidates.
-	// Each later session's cohort: whether it declared ANY MCP tool, and whether it carried a
-	// skills listing. This is what makes a later session able to testify. A session that
-	// declared no MCP tools cannot be evidence that one particular MCP tool was removed — it is
-	// evidence that this session was not an MCP session.
-	type sessRow struct {
-		started              int64
-		reads, writes, fresh int
-		model                string
-		hasMCP, hasSkills    bool
-	}
-	// The cohort flags come from a SEPARATE query, not a join onto the request aggregate.
-	//
-	// Joining tool_declarations onto requests multiplies every request row by the number of
-	// declarations in its session, so the SUMs below counted each request dozens of times and
-	// the avoided-cost figures came out at $456 for a 142-token skill — larger than this
-	// deployment's entire measured savings. A fanned-out join under an aggregate is silent and
-	// the result is merely implausible rather than an error, which is exactly why the sanity
-	// check ("is this number bigger than the whole bill?") is worth doing on any new figure.
-	crows, err := d.sql.Query(`SELECT d.session_id,
-			MAX(CASE WHEN d.kind = '`+KindMCPTool+`' THEN 1 ELSE 0 END),
-			MAX(CASE WHEN d.kind IN ('`+KindSkill+`','`+KindSkillListing+`') THEN 1 ELSE 0 END)
-		FROM tool_declarations d
-		WHERE d.session_id IN (SELECT r.session_id FROM requests r WHERE `+where+` AND r.tools > 0)
-		GROUP BY 1`, args...)
-	if err != nil {
-		return nil, err
-	}
-	cohortBySession := map[string]struct{ mcp, skills bool }{}
-	for crows.Next() {
-		var sid string
-		var mcp, sk int
-		if err := crows.Scan(&sid, &mcp, &sk); err != nil {
-			crows.Close()
-			return nil, err
+		key := [4]string{tenant, kind, name, server}
+		c, ok := cands[key]
+		if !ok {
+			c = &cand{tenant: tenant, kind: kind, name: name, server: server, sessionsSeen: map[string]bool{}}
+			cands[key] = c
 		}
-		cohortBySession[sid] = struct{ mcp, skills bool }{mcp == 1, sk == 1}
-	}
-	crows.Close()
-	if err := crows.Err(); err != nil {
-		return nil, err
-	}
-	srows, err := d.sql.Query(`SELECT r.session_id, MIN(r.ts),
-			SUM(CASE WHEN r.cache_read > 0 THEN 1 ELSE 0 END),
-			SUM(CASE WHEN r.cache_read = 0 AND r.cache_write > 0 THEN 1 ELSE 0 END),
-			SUM(CASE WHEN r.cache_read = 0 AND r.cache_write = 0 THEN 1 ELSE 0 END),
-			MIN(r.model)
-		FROM requests r WHERE `+where+` AND r.tools > 0 GROUP BY r.session_id`, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer srows.Close()
-	var sess []sessRow
-	for srows.Next() {
-		var s sessRow
-		var sid string
-		if err := srows.Scan(&sid, &s.started, &s.reads, &s.writes, &s.fresh, &s.model); err != nil {
-			return nil, err
+		if tokens > c.tokens {
+			c.tokens = tokens
 		}
-		c := cohortBySession[sid]
-		s.hasMCP, s.hasSkills = c.mcp, c.skills
-		sess = append(sess, s)
+		if s.started > c.lastSeen {
+			c.lastSeen = s.started
+		}
+		c.sessionsSeen[sid] = true
 	}
-	if err := srows.Err(); err != nil {
+	drows.Close()
+	if err := drows.Err(); err != nil {
 		return nil, err
 	}
 
@@ -1102,12 +1117,15 @@ func (d *DB) SelfRemovals(f Filter, price func(string) (modelinfo.Price, bool), 
 	for _, c := range cands {
 		r := SelfRemoval{
 			Kind: c.kind, Name: c.name, Server: c.server,
-			Tokens: c.tokens, LastSeen: c.lastSeen, SessionsBefore: c.before,
+			Tokens: c.tokens, LastSeen: c.lastSeen, SessionsBefore: len(c.sessionsSeen),
 			Overlap: filtered[statKey{c.kind, c.name}] ||
 				(c.server != "" && filtered[statKey{"mcp_server", c.server}]),
 		}
 		priced := true
 		for _, s := range sess {
+			if s.tenant != c.tenant {
+				continue // a different tenant's session is not evidence about this tenant's removal
+			}
 			if s.started <= c.lastSeen {
 				continue // ran before or alongside the last sighting: proves nothing
 			}

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -7294,6 +7294,22 @@ async function openStrategyLedger(s) {
       'all, is not counted here. This ledger is ALL TIME — unlike Overview or the Keep-Alive ' +
       'tab, it ignores whatever date range the dashboard is set to, so a lower or higher ' +
       'number here than those pages show is not a discrepancy.'));
+    // Pings > 0 with Saved stuck at exactly $0 is not a broken calculation — it is what a
+    // strategy looks like before its FIRST real rescue under the current attribution code
+    // (2026-08-30). A ping only earns a Saved credit once the real request it protected
+    // actually resumes after the idle gap; every ping this strategy has sent so far either
+    // predates that code (so the row it rescued was written before this column existed to
+    // carry the strategy id at all) or has not yet been followed by such a resumption. Saved
+    // populates the next time this strategy is in a matching window AND a session it pinged
+    // comes back — there is nothing to fix here by waiting longer on this page.
+    if (led.pings > 0 && led.saved_usd === 0) {
+      body.appendChild(el('p', { class: 'note' },
+        'Saved reads $0 with real pings above: none of them has yet been followed by the ' +
+        'real request it protected actually resuming — that is the moment a ping turns into ' +
+        'a credit, not the moment it is sent. This is expected for a strategy whose pings are ' +
+        'all recent or predate 2026-08-30’s per-strategy attribution; it is not a stuck ' +
+        'calculation, and it will move the next time this strategy pings a session that then comes back.'));
+    }
     if (!led.tenants || !led.tenants.length) {
       emptyState(body, 'No pings under this strategy yet', '');
       return;

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -613,20 +613,27 @@
         <div id="ka-chart-usd" class="chart" data-testid="ka-chart-usd"></div>
       </div>
     </div>
-    <h3>Idle gap when the cache lapsed</h3>
-    <p class="note" id="ka-gap-note"></p>
-    <div id="ka-gap-bands" data-testid="ka-gap-bands"></div>
-    <h3>Cached prompt size when it lapsed</h3>
-    <p class="note" id="ka-prefix-note"></p>
-    <div id="ka-prefix-bands" data-testid="ka-prefix-bands"></div>
-    <h3>Time of day</h3>
-    <p class="note" id="ka-hour-note"></p>
-    <div id="ka-hour-bins" data-testid="ka-hour-bins"></div>
-    <h3>How long between expiries</h3>
-    <p class="note">Per account, never blended: on this service the per-account mean runs
-      from 0.64 h to 6.56 h with maxima past 30 h, so a single service-wide average would
-      describe nobody.</p>
-    <div id="ka-account-gaps" data-testid="ka-account-gaps"></div>
+    <!-- The two charts above answer "is this trending up or down"; everything below answers
+         "why" — gap timing, prompt size, time of day, per-account spread. Real and still one
+         click away, just not at the same weight as the trend. Same collapsed-by-default
+         pattern as Setup's "Other agents" (.setup-others). -->
+    <details class="setup-others">
+      <summary>Diagnostics: gap timing, prompt size, time of day, per-account spread</summary>
+      <h3>Idle gap when the cache lapsed</h3>
+      <p class="note" id="ka-gap-note"></p>
+      <div id="ka-gap-bands" data-testid="ka-gap-bands"></div>
+      <h3>Cached prompt size when it lapsed</h3>
+      <p class="note" id="ka-prefix-note"></p>
+      <div id="ka-prefix-bands" data-testid="ka-prefix-bands"></div>
+      <h3>Time of day</h3>
+      <p class="note" id="ka-hour-note"></p>
+      <div id="ka-hour-bins" data-testid="ka-hour-bins"></div>
+      <h3>How long between expiries</h3>
+      <p class="note">Per account, never blended: on this service the per-account mean runs
+        from 0.64 h to 6.56 h with maxima past 30 h, so a single service-wide average would
+        describe nobody.</p>
+      <div id="ka-account-gaps" data-testid="ka-account-gaps"></div>
+    </details>
   </div>
 
   <div class="panel">

--- a/deploy/grafana/dashboards/context-guru.json
+++ b/deploy/grafana/dashboards/context-guru.json
@@ -74,7 +74,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 0
+    "y": 22
    },
    "panels": []
   },
@@ -91,7 +91,7 @@
     "h": 5,
     "w": 4,
     "x": 0,
-    "y": 1
+    "y": 23
    },
    "targets": [
     {
@@ -171,7 +171,7 @@
     "h": 5,
     "w": 6,
     "x": 4,
-    "y": 1
+    "y": 23
    },
    "targets": [
     {
@@ -234,7 +234,7 @@
     "h": 5,
     "w": 5,
     "x": 10,
-    "y": 1
+    "y": 23
    },
    "targets": [
     {
@@ -296,7 +296,7 @@
     "h": 5,
     "w": 5,
     "x": 15,
-    "y": 1
+    "y": 23
    },
    "targets": [
     {
@@ -364,7 +364,7 @@
     "h": 5,
     "w": 4,
     "x": 20,
-    "y": 1
+    "y": 23
    },
    "targets": [
     {
@@ -426,7 +426,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 6
+    "y": 0
    },
    "panels": []
   },
@@ -443,7 +443,7 @@
     "h": 5,
     "w": 3,
     "x": 12,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -506,7 +506,7 @@
     "h": 5,
     "w": 3,
     "x": 6,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -570,7 +570,7 @@
     "h": 5,
     "w": 3,
     "x": 15,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -649,7 +649,7 @@
     "h": 5,
     "w": 3,
     "x": 18,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -715,7 +715,7 @@
     "h": 8,
     "w": 12,
     "x": 0,
-    "y": 12
+    "y": 6
    },
    "targets": [
     {
@@ -837,7 +837,7 @@
     "h": 8,
     "w": 12,
     "x": 12,
-    "y": 12
+    "y": 6
    },
    "targets": [
     {
@@ -959,7 +959,7 @@
     "h": 8,
     "w": 12,
     "x": 0,
-    "y": 20
+    "y": 14
    },
    "targets": [
     {
@@ -1101,7 +1101,7 @@
     "h": 8,
     "w": 12,
     "x": 12,
-    "y": 20
+    "y": 14
    },
    "targets": [
     {
@@ -1726,1219 +1726,1221 @@
    "id": 24,
    "type": "row",
    "title": "Is storage and cold storage healthy?",
-   "collapsed": false,
+   "collapsed": true,
    "gridPos": {
     "h": 1,
     "w": 24,
     "x": 0,
     "y": 51
    },
-   "panels": []
-  },
-  {
-   "id": 25,
-   "type": "timeseries",
-   "title": "Local database against cold storage",
-   "description": "Blue is what is still on this box, orange is what moved to Box. Blue climbing while orange stays flat is the bad shape \u2014 tiering has stopped and the disk fills.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 0,
-    "y": 52
-   },
-   "targets": [
+   "panels": [
     {
-     "refId": "A",
+     "id": 25,
+     "type": "timeseries",
+     "title": "Local database against cold storage",
+     "description": "Blue is what is still on this box, orange is what moved to Box. Blue climbing while orange stays flat is the bad shape \u2014 tiering has stopped and the disk fills.",
      "datasource": {
       "type": "prometheus",
       "uid": "cg-prom"
      },
-     "expr": "cg_dash_db_bytes",
-     "editorMode": "code",
-     "legendFormat": "local database"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 52
      },
-     "expr": "cg_archive_bytes_total",
-     "editorMode": "code",
-     "legendFormat": "cold storage"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "bytes",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      }
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#3987e5"
-     }
-    },
-    "overrides": [
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "local database"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#3987e5"
-        }
-       }
-      ]
-     },
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "cold storage"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#d95926"
-        }
-       }
-      ]
-     }
-    ]
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "multi",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 26,
-   "type": "stat",
-   "title": "Filesystem in use",
-   "description": "Crossing 90% starts evicting the oldest sessions. With cold storage ready that is a migration; with it unreachable it is deletion.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 12,
-    "y": 52
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "cg_dash_disk_used_ratio",
-     "editorMode": "code",
-     "legendFormat": "used"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percentunit",
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "#199e70",
-        "value": null
-       },
-       {
-        "color": "#c98500",
-        "value": 0.85
-       },
-       {
-        "color": "#e66767",
-        "value": 0.9
-       }
-      ]
-     },
-     "decimals": 1,
-     "min": 0,
-     "max": 1
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "textMode": "value",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 27,
-   "type": "stat",
-   "title": "Cold storage",
-   "description": "NOT CONFIGURED is the bad value: while it reads that, disk pressure deletes sessions instead of archiving them.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 16,
-    "y": 52
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "cg_archive_configured",
-     "editorMode": "code",
-     "legendFormat": "configured",
-     "instant": true,
-     "range": false
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "none",
-     "mappings": [
+     "targets": [
       {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "NOT CONFIGURED",
-         "color": "#e66767",
-         "index": 0
-        },
-        "1": {
-         "text": "ready",
-         "color": "#199e70",
-         "index": 1
-        }
-       }
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "cg_dash_db_bytes",
+       "editorMode": "code",
+       "legendFormat": "local database"
+      },
+      {
+       "refId": "B",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "cg_archive_bytes_total",
+       "editorMode": "code",
+       "legendFormat": "cold storage"
       }
      ],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
+     "fieldConfig": {
+      "defaults": {
+       "unit": "bytes",
+       "custom": {
+        "drawStyle": "line",
+        "lineWidth": 2,
+        "fillOpacity": 8,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        }
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#3987e5"
+       }
+      },
+      "overrides": [
        {
-        "color": "#e66767",
-        "value": null
+        "matcher": {
+         "id": "byName",
+         "options": "local database"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#3987e5"
+          }
+         }
+        ]
        },
        {
-        "color": "#199e70",
-        "value": 1
+        "matcher": {
+         "id": "byName",
+         "options": "cold storage"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#d95926"
+          }
+         }
+        ]
        }
       ]
      },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "textMode": "value",
-    "colorMode": "value",
-    "graphMode": "none",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 28,
-   "type": "stat",
-   "title": "Sessions archived",
-   "description": "Cumulative sessions moved to cold storage. Stuck at zero while the filesystem gauge climbs means eviction is deleting, not tiering.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 20,
-    "y": 52
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(cg_archive_sessions_total)",
-     "editorMode": "code",
-     "legendFormat": "archived",
-     "instant": true,
-     "range": false
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "decimals": 0,
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#3987e5"
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": true,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "multi",
+       "sort": "none"
+      }
      }
     },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "textMode": "value",
-    "colorMode": "value",
-    "graphMode": "none",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 29,
-   "type": "timeseries",
-   "title": "Dropped capture events",
-   "description": "The capture queue filled and events were discarded. ANY non-zero bar means the dashboard is losing history exactly when load makes it most wanted.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 12,
-    "x": 12,
-    "y": 56
-   },
-   "targets": [
     {
-     "refId": "A",
+     "id": 26,
+     "type": "stat",
+     "title": "Filesystem in use",
+     "description": "Crossing 90% starts evicting the oldest sessions. With cold storage ready that is a migration; with it unreachable it is deletion.",
      "datasource": {
       "type": "prometheus",
       "uid": "cg-prom"
      },
-     "expr": "sum(increase(cg_dash_events_total{disposition=\"dropped\"}[5m]))",
-     "editorMode": "code",
-     "legendFormat": "dropped"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
+     "gridPos": {
+      "h": 4,
+      "w": 4,
+      "x": 12,
+      "y": 52
      },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "cg_dash_disk_used_ratio",
+       "editorMode": "code",
+       "legendFormat": "used"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "percentunit",
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "#199e70",
+          "value": null
+         },
+         {
+          "color": "#c98500",
+          "value": 0.85
+         },
+         {
+          "color": "#e66767",
+          "value": 0.9
+         }
+        ]
+       },
+       "decimals": 1,
+       "min": 0,
+       "max": 1
+      },
+      "overrides": []
+     },
+     "options": {
+      "reduceOptions": {
+       "calcs": [
+        "lastNotNull"
+       ],
+       "fields": "",
+       "values": false
+      },
+      "textMode": "value",
+      "colorMode": "value",
+      "graphMode": "area",
+      "justifyMode": "auto"
+     }
+    },
+    {
+     "id": 27,
+     "type": "stat",
+     "title": "Cold storage",
+     "description": "NOT CONFIGURED is the bad value: while it reads that, disk pressure deletes sessions instead of archiving them.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 4,
+      "x": 16,
+      "y": 52
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "cg_archive_configured",
+       "editorMode": "code",
+       "legendFormat": "configured",
+       "instant": true,
+       "range": false
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "none",
+       "mappings": [
+        {
+         "type": "value",
+         "options": {
+          "0": {
+           "text": "NOT CONFIGURED",
+           "color": "#e66767",
+           "index": 0
+          },
+          "1": {
+           "text": "ready",
+           "color": "#199e70",
+           "index": 1
+          }
+         }
+        }
+       ],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "#e66767",
+          "value": null
+         },
+         {
+          "color": "#199e70",
+          "value": 1
+         }
+        ]
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "reduceOptions": {
+       "calcs": [
+        "lastNotNull"
+       ],
+       "fields": "",
+       "values": false
+      },
+      "textMode": "value",
+      "colorMode": "value",
+      "graphMode": "none",
+      "justifyMode": "auto"
+     }
+    },
+    {
+     "id": 28,
+     "type": "stat",
+     "title": "Sessions archived",
+     "description": "Cumulative sessions moved to cold storage. Stuck at zero while the filesystem gauge climbs means eviction is deleting, not tiering.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 4,
+      "x": 20,
+      "y": 52
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(cg_archive_sessions_total)",
+       "editorMode": "code",
+       "legendFormat": "archived",
+       "instant": true,
+       "range": false
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "decimals": 0,
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#3987e5"
        }
-      ]
+      },
+      "overrides": []
      },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#e66767"
+     "options": {
+      "reduceOptions": {
+       "calcs": [
+        "lastNotNull"
+       ],
+       "fields": "",
+       "values": false
+      },
+      "textMode": "value",
+      "colorMode": "value",
+      "graphMode": "none",
+      "justifyMode": "auto"
+     }
+    },
+    {
+     "id": 29,
+     "type": "timeseries",
+     "title": "Dropped capture events",
+     "description": "The capture queue filled and events were discarded. ANY non-zero bar means the dashboard is losing history exactly when load makes it most wanted.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
      },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": false,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "single",
-     "sort": "none"
+     "gridPos": {
+      "h": 4,
+      "w": 12,
+      "x": 12,
+      "y": 56
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(increase(cg_dash_events_total{disposition=\"dropped\"}[5m]))",
+       "editorMode": "code",
+       "legendFormat": "dropped"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#e66767"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": false,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     }
     }
-   }
+   ]
   },
   {
    "id": 30,
    "type": "row",
    "title": "Is anything failing?",
-   "collapsed": false,
+   "collapsed": true,
    "gridPos": {
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 60
+    "y": 52
    },
-   "panels": [],
+   "panels": [
+    {
+     "id": 31,
+     "type": "timeseries",
+     "title": "Compaction-model failures",
+     "description": "Timeouts and errors from context-guru's own compaction model. A run of timeouts means the compactor silently did nothing: the arm looks fast because it stopped working.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 61
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum by (kind) (increase(cg_llm_failures_total[5m]))",
+       "editorMode": "code",
+       "legendFormat": "{{kind}}"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#3987e5"
+       },
+       "decimals": 0
+      },
+      "overrides": [
+       {
+        "matcher": {
+         "id": "byName",
+         "options": "timeout"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#d95926"
+          }
+         }
+        ]
+       },
+       {
+        "matcher": {
+         "id": "byName",
+         "options": "error"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#e66767"
+          }
+         }
+        ]
+       }
+      ]
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": true,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "multi",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 32,
+     "type": "timeseries",
+     "title": "Cache-write churn (frozen decisions flipped)",
+     "description": "Frozen decisions the store dropped and did not re-derive. Each one flips an already-cached message and forces the provider to re-write the suffix at ~12x the read price. Should sit at zero; anything above it is money.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 61
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(increase(cg_frozen_decisions_total{outcome=\"dropped\"}[15m])) - sum(increase(cg_frozen_decisions_total{outcome=\"repaired\"}[15m]))",
+       "editorMode": "code",
+       "legendFormat": "flips"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#d95926"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": false,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 33,
+     "type": "timeseries",
+     "title": "Tokens wasted recovering offloaded content",
+     "description": "Tokens spent re-serving something compaction removed. This is savings handed back \u2014 a rising line means the pipeline is too aggressive for this traffic.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 12,
+      "x": 0,
+      "y": 69
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(rate(cg_wasted_tokens_total[5m])) * 60",
+       "editorMode": "code",
+       "legendFormat": "wasted"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#e66767"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": false,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 34,
+     "type": "stat",
+     "title": "Buffered streams",
+     "description": "Share of responses context-guru had to buffer in full before the client saw a byte. High on traffic that never expands is a straight latency regression.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 4,
+      "x": 12,
+      "y": 69
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(cg_sse_streams_total{path=\"buffered\"}) / clamp_min(sum(cg_sse_streams_total), 1)",
+       "editorMode": "code",
+       "legendFormat": "buffered"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "percentunit",
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "#199e70",
+          "value": null
+         },
+         {
+          "color": "#c98500",
+          "value": 0.2
+         },
+         {
+          "color": "#e66767",
+          "value": 0.5
+         }
+        ]
+       },
+       "decimals": 0,
+       "min": 0,
+       "max": 1
+      },
+      "overrides": []
+     },
+     "options": {
+      "reduceOptions": {
+       "calcs": [
+        "lastNotNull"
+       ],
+       "fields": "",
+       "values": false
+      },
+      "textMode": "value",
+      "colorMode": "value",
+      "graphMode": "area",
+      "justifyMode": "auto"
+     }
+    },
+    {
+     "id": 35,
+     "type": "stat",
+     "title": "Tenants disabled",
+     "description": "Accounts the proxy is currently refusing. Anything above zero is somebody's agent failing right now.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 4,
+      "x": 16,
+      "y": 69
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(cg_tenant_disabled)",
+       "editorMode": "code",
+       "legendFormat": "disabled",
+       "instant": true,
+       "range": false
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "#199e70",
+          "value": null
+         },
+         {
+          "color": "#e66767",
+          "value": 1
+         }
+        ]
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "reduceOptions": {
+       "calcs": [
+        "lastNotNull"
+       ],
+       "fields": "",
+       "values": false
+      },
+      "textMode": "value",
+      "colorMode": "value",
+      "graphMode": "none",
+      "justifyMode": "auto"
+     }
+    },
+    {
+     "id": 37,
+     "type": "timeseries",
+     "title": "Expand bounces over time",
+     "description": "The same recoveries as the stat above, as a trend. A step up right after a config change means the new preset removes something the agent needs.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 12,
+      "x": 0,
+      "y": 73
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(increase(cg_expand_bounces_total[5m]))",
+       "editorMode": "code",
+       "legendFormat": "bounces"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#e66767"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": false,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 38,
+     "type": "timeseries",
+     "title": "Buffered against streamed responses",
+     "description": "Orange is responses context-guru had to read in full before the client saw a byte. Orange growing faster than blue is a straight latency regression.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 4,
+      "w": 12,
+      "x": 12,
+      "y": 73
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(cg_sse_streams_total{path=\"streamed\"})",
+       "editorMode": "code",
+       "legendFormat": "streamed"
+      },
+      {
+       "refId": "B",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum(cg_sse_streams_total{path=\"buffered\"})",
+       "editorMode": "code",
+       "legendFormat": "buffered"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "line",
+        "lineWidth": 2,
+        "fillOpacity": 8,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "fixed",
+        "fixedColor": "#3987e5"
+       },
+       "decimals": 0
+      },
+      "overrides": [
+       {
+        "matcher": {
+         "id": "byName",
+         "options": "streamed"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#3987e5"
+          }
+         }
+        ]
+       },
+       {
+        "matcher": {
+         "id": "byName",
+         "options": "buffered"
+        },
+        "properties": [
+         {
+          "id": "color",
+          "value": {
+           "mode": "fixed",
+           "fixedColor": "#d95926"
+          }
+         }
+        ]
+       }
+      ]
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": true,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "multi",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 39,
+     "type": "timeseries",
+     "title": "Requests refused, by reason",
+     "description": "Requests turned away before an upstream was called. ANY sustained bar is somebody's agent failing right now. rate_limit and concurrency are both 429 with different fixes (raise TENANT_RPM, raise the in-flight cap), auth/forbidden is a bad or disabled token, no_upstream is our own misconfiguration and upstream_error is the provider.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 77
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum by (reason) (increase(cg_refused_requests_total[5m]))",
+       "editorMode": "code",
+       "legendFormat": "{{reason}}"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "palette-classic-by-name"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": true,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "multi",
+       "sort": "none"
+      }
+     }
+    },
+    {
+     "id": 40,
+     "type": "timeseries",
+     "title": "Refusals per tenant",
+     "description": "Which account is being refused, and for what. This is the panel that tells a quiet tenant apart from a blocked one: a tenant absent from 'Requests per tenant' AND present here is not idle, it is being turned away. Zero everywhere is healthy.",
+     "datasource": {
+      "type": "prometheus",
+      "uid": "cg-prom"
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 77
+     },
+     "targets": [
+      {
+       "refId": "A",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "cg-prom"
+       },
+       "expr": "sum by (label, reason) (increase(cg_tenant_refused_requests_total{label=~\"$tenant\"}[5m]))",
+       "editorMode": "code",
+       "legendFormat": "{{label}} / {{reason}}"
+      }
+     ],
+     "fieldConfig": {
+      "defaults": {
+       "unit": "short",
+       "custom": {
+        "drawStyle": "bars",
+        "lineWidth": 1,
+        "fillOpacity": 70,
+        "showPoints": "never",
+        "pointSize": 8,
+        "spanNulls": true,
+        "axisSoftMin": 0,
+        "axisGridShow": true,
+        "axisBorderShow": false,
+        "lineInterpolation": "linear",
+        "gradientMode": "none",
+        "scaleDistribution": {
+         "type": "linear"
+        },
+        "stacking": {
+         "mode": "none",
+         "group": "A"
+        },
+        "axisSoftMax": 1
+       },
+       "mappings": [],
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+         {
+          "color": "text",
+          "value": null
+         }
+        ]
+       },
+       "color": {
+        "mode": "palette-classic-by-name"
+       },
+       "decimals": 0
+      },
+      "overrides": []
+     },
+     "options": {
+      "legend": {
+       "displayMode": "list",
+       "placement": "bottom",
+       "showLegend": true,
+       "calcs": []
+      },
+      "tooltip": {
+       "mode": "multi",
+       "sort": "none"
+      }
+     }
+    }
+   ],
    "description": "Rate-limit (429) REJECTIONS are not on this row because the proxy exports no counter for them \u2014 proxy/limits.go returns the status without recording it. Disabled accounts below are the closest available proxy."
-  },
-  {
-   "id": 31,
-   "type": "timeseries",
-   "title": "Compaction-model failures",
-   "description": "Timeouts and errors from context-guru's own compaction model. A run of timeouts means the compactor silently did nothing: the arm looks fast because it stopped working.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 0,
-    "y": 61
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum by (kind) (increase(cg_llm_failures_total[5m]))",
-     "editorMode": "code",
-     "legendFormat": "{{kind}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#3987e5"
-     },
-     "decimals": 0
-    },
-    "overrides": [
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "timeout"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#d95926"
-        }
-       }
-      ]
-     },
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "error"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#e66767"
-        }
-       }
-      ]
-     }
-    ]
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "multi",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 32,
-   "type": "timeseries",
-   "title": "Cache-write churn (frozen decisions flipped)",
-   "description": "Frozen decisions the store dropped and did not re-derive. Each one flips an already-cached message and forces the provider to re-write the suffix at ~12x the read price. Should sit at zero; anything above it is money.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 12,
-    "y": 61
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(increase(cg_frozen_decisions_total{outcome=\"dropped\"}[15m])) - sum(increase(cg_frozen_decisions_total{outcome=\"repaired\"}[15m]))",
-     "editorMode": "code",
-     "legendFormat": "flips"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#d95926"
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": false,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "single",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 33,
-   "type": "timeseries",
-   "title": "Tokens wasted recovering offloaded content",
-   "description": "Tokens spent re-serving something compaction removed. This is savings handed back \u2014 a rising line means the pipeline is too aggressive for this traffic.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 12,
-    "x": 0,
-    "y": 69
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(rate(cg_wasted_tokens_total[5m])) * 60",
-     "editorMode": "code",
-     "legendFormat": "wasted"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#e66767"
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": false,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "single",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 34,
-   "type": "stat",
-   "title": "Buffered streams",
-   "description": "Share of responses context-guru had to buffer in full before the client saw a byte. High on traffic that never expands is a straight latency regression.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 12,
-    "y": 69
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(cg_sse_streams_total{path=\"buffered\"}) / clamp_min(sum(cg_sse_streams_total), 1)",
-     "editorMode": "code",
-     "legendFormat": "buffered"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percentunit",
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "#199e70",
-        "value": null
-       },
-       {
-        "color": "#c98500",
-        "value": 0.2
-       },
-       {
-        "color": "#e66767",
-        "value": 0.5
-       }
-      ]
-     },
-     "decimals": 0,
-     "min": 0,
-     "max": 1
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "textMode": "value",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 35,
-   "type": "stat",
-   "title": "Tenants disabled",
-   "description": "Accounts the proxy is currently refusing. Anything above zero is somebody's agent failing right now.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 16,
-    "y": 69
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(cg_tenant_disabled)",
-     "editorMode": "code",
-     "legendFormat": "disabled",
-     "instant": true,
-     "range": false
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "#199e70",
-        "value": null
-       },
-       {
-        "color": "#e66767",
-        "value": 1
-       }
-      ]
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "textMode": "value",
-    "colorMode": "value",
-    "graphMode": "none",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 37,
-   "type": "timeseries",
-   "title": "Expand bounces over time",
-   "description": "The same recoveries as the stat above, as a trend. A step up right after a config change means the new preset removes something the agent needs.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 12,
-    "x": 0,
-    "y": 73
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(increase(cg_expand_bounces_total[5m]))",
-     "editorMode": "code",
-     "legendFormat": "bounces"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#e66767"
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": false,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "single",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 38,
-   "type": "timeseries",
-   "title": "Buffered against streamed responses",
-   "description": "Orange is responses context-guru had to read in full before the client saw a byte. Orange growing faster than blue is a straight latency regression.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 4,
-    "w": 12,
-    "x": 12,
-    "y": 73
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(cg_sse_streams_total{path=\"streamed\"})",
-     "editorMode": "code",
-     "legendFormat": "streamed"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum(cg_sse_streams_total{path=\"buffered\"})",
-     "editorMode": "code",
-     "legendFormat": "buffered"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "#3987e5"
-     },
-     "decimals": 0
-    },
-    "overrides": [
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "streamed"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#3987e5"
-        }
-       }
-      ]
-     },
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "buffered"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "#d95926"
-        }
-       }
-      ]
-     }
-    ]
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "multi",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 39,
-   "type": "timeseries",
-   "title": "Requests refused, by reason",
-   "description": "Requests turned away before an upstream was called. ANY sustained bar is somebody's agent failing right now. rate_limit and concurrency are both 429 with different fixes (raise TENANT_RPM, raise the in-flight cap), auth/forbidden is a bad or disabled token, no_upstream is our own misconfiguration and upstream_error is the provider.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 0,
-    "y": 77
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum by (reason) (increase(cg_refused_requests_total[5m]))",
-     "editorMode": "code",
-     "legendFormat": "{{reason}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "palette-classic-by-name"
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "multi",
-     "sort": "none"
-    }
-   }
-  },
-  {
-   "id": 40,
-   "type": "timeseries",
-   "title": "Refusals per tenant",
-   "description": "Which account is being refused, and for what. This is the panel that tells a quiet tenant apart from a blocked one: a tenant absent from 'Requests per tenant' AND present here is not idle, it is being turned away. Zero everywhere is healthy.",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "cg-prom"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 12,
-    "y": 77
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "cg-prom"
-     },
-     "expr": "sum by (label, reason) (increase(cg_tenant_refused_requests_total{label=~\"$tenant\"}[5m]))",
-     "editorMode": "code",
-     "legendFormat": "{{label}} / {{reason}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "lineWidth": 1,
-      "fillOpacity": 70,
-      "showPoints": "never",
-      "pointSize": 8,
-      "spanNulls": true,
-      "axisSoftMin": 0,
-      "axisGridShow": true,
-      "axisBorderShow": false,
-      "lineInterpolation": "linear",
-      "gradientMode": "none",
-      "scaleDistribution": {
-       "type": "linear"
-      },
-      "stacking": {
-       "mode": "none",
-       "group": "A"
-      },
-      "axisSoftMax": 1
-     },
-     "mappings": [],
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "text",
-        "value": null
-       }
-      ]
-     },
-     "color": {
-      "mode": "palette-classic-by-name"
-     },
-     "decimals": 0
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true,
-     "calcs": []
-    },
-    "tooltip": {
-     "mode": "multi",
-     "sort": "none"
-    }
-   }
   },
   {
    "id": 43,
@@ -2953,7 +2955,7 @@
     "h": 5,
     "w": 3,
     "x": 0,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -3011,7 +3013,7 @@
     "h": 5,
     "w": 3,
     "x": 9,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {
@@ -3071,7 +3073,7 @@
     "h": 5,
     "w": 3,
     "x": 3,
-    "y": 7
+    "y": 1
    },
    "targets": [
     {

--- a/proxy/keepalive_test.go
+++ b/proxy/keepalive_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rossoctl/context-guru/dash"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
 	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/tenant"
 	"github.com/tidwall/gjson"
 )
 
@@ -419,6 +420,30 @@ func TestArriveCancelsAndReports(t *testing.T) {
 	}
 	if p, r, s := k.arrive("t1", "sess-1"); p != 0 || r != 0 || s != "" {
 		t.Errorf("arrive reported %d/%d/%q for an untracked session, want 0/0/\"\"", p, r, s)
+	}
+}
+
+// The property dash/keepalivestrategy.go's per-strategy ledger is built on: arrive() must
+// report the SAME strategy id the ping that rescued this session was itself tagged with,
+// because that id is what lets a real request's credit be attributed to one strategy instead
+// of the tenant's whole lifetime credit repeating under every strategy that ever touched them.
+// TestArriveCancelsAndReports above already covers the no-strategy case (empty, correctly);
+// this covers the case dash/keepalivestrategy.go actually depends on.
+func TestArriveReportsTheStrategyThatSentThePing(t *testing.T) {
+	k, _, clock := testKeeper(t, Limits{})
+	k.setStrategies([]tenant.Strategy{{
+		ID: "s1", Active: true, Target: tenant.Target{Mode: tenant.TargetAll},
+		Windows:     []tenant.Window{{Start: "00:00", End: "23:59"}},
+		IdleSeconds: 280, MaxPings: 2, MaxUSDPerPing: 0.25, MinPrefixTokens: 20000,
+	}})
+	recordOne(t, k, kaPolicy(), kaBody, clock.now(), upstream{base: "http://up", path: "/v1/messages"})
+	k.sweep(clock.advance(281 * time.Second))
+	waitPings(t, k, 1)
+
+	_, _, strategyID := k.arrive("t1", "sess-1")
+	if strategyID != "s1" {
+		t.Errorf("strategyID = %q, want %q — a real request's credit must trace back to the "+
+			"strategy that sent the ping which earned it", strategyID, "s1")
 	}
 }
 

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -215,12 +215,20 @@ func (h *Handler) metricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.promCache.mu.Unlock()
-	// Rendered OUTSIDE the lock: renderMetrics does real work (a per-tenant DB query), and
-	// holding the lock across it used to serialize every concurrent scraper behind whichever
-	// one rendered first — one slow render, and every other caller queues up behind it rather
-	// than getting the stale-but-fine cached body. A cache-miss race now costs at most one
-	// redundant render, not a growing queue.
-	body := h.renderMetrics()
+	// SINGLE-FLIGHT, not a bare re-render: rendering used to happen OUTSIDE any lock, on the
+	// stated assumption that a cache-miss race costs "at most one redundant render." That
+	// held only while a render finishes faster than requests arrive. Once real write
+	// contention (this driver blocks a read across the writer's whole open transaction —
+	// see CLAUDE.local.md) pushes a render's own time past that interval, EVERY request
+	// during the slow render sees the same stale cache and starts ANOTHER render — and more
+	// concurrent renders competing for the same bounded connection pool makes each one
+	// slower still, a spiral that measured live as /metrics reliably timing out. Collapsing
+	// every concurrent cache-miss into the one render already in flight stops that spiral at
+	// any render duration: however long it takes, it happens once, and every waiter shares it.
+	v, _, _ := h.metricsInflight.Do("metrics", func() (any, error) {
+		return h.renderMetrics(), nil
+	})
+	body := v.(string)
 	h.promCache.mu.Lock()
 	h.promCache.at, h.promCache.body = time.Now(), body
 	h.promCache.mu.Unlock()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -40,6 +40,7 @@ import (
 	"github.com/rossoctl/context-guru/store"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/sync/singleflight"
 )
 
 // Options configures upstreams and credential injection. Each upstream is a base
@@ -234,6 +235,9 @@ type Handler struct {
 	// promCache memoises the Prometheus body for a scrape interval; the per-tenant
 	// series cost a SQL query and Grafana scrapes every few seconds.
 	promCache promCache
+	// metricsInflight collapses every concurrent cache-miss into the one render already
+	// running — see metricsHandler.
+	metricsInflight singleflight.Group
 }
 
 // upstreamTransport is the default upstream client's transport, and the reason there is no


### PR DESCRIPTION
## Summary

Production incident: `/metrics` and `/api/stats` were failing on nearly every call (Prometheus scrapes timing out, the dashboard showing "Could not load statistics"), and the Strategies tab's per-strategy Saved figure was reading $0 for every strategy, including historical activity from well before the incident. Root-caused each by profiling against a copy of the database rather than guessing, and fixed what needed fixing.

## `/metrics` outage — root cause and fix

The one-time prompt-text backfill (`dash/dedupetext.go`) re-scanned the whole `tool_declarations` table on every single process restart to re-confirm nothing was left to migrate. That scan's cost grows with the table, and re-running it unconditionally on every restart forever is real, avoidable contention. Fixed by persisting a completion marker in the existing `meta` table so the scan runs at most once, ever, once it has proven there is nothing pending.

Also collapsed concurrent `/metrics` renders into one via `singleflight`, since the prior design (render outside any lock, accepting "at most one redundant render") only held while a render finished faster than requests arrived — once render time grew past that under real contention, every concurrent request triggered another render, a spiral that reproduced live as reliable timeouts.

## `/api/stats` outage — root cause and fix

Two compounding costs, both confirmed by profiling against a copy of the database with no other load:
- `Overview()` ran roughly a dozen independent SQL queries one after another.
- `DeclCreditFor`/`SelfRemovals` cost several more seconds via the same anti-pattern `CompactionResets` had historically (a per-row index probe into a large table instead of one sequential scan) — see `dash/CLAUDE.local.md` for that history.

Fixed by running each handler's independent queries concurrently (`errgroup`/`sync.WaitGroup`, chosen per call's own error-handling contract) at both the `Overview()` level and the `stats()` handler level, and by rewriting `SelfRemovals` to one sequential scan plus a Go-side map join instead of two per-row joins. Confirmed the combined handler now completes comfortably within its own timeout where it previously did not, and that `SelfRemovals` alone dropped from a cold cost that blew well past that timeout to a small, cache-independent cost.

## A real correctness bug found along the way

While rewriting `SelfRemovals` for performance, found it was also pooling declaration history **across tenants** whenever the caller had a service-wide view (grouped by tool identity with no tenant filter) — invisible in every fixture and single-tenant deployment, reproducible only on a real multi-tenant one. A removal genuinely made by one tenant was being credited partly on the strength of other, unrelated tenants' sessions that never even had that tool available. Fixed by keying every step of the computation on tenant throughout, and locked in with a new regression test that fails on the pre-fix code and passes after.

## The Strategies-tab $0 — real historical data recovered, not just explained

First pass verified the per-strategy attribution mechanism itself (merged just before this branch started) is correct going forward: `arrive()` does report the sending strategy's id back to the real request it rescues, confirmed with a new unit test. But the user pointed out the $0 wasn't just a "too new" gap — strategies with a full history of activity from well before the incident were reading $0 too, and that turned out to be a second, real, fixable problem: any real request credited *before* the real-row tagging code shipped has a permanently NULL strategy id, because nothing ever went back and set it.

That information wasn't actually lost. The pings that rescued those older real rows were already tagged (that half of the feature is much older), and each real row's own ping count says a ping preceded it. Added a one-time, additive-only backfill that recovers the strategy id from the ping(s) that immediately preceded each untagged real row in the same session — never reaching into an earlier, already-consumed idle span — and leaves a row NULL when no matching tagged ping exists (meaning the rescue genuinely came from plain account config, not a strategy). Verified against a copy of the production database: most of the previously-$0 historical activity now shows a real, nonzero recovered figure; a smaller remainder correctly stays at $0 because no strategy was ever involved in those specific rescues.

Also caught and fixed a real concurrency regression while building this: running the new backfill as its own goroutine alongside the existing one-time migration doubled SQLite write-lock contention on every startup, enough to make an existing test miss its own busy-timeout under the race detector. Fixed by sequencing both one-time migrations onto a single shared goroutine instead.

## Also fixed

- The connection pool had no cap and could exhaust process memory under a burst; bounded it, and moved gzip compression out of the write transaction so it stops blocking concurrent readers for CPU work the lock never needed to cover.
- A genuine data race (caught by `-race`): a test was swapping a live `Recorder`'s DB out from under its own already-running background goroutine.
- Grafana's total-savings panel now reconciles exactly with the dashboard's own total — the gap was a missing fold-in in `dash/api.go`, not a missing metric series.
- Grafana layout: promoted the savings panels to the top, collapsed the two ops/host rows into native collapsed rows — every existing panel preserved, nothing deleted.
- Collapsed the Keep-alive tab's behavioral-breakdown histograms into a details block, matching an existing UI pattern elsewhere on the same page.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./...` — every package green.
- `go test -race ./dash/... ./proxy/... ./cmd/...` — green, including both the newly-fixed race and the newly-fixed contention regression.
- Every performance and recovery claim above was measured before/after against a copy of the production database, not assumed.
- Deployed and monitored live: zero crashes, stable memory, and the first successful `/api/stats` response from a real user session since the incident began.