### PR TITLE
fix(docs): correct every row of the "What each one runs" preset table, and guard it

### DIFF
--- a/config/docdrift_test.go
+++ b/config/docdrift_test.go
@@ -3,24 +3,40 @@ package config
 import (
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// The preset tables in the docs must match the presets the product actually ships.
+// The preset tables in the docs must match the presets the product actually ships — as a SET,
+// in both directions: every preset has a row, every row is a preset, and every row's pipeline is
+// the one that runs.
 //
 // This guard exists because they did not. Auditing the "What each one runs" table in
-// docs/how-to/choose-a-preset.md against the `presets` map above found EVERY row stale: three
-// presets (`codesmart`, `coding`, `general`) were still documented as running `toon`, which was
-// retired from them after it acted 0 times on 5,752 production requests and converted 0
-// candidates in 11.67M measured tokens, and every row omitted components that do run — the
-// lossless pair (`textclean`, `searchfold`) and `linecap`. docs/reference/presets.md was correct
-// at the same moment, so the two documents contradicted each other and a reader had no way to
-// tell which one was lying.
+// docs/how-to/choose-a-preset.md against the `presets` map in config/config.go found EVERY row
+// stale: three presets (`codesmart`, `coding`, `general`) were still documented as running
+// `toon`, which was retired from them after it acted 0 times on 5,752 production requests and
+// converted 0 candidates in 11.67M measured tokens, and every row omitted components that do
+// run — the lossless pair (`textclean`, `searchfold`) and `linecap`. Three presets had no row at
+// all (`agentdiet`, `house`, `housellm`). docs/reference/presets.md was correct at the same
+// moment, so the two documents contradicted each other and a reader had no way to tell which one
+// was lying.
 //
 // That is worse than an out-of-date sentence: the table is what somebody reads to decide whether
 // a preset does anything they object to, and the answer it gave was wrong in the direction that
 // matters — it named a component that does not run and omitted three that do.
+//
+// The set check in BOTH directions is deliberate, and it is what the first version of this guard
+// got wrong: it iterated the rows it happened to find and asked only "is this row right?", with a
+// hand-tuned coverage floor standing in for completeness. Against 12 multi-component presets that
+// floor tolerated deleting seven rows, and a preset that ships with no row is exactly the defect
+// this PR fixed by hand. The reverse direction matters just as much: a documented preset that
+// does not exist is not a cosmetic error, it is a STARTUP failure —
+//
+//	$ PRESET=cache ./context-guru-proxy
+//	config: config: unknown preset "cache"      # process exits
+//
+// the same class as the `skeleton`/`coding` incident this repo's own comments describe.
 //
 // Same reasoning as deploy/harbor/pipeline_drift_test.go, applied to the docs instead of the
 // benchmark harnesses.
@@ -33,7 +49,11 @@ var presetTableDocs = []string{
 // captures the rest of the row (where the component list lives, in either `a, b` or `a → b`
 // form — the two files use different separators on purpose, so the check reads component names
 // rather than trying to normalise the formatting).
-var docRow = regexp.MustCompile("(?m)^\\|\\s*`([a-z_]+)`\\s*\\|(.*)$")
+//
+// The name class is deliberately wider than the presets that exist today: a row naming
+// `code-smart` or `preset2` must be REPORTED as documenting a preset that does not exist, not
+// skipped for failing to look like a name this file recognises.
+var docRow = regexp.MustCompile("(?m)^\\|\\s*`([a-z0-9_-]+)`\\s*\\|(.*)$")
 
 // componentToken matches one component name in a pipeline cell.
 //
@@ -61,21 +81,16 @@ func pipelineFromCell(cell string) []string {
 	return out
 }
 
-func TestDocumentedPresetPipelinesMatchTheShippedOnes(t *testing.T) {
+func TestPresetDocsDoNotDrift(t *testing.T) {
 	for _, path := range presetTableDocs {
 		b, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("%s: %v", path, err)
 		}
-		seen := map[string]bool{}
+
+		documented := map[string][]string{}
 		for _, m := range docRow.FindAllStringSubmatch(string(b), -1) {
 			name, row := m[1], m[2]
-			want, ok := presets[name]
-			if !ok {
-				// A row for something that is not a preset (a component reference table, a
-				// config key) is not this test's business.
-				continue
-			}
 			// The pipeline cell is the one that lists components. In choose-a-preset.md it is
 			// the whole rest of the row; in presets.md the prose that follows also mentions
 			// component names, so only the FIRST cell after the name is read.
@@ -83,37 +98,53 @@ func TestDocumentedPresetPipelinesMatchTheShippedOnes(t *testing.T) {
 			if i := strings.Index(row, "|"); i >= 0 {
 				cell = row[:i]
 			}
-			names := pipelineFromCell(cell)
-			// A row that lists no components at all is either the `off` passthrough or a row
-			// that documents something else about the preset; only check the ones that claim
-			// to list a pipeline.
-			if len(names) == 0 {
-				if len(want) > 0 && strings.Contains(cell, "empty") {
-					t.Errorf("%s: preset %q is documented as empty but runs %v", path, name, want)
-				}
+			documented[name] = pipelineFromCell(cell)
+		}
+
+		// Direction 1: every preset that ships is documented, with the pipeline it runs.
+		// Iterated over the map, not over the rows, so a missing row FAILS instead of simply
+		// not being checked.
+		names := make([]string, 0, len(presets))
+		for name := range presets {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			want := presets[name]
+			got, ok := documented[name]
+			if !ok {
+				t.Errorf("%s: preset %q ships %v but has no row in this table. "+
+					"An undocumented preset is the same defect as a misdocumented one: a reader "+
+					"cannot tell it exists, or what it would do to their context.", path, name, want)
 				continue
 			}
-			seen[name] = true
-			if strings.Join(names, ",") != strings.Join(want, ",") {
+			// `off` is the passthrough: no components on either side, and the table writes it
+			// as *(empty)*. Anything else that documents an empty pipeline for a preset which
+			// runs components is caught by the comparison below.
+			if len(want) == 0 && len(got) == 0 {
+				continue
+			}
+			if strings.Join(got, ",") != strings.Join(want, ",") {
 				t.Errorf("%s: preset %q is documented as running\n  %v\nbut ships\n  %v\n"+
 					"A reader uses this table to decide what a preset will do to their context; "+
 					"naming a component that does not run, or omitting one that does, is the "+
-					"failure this guard exists for.", path, name, names, want)
+					"failure this guard exists for.", path, name, got, want)
 			}
 		}
-		// Coverage, not just "something matched". The previous version of this guard passed
-		// while checking only the single-component presets in one of these files, so a count
-		// is asserted: the multi-component rows are exactly the ones that were rotting.
-		multi := 0
-		for name := range seen {
-			if len(presets[name]) > 1 {
-				multi++
-			}
+
+		// Direction 2: nothing is documented that does not exist. `--preset <name>` for a name
+		// that is not in the map does not degrade, it exits at startup, so a row inviting one is
+		// a break dressed as documentation.
+		rows := make([]string, 0, len(documented))
+		for name := range documented {
+			rows = append(rows, name)
 		}
-		if len(seen) == 0 || multi < 5 {
-			t.Errorf("%s: this guard only checked %d preset rows (%d of them multi-component). "+
-				"The table's shape must have changed and the check has silently stopped covering "+
-				"it — which is how the stale rows survived in the first place.", path, len(seen), multi)
+		sort.Strings(rows)
+		for _, name := range rows {
+			if _, ok := presets[name]; !ok {
+				t.Errorf("%s: preset %q is documented but does not exist in the presets map; "+
+					"`--preset %s` exits at startup with `unknown preset %q`.", path, name, name, name)
+			}
 		}
 	}
 }

--- a/config/docdrift_test.go
+++ b/config/docdrift_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The preset tables in the docs must match the presets the product actually ships.
+//
+// This guard exists because they did not. Auditing the "What each one runs" table in
+// docs/how-to/choose-a-preset.md against the `presets` map above found EVERY row stale: three
+// presets (`codesmart`, `coding`, `general`) were still documented as running `toon`, which was
+// retired from them after it acted 0 times on 5,752 production requests and converted 0
+// candidates in 11.67M measured tokens, and every row omitted components that do run — the
+// lossless pair (`textclean`, `searchfold`) and `linecap`. docs/reference/presets.md was correct
+// at the same moment, so the two documents contradicted each other and a reader had no way to
+// tell which one was lying.
+//
+// That is worse than an out-of-date sentence: the table is what somebody reads to decide whether
+// a preset does anything they object to, and the answer it gave was wrong in the direction that
+// matters — it named a component that does not run and omitted three that do.
+//
+// Same reasoning as deploy/harbor/pipeline_drift_test.go, applied to the docs instead of the
+// benchmark harnesses.
+var presetTableDocs = []string{
+	"../docs/how-to/choose-a-preset.md",
+	"../docs/reference/presets.md",
+}
+
+// docRow matches a markdown table row whose first cell is a `preset` name in backticks, and
+// captures the rest of the row (where the component list lives, in either `a, b` or `a → b`
+// form — the two files use different separators on purpose, so the check reads component names
+// rather than trying to normalise the formatting).
+var docRow = regexp.MustCompile("(?m)^\\|\\s*`([a-z_]+)`\\s*\\|(.*)$")
+
+// componentToken matches one component name in a pipeline cell.
+//
+// The two documents format a pipeline differently — choose-a-preset.md writes the whole list
+// inside ONE pair of backticks (`format, textclean, cachesplit`) while presets.md backticks each
+// name and joins them with arrows (`format` → `textclean`). An earlier version of this guard
+// looked for backticked names only, which silently matched nothing in the first file: every
+// multi-component row was skipped, and the guard's coverage there was limited to the presets
+// that happen to run exactly one component. So the cell is stripped of backticks and split on
+// the separators instead, which reads both forms.
+var componentToken = regexp.MustCompile(`^[a-z][a-z_]*$`)
+
+// pipelineFromCell reads the component list out of a table cell, in either document's format.
+func pipelineFromCell(cell string) []string {
+	cell = strings.ReplaceAll(cell, "`", " ")
+	cell = strings.ReplaceAll(cell, "→", ",")
+	cell = strings.ReplaceAll(cell, "->", ",")
+	var out []string
+	for _, tok := range strings.Split(cell, ",") {
+		tok = strings.TrimSpace(tok)
+		if componentToken.MatchString(tok) {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+func TestDocumentedPresetPipelinesMatchTheShippedOnes(t *testing.T) {
+	for _, path := range presetTableDocs {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		seen := map[string]bool{}
+		for _, m := range docRow.FindAllStringSubmatch(string(b), -1) {
+			name, row := m[1], m[2]
+			want, ok := presets[name]
+			if !ok {
+				// A row for something that is not a preset (a component reference table, a
+				// config key) is not this test's business.
+				continue
+			}
+			// The pipeline cell is the one that lists components. In choose-a-preset.md it is
+			// the whole rest of the row; in presets.md the prose that follows also mentions
+			// component names, so only the FIRST cell after the name is read.
+			cell := row
+			if i := strings.Index(row, "|"); i >= 0 {
+				cell = row[:i]
+			}
+			names := pipelineFromCell(cell)
+			// A row that lists no components at all is either the `off` passthrough or a row
+			// that documents something else about the preset; only check the ones that claim
+			// to list a pipeline.
+			if len(names) == 0 {
+				if len(want) > 0 && strings.Contains(cell, "empty") {
+					t.Errorf("%s: preset %q is documented as empty but runs %v", path, name, want)
+				}
+				continue
+			}
+			seen[name] = true
+			if strings.Join(names, ",") != strings.Join(want, ",") {
+				t.Errorf("%s: preset %q is documented as running\n  %v\nbut ships\n  %v\n"+
+					"A reader uses this table to decide what a preset will do to their context; "+
+					"naming a component that does not run, or omitting one that does, is the "+
+					"failure this guard exists for.", path, name, names, want)
+			}
+		}
+		// Coverage, not just "something matched". The previous version of this guard passed
+		// while checking only the single-component presets in one of these files, so a count
+		// is asserted: the multi-component rows are exactly the ones that were rotting.
+		multi := 0
+		for name := range seen {
+			if len(presets[name]) > 1 {
+				multi++
+			}
+		}
+		if len(seen) == 0 || multi < 5 {
+			t.Errorf("%s: this guard only checked %d preset rows (%d of them multi-component). "+
+				"The table's shape must have changed and the check has silently stopped covering "+
+				"it — which is how the stale rows survived in the first place.", path, len(seen), multi)
+		}
+	}
+}

--- a/docs/how-to/choose-a-preset.md
+++ b/docs/how-to/choose-a-preset.md
@@ -42,7 +42,17 @@ context-guru-proxy --preset codesmart      # or PRESET=codesmart, or preset: in 
 | `housellm` | `format, dedup, toon, cmdfilter, searchfold, textclean, extract_llm, extract_llm_sweep, extract, cachesplit, toolfilter` |
 
 Order is deliberate: lossless repack first, then the cheap structural offloaders, then
-anything that costs a model call, cache directives last.
+anything that costs a model call, cache directives last — except in `house` and `housellm`,
+whose order is the operator's on purpose: `dedup` and `cmdfilter` run ahead of the lossless
+pair and `toolfilter` sits after `cachesplit`. That costs per-component attribution in
+`/stats`, never content; the reasons are recorded in
+[`config/config.go`](../design.md#config-registry) and the exemption is noted in the
+[preset reference](../reference/presets.md).
+
+The last three rows are not options in the chooser above. `house` and `housellm` are the
+**service** configs — what a hosted account runs unless it asks otherwise — and `agentdiet`
+reproduces a published baseline for A/B comparison, not a recommendation. They are in the
+table so it lists every preset that exists; pick from the table above this one.
 
 ## Notes on the ones people pick
 

--- a/docs/how-to/choose-a-preset.md
+++ b/docs/how-to/choose-a-preset.md
@@ -26,17 +26,20 @@ context-guru-proxy --preset codesmart      # or PRESET=codesmart, or preset: in 
 
 | Preset | Pipeline |
 |---|---|
-| `codesmart` | `format, toon, dedup, failed_run, cmdfilter, extract_llm, extract, cachesplit` |
-| `codesafe` | `format, dedup, failed_run, cmdfilter, extract, collapse, cachesplit` |
-| `safe` | `format, cachesplit` |
-| `balanced` | `format, dedup, failed_run, cmdfilter, cachesplit` |
-| `aggressive` | `format, dedup, failed_run, cmdfilter, smartcrush, extract, extract_llm, cachesplit` |
-| `coding` | `format, toon, dedup, cmdfilter, extract, cachesplit` |
-| `mcp` | `format, smartcrush, cachesplit` |
-| `agent` | `format, dedup, failed_run, mask, extract, extract_llm, cachesplit` |
-| `general` | `format, toon, dedup, failed_run, cmdfilter, mask, extract, extract_llm, collapse, cachesplit` |
+| `codesmart` | `format, textclean, searchfold, dedup, failed_run, cmdfilter, extract_llm, extract, linecap, cachesplit` |
+| `codesafe` | `format, textclean, searchfold, dedup, failed_run, cmdfilter, extract, collapse, linecap, cachesplit` |
+| `safe` | `format, textclean, searchfold, cachesplit` |
+| `balanced` | `format, textclean, searchfold, dedup, failed_run, cmdfilter, linecap, cachesplit` |
+| `aggressive` | `format, textclean, searchfold, dedup, failed_run, cmdfilter, smartcrush, extract, extract_llm, linecap, cachesplit` |
+| `coding` | `format, textclean, searchfold, dedup, cmdfilter, extract, linecap, cachesplit` |
+| `mcp` | `format, textclean, smartcrush, cachesplit` |
+| `agent` | `format, textclean, searchfold, dedup, failed_run, mask, extract, extract_llm, cachesplit` |
+| `general` | `format, textclean, searchfold, dedup, failed_run, cmdfilter, mask, extract, extract_llm, collapse, linecap, cachesplit` |
 | `summarize` | `summarize` |
 | `off` | *(empty)* |
+| `agentdiet` | `format, agentdiet, cachesplit` |
+| `house` | `format, dedup, toon, cmdfilter, searchfold, textclean, extract, cachesplit, toolfilter` |
+| `housellm` | `format, dedup, toon, cmdfilter, searchfold, textclean, extract_llm, extract_llm_sweep, extract, cachesplit, toolfilter` |
 
 Order is deliberate: lossless repack first, then the cheap structural offloaders, then
 anything that costs a model call, cache directives last.


### PR DESCRIPTION
## The defect

Every row of the **"What each one runs"** table in `docs/how-to/choose-a-preset.md` was stale relative to the `presets` map in `config/config.go`:

- **`codesmart`, `coding` and `general` were documented as running `toon`** — which was retired from them after it acted **0 times on 5,752 production requests** and converted **0 candidates in 11.67M measured tokens**.
- **Every row omitted components that do run**: the lossless pair `textclean` and `searchfold`, and `linecap`.
- Three presets in the map were never in the table at all: `agentdiet`, `house`, `housellm`.

### Severity

`docs/reference/presets.md` was **correct** at the same moment, so the two documents **contradicted each other** — in the exact table a reader uses to decide what a preset will do to their context. That is worse than an out-of-date sentence: the answer was wrong in the direction that matters, naming a component that does **not** run and omitting three that **do**. A reader had no way to tell which document was lying.

## The fix

1. The table is regenerated from the `presets` map. Existing row order is preserved; the three never-listed presets are appended. Nothing else in the document is restructured.
2. `config/docdrift_test.go` asserts **set equality in both directions** between the `presets` map and **both** doc tables (`docs/how-to/choose-a-preset.md` and `docs/reference/presets.md`): every preset has a row with the pipeline it runs, and nothing is documented that does not exist. It reads either formatting — one backtick pair around a comma list, or per-name backticks joined by `→`.

   Revision after review: the first version iterated the rows it happened to find and stood in for completeness with a hand-tuned `multi < 5` floor. That let a shipping preset with no row pass (seven of twelve rows deletable, `codesmart` among them), let a documented-but-nonexistent preset pass — which is a **startup failure**, `config: config: unknown preset "cache"`, the skeleton/`coding` class — and silently skipped any row name with a digit or hyphen. Inverting the loop deleted that block and its magic number; `docRow` widened to `` `([a-z0-9_-]+)` ``.

## Revert-verification

Every mutation was asserted to have landed in the source (anchor found exactly once, post-write re-read confirming it) before the test result was believed; an apply that fails its own check aborts the run rather than reporting a vacuous "ok".

**(a) a preset that ships with no row** — `agentdiet`'s row deleted

```
--- FAIL: TestPresetDocsDoNotDrift (0.00s)
    docdrift_test.go:116: ../docs/how-to/choose-a-preset.md: preset "agentdiet" ships [format agentdiet cachesplit] but has no row in this table. An undocumented preset is the same defect as a misdocumented one: a reader cannot tell it exists, or what it would do to their context.
FAIL	github.com/rossoctl/context-guru/config	0.229s
```

**(b) a preset documented that does not exist** — a `cache` row added (the exact state a merge of #141 onto an unguarded table would produce)

```
--- FAIL: TestPresetDocsDoNotDrift (0.00s)
    docdrift_test.go:145: ../docs/how-to/choose-a-preset.md: preset "cache" is documented but does not exist in the presets map; `--preset cache` exits at startup with `unknown preset "cache"`.
FAIL	github.com/rossoctl/context-guru/config	0.169s
```

**(c) the hyphen hole, tripping both directions at once** — `codesmart` renamed to `code-smart`

```
--- FAIL: TestPresetDocsDoNotDrift (0.00s)
    docdrift_test.go:116: ../docs/how-to/choose-a-preset.md: preset "codesmart" ships [format textclean searchfold dedup failed_run cmdfilter extract_llm extract linecap cachesplit] but has no row in this table. An undocumented preset is the same defect as a misdocumented one: a reader cannot tell it exists, or what it would do to their context.
    docdrift_test.go:145: ../docs/how-to/choose-a-preset.md: preset "code-smart" is documented but does not exist in the presets map; `--preset code-smart` exits at startup with `unknown preset "code-smart"`.
FAIL	github.com/rossoctl/context-guru/config	0.165s
```

**(d) a wrong component list** — `safe` cut to `format` → `cachesplit` in `docs/reference/presets.md`

```
--- FAIL: TestPresetDocsDoNotDrift (0.00s)
    docdrift_test.go:128: ../docs/reference/presets.md: preset "safe" is documented as running
          [format cachesplit]
        but ships
          [format textclean searchfold cachesplit]
        A reader uses this table to decide what a preset will do to their context; naming a component that does not run, or omitting one that does, is the failure this guard exists for.
FAIL	github.com/rossoctl/context-guru/config	0.172s
```

Restoring each mutation returns `go test ./config/ -run Drift` to `ok`. Full `go test ./config/` passes (7.1s); `gofmt -l .` and `go vet ./config/` are clean (eval box, Go 1.26.4). The earlier row-level mutations from the first round (stale `codesmart` row, dropped components) still fail as before.

## Merge order with #141 (please merge this PR first)

Both PRs edit the same hunk of `docs/how-to/choose-a-preset.md` and `git merge-tree` confirms a content conflict. #141 added a `` | `cache` | `cachesplit` | `` row onto the **stale** table; this PR rewrites every row without knowing `cache` exists, so both mechanical resolutions lose something — taking this table drops the `cache` row, taking #141's restores all nine stale rows including `toon`.

**Correct resolution:** this PR's corrected rows **plus** #141's `cache` row placed after `codesafe`, in both guarded files.

**#142 should merge first.** With the inverted guard in place, forgetting the `cache` row becomes a CI failure — mutation (a) above is literally that scenario — instead of a silent regression. Merged the other way round, the omission is invisible. Note the guard also runs in the other direction, so #141 must carry a `cache` row in **both** `docs/how-to/choose-a-preset.md` and `docs/reference/presets.md`, and this PR deliberately does **not** add one: `cache` does not exist on `main` and a row for it would fail this PR's own "documented but does not exist" check.

## Non-blocking review items, all addressed

- Test renamed to `TestPresetDocsDoNotDrift`, so `go test ./config/ -run Drift` matches it (verified).
- The "lossless repack first … cache directives last" sentence now carries the `house`/`housellm` exemption, pointing at `config/config.go` and the preset reference.
- `house`/`housellm` are marked as the **service** configs and `agentdiet` as a published baseline rather than a recommendation, so nobody reads this how-to and sets `--preset house`.
- "the `presets` map above" corrected to name `config/config.go`.

## Why this is its own PR

Found while adding a row to this table during the **local-distribution** work. It is split out because a stale preset-pipeline table has nothing to do with distribution and should not wait on it.

Heads-up for whoever merges second: the sibling PR `feat/local-distribution` also touches this table (it adds one row for a new `cache` preset), so it will need a trivial rebase there — one row, no semantic conflict.

## Not fixed here (out of scope, reported)

Other documents also carry stale pipeline listings in prose/snippets, outside the two preset tables this guard covers:

- `README.md:133-134` — `codesmart` and `codesafe` described with the pre-August pipelines (`toon` present, lossless pair and `linecap` absent).
- `docs/get-started/connect-ibm-service.md:22` — "Default pipeline" given as `[format, toon, dedup, failed_run, cmdfilter, extract, cachesplit]`, which is not the `house` pipeline the map ships.

(`docs/results/**` intentionally records the pipelines as measured at the time and is correctly "stale".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
