### PR TITLE
fix(collapse): cut a head/tail window whenever the output is oversized — including single-line and huge-line payloads

### DIFF
--- a/components/offload/collapse.go
+++ b/components/offload/collapse.go
@@ -18,8 +18,8 @@ func init() { components.Register("collapse", newCollapse) }
 // cmdfilter/format), and skips anything already carrying a marker so it never
 // double-collapses.
 //
-// The window is cut by LINES when there are enough of them, and by CHARACTERS when
-// there are not. The character path is not a nicety. Being the last-resort catch-all,
+// The window is cut by LINES when that actually shrinks the output, and by CHARACTERS when
+// it does not. The character path is not a nicety. Being the last-resort catch-all,
 // collapse declining a payload means nothing caps it, and the line-only version
 // declined every output of head_lines+tail_lines lines or fewer — which includes the
 // single most common shape of an enormous tool result: a database or HTTP API response
@@ -35,11 +35,21 @@ func init() { components.Register("collapse", newCollapse) }
 // allow-list exempts any line matching `^\S+:\d+`, and a one-line JSON body
 // (`{"items":[{"id":1,...`) matches that by accident.
 //
-// ponytail: an output with MORE than head_lines+tail_lines lines still takes the line
-// window and can stay multi-megabyte if the kept lines are themselves huge (linecap,
-// which runs after, caps those lines unless neverTruncate exempts them). Deliberately
-// out of scope here so the line path stays byte-identical; the character window is a
-// natural second stage for it if that shape shows up in production.
+// The choice between the two windows is made on BYTES, not on the line count: an output
+// with more than head_lines+tail_lines lines whose kept head or tail is itself
+// multi-megabyte takes the CHARACTER window too. Gating on the line count alone left the
+// motivating shape alive above 40 lines — measured at 4,195,111 B in, 4,194,922 B out, and
+// worse than declining, because dropping the small filler lines in the middle counts as
+// acting and stamps a marker, which then makes linecap decline (marker_or_kept_verbatim)
+// and forwards 1.57 M tokens. linecap could not have capped it even without the marker:
+// its neverTruncate allow-list exempts any line matching `^\S+:\d+`, which one-line JSON
+// matches by accident (issue #151), so the mitigation this comment used to name is void
+// rather than conditional.
+//
+// ponytail: []rune(content) on the character path copies the whole output — ~59 MB for the
+// 14.8 MB payloads that motivated this component — once per oversized message per turn, on
+// top of the strings.Split above it. Fine at the measured rate (16 bodies in 3,347
+// requests) but it is the obvious thing to make streaming if that rate rises.
 type Collapse struct {
 	maxTokens int
 	maxFrac   float64
@@ -66,8 +76,12 @@ func newCollapse(raw []byte) (components.Component, error) {
 	if err := components.Decode(raw, &cfg); err != nil {
 		return nil, err
 	}
-	return &Collapse{maxTokens: cfg.MaxTokens, maxFrac: cfg.MaxFrac, headLines: cfg.HeadLines,
-		tailLines: cfg.TailLines, mode: parseMarkerMode(cfg.MarkerMode), coldCache: coldCacheDefault(cfg.ColdCache)}, nil
+	// Clamp here rather than at each use: a negative head_lines used to panic on the line
+	// path (`1 > -10` sends even a one-liner there, then lines[:-10] slices out of range),
+	// which fail-open contained but which also made splitWindow's own guard unreachable for
+	// the config it looked like it defended.
+	return &Collapse{maxTokens: cfg.MaxTokens, maxFrac: cfg.MaxFrac, headLines: max(cfg.HeadLines, 0),
+		tailLines: max(cfg.TailLines, 0), mode: parseMarkerMode(cfg.MarkerMode), coldCache: coldCacheDefault(cfg.ColdCache)}, nil
 }
 
 func (Collapse) Name() string                 { return "collapse" }
@@ -180,20 +194,35 @@ const collapseMinWindowChars = 200
 // after it in every live session mid-flight.
 func (cl *Collapse) window(content string, maxTokens int, rep *components.Report) (assemble func(string) string, byChars, ok bool) {
 	lines := strings.Split(content, "\n")
-	if len(lines) > cl.headLines+cl.tailLines {
+	if cl.headLines+cl.tailLines > 0 && len(lines) > cl.headLines+cl.tailLines {
 		omitted := len(lines) - cl.headLines - cl.tailLines
 		head := strings.Join(lines[:cl.headLines], "\n")
 		tail := strings.Join(lines[len(lines)-cl.tailLines:], "\n")
-		return func(tok string) string {
+		asm := func(tok string) string {
 			return fmt.Sprintf("%s\n... (%d lines omitted) %s\n%s", head, omitted, tok, tail)
-		}, false, true
+		}
+		// Take the line window only if it actually CUT: having more lines than the window
+		// says nothing about their size, and a multi-megabyte line inside the kept head or
+		// tail survives it untouched. Halving is the test because the line window is the
+		// byte-identical path and every shape it handles today clears it by orders of
+		// magnitude; the shapes that do not are the ones this fall-through exists for.
+		//
+		// BYTES, deliberately, and not a token comparison against maxTokens: maxTokens comes
+		// from resolveBudget(..., c.CtxWindow), CtxWindow can resolve differently mid-session,
+		// and repairLostFreeze re-derives at depth (see Offload). A token gate could therefore
+		// classify the same content line-window on one turn and character-window on the next
+		// and emit different bytes, trading a savings bug for a cache bug. This form depends
+		// only on content, head_lines and tail_lines, so it is replay-safe unconditionally.
+		if len(asm(""))*2 <= len(content) {
+			return asm, false, true
+		}
 	}
 	asm, ok := cl.runeWindow(content, maxTokens)
 	if !ok {
-		// The only genuine decline left: too few lines for a line window AND too few
-		// characters for a character one. `too_few_lines` is deliberately NOT reused —
-		// most of what it counted is now HANDLED, and exporting handled work under a
-		// decline's name yields a series that falls as the component works better.
+		// The only genuine decline left: no usable line window AND fewer characters than the
+		// smallest character one. `too_few_lines` is deliberately NOT reused — most of what
+		// it counted is now HANDLED, and exporting handled work under a decline's name yields
+		// a series that falls as the component works better.
 		rep.Gate("too_few_lines_and_chars")
 		return nil, false, false
 	}
@@ -207,12 +236,23 @@ func (cl *Collapse) window(content string, maxTokens int, rep *components.Report
 // The budget is the component's own token threshold expressed in characters, split
 // between head and tail in the head_lines:tail_lines ratio, so the existing knobs keep
 // meaning what they say ("how much of the start / the end is kept") without a second set
-// of char knobs to keep in sync. The assembled window is then measured against maxTokens
-// and the budget scaled down if it overshoots, which is what keeps the promise the
-// threshold makes: an output above max_tokens comes back at or under it.
+// of char knobs to keep in sync. The assembled window is then measured against maxTokens and
+// the budget scaled down if it overshoots, which brings an output above max_tokens back to
+// roughly it — not exactly it, on two counts worth naming rather than implying otherwise.
+// The collapseMinWindowChars floor returns before any measurement, so a very small
+// max_tokens buys a 200-character window regardless (max_tokens: 100 measures 118 tokens
+// out). And `got` measures asm("") — an EMPTY marker — while the shipped text carries the
+// ~15 tokens of `<<cg:HASH>> [full output: ...]`, which only the 10% margin below absorbs.
+// tryMark's never-worse guard is what makes the residue harmless: it measures the real
+// marker and declines rather than growing the message.
 func (cl *Collapse) runeWindow(content string, maxTokens int) (func(string) string, bool) {
 	r := []rune(content)
-	budget := maxTokens * collapseCharsPerToken
+	// Never seed above the content. chars/4 OVERESTIMATES on dense JSON (~2.5 chars/token),
+	// so bailing out below on the un-measured seed declined content the fit loop would have
+	// cut: at max_tokens 3000 — what the shipped codesafe preset sets — one-line JSON from
+	// 3,006 to 4,491 tokens was oversized and left entirely uncut. marker_no_win already
+	// protects the downside of seeding low.
+	budget := min(maxTokens*collapseCharsPerToken, len(r)-1)
 	for pass := 0; ; pass++ {
 		if budget < collapseMinWindowChars {
 			budget = collapseMinWindowChars
@@ -245,10 +285,13 @@ func (cl *Collapse) runeWindow(content string, maxTokens int) (func(string) stri
 
 // splitWindow divides a character budget between head and tail in the head_lines:tail_lines
 // ratio, so `head_lines: 40, tail_lines: 10` keeps four fifths of the window at the start on
-// the character path too. Both zero (or negative) means an even split rather than an empty
-// window, since a component configured with no line window still has to cap the output.
+// the character path too. Both zero means an even split rather than an empty window, since a
+// component configured with no line window still has to cap the output — and with both zero
+// window() routes here rather than to the line path, which would otherwise emit a bare
+// marker with no cue about what to expand (a 64 KB output became 87 bytes). Negatives are
+// clamped in newCollapse, so this only has to handle zero.
 func (cl *Collapse) splitWindow(budget int) (head, tail int) {
-	hl, tl := max(cl.headLines, 0), max(cl.tailLines, 0)
+	hl, tl := cl.headLines, cl.tailLines
 	if hl+tl == 0 {
 		hl, tl = 1, 1
 	}
@@ -263,9 +306,9 @@ func init() {
 		{Key: "max_frac", Type: components.FieldFloat,
 			Hint: "The same threshold as a fraction of the model's context window; wins when the window is known. 0 = unset."},
 		{Key: "head_lines", Type: components.FieldInt, Default: 20,
-			Hint: "Lines kept from the start of a collapsed output. On an output with too few lines to cut (a one-line JSON payload), the same ratio splits a CHARACTER window sized from max_tokens."},
+			Hint: "Lines kept from the start of a collapsed output. When a line window would not shrink it (a one-line JSON payload, or a huge line inside the kept window), the same ratio splits a CHARACTER window sized from max_tokens."},
 		{Key: "tail_lines", Type: components.FieldInt, Default: 20,
-			Hint: "Lines kept from the end of a collapsed output. Also the tail share of the character window used when there are too few lines."},
+			Hint: "Lines kept from the end of a collapsed output. Also the tail share of the character window used when a line window would not shrink the output."},
 		markerModeField(),
 		coldCacheField(),
 	})

--- a/components/offload/collapse.go
+++ b/components/offload/collapse.go
@@ -17,6 +17,29 @@ func init() { components.Register("collapse", newCollapse) }
 // full original, and leaves an expand marker. Runs late in the pipeline (after
 // cmdfilter/format), and skips anything already carrying a marker so it never
 // double-collapses.
+//
+// The window is cut by LINES when there are enough of them, and by CHARACTERS when
+// there are not. The character path is not a nicety. Being the last-resort catch-all,
+// collapse declining a payload means nothing caps it, and the line-only version
+// declined every output of head_lines+tail_lines lines or fewer — which includes the
+// single most common shape of an enormous tool result: a database or HTTP API response
+// serialised as ONE line of JSON. Measured on a live 128k-band arm: 16 upstream 400s
+// ("prompt is too long") in 3,347 requests on outgoing bodies of 2.6 MB to 14.8 MB,
+// and 17 of 75 runs errored. Nothing else caught them either — extract acted 0 times
+// (no_obvious_noise 16,891, it only strips KNOWN noise patterns), cmdfilter 0
+// (no_filter_match, only known command families), toon 21 (not_uniform_object_array
+// 233,501), dedup 774 (exact duplicates only), extract_llm declines by design when the
+// output exceeds the compaction model's own window (over_model_context), and
+// summarize protects keep_last, which is exactly where a FRESH oversized output sits.
+// linecap's per-line cap does not rescue this shape either: its neverTruncate
+// allow-list exempts any line matching `^\S+:\d+`, and a one-line JSON body
+// (`{"items":[{"id":1,...`) matches that by accident.
+//
+// ponytail: an output with MORE than head_lines+tail_lines lines still takes the line
+// window and can stay multi-megabyte if the kept lines are themselves huge (linecap,
+// which runs after, caps those lines unless neverTruncate exempts them). Deliberately
+// out of scope here so the line path stays byte-identical; the character window is a
+// natural second stage for it if that shape shows up in production.
 type Collapse struct {
 	maxTokens int
 	maxFrac   float64
@@ -86,10 +109,12 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			rep.Gate("marker_or_kept_verbatim") // already offloaded, or expanded by the agent
 			continue
 		}
-		lines := strings.Split(content, "\n")
-		if len(lines) <= cl.headLines+cl.tailLines {
-			rep.Gate("too_few_lines") // few long lines; head/tail wouldn't help
-			continue
+		// Pick the window BEFORE the depth gate so a message that has no usable window is
+		// not charged as a cache decline. assemble places the marker token; it is a pure
+		// function of (content, config, maxTokens), which is what lets freeze replay it.
+		assemble, byChars, ok := cl.window(content, maxTokens, rep)
+		if !ok {
+			continue // window() named the reason
 		}
 		// A NEW collapse only in the uncached tail. This component used to carry no depth
 		// restriction at all, contradicting the contract in components/component.go: it
@@ -102,13 +127,7 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			rep.Gate("cached_prefix")
 			continue
 		}
-		omitted := len(lines) - cl.headLines - cl.tailLines
-		head := strings.Join(lines[:cl.headLines], "\n")
-		tail := strings.Join(lines[len(lines)-cl.tailLines:], "\n")
-		newText, key, eff, ok := tryMark(c, cl.mode, content, " [full output: call "+expand.ToolName+"]",
-			func(tok string) string {
-				return fmt.Sprintf("%s\n... (%d lines omitted) %s\n%s", head, omitted, tok, tail)
-			})
+		newText, key, eff, ok := tryMark(c, cl.mode, content, " [full output: call "+expand.ToolName+"]", assemble)
 		if !ok {
 			rep.Gate("marker_no_win") // head/tail window+marker wouldn't shrink this output
 			continue
@@ -116,6 +135,12 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 		commitMark(c, rep, eff, key, content)
 		schema.SetMessageText(m, newText)
 		freeze(c, cl.Name(), content, newText) // freeze so later turns replay it (no churn)
+		if byChars {
+			// Counted as an EVENT, not a gate: this population used to be the
+			// `too_few_lines` DECLINE, and exporting "handled" under the old decline name
+			// would make the series fall as the component works better.
+			rep.Event("char_window")
+		}
 		changed++
 		if key != "" {
 			keys = append(keys, key)
@@ -127,6 +152,110 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 	return keys, nil
 }
 
+// collapseCharsPerToken converts the token threshold into a CHARACTER budget for the character
+// window. 4 is not a fresh magic number: it is the same ratio internal/tokens.Count
+// itself falls back to when the BPE codec is unavailable, so the two places in the tree
+// that have to relate bytes to tokens agree on the exchange rate. It is only a starting
+// estimate — the window is then MEASURED and tightened (see collapseFitPasses), because dense
+// JSON tokenizes closer to 2.5 chars/token and a flat chars/4 window would overshoot by
+// half the budget it exists to enforce.
+const collapseCharsPerToken = 4
+
+// collapseFitPasses bounds the corrective re-measure of the character window. Each pass scales
+// the budget by the measured token ratio, so one pass is normally enough; the bound is
+// there so a pathological tokenization cannot spin.
+const collapseFitPasses = 3
+
+// collapseMinWindowChars floors the character window. Without a floor, a max_tokens of 0 (or a
+// tiny max_frac against a small window) collapses an output to nothing but a marker,
+// which is a legal but useless rewrite: the model then has no cue about WHAT to expand.
+const collapseMinWindowChars = 200
+
+// window chooses how to cut content and returns the layout closure tryMark will
+// size-check, plus whether the CHARACTER path was used. It names its own decline reason.
+//
+// Line window first, and byte-for-byte as it always was: anything the line path already
+// handled must keep producing identical bytes, because a message's collapsed form is
+// frozen and replayed at depth — a changed layout would re-anchor every cached position
+// after it in every live session mid-flight.
+func (cl *Collapse) window(content string, maxTokens int, rep *components.Report) (assemble func(string) string, byChars, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) > cl.headLines+cl.tailLines {
+		omitted := len(lines) - cl.headLines - cl.tailLines
+		head := strings.Join(lines[:cl.headLines], "\n")
+		tail := strings.Join(lines[len(lines)-cl.tailLines:], "\n")
+		return func(tok string) string {
+			return fmt.Sprintf("%s\n... (%d lines omitted) %s\n%s", head, omitted, tok, tail)
+		}, false, true
+	}
+	asm, ok := cl.runeWindow(content, maxTokens)
+	if !ok {
+		// The only genuine decline left: too few lines for a line window AND too few
+		// characters for a character one. `too_few_lines` is deliberately NOT reused —
+		// most of what it counted is now HANDLED, and exporting handled work under a
+		// decline's name yields a series that falls as the component works better.
+		rep.Gate("too_few_lines_and_chars")
+		return nil, false, false
+	}
+	return asm, true, true
+}
+
+// runeWindow is the head+tail window measured in RUNES rather than lines, for content the
+// line window cannot cut. Runes, not bytes, so a multibyte character is never split into
+// invalid UTF-8 (the text is spliced back into the request body verbatim).
+//
+// The budget is the component's own token threshold expressed in characters, split
+// between head and tail in the head_lines:tail_lines ratio, so the existing knobs keep
+// meaning what they say ("how much of the start / the end is kept") without a second set
+// of char knobs to keep in sync. The assembled window is then measured against maxTokens
+// and the budget scaled down if it overshoots, which is what keeps the promise the
+// threshold makes: an output above max_tokens comes back at or under it.
+func (cl *Collapse) runeWindow(content string, maxTokens int) (func(string) string, bool) {
+	r := []rune(content)
+	budget := maxTokens * collapseCharsPerToken
+	for pass := 0; ; pass++ {
+		if budget < collapseMinWindowChars {
+			budget = collapseMinWindowChars
+		}
+		head, tail := cl.splitWindow(budget)
+		if head+tail >= len(r) {
+			return nil, false // the window is not smaller than the content; nothing to cut
+		}
+		h, t := head, tail // snapshot: the closure must not see a later pass's budget
+		asm := func(tok string) string {
+			return fmt.Sprintf("%s\n... (%d characters omitted) %s\n%s",
+				string(r[:h]), len(r)-h-t, tok, string(r[len(r)-t:]))
+		}
+		if pass == collapseFitPasses || budget == collapseMinWindowChars {
+			return asm, true
+		}
+		got := schema.TextTokens(asm(""))
+		if got <= maxTokens {
+			return asm, true
+		}
+		// Overshoot: scale by the measured ratio, with a 10% margin so a second pass is
+		// rarely needed. Never grow the budget — this loop only ever tightens.
+		next := budget * maxTokens / got * 9 / 10
+		if next >= budget {
+			return asm, true
+		}
+		budget = next
+	}
+}
+
+// splitWindow divides a character budget between head and tail in the head_lines:tail_lines
+// ratio, so `head_lines: 40, tail_lines: 10` keeps four fifths of the window at the start on
+// the character path too. Both zero (or negative) means an even split rather than an empty
+// window, since a component configured with no line window still has to cap the output.
+func (cl *Collapse) splitWindow(budget int) (head, tail int) {
+	hl, tl := max(cl.headLines, 0), max(cl.tailLines, 0)
+	if hl+tl == 0 {
+		hl, tl = 1, 1
+	}
+	head = budget * hl / (hl + tl)
+	return head, budget - head
+}
+
 func init() {
 	components.RegisterFields("collapse", collapseConfig{}, []components.Field{
 		{Key: "max_tokens", Type: components.FieldInt, Default: 2000,
@@ -134,9 +263,9 @@ func init() {
 		{Key: "max_frac", Type: components.FieldFloat,
 			Hint: "The same threshold as a fraction of the model's context window; wins when the window is known. 0 = unset."},
 		{Key: "head_lines", Type: components.FieldInt, Default: 20,
-			Hint: "Lines kept from the start of a collapsed output."},
+			Hint: "Lines kept from the start of a collapsed output. On an output with too few lines to cut (a one-line JSON payload), the same ratio splits a CHARACTER window sized from max_tokens."},
 		{Key: "tail_lines", Type: components.FieldInt, Default: 20,
-			Hint: "Lines kept from the end of a collapsed output."},
+			Hint: "Lines kept from the end of a collapsed output. Also the tail share of the character window used when there are too few lines."},
 		markerModeField(),
 		coldCacheField(),
 	})

--- a/components/offload/collapse_charwindow_test.go
+++ b/components/offload/collapse_charwindow_test.go
@@ -1,0 +1,271 @@
+package offload
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// collapseFor builds a collapse with the shipped defaults unless yaml overrides them.
+func collapseFor(t *testing.T, yaml string) *Collapse {
+	t.Helper()
+	c, err := newCollapse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c.(*Collapse)
+}
+
+// collapseCtx is a warm turn with no cached prefix, so every message is in the tail and the
+// depth gate is not what these tests are measuring (cold_gate_test.go covers that).
+func collapseCtx() *components.Ctx {
+	return &components.Ctx{Session: "s", Store: store.NewMemory(store.Options{})}
+}
+
+// oneLineJSON is the shape the character window exists for: a database/HTTP result
+// serialised as a SINGLE line, which the line window declined outright — so nothing in the
+// pipeline capped it and the provider answered 400 "prompt is too long" on a multi-megabyte
+// body. No newline anywhere in it.
+func oneLineJSON(approxBytes int) string {
+	var b strings.Builder
+	b.WriteString(`{"rows":[`)
+	for i := 0; b.Len() < approxBytes; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%d,"sku":"SKU-%06d","name":"widget %d","qty":%d,"price":%d.99}`, i, i, i, i%97, i%1000)
+	}
+	b.WriteString(`],"total":1}`)
+	return b.String()
+}
+
+// The defect: a multi-megabyte ONE-LINE payload used to fall through collapse entirely
+// (too_few_lines), and nothing downstream capped it. It must now be capped, stashed and
+// marked — the three properties that make it a legal Offload.
+func TestCollapseCapsSingleLineMegabytePayload(t *testing.T) {
+	body := oneLineJSON(3 << 20)
+	if strings.Contains(body, "\n") {
+		t.Fatal("fixture must be a single line")
+	}
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	c := collapseCtx()
+	var rep components.Report
+	cl := collapseFor(t, "")
+	keys, err := cl.Offload(req, &rep, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	if got == body {
+		t.Fatalf("a %d-byte single-line output was left verbatim; gates %v", len(body), rep.Gates)
+	}
+	// Capped: at or under the token threshold it was judged oversized against.
+	if n := schema.TextTokens(got); n > cl.maxTokens {
+		t.Fatalf("collapsed output is %d tokens, above the %d-token threshold:\n%.200q", n, cl.maxTokens, got)
+	}
+	// Marked, and the marker resolves to the stash.
+	if !expand.HasPlaceholder(got) {
+		t.Fatalf("no expand marker left behind: %.300q", got)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want 1 stash key, got %v", keys)
+	}
+	// Reversible: the recovered original is byte-complete.
+	raw, ok := c.Store.Get(keys[0])
+	if !ok {
+		t.Fatalf("original not stashed under %q", keys[0])
+	}
+	if string(raw) != body {
+		t.Fatalf("recovered original is not the input (%d bytes vs %d)", len(raw), len(body))
+	}
+	// Both ends kept, so the model can see WHAT it would be expanding.
+	if !strings.HasPrefix(got, body[:64]) {
+		t.Errorf("head of the payload not kept: %.100q", got)
+	}
+	if !strings.HasSuffix(got, body[len(body)-64:]) {
+		t.Errorf("tail of the payload not kept: %q", got[len(got)-100:])
+	}
+	if rep.Events["char_window"] != 1 {
+		t.Errorf("character path must be counted as an event, got events %v gates %v", rep.Events, rep.Gates)
+	}
+	if _, dead := rep.Gates["too_few_lines"]; dead {
+		t.Error("too_few_lines must no longer count a message the character path handled")
+	}
+}
+
+// A handful of long lines is the same defect: 40 lines of 100 KB each was declined too.
+func TestCollapseCapsFewVeryLongLines(t *testing.T) {
+	body := strings.Repeat(oneLineJSON(100<<10)+"\n", 5)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	cl := collapseFor(t, "")
+	if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	if got := schema.MessageText(req.Input[0]); got == body {
+		t.Fatalf("5 lines of 100 KB left verbatim; gates %v", rep.Gates)
+	}
+}
+
+// The property most likely to break: everything the LINE window already handled must come
+// out byte-identical. A collapsed form is frozen and replayed at depth, so a changed layout
+// re-anchors every cached position after it in live sessions. The expectation is spelled out
+// here rather than captured from the implementation, so a layout change fails this test.
+func TestCollapseLineWindowIsByteIdentical(t *testing.T) {
+	cases := map[string]string{
+		"plain log":      strings.Repeat("verbose tool output line with a bit of detail\n", 200),
+		"uneven lines":   strings.Repeat("short\na much longer line carrying a path src/pkg/file.go:42 and words\n", 60),
+		"trailing blank": strings.Repeat("data row\n", 100) + "\n\n",
+		"no trailing nl": strings.TrimSuffix(strings.Repeat("data row\n", 100), "\n"),
+	}
+	for name, body := range cases {
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+		c := collapseCtx()
+		var rep components.Report
+		// A low threshold, so the fixtures can stay small and fast: max_tokens decides
+		// WHETHER an output is collapsed, never how the line window is laid out.
+		cl := collapseFor(t, "max_tokens: 50\n")
+		if _, err := cl.Offload(req, &rep, c); err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.Split(body, "\n")
+		want := fmt.Sprintf("%s\n... (%d lines omitted) %s [full output: call %s]\n%s",
+			strings.Join(lines[:cl.headLines], "\n"),
+			len(lines)-cl.headLines-cl.tailLines,
+			expand.Marker(hashKey(body)), expand.ToolName,
+			strings.Join(lines[len(lines)-cl.tailLines:], "\n"))
+		if got := schema.MessageText(req.Input[0]); got != want {
+			t.Fatalf("%s: line window is not byte-identical\n want %q\n got  %q", name, want, got)
+		}
+		if rep.Events["char_window"] != 0 {
+			t.Fatalf("%s: multi-line output must not take the character path", name)
+		}
+	}
+}
+
+// never-worse, on the character path: when the window plus its marker would not actually
+// shrink the output, it is left verbatim. The pipeline's own guard is per REQUEST, so
+// without this a small-but-oversized message grows by the marker's tokens.
+func TestCollapseCharWindowNeverWorse(t *testing.T) {
+	// 300 characters on one line: above a 40-token threshold, but the window this
+	// threshold buys (floored at collapseMinWindowChars) plus a <<cg:HASH>> marker and its
+	// hint costs more tokens than the original.
+	body := strings.Repeat("abcdefghij", 30)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	c := collapseCtx()
+	var rep components.Report
+	cl := collapseFor(t, "max_tokens: 40\n")
+	if schema.TextTokens(body) <= cl.maxTokens {
+		t.Fatalf("fixture must be oversized: %d tokens", schema.TextTokens(body))
+	}
+	if _, err := cl.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	if got := schema.MessageText(req.Input[0]); got != body {
+		t.Fatalf("an output the window cannot shrink must stay verbatim, got %q", got)
+	}
+	if rep.Gates["marker_no_win"] == 0 {
+		t.Fatalf("the decline must be named marker_no_win, gates %v", rep.Gates)
+	}
+	if !rep.Skipped {
+		t.Error("a component that changed nothing must report Skipped")
+	}
+}
+
+// Idempotent: content already carrying a marker is another component's stash (or an
+// expansion the agent asked for). Cutting it again would orphan that stash.
+func TestCollapseCharWindowSkipsMarkedContent(t *testing.T) {
+	body := expand.Marker("deadbeef") + " " + oneLineJSON(1<<20)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	if _, err := collapseFor(t, "").Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	if got := schema.MessageText(req.Input[0]); got != body {
+		t.Fatalf("marker-bearing content must be untouched, got %.200q", got)
+	}
+	if rep.Gates["marker_or_kept_verbatim"] == 0 {
+		t.Fatalf("want marker_or_kept_verbatim, gates %v", rep.Gates)
+	}
+}
+
+// The window is cut on RUNE boundaries: the result is spliced back into the request body,
+// so a split multibyte rune would emit invalid UTF-8 upstream.
+//
+// The fixture keeps ASCII separators between the CJK runs on purpose. tiktoken's merge loop
+// is superlinear in the length of a single unbroken word, and a separator-free CJK blob is
+// exactly that: 600 KB of it did not finish tokenizing in a ten-minute test timeout. That is
+// pre-existing (collapse's own size test tokenizes the whole content), but it means a test
+// fixture must not be a separator-free wall of text.
+func TestCollapseCharWindowKeepsValidUTF8(t *testing.T) {
+	body := strings.Repeat("日本語のログ行 ", 3000) // one line, multibyte, with separators
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	if _, err := collapseFor(t, "max_tokens: 300\n").Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	if got == body {
+		t.Fatalf("single-line CJK payload left verbatim, gates %v", rep.Gates)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("character window split a multibyte rune")
+	}
+}
+
+// head_lines:tail_lines is the ratio the character window splits by, so the existing knobs
+// keep meaning "how much of the start / the end is kept" on both paths.
+func TestCollapseCharWindowHonoursHeadTailRatio(t *testing.T) {
+	body := oneLineJSON(1 << 20)
+	head, tail := collapseFor(t, "head_lines: 90\ntail_lines: 10\n").splitWindow(1000)
+	if head != 900 || tail != 100 {
+		t.Fatalf("want 900/100 split, got %d/%d", head, tail)
+	}
+	// And the skew shows up in the rewrite.
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	cl := collapseFor(t, "head_lines: 90\ntail_lines: 10\nmax_tokens: 500\n")
+	if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	i := strings.Index(got, "\n... (")
+	if i < 0 {
+		t.Fatalf("no elision notice: %.200q", got)
+	}
+	if kept := len([]rune(got[i+1:])); len([]rune(got[:i])) < 4*kept {
+		t.Fatalf("head share not skewed: head %d runes, rest %d", len([]rune(got[:i])), kept)
+	}
+}
+
+// The only genuine decline left, and it must still be named: too few lines for a line window
+// AND fewer characters than the smallest character window. `too_few_lines` is gone, so this
+// is where the residual gap stays visible on /stats.
+func TestCollapseTooSmallForEitherWindow(t *testing.T) {
+	body := strings.Repeat("x", collapseMinWindowChars-50) // one line, shorter than the floor
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	cl := collapseFor(t, "max_tokens: 1\n")
+	if schema.TextTokens(body) <= cl.maxTokens {
+		t.Fatal("fixture must be oversized")
+	}
+	if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	if got := schema.MessageText(req.Input[0]); got != body {
+		t.Fatalf("must stay verbatim, got %q", got)
+	}
+	if rep.Gates["too_few_lines_and_chars"] != 1 {
+		t.Fatalf("want too_few_lines_and_chars, gates %v", rep.Gates)
+	}
+	if _, dead := rep.Gates["too_few_lines"]; dead {
+		t.Error("too_few_lines is retired; it must not reappear")
+	}
+}

--- a/components/offload/collapse_charwindow_test.go
+++ b/components/offload/collapse_charwindow_test.go
@@ -269,3 +269,227 @@ func TestCollapseTooSmallForEitherWindow(t *testing.T) {
 		t.Error("too_few_lines is retired; it must not reappear")
 	}
 }
+
+// charWindowFloored is the exact head/tail split every fixture below is cut with: at
+// max_tokens 50 the character budget is min(50*4, len(r)-1) = 200, which IS
+// collapseMinWindowChars, so runeWindow returns at pass 0 without a fit pass and
+// splitWindow divides 200 in the default 20:20 ratio. Spelled out here so the expectations
+// further down are a statement about the LAYOUT rather than a re-run of the budget code.
+const charWindowFlooredHead, charWindowFlooredTail = 100, 100
+
+// The character path's output is frozen and replayed at depth exactly like the line path's,
+// so it needs the same protection the line path got in TestCollapseLineWindowIsByteIdentical:
+// a changed layout re-anchors every cached position after it in every live session
+// mid-flight. Without a byte-exact expectation, an off-by-one head slice (r[:h+1]) or a
+// wrong omitted count passes the whole suite — both did.
+//
+// The expectation is written out as a literal format string rather than captured from
+// window(), so a layout change fails here instead of being adopted silently.
+func TestCollapseCharWindowIsByteIdentical(t *testing.T) {
+	longLine := oneLineJSON(5 << 10)
+	cases := map[string]string{
+		// The motivating shape: one line, dense, no newline anywhere.
+		"one line json": oneLineJSON(600),
+		// Multibyte, so a mutation from runes to bytes moves the cut and fails here.
+		"multibyte": strings.Repeat("日本語のログ行 ", 40),
+		// Plenty of lines, but a huge one inside the kept head, so the line window does not
+		// shrink it and the byte gate falls through to this path. The layout must be the
+		// same as any other character cut.
+		"huge line in head": longLine + "\n" + strings.Repeat("filler row\n", 60),
+		// Same, with the huge line in the kept tail.
+		"huge line in tail": strings.Repeat("filler row\n", 60) + longLine,
+	}
+	for name, body := range cases {
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+		c := collapseCtx()
+		var rep components.Report
+		cl := collapseFor(t, "max_tokens: 50\n")
+		if _, err := cl.Offload(req, &rep, c); err != nil {
+			t.Fatal(err)
+		}
+		r := []rune(body)
+		if len(r) <= charWindowFlooredHead+charWindowFlooredTail {
+			t.Fatalf("%s: fixture must be longer than the floored window (%d runes)", name, len(r))
+		}
+		want := fmt.Sprintf("%s\n... (%d characters omitted) %s [full output: call %s]\n%s",
+			string(r[:charWindowFlooredHead]),
+			len(r)-charWindowFlooredHead-charWindowFlooredTail,
+			expand.Marker(hashKey(body)), expand.ToolName,
+			string(r[len(r)-charWindowFlooredTail:]))
+		if got := schema.MessageText(req.Input[0]); got != want {
+			t.Fatalf("%s: character window is not byte-identical\n want %q\n got  %q", name, want, got)
+		}
+		// A precondition, not a nicety: if the line path had handled the fixture the
+		// comparison above would be vacuous as an assertion about THIS window.
+		if rep.Events["char_window"] != 1 {
+			t.Fatalf("%s: fixture did not take the character path, events %v gates %v", name, rep.Events, rep.Gates)
+		}
+	}
+}
+
+// The boundary this PR moves, asserted from the other side. At EXACTLY head_lines+tail_lines
+// lines the line window would omit zero lines, so it must not be taken. Flipping the gate to
+// `>=` survived all eight of the first round's tests: the line path computes omitted = 0,
+// emits the whole content plus a marker, fails tryMark and declines marker_no_win — so a
+// 40-line multi-megabyte output sails through with a green suite.
+func TestCollapseCharWindowAtExactlyTheLineWindowSize(t *testing.T) {
+	cl := collapseFor(t, "")
+	var b strings.Builder
+	for i := 0; i < cl.headLines+cl.tailLines; i++ {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(oneLineJSON(2 << 10))
+	}
+	body := b.String()
+	if n := strings.Count(body, "\n") + 1; n != cl.headLines+cl.tailLines {
+		t.Fatalf("fixture must have exactly %d lines, has %d", cl.headLines+cl.tailLines, n)
+	}
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	c := collapseCtx()
+	var rep components.Report
+	if _, err := cl.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	if got == body {
+		t.Fatalf("a %d-byte output of exactly %d lines was left verbatim; gates %v events %v",
+			len(body), cl.headLines+cl.tailLines, rep.Gates, rep.Events)
+	}
+	if rep.Events["char_window"] != 1 {
+		t.Fatalf("exactly headLines+tailLines lines must take the character path, events %v gates %v", rep.Events, rep.Gates)
+	}
+	if n := schema.TextTokens(got); n > cl.maxTokens {
+		t.Fatalf("collapsed output is %d tokens, above the %d-token threshold", n, cl.maxTokens)
+	}
+}
+
+// The blocking defect the review measured: the window was chosen on the LINE COUNT, so an
+// output with more than head_lines+tail_lines lines took the line path however big those
+// lines were. A multi-megabyte line inside the kept head or tail survived untouched — and
+// worse than being declined, because dropping the small filler lines in the middle counts as
+// acting and stamps a marker, which then makes linecap decline marker_or_kept_verbatim.
+// Measured: 4,195,111 B in, 4,194,922 B out, 189 bytes saved, 1.57 M tokens forwarded.
+func TestCollapseCutsAHugeLineInsideTheLineWindow(t *testing.T) {
+	huge := oneLineJSON(1 << 20) // one line, bigger than any window
+	filler := strings.Repeat("filler row\n", 60)
+	for name, body := range map[string]string{
+		"huge line in head": huge + "\n" + filler,
+		"huge line in tail": filler + huge,
+	} {
+		cl := collapseFor(t, "")
+		if n := strings.Count(body, "\n") + 1; n <= cl.headLines+cl.tailLines {
+			t.Fatalf("%s: fixture must have MORE lines than the line window, has %d", name, n)
+		}
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+		c := collapseCtx()
+		var rep components.Report
+		keys, err := cl.Offload(req, &rep, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := schema.MessageText(req.Input[0])
+		// The old behaviour: acted, marked, and still multi-megabyte.
+		if len(got)*2 > len(body) {
+			t.Fatalf("%s: %d-byte output came back %d bytes — the line window kept it; gates %v events %v",
+				name, len(body), len(got), rep.Gates, rep.Events)
+		}
+		if n := schema.TextTokens(got); n > cl.maxTokens {
+			t.Fatalf("%s: collapsed output is %d tokens, above the %d-token threshold", name, n, cl.maxTokens)
+		}
+		if rep.Events["char_window"] != 1 {
+			t.Fatalf("%s: a huge kept line must fall through to the character window, events %v gates %v", name, rep.Events, rep.Gates)
+		}
+		// Still reversible: the fall-through goes through the same stash.
+		if len(keys) != 1 {
+			t.Fatalf("%s: want 1 stash key, got %v", name, keys)
+		}
+		if raw, ok := c.Store.Get(keys[0]); !ok || string(raw) != body {
+			t.Fatalf("%s: original not recoverable byte-for-byte", name)
+		}
+	}
+}
+
+// A units mismatch declined a 55%-wide band of genuinely oversized content: the bail-out at
+// `head+tail >= len(r)` was tested against the UN-measured chars/4 seed, and dense JSON
+// tokenizes closer to 2.5 chars/token, so content over max_tokens was still shorter in runes
+// than its chars/4 budget and was declined outright as too_few_lines_and_chars. max_tokens
+// 3000 is what the shipped codesafe preset sets, which gave it the widest hole
+// (3,006-4,491 tokens uncut) and no test covered it.
+func TestCollapseCutsDenseJSONInTheOversizeBand(t *testing.T) {
+	for _, maxTokens := range []int{2000, 3000} {
+		cl := collapseFor(t, fmt.Sprintf("max_tokens: %d\n", maxTokens))
+		// Sized into the band: over the threshold in TOKENS, under it in chars/4 runes.
+		body := oneLineJSON(maxTokens * 8 / 3)
+		tokens, runes := schema.TextTokens(body), len([]rune(body))
+		if tokens <= maxTokens {
+			t.Fatalf("max_tokens %d: fixture must be oversized, is %d tokens", maxTokens, tokens)
+		}
+		if runes >= maxTokens*collapseCharsPerToken {
+			t.Fatalf("max_tokens %d: fixture must be INSIDE the band (%d runes vs a %d-char seed)",
+				maxTokens, runes, maxTokens*collapseCharsPerToken)
+		}
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+		var rep components.Report
+		if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil {
+			t.Fatal(err)
+		}
+		got := schema.MessageText(req.Input[0])
+		if got == body {
+			t.Fatalf("max_tokens %d: %d-token single-line output left uncut; gates %v", maxTokens, tokens, rep.Gates)
+		}
+		if n := schema.TextTokens(got); n > maxTokens {
+			t.Fatalf("max_tokens %d: collapsed output is %d tokens, still above the threshold", maxTokens, n)
+		}
+		if rep.Events["char_window"] != 1 {
+			t.Fatalf("max_tokens %d: want the character window, events %v gates %v", maxTokens, rep.Events, rep.Gates)
+		}
+	}
+}
+
+// head_lines: 0, tail_lines: 0 reached the LINE path (`1 > 0+0`) and produced a bare marker
+// with no content cue — an 87-byte rewrite of a 64 KB output, which is precisely what
+// collapseMinWindowChars exists to prevent. With no line window configured the character
+// window (even split, floored) is the only sensible reading of "cap this output".
+func TestCollapseZeroLineWindowStillKeepsContent(t *testing.T) {
+	body := strings.Repeat("payload line with some detail in it\n", 2000)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	cl := collapseFor(t, "head_lines: 0\ntail_lines: 0\n")
+	if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	if got == body {
+		t.Fatalf("output left verbatim; gates %v", rep.Gates)
+	}
+	if len(got) < collapseMinWindowChars {
+		t.Fatalf("a %d-byte output collapsed to %d bytes — a bare marker with no cue: %q", len(body), len(got), got)
+	}
+	if !strings.HasPrefix(got, body[:64]) {
+		t.Errorf("head of the payload not kept: %.120q", got)
+	}
+	if rep.Events["char_window"] != 1 {
+		t.Fatalf("no line window means the character window, events %v gates %v", rep.Events, rep.Gates)
+	}
+}
+
+// A negative head_lines used to panic: `1 > -10` sent even a one-liner down the line path,
+// where lines[:-10] slices out of range. Fail-open contained it, and splitWindow's own
+// max(...) guard was unreachable for exactly the config it looked like it defended. The
+// clamp is now in newCollapse, so it covers both paths.
+func TestCollapseNegativeLineWindowIsClamped(t *testing.T) {
+	cl := collapseFor(t, "head_lines: -10\ntail_lines: -5\nmax_tokens: 50\n")
+	if cl.headLines != 0 || cl.tailLines != 0 {
+		t.Fatalf("negative line knobs must be clamped to 0, got %d/%d", cl.headLines, cl.tailLines)
+	}
+	body := oneLineJSON(4 << 10)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body)}}
+	var rep components.Report
+	if _, err := cl.Offload(req, &rep, collapseCtx()); err != nil { // must not panic
+		t.Fatal(err)
+	}
+	if got := schema.MessageText(req.Input[0]); got == body {
+		t.Fatalf("output left verbatim; gates %v", rep.Gates)
+	}
+}

--- a/docs/components.md
+++ b/docs/components.md
@@ -286,7 +286,8 @@ cut by **characters** instead, on rune boundaries, sized from `max_tokens` and s
 - **Config:** `max_tokens` (2000 threshold), `max_frac` (fraction of the context window; wins when
   known), `head_lines` (20), `tail_lines` (20), `marker_mode`. **Shines:** a
   catch-all last stage for huge outputs, including single-line ones. **Inert:** output ≤
-  `max_tokens`, or too small for either window to shrink it (`too_few_lines_and_chars`).
+  `max_tokens`, or shorter than the 200-character character-window floor
+  (`too_few_lines_and_chars`).
 
 ### `failed_run`
 Recognizes test/build run output (regex: `N passed/failed`, `BUILD SUCCESS/FAIL`, `Traceback`,

--- a/docs/components.md
+++ b/docs/components.md
@@ -20,7 +20,7 @@ messages (`role:"tool"`; for Anthropic, `tool_result` blocks normalized to that 
 | `skeleton` | Offload | function/method bodies | via expand | fenced ` ```lang ` code blocks and raw file dumps (`Read`/`cat`/`sed -n`); **behind the `cg_skeleton` build tag, needs CGO, in no preset, and must not be enabled** — it removes 0 tokens per live turn because every `Read` is the newest of its path, and the guards that make it safe are what make it worthless, see the measurement | `min_tokens` (80) |
 | `dedup` | Offload | later byte-identical tool outputs | via expand | repeated identical outputs | `min_tokens` (100) |
 | `readlifecycle` | Offload | file `Read` bodies the transcript proves are stale (file edited later) or superseded (re-read later) | via expand | `Read` results in an editing session; **opt-in, in no preset** — 0 tokens warm, a third of a *cold* request, see the break-even | `min_tokens` (100), `stale`, `superseded`, `bash_edits`, `stale_at_depth`, `cold_cache` |
-| `collapse` | Offload | middle of an oversized output | via expand | any large tool output (fallback) | `max_tokens` (2000), `head_lines` (20), `tail_lines` (20), `cold_cache` (**true**) |
+| `collapse` | Offload | middle of an oversized output (by lines, or by characters when there are too few lines) | via expand | any large tool output (fallback) | `max_tokens` (2000), `head_lines` (20), `tail_lines` (20), `cold_cache` (**true**) |
 | `failed_run` | Offload | earlier superseded test/build runs | via expand | ≥2 run-like outputs | `min_tokens` (100), `cold_cache` (**true**) |
 | `cmdfilter` | Offload | lines per declarative DSL filter | via expand | output matching a filter | `filters` ([]), `disable_builtins` (false), `min_size` (400) |
 | `linecap` | Offload | the tail of any line over 500 chars, and every NON-adjacent repeat of a line (first copy annotated `(xN)`) | via expand | any tool output ≥ `min_size`; command-agnostic, so it fires where per-command filters do not | `max_line_chars` (500), `collapse_duplicate_lines` (true), `min_size` (400) |
@@ -278,10 +278,15 @@ after:   <first 20 lines>
          <last 20 lines>
 ```
 
+When there are too few lines to cut (canonically a database/HTTP result serialised as ONE line of
+JSON — the shape behind measured `prompt is too long` 400s on 2.6–14.8 MB bodies), the same window is
+cut by **characters** instead, on rune boundaries, sized from `max_tokens` and split in the
+`head_lines`:`tail_lines` ratio.
+
 - **Config:** `max_tokens` (2000 threshold), `max_frac` (fraction of the context window; wins when
   known), `head_lines` (20), `tail_lines` (20), `marker_mode`. **Shines:** a
-  catch-all last stage for huge outputs. **Inert:** output ≤ `max_tokens`, or too few lines for
-  head/tail to help.
+  catch-all last stage for huge outputs, including single-line ones. **Inert:** output ≤
+  `max_tokens`, or too small for either window to shrink it (`too_few_lines_and_chars`).
 
 ### `failed_run`
 Recognizes test/build run output (regex: `N passed/failed`, `BUILD SUCCESS/FAIL`, `Traceback`,

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -9,6 +9,26 @@
 handled: it keeps a `head_lines` + `tail_lines` window and stashes the full original behind a
 `<<cg:HASH>>` marker. It runs late (after `cmdfilter`/`format`) and skips content already marked.
 
+The window is cut by **lines** when there are enough of them, and by **characters** when there are
+not. The character path matters because `collapse` is the last resort: if it declines, nothing caps
+the output. The line-only version declined every output of `head_lines + tail_lines` lines or fewer
+(40 by default) — which is exactly the shape of the largest tool results in practice, a database or
+HTTP API response serialised as **one line** of JSON. Measured on a live 128k-band arm: 16 upstream
+400 `prompt is too long` responses in 3,347 requests, on outgoing bodies of **2.6 MB to 14.8 MB**,
+and 17 of 75 runs errored. Nothing else caught them — `extract` acted 0 times (`no_obvious_noise`
+16,891; it only strips known noise patterns), `cmdfilter` 0 (`no_filter_match`), `toon` 21
+(`not_uniform_object_array` 233,501), `dedup` 774 (exact duplicates only), `extract_llm` declines by
+design once the output exceeds the compaction model's own window (`over_model_context`), and
+`summarize` protects `keep_last`, which is where a fresh oversized output sits. `linecap`'s per-line
+cap does not rescue it either: its `neverTruncate` allow-list exempts any line matching
+`^\S+:\d+`, and `{"items":[{"id":1,...` matches that by accident.
+
+The character budget is the component's own token threshold expressed in characters — no new knob.
+It starts at `max_tokens × 4` (the same ratio `internal/tokens` falls back to), is split between
+head and tail in the `head_lines`:`tail_lines` ratio, and is then **measured** and tightened if the
+assembled window overshoots `max_tokens`, because dense JSON tokenizes closer to 2.5 chars/token.
+The cut is on rune boundaries, so a multibyte character is never split.
+
 ## Before → After
 
 ```
@@ -40,8 +60,14 @@ A catch-all last stage for huge outputs.
 
 ## When it's inert
 
-It now names its reason instead of passing silently: `below_max_tokens`, `too_few_lines` (head/tail
-would not help), `marker_or_kept_verbatim`, `non_text_blocks`, `marker_no_win`, or `cached_prefix`.
+It now names its reason instead of passing silently: `below_max_tokens`,
+`too_few_lines_and_chars` (too few lines for a line window *and* too few characters for a character
+one — the only genuine decline left), `marker_or_kept_verbatim`, `non_text_blocks`, `marker_no_win`,
+or `cached_prefix`.
+
+`too_few_lines` is **gone** and was not renamed: its population is now either handled (the
+`char_window` *event*) or a real decline (`too_few_lines_and_chars`). Exporting a decline and a
+success under one metric name gives a series that falls as the component works better.
 
 `cached_prefix` is new. `collapse` used to carry **no depth restriction at all** — it re-derived the
 whole transcript on every turn, which contradicted the cache-safety contract every other

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -9,11 +9,11 @@
 handled: it keeps a `head_lines` + `tail_lines` window and stashes the full original behind a
 `<<cg:HASH>>` marker. It runs late (after `cmdfilter`/`format`) and skips content already marked.
 
-The window is cut by **lines** when there are enough of them, and by **characters** when there are
-not. The character path matters because `collapse` is the last resort: if it declines, nothing caps
-the output. The line-only version declined every output of `head_lines + tail_lines` lines or fewer
-(40 by default) — which is exactly the shape of the largest tool results in practice, a database or
-HTTP API response serialised as **one line** of JSON. Measured on a live 128k-band arm: 16 upstream
+The window is cut by **lines** when that actually shrinks the output, and by **characters** when it
+does not. The character path matters because `collapse` is the last resort: if it declines, nothing
+caps the output. The line-only version declined every output of `head_lines + tail_lines` lines or
+fewer (40 by default) — which is exactly the shape of the largest tool results in practice, a
+database or HTTP API response serialised as **one line** of JSON. Measured on a live 128k-band arm: 16 upstream
 400 `prompt is too long` responses in 3,347 requests, on outgoing bodies of **2.6 MB to 14.8 MB**,
 and 17 of 75 runs errored. Nothing else caught them — `extract` acted 0 times (`no_obvious_noise`
 16,891; it only strips known noise patterns), `cmdfilter` 0 (`no_filter_match`), `toon` 21
@@ -21,13 +21,37 @@ and 17 of 75 runs errored. Nothing else caught them — `extract` acted 0 times 
 design once the output exceeds the compaction model's own window (`over_model_context`), and
 `summarize` protects `keep_last`, which is where a fresh oversized output sits. `linecap`'s per-line
 cap does not rescue it either: its `neverTruncate` allow-list exempts any line matching
-`^\S+:\d+`, and `{"items":[{"id":1,...` matches that by accident.
+`^\S+:\d+`, and `{"items":[{"id":1,...` matches that by accident ([#151](https://github.com/rossoctl/context-guru/issues/151)).
+
+The choice between the two windows is made on **bytes, not on the line count**. Having more lines
+than the window says nothing about their size: an output with a multi-megabyte line inside the kept
+head or tail survived a line-count gate untouched, and *worse than being declined* — dropping the
+small filler lines in the middle counts as acting, which stamps a marker, which then makes `linecap`
+decline `marker_or_kept_verbatim`. Measured at 4,195,111 B in and 4,194,922 B out, 189 bytes saved
+on a body forwarding 1.57 M tokens. The line window is therefore taken only when it at least halves
+the output; anything else falls through to the character window. The test is in bytes rather than
+tokens deliberately: `max_tokens` is resolved through `max_frac` × the model's context window, which
+can change mid-session, so a token test could classify the same content differently on a later turn
+and emit different bytes — trading a savings bug for a cache bug. Bytes depend only on the content
+and `head_lines`/`tail_lines`, so the classification is replay-safe.
 
 The character budget is the component's own token threshold expressed in characters — no new knob.
 It starts at `max_tokens × 4` (the same ratio `internal/tokens` falls back to), is split between
 head and tail in the `head_lines`:`tail_lines` ratio, and is then **measured** and tightened if the
 assembled window overshoots `max_tokens`, because dense JSON tokenizes closer to 2.5 chars/token.
 The cut is on rune boundaries, so a multibyte character is never split.
+
+Two bounds on that loop are worth knowing, because they mean a very small `max_tokens` does not
+deliver what it says. The tightening is bounded at **3 passes**, and the window has a **200-character
+floor** — so `max_tokens: 50` or lower buys a 200-character window regardless, and `max_tokens: 100`
+measures ~118 tokens out. The floor exists so a `max_tokens` of 0 cannot reduce an output to a bare
+marker with no cue about what to expand; `head_lines: 0, tail_lines: 0` routes to the character
+window for the same reason. The seed is also never allowed above the content itself: `max_tokens
+× 4` overestimates on dense JSON, and testing the bail-out against the un-measured seed used to
+decline content the fit loop would have cut (at `max_tokens: 3000`, what `codesafe` sets, one-line
+JSON from 3,006 to 4,491 tokens was oversized and left entirely uncut). The never-worse guard
+measures the real marker and declines rather than growing a message, which is what makes the
+residual slack harmless. Negative `head_lines`/`tail_lines` are clamped to 0.
 
 ## Before → After
 
@@ -61,8 +85,8 @@ A catch-all last stage for huge outputs.
 ## When it's inert
 
 It now names its reason instead of passing silently: `below_max_tokens`,
-`too_few_lines_and_chars` (too few lines for a line window *and* too few characters for a character
-one — the only genuine decline left), `marker_or_kept_verbatim`, `non_text_blocks`, `marker_no_win`,
+`too_few_lines_and_chars` (no window that shrinks it: no usable line window *and* fewer characters
+than the character window's floor — the only genuine decline left), `marker_or_kept_verbatim`, `non_text_blocks`, `marker_no_win`,
 or `cached_prefix`.
 
 `too_few_lines` is **gone** and was not renamed: its population is now either handled (the

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -321,9 +321,12 @@ to content-token counts), and a component that burned wall time for nothing read
 `overcount_ratio` is the number that keeps the rest honest: a ratio of 7× means the
 gross figure counted the same compaction seven times as the agent re-sent its transcript.
 
-**Why declined** is the column to read when `act rate` is 0%. It is the component's own gate
-counts — `no_filter_match`, `no_obvious_noise`, `below_output_floor` — commonest first, with
-the full list on hover, and the same column appears per component in the request drawer.
+**Why / what happened** is the column to read when `act rate` is 0%. It is mostly the
+component's own gate counts — `no_filter_match`, `no_obvious_noise`, `below_output_floor` —
+commonest first, with the full list on hover, and the same column appears per component in the
+request drawer. It also carries *events*, which are not declines: `collapse`'s `char_window`
+appears there on a row that acted. The header said "Why declined" until the first event
+surfaced under it.
 Without it a table of zeros is unfalsifiable: it looks the same whether the pipeline is
 broken, the traffic is uncompactable, or the heuristics were written for a different agent's
 tool-output shapes. On a Bob session it is usually the last of those, and it says so.


### PR DESCRIPTION
## Headline

**17 of 75 runs errored** in a live 128k-band arm. Every one of them was an upstream 400
`prompt is too long` on an outgoing body of 2.6–14.8 MB, and no component in the pipeline
touched those bodies. `collapse` is documented as the last resort for an oversized tool
output, so when it declines, nothing caps the output — and it declined this entire shape by
construction.

**The payoff here is avoided hard failures, not a savings line, and a reader primed by the
four-denominator convention should not go looking for one.** `collapse` is tail-gated and
freezes its decision, so a new cut happens only on the turn the output arrives — the cold
tail. That is exactly where a multi-megabyte `tool_result` lands and exactly where the 400
fires. A savings series aggregated over turns will barely move; what moves is the error
count. (Independently, a dashboard agent driving the live UI measured 113,975 → 1,824 bytes
on a novel 200 KB single-line blob where `main` reduced it by zero, so the cut is real and
visible in `/api/components` with no `dash/` changes.)

## The defect

`collapse` was line-oriented only:

```go
lines := strings.Split(content, "\n")
if len(lines) <= cl.headLines+cl.tailLines {
    rep.Gate("too_few_lines") // few long lines; head/tail wouldn't help
    continue
}
```

Defaults are `head_lines: 20`, `tail_lines: 20`, so **any output of 40 lines or fewer was
skipped**. For the single largest shape of tool output in practice the reasoning is inverted: a
database or HTTP API result serialised as JSON is very often **ONE line**, so a single-line
multi-megabyte payload fell through `collapse` entirely.

Review then found the same defect one level up: the fix's own gate was still in **line-count**
units, so an output with *more* than 40 lines took the line path however big those lines were.
Both are fixed here; see *The gate is in bytes* below.

### Nothing else caught it (measured, live 128k-band arm)

| component | acted | why not |
|---|---|---|
| `extract` | **0** | `no_obvious_noise` 16,891 — it only strips known noise patterns |
| `cmdfilter` | **0** | `no_filter_match` — only known command families |
| `toon` | 21 | `not_uniform_object_array` 233,501 |
| `dedup` | 774 | exact duplicates only |
| `summarize` | 2,349 | the only real compactor — and it protects `keep_last`, where a FRESH oversized output sits |
| `extract_llm` | — | declines by design: an output exceeding the compaction model's context is left verbatim (`over_model_context`) |
| `linecap` | **0** | `no_long_or_repeated_lines` — `neverTruncate` exempts the line; see below |

**`linecap` is not a partial mitigation for this shape — it is void for it.** On paper its
500-char per-line cap should rescue a huge line. It does not: `neverTruncate` exempts any line
matching `^\S+:\d+`, and a one-line JSON body (`{"items":[{"id":1,...`) matches that **by
accident**. Measured directly by the reviewer: `in=2097191B out=2097191B acted=False
gates=map[no_long_or_repeated_lines:1] neverTruncate(line)=true`. Earlier revisions of this PR
described `linecap` as capping huge kept lines "unless `neverTruncate` exempts them", which
implied a conditional mitigation; for the exact payload shape this PR exists to handle the
exemption always fires. That claim has been removed from the code comment, the commit message
and this body. Filed as #151.

### Consequence

- **17 of 75 benchmark runs errored** in that arm
- **17 upstream 400s**, all `"prompt is too long"`, in 3,347 requests
- outgoing bodies of **2.6 MB to 14.8 MB**

A note on those counts, because an earlier version of this body said 16. The capture digest for
the arm (`capfail-i21A.jsonl`) holds **19** records: 17 × `400 prompt is too long` and 2
transport-level failures (`IncompleteRead`, read timeout) that are not provider rejections. I
cannot reconstruct the filter that produced 16, so the number the record actually supports is
17, and that is what this body now uses.

### Correction: the evidence does NOT show the fix would have prevented those failures

Earlier revisions argued: *"a digest of one failing 14.8 MB body held only 4 messages, so a
single `tool_result` was multiple megabytes."* Review is right that this is a **message** count,
not a **line** count, and that nothing in it establishes those bodies had ≤ 40 lines — i.e.
nothing established the old `too_few_lines` gate was what let any of them through.

**The line-count histogram asked for cannot be produced, and not because the data is
inconvenient to reach — it was never recorded.** I went back to the experiment record on the
box that still holds it (`/tmp/cg-loca/capfail-i21A.jsonl`, read-only). The digest schema is:

```
status, body_bytes, rig_seq, n_messages, system_present, error,
digest[] = { i, role, types[], tool_use[], tool_result[] }
```

Per message it records **structure only** — index, role, block-type names, tool-use ids. No
content, not even a truncated head (the writer's `data[:600]` truncation applies to the *error*
string, not the request). No per-message or per-block size of any kind, so the largest
`tool_result` cannot even be identified, let alone measured in lines. The only size datum is
whole-request `body_bytes`, which includes JSON escaping, the system prompt and 94–149 tool
definitions, and cannot be converted to a line count of anything. `rig_seq` — the field added
so a record could be joined back to the request the shim handed the proxy — is `null` in all 19
records, and no raw copy of the bodies survives anywhere on the box (`proxy-i21A.log` and
`flap-i21A.jsonl` record bytes, never lines). Verified against the writer,
`/tmp/cg-loca/capture_hop.py`.

So: **the question "did those 17 failing bodies have ≤ 40 lines" cannot be answered from this
experiment record, in either direction.** What the record establishes is the class — 17
oversize-prompt 400s on 2.6–14.8 MB bodies with 4–57 messages — not that this specific gate was
the one that let them through. The case for the change therefore rests on the *class* being
real and on `collapse` being the only component contracted to catch it, plus the reproduced
mechanism in tests and the reviewer's live measurements — not on a demonstrated one-to-one with
those 17. Answering it properly needs a new capture that records newline counts per block;
that is worth doing before the next arm and is not something this PR can retrofit.

## The design

`collapse` picks its window before the depth gate: **by lines** when a line window actually
shrinks the output, **by runes** when it does not. Runes rather than bytes, because the result
is spliced back into the request body verbatim and a split multibyte rune would emit invalid
UTF-8 upstream.

### The gate is in BYTES, not lines, and not tokens

Having more lines than the window says nothing about their size. With a line-count gate, an
output with a multi-megabyte line inside the kept head or tail survived untouched — and *worse
than being declined*, because dropping the small filler lines in the middle counts as acting,
which stamps a marker, which then makes `linecap` decline `marker_or_kept_verbatim`. Measured:

```
huge line in head: in=4195111B  after collapse=4194922B (events=map[])
                   after linecap=4194922B (gates=map[marker_or_kept_verbatim:1])  tokens=1570220
```

**4 MB in, 189 bytes saved, 1.57 M tokens forwarded.** The line window is now taken only when
it at least **halves** the output; anything else falls through to the character window:

```go
if cl.headLines+cl.tailLines > 0 && len(lines) > cl.headLines+cl.tailLines {
    asm := /* the existing line closure, unchanged */
    if len(asm(""))*2 <= len(content) {
        return asm, false, true // the line window really cut it: byte-identical, as before
    }
    // it kept most of the bytes (a giant kept line) -> fall through to the rune window
}
```

**Bytes deliberately, not tokens.** `maxTokens` comes from `resolveBudget(..., c.CtxWindow)`,
`CtxWindow` can resolve differently mid-session (model swap, refreshed `modelinfo`), and
`repairLostFreeze` re-derives at depth. A token gate could therefore classify the same content
line-window on one turn and character-window on the next and emit **different bytes** — trading
a savings bug for a cache bug, in a component whose collapsed form is frozen and replayed
inside the cached prefix. The byte form depends only on the content and
`head_lines`/`tail_lines`, so it is replay-safe unconditionally. Both forms classify every
fixture identically, including all four in `TestCollapseLineWindowIsByteIdentical`, which is
what preserves byte-identity for everything the line window handles today.

### Where the character budget comes from — no new knob

It is the component's own token threshold expressed in characters:

- `max_tokens`, resolved through `resolveBudget` (so `max_frac` × the model window still wins),
  × **4** — the same chars/token ratio `internal/tokens.Count` itself falls back to when the
  BPE codec is unavailable, so the two places in the tree that relate bytes to tokens agree;
- **never seeded above the content**: `min(maxTokens*collapseCharsPerToken, len(r)-1)`. chars/4
  *overestimates* on dense JSON (~2.5 chars/token), and the bail-out was tested against that
  **un-measured** seed, so content genuinely oversized in tokens was still shorter in runes
  than its char budget and was declined outright as `too_few_lines_and_chars`. That hole was 55%
  wide, and widest in a shipped preset — `codesafe` sets `max_tokens: 3000`, so one-line JSON
  from **3,006 to 4,491 tokens was oversized and left entirely uncut**, with no test at 3000.
  `marker_no_win` already protects the downside of seeding low;
- split between head and tail in the **`head_lines`:`tail_lines` ratio**, so those knobs keep
  meaning what they say on both paths;
- then **measured and tightened**. On the 3 MB JSON fixture, unmeasured chars/4 lands at
  **3,056 tokens against a 2,000-token threshold**. The fit loop is bounded at 3 passes and only
  ever tightens;
- floored at **200 characters**, so a `max_tokens: 0` cannot collapse an output to a bare marker
  with no cue about what to expand. `head_lines: 0, tail_lines: 0` now routes here for the same
  reason — it used to reach the *line* path (`1 > 0+0`) and emit a bare 90-byte marker.

The 200-char floor and the 3-pass bound are now **documented** (they were not), because they
mean a very small `max_tokens` does not deliver what it says: `max_tokens: 100` measures ~118
tokens out. Two causes, both now stated in the code rather than implied away — the floor returns
before any measurement, and `got` measures `asm("")`, an *empty* marker, while the shipped text
carries the ~15 tokens of `<<cg:HASH>> [full output: ...]`. `tryMark`'s never-worse guard
measures the real marker and declines rather than growing a message, which is what makes the
residue harmless.

**Legality is inherited, not re-implemented.** The character path goes through exactly the same
shared helpers as the line path — `tryMark`/`commitMark` (reversible stash + `<<cg:HASH>>`
marker, and the marker-inclusive never-worse guard), `skipReduce` (idempotence), `freeze`
(replay at depth). The only new code is the window arithmetic.

### What I rejected

- **Making `linecap` own it** by loosening `neverTruncate`. Its exemptions exist because a
  600-char stack frame or compiler diagnostic is exactly the line a model needs whole, and the
  file carries measured evidence against narrowing the pattern. `collapse` is the component
  whose *stated contract* is "the last resort for anything still oversized" — a hole in the last
  resort belongs to the last resort. (#151/#140.)
- **A structure-aware JSON cut** (parse, keep the first N array elements). Strictly better
  output when it applies, but it is a new component's worth of work with a parse cost on every
  megabyte-scale payload, it fails on truncated/non-JSON bodies, and it is not what a
  *content-agnostic fallback* is for. A `jsoncut` component can be layered ahead of `collapse`
  later.
- **A token-based fall-through gate.** Rejected on cache-safety grounds; see above.
- **Grapheme-safety.** With decomposed content the kept tail can begin with an orphaned
  combining mark. Cosmetic, and the output stays valid UTF-8, which is the property that matters
  for splicing into a request body. Not worth a segmentation dependency here.

Earlier revisions rejected *"applying the character window as a second stage after the line
window"* on byte-identity grounds. That was the wrong call and review was right to block it: the
byte gate gets the same coverage **without** changing the bytes for anything the line window
already cut, because the halving test is passed by every shape it handles today by orders of
magnitude. The `ponytail` note recording that rejection is gone, along with the residual gap it
described.

### The counters

`too_few_lines` is **gone, not renamed**. Most of what it counted is now *handled*, and
exporting handled work under a decline's name yields a series that falls as the component works
better — the distinction `components/component.go`'s `Gate`/`Event` split exists for. Its
population is now:

- `char_window` **event** — the character path acted;
- `too_few_lines_and_chars` **gate** — the only genuine decline left: no window that shrinks the
  output, i.e. no usable line window *and* fewer characters than the character window's floor.

## Byte-identical layouts, both paths

`TestCollapseLineWindowIsByteIdentical` asserts the **exact expected string** for four
multi-line fixtures. `TestCollapseCharWindowIsByteIdentical` is the equivalent for the character
path, which review correctly identified as missing: its output is frozen and replayed at depth
in exactly the same way, so a changed layout re-anchors every cached position after it in every
live session mid-flight. Four fixtures (one-line JSON, multibyte, huge line in the kept head,
huge line in the kept tail), expectation written out as a literal format string rather than
captured from `window()`, with the head/tail split pinned to 100/100 by construction (at
`max_tokens: 50` the budget floors, so `runeWindow` returns at pass 0 and there is no
budget-dependent arithmetic in the expectation). Each case also asserts `char_window` fired, so
the comparison cannot pass vacuously via the line path.

`TestCollapseCharWindowAtExactlyTheLineWindowSize` pins the boundary this PR moves from the
other side: at exactly `head_lines+tail_lines` lines the line window would omit zero lines, so
it must not be taken.

## Mutation results

Standing rule: for each new test, revert the code it covers and confirm the test FAILS.
Review's separate point is taken — vacuity of an assertion is weaker than catching a plausible
wrong implementation — so this round is stated as mutation results, with the mutants review
found surviving.

**8 mutations, 7 caught, 1 equivalent.**

| mutation | outcome | failure |
|---|---|---|
| remove the byte gate (revert to the line-COUNT gate) | **CAUGHT** | `huge line in head: character window is not byte-identical` |
| revert the budget clamp to `maxTokens*4` | **CAUGHT** | `max_tokens 2000: 2061-token single-line output left uncut; gates map[too_few_lines_and_chars:1]` |
| flip the too-few-lines gate to `>=` | **EQUIVALENT** | see below |
| off-by-one head slice `r[:h+1]` | **CAUGHT** | `one line json: character window is not byte-identical` |
| off-by-one omitted count | **CAUGHT** | `huge line in tail: character window is not byte-identical` |
| byte slicing instead of rune slicing | **CAUGHT** | `character window split a multibyte rune` |
| remove the zero-line-window routing | **CAUGHT** | `a 72000-byte output collapsed to 90 bytes — a bare marker with no cue` |
| revert the `newCollapse` negative clamp | **CAUGHT** | `negative line knobs must be clamped to 0, got -10/-5` |

**On the `>=` survivor** — review's worst one, and it survives now for a different reason than
before. Under the byte gate it is an **equivalent mutant**, not a wrong implementation: at
exactly `head_lines+tail_lines` lines the mutant does take the line path and compute
`omitted = 0`, but `asm("")` is then the whole content plus ~24 characters, which fails the
halving test and falls through to the character window anyway. The behaviour the mutation used
to produce — whole content plus a marker, `marker_no_win`, a 40-line multi-megabyte output
sailing through a green suite — can no longer be expressed by that edit.
`TestCollapseCharWindowAtExactlyTheLineWindowSize` pins the boundary and is non-vacuous (the
byte-gate mutation fails it), but no test can distinguish equivalent code, and killing the
behaviour is a stronger outcome than catching the mutant. The other two survivors are caught.

The earlier round's 11 vacuity checks stand as reported; nothing in them is retracted.

## Follow-ups fixed here

- `head_lines: 0, tail_lines: 0` reached the line path and produced a bare marker with no
  content cue — 2,001 lines became 90 bytes, precisely what `collapseMinWindowChars` exists to
  prevent. Routed to the character window.
- Negative `head_lines`/`tail_lines` **panicked** on the line path (`1 > -10` sends even a
  one-liner there, then `lines[:-10]` slices out of range), which also made `splitWindow`'s
  `max(...)` guard unreachable for the config it looked like it defended. Clamped once in
  `newCollapse`, covering both paths; `splitWindow` now only handles zero.
- The `runeWindow` doc comment's claim that "an output above `max_tokens` comes back at or under
  it" is softened to the truth, with both causes named.
- The 200-char floor, the 3-pass bound, the seed clamp and the negative-knob clamp are
  documented in `docs/components/collapse.md`; `docs/components.md`'s "too small for either
  window to shrink it" now describes the gate rather than the intent.
- `[]rune` on a 14.8 MB payload allocates ~59 MB per oversized message per turn, on top of the
  `strings.Split` above it. Recorded as a `ponytail` with the measured rate that makes it
  tolerable for now (17 bodies in 3,347 requests).
- **Dashboard, from the follow-up review:** `char_window` rendered under a column header reading
  *"Why declined"* on a row that acted. The merged cell is deliberate (`dash/event.go` folded
  events in to fix an empty-cell bug) and is left merged; the header is now *"Why / what
  happened"* in `dash/ui/index.html`, `dash/ui/app.js` and `docs/dashboard.md`. `collapse` is the
  first component to surface an event there, which is why it was never revisited.

## Not fixed here, filed instead

- **#158 — the first savings bar renders 158% in a 100%-wide track.** The arithmetic is
  intended and documented (gross over attempted, re-counted every turn); the presentation is
  not. This PR pushes it from 115% to 158% precisely because `collapse` now catches enormous
  blobs, so it gets worse as the product gets better. Left out because it is a change to the
  headline savings display affecting all four denominator rows, and belongs with its own
  screenshot verification rather than bolted to a `components/offload` fix.
- **#151 / #140 — `linecap`'s `neverTruncate` exempts one-line JSON.** Pre-existing; the claim
  that it mitigated this shape is removed from this PR rather than the exemption being loosened.
- **#139 — `internal/tokens.Count` is superlinear on a single unbroken word.** 600 KB of
  separator-free CJK does not finish tokenizing inside a ten-minute `go test` timeout.
  Pre-existing (the size check has always tokenized full content), but note the population
  change: single-line payloads used to be skipped by `too_few_lines`, so `collapse` is now the
  component most likely to meet such an input. It is why the UTF-8 fixture keeps ASCII
  separators between the CJK runs.
- **#157 — `dash/TestSpendSurvivesRowEviction` is red for the first 10 hours of every month.**
  Found running the full suite for this PR; its fixture backdates 10 hours and today is the 1st,
  so 3 of 10 sessions land in the previous month. Reproduced 3/3 on unmodified `main`
  (`e88f5d8`), and this PR touches no `dash` Go code. Distinct from the two load-dependent
  flakes in #91.

## One review item that does not apply

Review's follow-up asks to fix a vacuous `combining` case using `"éà"` (which compiles to
precomposed runes in Go source). There is no `combining` case in this suite — the rune-safety
test is `TestCollapseCharWindowKeepsValidUTF8`, which uses CJK, where the multibyte property is
real and the byte-slicing mutation is caught. Nothing to fix; flagging it rather than silently
skipping it in case the note came from a different branch.

## Build and test

Eval box, Go 1.26.4, `CGO_ENABLED=1`: `gofmt` clean on every touched file, `go build ./...`
clean, `mkdocs build --strict` clean, full `go test ./...` green **except**
`dash/TestSpendSurvivesRowEviction`, which fails identically on unmodified `main` (#157).

## One correction to the brief

The brief quoted `collapse.go` without the depth gate, the freeze/replay logic, or the
`rep.Gate("non_text_blocks")` / `below_max_tokens` counters. `origin/main` has all of them, so
the fix had to slot into `TailOnlyCold` + `freeze` + `repairLostFreeze`. The window choice is
placed **before** the depth gate on purpose, so a message with no usable window is not
miscounted as a cache decline.

Separately, `docs/components/collapse.md` documents `cold_cache` as defaulting to `false` while
`coldCacheField()` defaults it to `true` (and `docs/components.md` says **true**). Pre-existing
inconsistency, unrelated, left alone.
