### PR TITLE
feat(dash): filter, hold out and honestly attribute strategy campaigns

### DIFF
--- a/dash/campaignsavings.go
+++ b/dash/campaignsavings.go
@@ -7,17 +7,48 @@ import (
 
 // The real-saving half of a strategy campaign's drill-down — see
 // proxy/campaign.go for how a campaign turns suggest cells into strategies and
-// dash/keepalivestrategy.go's StrategyLedger, whose two-disjoint-query shape this
-// generalizes: a ping's cost carries its strategy id, but the real request it later
-// rescues does not (see the design doc's "Attribution for stats") — so cost and saving
-// can never come from one query, and every number here is a ceiling on this campaign's
-// own contribution, not an exact share of it, exactly as StrategyLedgerView already is.
+// dash/keepalivestrategy.go's StrategyLedger, whose per-strategy attribution this
+// generalizes from one strategy's totals to a (tenant, hour-of-day) grid.
 //
-// Unlike StrategyLedger, every read here is bounded by `since` (a campaign's own
-// activated_at): comparing a strategy's predicted saving against traffic that predates
-// the campaign would credit it for a period it never ran in, which the design doc's
-// "Out of scope" explicitly refuses to do for pings and which this refuses too, for the
-// same reason.
+// # Why the credited half is scoped by strategy id, not by tenant alone
+//
+// This file shipped believing a credited REAL row carried no strategy id — that only the
+// ping did — and so summed a tenant's WHOLE keep-alive credit into whichever campaign
+// happened to name that tenant, declaring the result a documented "ceiling" that could
+// not be narrowed. That premise was already false when this shipped: keeper.arrive
+// returns the strategy that resolved the idle entry, capture threads it onto the credited
+// row (see dash/schema.go's keepalive_strategy_id comment), and
+// keepalivestrategybackfill.go recovers it on rows written before that tagging existed.
+// StrategyLedger was corrected to filter on it; this was not, and the two disagreed.
+//
+// The cost of leaving it was not theoretical. On this deployment every tenant with any
+// credit at all is credited under three to six DISTINCT strategies, so a campaign owning
+// one of them reported all six strategies' savings as its own — and two campaigns over
+// one tenant each reported 100% of that tenant's credit, so the campaigns summed to
+// several times the money that actually existed. That is the one thing the Strategies
+// tab's own copy promises does not happen ("exact and additive across strategies, no
+// double-counting"); a campaign is a bulk way to create those same rows and owes the
+// reader the same guarantee.
+//
+// So SavedUSD is now EXACT, attributed once, the same way StrategyLedger's is. What it
+// deliberately excludes: a credit whose ping matched no strategy at all (plain account
+// config, or a session override) belongs to no campaign and is counted by none of them —
+// the same population gap renderStrategiesList already explains to the reader, not a new
+// one introduced here.
+//
+// # Why Requests and ActiveDays stay tenant-wide
+//
+// They are DENOMINATORS, not credit: "$ saved per 1k requests this tenant sent in this
+// hour" only means anything if the denominator is all of that traffic. Narrowing them to
+// the rescued rows would divide a strategy's saving by its own successes, which is a rate
+// that always looks the same no matter how much traffic it missed. So the two halves of
+// this query are scoped differently ON PURPOSE — a conditional SUM inside one scan rather
+// than two, so the difference is visible in one place instead of split across queries.
+//
+// Every read here is bounded by `since` (a campaign's own activated_at): comparing a
+// strategy's predicted saving against traffic that predates the campaign would credit it
+// for a period it never ran in, which the design doc's "Out of scope" explicitly refuses
+// to do for pings and which this refuses too, for the same reason.
 
 // CampaignSavingCell is one (tenant, hour-of-day) cell's real economics since a
 // campaign went live.
@@ -35,7 +66,9 @@ type CampaignSavingCell struct {
 	// ping row one of this campaign's own strategies caused carries that strategy's id.
 	Pings   int64   `json:"pings"`
 	PingUSD float64 `json:"ping_usd"`
-	// SavedUSD is a CEILING — see the file doc comment and StrategyLedgerView's own.
+	// SavedUSD is EXACT too, as of the strategy-id scoping described in the file doc
+	// comment: only credit a ping from one of THIS campaign's own strategies rescued,
+	// never the tenant's whole keep-alive credit in the cell.
 	SavedUSD float64 `json:"saved_usd"`
 	NetUSD   float64 `json:"net_usd"`
 }
@@ -112,20 +145,40 @@ func (d *DB) CampaignRealSavings(strategyIDs, tenantIDs []string, since int64) (
 	}
 
 	// Saving half: every REAL (non-ping) request for one of this campaign's tenants,
-	// grouped the same way — total volume and active-day count for normalization, plus
-	// the credited saving. Not filtered by keepalive_strategy_id: the credited row
-	// carries none (only the ping does), so this is the tenant's whole credit in this
-	// cell, the same ceiling StrategyLedger already declares.
+	// grouped the same way. Requests and ActiveDays cover ALL of that traffic (they are
+	// normalization denominators); the credited sum inside the same scan is narrowed to
+	// rows one of THIS campaign's own strategies rescued — see the file doc comment for
+	// why the two are scoped differently, and why that is not the ceiling this once was.
+	//
+	// With no strategy ids at all (a campaign whose every cell resolved to a
+	// non-activatable arm), the credited sum is a literal 0 rather than an "IN ()" —
+	// which is not SQLite-valid — and the denominators still report, so the drill-down
+	// can honestly say "this much traffic, none of it ours to claim."
 	if len(tenantIDs) > 0 {
-		savingArgs := make([]any, 0, len(tenantIDs)+1)
+		savedExpr := `0`
+		savingArgs := make([]any, 0, len(strategyIDs)+len(tenantIDs)+1)
+		if len(strategyIDs) > 0 {
+			savedExpr = `COALESCE(SUM(CASE WHEN keepalive_saved_usd > 0
+				AND keepalive_strategy_id IN (` + placeholders(len(strategyIDs)) + `)
+				THEN keepalive_saved_usd ELSE 0 END),0)`
+			// Bound before the tenant list because the CASE sits in the SELECT clause,
+			// which SQLite binds ahead of the WHERE — the args must follow the ORDER THE
+			// TEXT reads, not the order the two lists are named in this function's own
+			// signature. Getting this backwards would silently filter by tenant ids in
+			// the strategy position and vice versa, with no error at all: both are
+			// opaque hex strings of the same shape, so every row would simply fail to
+			// match and every cell would read $0.00 saved.
+			for _, id := range strategyIDs {
+				savingArgs = append(savingArgs, id)
+			}
+		}
 		for _, id := range tenantIDs {
 			savingArgs = append(savingArgs, id)
 		}
 		savingArgs = append(savingArgs, since)
 		savingRows, err := d.sql.Query(`SELECT tenant_id,
 				CAST(strftime('%H', ts/1000, 'unixepoch') AS INTEGER) h,
-				COUNT(*), COUNT(DISTINCT ts/86400000),
-				COALESCE(SUM(CASE WHEN keepalive_saved_usd > 0 THEN keepalive_saved_usd ELSE 0 END),0)
+				COUNT(*), COUNT(DISTINCT ts/86400000), `+savedExpr+`
 			FROM requests WHERE keepalive = 0 AND tenant_id IN (`+
 			placeholders(len(tenantIDs))+`) AND ts >= ?
 			GROUP BY tenant_id, h`, savingArgs...)

--- a/dash/campaignsavings_test.go
+++ b/dash/campaignsavings_test.go
@@ -18,12 +18,12 @@ func TestCampaignRealSavingsGroupsByTenantAndHour(t *testing.T) {
 	t1ping9 := kaPing(hourUTC(1, 9), "s1", 0.02, 40_000, 0)
 	t1ping9.TenantID, t1ping9.KeepAliveStrategyID = "t1", "camp-strat-1"
 	t1credit9 := kaCredit(hourUTC(1, 9), "s1", 0.10)
-	t1credit9.TenantID = "t1"
+	t1credit9.TenantID, t1credit9.KeepAliveStrategyID = "t1", "camp-strat-1"
 
 	t1ping10 := kaPing(hourUTC(1, 10), "s1", 0.03, 40_000, 0)
 	t1ping10.TenantID, t1ping10.KeepAliveStrategyID = "t1", "camp-strat-1"
 	t1credit10 := kaCredit(hourUTC(1, 10), "s1", 0.07)
-	t1credit10.TenantID = "t1"
+	t1credit10.TenantID, t1credit10.KeepAliveStrategyID = "t1", "camp-strat-1"
 
 	// A ping under a strategy this campaign does NOT own — must not be counted.
 	otherStrategyPing := kaPing(hourUTC(1, 9), "s2", 0.09, 90_000, 0)
@@ -78,12 +78,12 @@ func TestCampaignRealSavingsRespectsTheSinceBound(t *testing.T) {
 	before := kaPing(hourUTC(1, 9), "s1", 0.02, 40_000, 0)
 	before.TenantID, before.KeepAliveStrategyID = "t1", "camp-strat-1"
 	beforeCredit := kaCredit(hourUTC(1, 9), "s1", 0.10)
-	beforeCredit.TenantID = "t1"
+	beforeCredit.TenantID, beforeCredit.KeepAliveStrategyID = "t1", "camp-strat-1"
 
 	after := kaPing(hourUTC(2, 9), "s2", 0.05, 40_000, 0)
 	after.TenantID, after.KeepAliveStrategyID = "t1", "camp-strat-1"
 	afterCredit := kaCredit(hourUTC(2, 9), "s2", 0.20)
-	afterCredit.TenantID = "t1"
+	afterCredit.TenantID, afterCredit.KeepAliveStrategyID = "t1", "camp-strat-1"
 
 	if err := db.insertBatch([]*Event{before, beforeCredit, after, afterCredit}); err != nil {
 		t.Fatal(err)
@@ -152,23 +152,35 @@ func TestCampaignRealSavingsOnEmptyInputs(t *testing.T) {
 // The cost half only needs strategyIDs and the saving half only needs tenantIDs — they
 // must run independently of each other, not both be skipped just because the OTHER
 // list happened to be empty. A campaign whose every cell resolved to a non-activatable
-// arm has strategyIDs=nil but a real, non-empty tenantIDs list, and its tenants can
-// still have real credited savings that this call must not silently omit.
+// arm has strategyIDs=nil but a real, non-empty tenantIDs list, and its traffic VOLUME
+// must still be reported.
+//
+// It must report $0.00 CREDIT in that case, though, which is the assertion this test
+// used to make backwards: it asserted a campaign owning no strategy at all still
+// collected $0.10 of a tenant's credit, because the query summed the tenant's whole
+// keep-alive saving. That was the double-count, encoded as an expectation — so the
+// numbers here changed with the fix while the "both halves still run" property it exists
+// to protect did not.
 func TestCampaignRealSavingsHalvesRunIndependentlyOfEachOther(t *testing.T) {
 	db := openTestDB(t)
 	credit := kaCredit(hourUTC(1, 9), "s1", 0.10)
-	credit.TenantID = "t1"
+	credit.TenantID, credit.KeepAliveStrategyID = "t1", "someone-elses-strategy"
 	if err := db.insertBatch([]*Event{credit}); err != nil {
 		t.Fatal(err)
 	}
 
-	// No strategy ids at all — the saving half must still run and find t1's credit.
+	// No strategy ids at all — the saving half must still run and report the traffic, but
+	// claim none of its credit.
 	cells, err := db.CampaignRealSavings(nil, []string{"t1"}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cells) != 1 || cells[0].SavedUSD < 0.099 || cells[0].SavedUSD > 0.101 {
-		t.Errorf("got %+v, want 1 cell with ~$0.10 saved even with no strategy ids given", cells)
+	if len(cells) != 1 || cells[0].Requests != 1 {
+		t.Fatalf("got %+v, want 1 cell with 1 request even with no strategy ids given", cells)
+	}
+	if cells[0].SavedUSD != 0 {
+		t.Errorf("SavedUSD = %v, want exactly 0: a campaign that created no strategy has "+
+			"no claim on this tenant's credit", cells[0].SavedUSD)
 	}
 
 	ping := kaPing(hourUTC(1, 9), "s2", 0.02, 40_000, 0)
@@ -183,5 +195,56 @@ func TestCampaignRealSavingsHalvesRunIndependentlyOfEachOther(t *testing.T) {
 	}
 	if len(cells) != 1 || cells[0].Pings != 1 || cells[0].PingUSD < 0.019 || cells[0].PingUSD > 0.021 {
 		t.Errorf("got %+v, want 1 cell with 1 ping at ~$0.02 even with no tenant ids given", cells)
+	}
+}
+
+// The regression this file's whole strategy-id scoping exists for: one tenant credited
+// under two different strategies, read by two campaigns that own one strategy each. Each
+// campaign must see only its own strategy's credit, and the two must SUM to the tenant's
+// total rather than each reporting all of it.
+//
+// On the live deployment every credited tenant is credited under three to six distinct
+// strategies, so the pre-fix behaviour was not an edge case — it was every row.
+func TestCampaignRealSavingsAttributesCreditToOneStrategyOnly(t *testing.T) {
+	db := openTestDB(t)
+
+	// Same tenant, same hour, two strategies — one owned by each of two campaigns.
+	mine := kaCredit(hourUTC(1, 9), "s1", 0.10)
+	mine.TenantID, mine.KeepAliveStrategyID = "t1", "strat-mine"
+	theirs := kaCredit(hourUTC(1, 9), "s2", 0.25)
+	theirs.TenantID, theirs.KeepAliveStrategyID = "t1", "strat-theirs"
+	// A credit with NO strategy at all: plain account config or a session override. It
+	// belongs to neither campaign and must be claimed by neither.
+	unowned := kaCredit(hourUTC(1, 9), "s3", 4.00)
+	unowned.TenantID = "t1"
+
+	if err := db.insertBatch([]*Event{mine, theirs, unowned}); err != nil {
+		t.Fatal(err)
+	}
+
+	one, err := db.CampaignRealSavings([]string{"strat-mine"}, []string{"t1"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := db.CampaignRealSavings([]string{"strat-theirs"}, []string{"t1"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(one) != 1 || len(two) != 1 {
+		t.Fatalf("got %d and %d cells, want 1 each", len(one), len(two))
+	}
+	if one[0].SavedUSD < 0.099 || one[0].SavedUSD > 0.101 {
+		t.Errorf("campaign one SavedUSD = %v, want ~0.10 (its own strategy only, not the "+
+			"tenant's whole $4.35 of credit)", one[0].SavedUSD)
+	}
+	if two[0].SavedUSD < 0.249 || two[0].SavedUSD > 0.251 {
+		t.Errorf("campaign two SavedUSD = %v, want ~0.25", two[0].SavedUSD)
+	}
+	// Requests is a denominator, not credit: it stays the tenant's whole traffic in the
+	// cell for both readers, so a $-per-1k-requests rate divides by all the traffic a
+	// strategy was exposed to rather than only the requests it managed to rescue.
+	if one[0].Requests != 3 || two[0].Requests != 3 {
+		t.Errorf("Requests = %d and %d, want 3 each: the denominator is all real traffic "+
+			"in the cell, not the rescued subset", one[0].Requests, two[0].Requests)
 	}
 }

--- a/dash/kvcacheapi.go
+++ b/dash/kvcacheapi.go
@@ -36,6 +36,7 @@ func (a *API) kvCacheRoutes() []route {
 		{"GET /api/kvcache/simulate", scopeTenant, a.kvCacheSimulate},
 		{"GET /api/kvcache/pricing", scopeTenant, a.kvCachePricing},
 		{"GET /api/kvcache/suggest", scopeTenant, a.kvCacheSuggest},
+		{"GET /api/kvcache/suggest/holdout", scopeTenant, a.kvCacheSuggestHoldout},
 	}
 }
 
@@ -125,6 +126,47 @@ func (a *API) kvCacheSuggest(w http.ResponseWriter, r *http.Request) {
 			code = http.StatusBadRequest
 		}
 		httpErr(w, code, err.Error())
+		return
+	}
+	writeJSON(w, out)
+}
+
+// kvCacheSuggestHoldout serves the train/test split of that same suggestion: the arm each
+// cell's TRAIN window chose, scored on a disjoint TEST window it was not chosen on.
+//
+// Its four time bounds come from their own query parameters, NOT from the shared
+// since/until the rest of this package reads through a.scope: a holdout needs two windows
+// and the filter carries one. The scope's own bounds are deliberately ignored rather than
+// intersected with these — a global "last 24h" silently narrowing both halves of a
+// month-long split would produce a real-looking answer to a question nobody asked.
+func (a *API) kvCacheSuggestHoldout(w http.ResponseWriter, r *http.Request) {
+	f, _, ok := a.scope(r)
+	if !ok {
+		unauthorized(w)
+		return
+	}
+	// Two full dataset reads, so it takes the same slot the single-window routes do — and
+	// needs it more, not less.
+	if err := acquireKVCache(r.Context()); err != nil {
+		return
+	}
+	defer releaseKVCache()
+	q := r.URL.Query()
+	train := Window{Since: atoi64(q.Get("train_since")), Until: atoi64(q.Get("train_until"))}
+	test := Window{Since: atoi64(q.Get("test_since")), Until: atoi64(q.Get("test_until"))}
+	out, err := a.rec.DB().WithContext(r.Context()).KVCacheSuggestHoldout(
+		f, kvCacheOptionsFrom(r), a.pricer, kvCacheConfigFrom(r), train, test)
+	if err != nil {
+		// Every error validHoldoutWindows returns is the caller's own malformed window, and
+		// an unknown baseline is the caller's mistake exactly as on /api/kvcache/suggest.
+		// Anything else came from the store and must stay a 5xx so an alert can fire on it.
+		code := http.StatusInternalServerError
+		msg := err.Error()
+		if strings.Contains(msg, "unknown baseline strategy") ||
+			strings.Contains(msg, "window") {
+			code = http.StatusBadRequest
+		}
+		httpErr(w, code, msg)
 		return
 	}
 	writeJSON(w, out)

--- a/dash/kvcacheholdout.go
+++ b/dash/kvcacheholdout.go
@@ -126,6 +126,26 @@ type KVCacheHoldout struct {
 	Users []string             `json:"users"`
 	Cells []KVCacheHoldoutCell `json:"cells"`
 
+	// Each window's own read coverage, carried straight from the KVCacheSuggest run that
+	// produced it. KVCacheDataset caps one read at kvCacheMaxRows and the cap keeps the
+	// NEWEST rows, so a window bigger than the cap is silently reduced to its own recent
+	// tail — and the two windows here are read and capped INDEPENDENTLY.
+	//
+	// That matters more here than on the single-window page, which already declares it
+	// (KVCacheSuggestions.Truncated, banner in dash/ui/kvcache.js). A clipped TRAIN window
+	// means the arm was chosen on a slice of the period the reader asked for; a clipped
+	// TEST window means it was scored on one; and RetentionPct can then divide two totals
+	// whose populations cover very different fractions of their own windows. Every
+	// per-cell request count reports only the rows that were read, so without these fields
+	// nothing in the payload reveals any of it — the one silent data loss that would
+	// undermine every other honesty flag in this file.
+	TrainScanned   int64 `json:"train_scanned"`
+	TrainTotal     int64 `json:"train_total"`
+	TrainTruncated bool  `json:"train_truncated"`
+	TestScanned    int64 `json:"test_scanned"`
+	TestTotal      int64 `json:"test_total"`
+	TestTruncated  bool  `json:"test_truncated"`
+
 	// TotalTrainSavingUSD and TotalTestSavingUSD sum the CHOSEN arm over exactly the cells
 	// where BOTH sides are known and neither side is below the request floor — the only
 	// population where the two totals describe the same thing. ComparableCells is that
@@ -197,8 +217,12 @@ func (d *DB) KVCacheSuggestHoldout(f Filter, o KVCacheOptions, p modelinfo.Price
 		MinRequests: trainOut.MinRequests,
 		TrainSince:  train.Since, TrainUntil: train.Until,
 		TestSince: test.Since, TestUntil: test.Until,
-		Users: []string{},
-		Cells: []KVCacheHoldoutCell{},
+		TrainScanned: trainOut.Scanned, TrainTotal: trainOut.Total,
+		TrainTruncated: trainOut.Truncated,
+		TestScanned:    testOut.Scanned, TestTotal: testOut.Total,
+		TestTruncated: testOut.Truncated,
+		Users:         []string{},
+		Cells:         []KVCacheHoldoutCell{},
 	}
 
 	for _, tc := range trainOut.Cells {
@@ -333,6 +357,19 @@ func (d *DB) KVCacheSuggestHoldout(f Filter, o KVCacheOptions, p modelinfo.Price
 			"is never counted as a zero.",
 		"Both windows read Sunday-Thursday only and are replayed per hour-of-day in UTC, " +
 			"exactly as the live suggester does — see dash/kvcachesuggest.go.",
+	}
+	// Stated in words, not only in the flags, because a clipped window is the one defect
+	// here that every other number goes on looking correct through: the cap keeps each
+	// window's NEWEST rows, so the two halves of the ratio can cover very different
+	// fractions of the periods asked for, and no per-cell count says so.
+	if out.TrainTruncated || out.TestTruncated {
+		out.Notes = append(out.Notes, fmt.Sprintf(
+			"One or both windows were CAPPED at the analysis row limit: train read %d of %d "+
+				"matching requests, test read %d of %d. The cap keeps each window's most recent "+
+				"rows, so a capped window is its own recent tail rather than the period asked "+
+				"for, and the two were capped independently — narrow the windows until both read "+
+				"whole before comparing these totals.",
+			out.TrainScanned, out.TrainTotal, out.TestScanned, out.TestTotal))
 	}
 	return out, nil
 }

--- a/dash/kvcacheholdout.go
+++ b/dash/kvcacheholdout.go
@@ -1,0 +1,382 @@
+package dash
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/rossoctl/context-guru/internal/modelinfo"
+)
+
+// The per-user, per-hour suggester's train/test split.
+//
+// # Why this exists at all: every prediction on the KV-cache and Campaigns pages is in-sample
+//
+// KVCacheSuggest picks each (user, hour) cell's winning arm by replaying every candidate
+// over that cell's own rows and taking the argmax — then reports THAT REPLAY'S saving as
+// the cell's predicted saving. The arm is chosen to maximise the very number that is
+// then presented as its prediction, over exactly the rows it was chosen on. That is a
+// measure of fit, not of forecast: it is biased upward by construction, and the bias
+// grows as a cell gets thinner, because the more arms compete over the fewer requests
+// the more likely one of them wins on noise alone.
+//
+// A campaign then freezes that figure as PredictedUSD (tenant/campaign.go) and the
+// Campaigns tab shows it beside a real, live measurement — inviting exactly the
+// comparison the frozen number is least able to support. Nothing was WRONG in that
+// chain; every function did what its doc comment said. What was missing is any way to
+// ask how much of a cell's predicted saving survives contact with rows it was not
+// chosen on.
+//
+// This answers that, and only that: choose on a TRAIN window, score on a disjoint TEST
+// window, report both. The gap between them is this deployment's own overfitting
+// estimate — not a correction to apply to the prediction, which would be inventing a
+// number, but the measurement a reader needs before trusting one.
+//
+// # Why it is built from two KVCacheSuggest calls and no new simulation code
+//
+// A suggest cell already carries every candidate's saving over its own rows
+// (KVCacheSuggestion.Candidates), not just the winner's. So "the arm train picked,
+// scored on test rows" is a LOOKUP in the test window's own candidate list, not a new
+// replay: run the existing suggester over each window and join on (user, hour, arm).
+// Both halves are then produced by the same code path that produces the live page, which
+// is the property that matters — a second, holdout-specific simulator could drift from
+// the one whose numbers a campaign actually freezes, and the comparison would quietly
+// stop meaning anything.
+//
+// # Why all four bounds are required, unlike every other filter in this package
+//
+// dash.Filter treats 0 as unbounded and the dashboard's own range control documents that
+// "either bound alone is a legitimate window". Here an unbounded train window would
+// include the test period, so the arm would be chosen partly on the rows it is then
+// scored on — a split that silently isn't one, reported as though it were. There is no
+// safe default for a bound whose absence destroys the only thing the view measures, so
+// an absent one is an error rather than a fallback.
+
+// KVCacheHoldoutArm is one arm's saving on the train window beside its saving on the test
+// window, for one (user, hour) cell.
+type KVCacheHoldoutArm struct {
+	Strategy string `json:"strategy"`
+	// TrainSavingUSD/TestSavingUSD are this arm's saving over the SAME BASELINE in each
+	// window (kvcache.Compare's AbsoluteUSD). Negative where the arm costs more than the
+	// baseline, and reported that way — see kvcache.Savings.AbsoluteUSD on why a
+	// comparison that clamps stops being one.
+	TrainSavingUSD float64 `json:"train_saving_usd"`
+	TrainKnown     bool    `json:"train_known"`
+	TestSavingUSD  float64 `json:"test_saving_usd"`
+	// TestKnown is false where this arm has no priced result in the test window at all —
+	// the cell had no test traffic, or nothing in it could be priced. The field is then
+	// meaningless and the UI must render "not enough data", never 0.00.
+	TestKnown bool `json:"test_known"`
+	// Chosen marks the arm the TRAIN window's own suggester picked as this cell's winner:
+	// the one a campaign built from the train window would actually have enforced.
+	Chosen bool `json:"chosen"`
+}
+
+// KVCacheHoldoutCell is one (user, hour-of-day) cell's train-chosen arm, scored on
+// held-out rows.
+type KVCacheHoldoutCell struct {
+	User    string `json:"user"`
+	HourUTC int    `json:"hour_utc"`
+
+	// TrainRequests/TestRequests are the two populations this cell was decided from and
+	// scored on. Both are Sunday-Thursday only, the same filter KVCacheSuggest applies —
+	// see its own doc comment on why the weekend is not read at all.
+	TrainRequests int64 `json:"train_requests"`
+	TestRequests  int64 `json:"test_requests"`
+	// TrainInsufficientData/TestInsufficientData mirror KVCacheSuggestion.InsufficientData
+	// on each side: below kvSuggestMinRequests the cell still reports every number, but
+	// acting on it as a pattern is what the flag warns against.
+	TrainInsufficientData bool `json:"train_insufficient_data"`
+	TestInsufficientData  bool `json:"test_insufficient_data"`
+
+	// Arm is the arm the train window chose — what a campaign created from that window
+	// would have enforced for this cell.
+	Arm string `json:"arm"`
+	// TrainSavingUSD is that arm's IN-SAMPLE saving: chosen on these rows, scored on these
+	// rows. This is the figure the live KV-cache page and a campaign's PredictedUSD both
+	// show today.
+	TrainSavingUSD float64 `json:"train_saving_usd"`
+	TrainKnown     bool    `json:"train_known"`
+	// TestSavingUSD is the same arm's saving on the test window's rows — out of sample,
+	// the honest forecast. TestKnown is false where the test window has nothing to score
+	// it on; the number is then absent, never a zero standing in for one.
+	TestSavingUSD float64 `json:"test_saving_usd"`
+	TestKnown     bool    `json:"test_known"`
+	// TestNote says why TestKnown is false, so a blank cell is explained rather than just
+	// blank. Empty when TestKnown is true.
+	TestNote string `json:"test_note,omitempty"`
+
+	// Arms is every candidate's train-and-test pair for this cell, the train-chosen one
+	// among them and flagged — so a reader can see whether the arm that won on train was
+	// anywhere near the best on test, which is the whole question this view exists for.
+	Arms []KVCacheHoldoutArm `json:"arms"`
+}
+
+// KVCacheHoldout is the whole /api/kvcache/suggest/holdout payload.
+type KVCacheHoldout struct {
+	Baseline    string   `json:"baseline"`
+	Weekdays    []string `json:"weekdays_included"`
+	TimeZone    string   `json:"time_zone"`
+	MinRequests int      `json:"min_requests"`
+
+	TrainSince int64 `json:"train_since"`
+	TrainUntil int64 `json:"train_until"`
+	TestSince  int64 `json:"test_since"`
+	TestUntil  int64 `json:"test_until"`
+
+	Users []string             `json:"users"`
+	Cells []KVCacheHoldoutCell `json:"cells"`
+
+	// TotalTrainSavingUSD and TotalTestSavingUSD sum the CHOSEN arm over exactly the cells
+	// where BOTH sides are known and neither side is below the request floor — the only
+	// population where the two totals describe the same thing. ComparableCells is that
+	// population's size, reported so the totals are never read as covering every cell.
+	TotalTrainSavingUSD float64 `json:"total_train_saving_usd"`
+	TotalTestSavingUSD  float64 `json:"total_test_saving_usd"`
+	ComparableCells     int     `json:"comparable_cells"`
+	// TotalCells is every cell the train window produced, comparable or not, so the gap
+	// between it and ComparableCells is visible rather than inferred.
+	TotalCells int `json:"total_cells"`
+	// RetentionPct is TotalTestSavingUSD / TotalTrainSavingUSD × 100: how much of the
+	// in-sample predicted saving survived contact with rows the arm was not chosen on.
+	// Below 100 is the expected direction; it can be negative, when the chosen arms cost
+	// more than the baseline out of sample, and that is reported rather than clamped for
+	// the same reason kvcache.Savings.AbsoluteUSD is.
+	//
+	// Computed here rather than left to the caller because the two conditions that make it
+	// undefined — no comparable cells at all, and a train total of exactly zero (a ratio
+	// against nothing is not 0%, it is undefined, the same rule kvcache.Savings.Known
+	// already encodes for percentages) — are properties of this data, not of whoever
+	// renders it. A UI that divides these two totals itself has to rediscover both, and
+	// dash/ui/campaigns.js deliberately does no arithmetic precisely so that it cannot get
+	// this wrong.
+	RetentionPct   float64 `json:"retention_pct"`
+	RetentionKnown bool    `json:"retention_known"`
+
+	Notes []string `json:"notes"`
+}
+
+// KVCacheSuggestHoldout runs the suggester over a train window and a disjoint test
+// window, and joins them per (user, hour): the arm train chose, and what that same arm
+// actually saved on rows it was not chosen on.
+//
+// f carries the scope (tenant, model, agent…) and is applied to BOTH windows — only the
+// time bounds differ between them, so the two populations are the same slice of traffic
+// observed over two periods rather than two different slices.
+func (d *DB) KVCacheSuggestHoldout(f Filter, o KVCacheOptions, p modelinfo.Pricer,
+	cfg KVCacheSimConfig, train, test Window) (*KVCacheHoldout, error) {
+	if err := validHoldoutWindows(train, test); err != nil {
+		return nil, err
+	}
+
+	trainF, testF := f, f
+	trainF.Since, trainF.Until = train.Since, train.Until
+	testF.Since, testF.Until = test.Since, test.Until
+
+	trainOut, err := d.KVCacheSuggest(trainF, o, p, cfg)
+	if err != nil {
+		return nil, err
+	}
+	testOut, err := d.KVCacheSuggest(testF, o, p, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Indexed by (user, hour): the test window's cells, so each train cell can look up its
+	// own counterpart and that counterpart's per-arm savings.
+	type cellKey struct {
+		user string
+		hour int
+	}
+	testCells := make(map[cellKey]KVCacheSuggestion, len(testOut.Cells))
+	for _, c := range testOut.Cells {
+		testCells[cellKey{c.User, c.HourUTC}] = c
+	}
+
+	out := &KVCacheHoldout{
+		Baseline: trainOut.Baseline, Weekdays: trainOut.Weekdays, TimeZone: trainOut.TimeZone,
+		MinRequests: trainOut.MinRequests,
+		TrainSince:  train.Since, TrainUntil: train.Until,
+		TestSince: test.Since, TestUntil: test.Until,
+		Users: []string{},
+		Cells: []KVCacheHoldoutCell{},
+	}
+
+	for _, tc := range trainOut.Cells {
+		cell := KVCacheHoldoutCell{
+			User: tc.User, HourUTC: tc.HourUTC,
+			TrainRequests: tc.Requests, TrainInsufficientData: tc.InsufficientData,
+			Arm:            tc.BestStrategy,
+			TrainSavingUSD: tc.SavingUSD,
+			// Valued, not SavingKnown: SavingKnown is kvcache.Savings' PERCENT-known flag
+			// (false when the baseline cost is zero, since a percentage of nothing is
+			// undefined), which says nothing about whether the absolute dollar figure
+			// could be priced. Valued is the flag that does.
+			TrainKnown: tc.Valued,
+			Arms:       []KVCacheHoldoutArm{},
+		}
+
+		testCell, haveTest := testCells[cellKey{tc.User, tc.HourUTC}]
+		if haveTest {
+			cell.TestRequests = testCell.Requests
+			cell.TestInsufficientData = testCell.InsufficientData
+		}
+
+		// Every arm the train window scored, paired with the same arm's test-window score.
+		// Driven by the TRAIN cell's candidate list, not the union of both: an arm that
+		// only the test window could build is not something a campaign made from the train
+		// window could ever have chosen, so it has no place in this comparison.
+		testByArm := map[string]struct {
+			usd    float64
+			valued bool
+		}{}
+		if haveTest {
+			for _, s := range testCell.Candidates {
+				// kvcache.Savings has no Valued field of its own; a candidate reaches the
+				// list whether or not it could be priced (see kvSuggestCell, which appends
+				// every comparison and only SKIPS unvalued ones from the argmax). An
+				// unpriceable arm's BaselineUSD and StrategyUSD are both zero, which is
+				// indistinguishable from "priced, and exactly free" — so a cell whose
+				// baseline could not be valued at all is treated as carrying no usable
+				// test figure for ANY arm, which is the conservative reading and the only
+				// one that cannot fabricate a $0.00.
+				testByArm[s.Strategy] = struct {
+					usd    float64
+					valued bool
+				}{s.AbsoluteUSD, testCell.Valued}
+			}
+		}
+		for _, s := range tc.Candidates {
+			arm := KVCacheHoldoutArm{
+				Strategy:       s.Strategy,
+				TrainSavingUSD: s.AbsoluteUSD,
+				TrainKnown:     tc.Valued,
+				Chosen:         s.Strategy == tc.BestStrategy,
+			}
+			if t, ok := testByArm[s.Strategy]; ok {
+				arm.TestSavingUSD, arm.TestKnown = t.usd, t.valued
+			}
+			cell.Arms = append(cell.Arms, arm)
+			if arm.Chosen {
+				cell.TestSavingUSD, cell.TestKnown = arm.TestSavingUSD, arm.TestKnown
+			}
+		}
+
+		// Why the chosen arm has no test figure, stated rather than left blank. Ordered
+		// most-specific-first: "no traffic at all" is a different fact from "traffic, but
+		// this arm could not be replayed on it", and reporting the generic reason for the
+		// specific case would send a reader looking for the wrong thing.
+		if !cell.TestKnown {
+			switch {
+			case !haveTest:
+				cell.TestNote = "this account sent no Sunday-Thursday traffic in this hour " +
+					"during the test window"
+			case cell.TestRequests == 0:
+				cell.TestNote = "no test-window requests in this cell"
+			case !testCell.Valued:
+				cell.TestNote = "the test window's traffic in this cell could not be priced"
+			default:
+				cell.TestNote = "the arm chosen on the train window could not be replayed " +
+					"on the test window's rows"
+			}
+		}
+
+		// The comparable population: both sides priced, and neither side thin. A cell that
+		// is below the request floor on EITHER side is excluded from the totals — a
+		// train-side floor breach means the arm was chosen from noise, and a test-side one
+		// means it was scored against noise. Either way the pair does not support the
+		// comparison, and folding it in would let a handful of three-request cells move a
+		// deployment-wide retention figure.
+		if cell.TrainKnown && cell.TestKnown &&
+			!cell.TrainInsufficientData && !cell.TestInsufficientData {
+			out.TotalTrainSavingUSD += cell.TrainSavingUSD
+			out.TotalTestSavingUSD += cell.TestSavingUSD
+			out.ComparableCells++
+		}
+
+		out.Cells = append(out.Cells, cell)
+	}
+	out.TotalCells = len(out.Cells)
+	if out.ComparableCells > 0 && out.TotalTrainSavingUSD != 0 {
+		out.RetentionPct = out.TotalTestSavingUSD / out.TotalTrainSavingUSD * 100
+		out.RetentionKnown = true
+	}
+
+	userSet := map[string]bool{}
+	for _, c := range out.Cells {
+		userSet[c.User] = true
+	}
+	for u := range userSet {
+		out.Users = append(out.Users, u)
+	}
+	sort.Strings(out.Users)
+	sort.Slice(out.Cells, func(i, j int) bool {
+		if out.Cells[i].User != out.Cells[j].User {
+			return out.Cells[i].User < out.Cells[j].User
+		}
+		return out.Cells[i].HourUTC < out.Cells[j].HourUTC
+	})
+
+	out.Notes = []string{
+		"Train saving is IN-SAMPLE: each cell's arm was chosen by replaying every candidate " +
+			"over exactly these rows and taking the best, so the figure it wins with is a " +
+			"measure of fit, not a forecast. It is the same number the KV-cache page's " +
+			"suggestions and a campaign's frozen predicted saving already show.",
+		"Test saving is the SAME arm replayed on the test window's rows, which it was not " +
+			"chosen on. Train minus test is this deployment's own overfitting estimate for " +
+			"that cell; it is not a correction to subtract from a prediction.",
+		"Expect test below train on average, including some negative cells. An arm that wins " +
+			"a thin cell on noise has nothing to reproduce, and a cell can genuinely change " +
+			"behaviour between two periods — both look the same here, which is why the " +
+			"request counts for both windows are shown per cell.",
+		"The two totals cover only cells priced on both sides and thin on neither " +
+			"(comparable_cells of total_cells). A cell missing a test figure says why, and " +
+			"is never counted as a zero.",
+		"Both windows read Sunday-Thursday only and are replayed per hour-of-day in UTC, " +
+			"exactly as the live suggester does — see dash/kvcachesuggest.go.",
+	}
+	return out, nil
+}
+
+// Window is a closed-open time range in epoch milliseconds. Named separately from
+// Filter's own Since/Until because a holdout takes TWO of them and passing four loose
+// int64s in a row is how two of them end up swapped with no compiler complaint.
+type Window struct {
+	Since int64 `json:"since"`
+	Until int64 `json:"until"`
+}
+
+// validHoldoutWindows refuses anything that is not a real split.
+//
+// Every bound must be present (see the file doc comment on why 0-as-unbounded is not
+// available here), each window must be non-empty, and the two must not overlap. The
+// overlap check is the load-bearing one: a train window that includes any test row means
+// the arm was partly chosen on the rows it is scored on, which reports an in-sample
+// number as an out-of-sample one — the single failure this whole view exists to avoid,
+// and one that is invisible in the output.
+//
+// Order is not constrained: scoring a train window against an EARLIER test window is a
+// legitimate check (does the pattern this month found also describe last month?), so a
+// test window before the train window is allowed as long as the two are disjoint.
+func validHoldoutWindows(train, test Window) error {
+	for _, w := range []struct {
+		name string
+		win  Window
+	}{{"train", train}, {"test", test}} {
+		if w.win.Since <= 0 || w.win.Until <= 0 {
+			return fmt.Errorf(
+				"dash: the %s window needs both a start and an end — an open-ended window would "+
+					"overlap the other one and silently stop being a holdout", w.name)
+		}
+		if w.win.Until <= w.win.Since {
+			return fmt.Errorf("dash: the %s window ends at or before it starts", w.name)
+		}
+	}
+	// Until is exclusive, so train.Until == test.Since is two adjacent, disjoint windows
+	// sharing an instant that belongs to exactly one of them — the most common split
+	// anyone will ask for, and not an overlap.
+	if train.Since < test.Until && test.Since < train.Until {
+		return fmt.Errorf("dash: the train and test windows overlap — an arm scored on rows it " +
+			"was chosen on is an in-sample number, which is what this view exists to avoid")
+	}
+	return nil
+}

--- a/dash/kvcacheholdout_test.go
+++ b/dash/kvcacheholdout_test.go
@@ -1,0 +1,317 @@
+package dash
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// findHoldoutCell returns the cell for one (user, hour), or nil.
+func findHoldoutCell(out *KVCacheHoldout, user string, hour int) *KVCacheHoldoutCell {
+	for i := range out.Cells {
+		if out.Cells[i].User == user && out.Cells[i].HourUTC == hour {
+			return &out.Cells[i]
+		}
+	}
+	return nil
+}
+
+// Two adjacent Sunday-Thursday weeks. 2023-01-01 is a Sunday, so week one runs
+// 2023-01-01..2023-01-06 and week two 2023-01-08..2023-01-13 — the same fixed points
+// kvcachesuggest_test.go builds from.
+func holdoutWeeks() (train, test Window) {
+	train = Window{
+		Since: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		Until: time.Date(2023, 1, 8, 0, 0, 0, 0, time.UTC).UnixMilli(),
+	}
+	test = Window{
+		Since: time.Date(2023, 1, 8, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		Until: time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC).UnixMilli(),
+	}
+	return train, test
+}
+
+// The whole point of the view: an overlapping train and test window is refused, because an
+// arm scored on rows it was chosen on is an in-sample number reported as an out-of-sample
+// one — a failure that is completely invisible in the output.
+func TestKVCacheHoldoutRefusesOverlappingWindows(t *testing.T) {
+	db := openTestDB(t)
+	day := int64(86_400_000)
+	cases := []struct {
+		name        string
+		train, test Window
+	}{
+		{"identical", Window{day, 5 * day}, Window{day, 5 * day}},
+		{"test inside train", Window{day, 10 * day}, Window{2 * day, 3 * day}},
+		{"train inside test", Window{2 * day, 3 * day}, Window{day, 10 * day}},
+		{"partial overlap", Window{day, 5 * day}, Window{4 * day, 9 * day}},
+		{"one instant of overlap", Window{day, 5 * day}, Window{5*day - 1, 9 * day}},
+	}
+	for _, c := range cases {
+		if _, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+			staticPricer{ibmSonnet}, KVCacheSimConfig{}, c.train, c.test); err == nil {
+			t.Errorf("%s: got no error, want a refusal", c.name)
+		} else if !strings.Contains(err.Error(), "overlap") {
+			t.Errorf("%s: error %q does not say the windows overlap", c.name, err)
+		}
+	}
+
+	// Until is exclusive, so two windows meeting at one instant are adjacent, not
+	// overlapping — the most common split anyone will ask for.
+	if _, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{},
+		Window{day, 5 * day}, Window{5 * day, 9 * day}); err != nil {
+		t.Errorf("adjacent windows were refused: %v", err)
+	}
+}
+
+// An absent bound is an error, not the "0 means unbounded" every other filter in this
+// package uses: an open-ended train window would swallow the test period and silently stop
+// being a holdout at all.
+func TestKVCacheHoldoutRequiresAllFourBounds(t *testing.T) {
+	db := openTestDB(t)
+	day := int64(86_400_000)
+	good := Window{5 * day, 9 * day}
+	cases := []struct {
+		name        string
+		train, test Window
+	}{
+		{"no train start", Window{0, 4 * day}, good},
+		{"no train end", Window{day, 0}, good},
+		{"no test start", Window{day, 4 * day}, Window{0, 9 * day}},
+		{"no test end", Window{day, 4 * day}, Window{5 * day, 0}},
+		{"train ends before it starts", Window{4 * day, day}, good},
+		{"train is empty", Window{day, day}, good},
+	}
+	for _, c := range cases {
+		if _, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+			staticPricer{ibmSonnet}, KVCacheSimConfig{}, c.train, c.test); err == nil {
+			t.Errorf("%s: got no error, want a refusal", c.name)
+		}
+	}
+}
+
+// The join that makes this a holdout: the arm chosen on the train window is the arm scored
+// on the test window, looked up in the test window's own candidate list — not re-chosen
+// there. A cell whose best arm differs between the two windows must still report the
+// TRAIN arm's test-window number, because that is the arm a campaign would have enforced.
+func TestKVCacheHoldoutScoresTheTrainChosenArmOnTestRows(t *testing.T) {
+	train, test := holdoutWeeks()
+	// Sunday and Monday of each week, hour 10, one user, enough requests to clear the
+	// floor on both sides.
+	var evs []*Event
+	for week, base := range []time.Time{
+		time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 8, 10, 0, 0, 0, time.UTC),
+	} {
+		for i := 0; i < 6; i++ {
+			ts := base.Add(time.Duration(i) * 3 * time.Minute).UnixMilli()
+			evs = append(evs, kvEvent("u1", "s-week-"+string(rune('a'+week)), "m", ts, 100_000, 0))
+		}
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := findHoldoutCell(out, "u1", 10)
+	if cell == nil {
+		t.Fatalf("no cell for u1 hour 10: %+v", out.Cells)
+	}
+	if cell.TrainRequests != 6 || cell.TestRequests != 6 {
+		t.Errorf("cell = %d train / %d test requests, want 6 each", cell.TrainRequests, cell.TestRequests)
+	}
+	if cell.Arm == "" {
+		t.Fatal("the cell names no chosen arm")
+	}
+	// The chosen arm's own pair must be the one promoted onto the cell, and it must be
+	// flagged exactly once in Arms.
+	chosen := 0
+	for _, a := range cell.Arms {
+		if !a.Chosen {
+			continue
+		}
+		chosen++
+		if a.Strategy != cell.Arm {
+			t.Errorf("Arms flags %q as chosen but the cell's arm is %q", a.Strategy, cell.Arm)
+		}
+		if a.TestSavingUSD != cell.TestSavingUSD || a.TestKnown != cell.TestKnown {
+			t.Errorf("the cell's test figure (%v/%v) does not match the chosen arm's (%v/%v)",
+				cell.TestSavingUSD, cell.TestKnown, a.TestSavingUSD, a.TestKnown)
+		}
+	}
+	if chosen != 1 {
+		t.Errorf("%d arms flagged Chosen, want exactly 1", chosen)
+	}
+	// Both windows produced a priced cell, so this pair is comparable and counted.
+	if out.ComparableCells != 1 {
+		t.Errorf("ComparableCells = %d, want 1", out.ComparableCells)
+	}
+}
+
+// A retention ratio against a train total of exactly zero is undefined, not 0% — the same
+// rule kvcache.Savings.Known already encodes for percentages. A cell can genuinely have a
+// zero train saving (nothing beat the baseline), so this is reachable, not defensive.
+func TestKVCacheHoldoutRetentionIsUnknownAgainstAZeroTrainTotal(t *testing.T) {
+	train, test := holdoutWeeks()
+	// Requests with no cache activity at all: every arm ties the baseline, so the chosen
+	// arm's saving is exactly 0 on both sides.
+	var evs []*Event
+	for week, base := range []time.Time{
+		time.Date(2023, 1, 2, 11, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 9, 11, 0, 0, 0, time.UTC),
+	} {
+		for i := 0; i < 6; i++ {
+			evs = append(evs, kvEvent("flat", "s-"+string(rune('a'+week)), "m",
+				base.Add(time.Duration(i)*3*time.Minute).UnixMilli(), 0, 0))
+		}
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.TotalTrainSavingUSD != 0 {
+		t.Skipf("this fixture no longer produces a zero train total (%v); the rule it pins "+
+			"still holds, but this is no longer the case that exercises it",
+			out.TotalTrainSavingUSD)
+	}
+	if out.RetentionKnown || out.RetentionPct != 0 {
+		t.Errorf("retention = %v/%v, want unknown: a ratio against a zero train total is "+
+			"undefined, not 0%%", out.RetentionPct, out.RetentionKnown)
+	}
+}
+
+// A cell with train traffic but NO test traffic must report its train numbers, say plainly
+// why there is no test figure, and be excluded from the totals — never counted as a $0.00
+// test result, which would read as "this arm saved nothing" rather than "nothing was
+// measured".
+func TestKVCacheHoldoutReportsAMissingTestCellRatherThanAZero(t *testing.T) {
+	train, test := holdoutWeeks()
+	// Six requests in the train week only.
+	var evs []*Event
+	base := time.Date(2023, 1, 2, 14, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		evs = append(evs, kvEvent("lonely", "s1", "m",
+			base.Add(time.Duration(i)*3*time.Minute).UnixMilli(), 100_000, 0))
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := findHoldoutCell(out, "lonely", 14)
+	if cell == nil {
+		t.Fatalf("no cell for the train-only user: %+v", out.Cells)
+	}
+	if cell.TrainRequests != 6 {
+		t.Errorf("TrainRequests = %d, want 6", cell.TrainRequests)
+	}
+	if cell.TestRequests != 0 {
+		t.Errorf("TestRequests = %d, want 0", cell.TestRequests)
+	}
+	if cell.TestKnown {
+		t.Error("TestKnown is true for a cell with no test traffic at all")
+	}
+	if cell.TestNote == "" {
+		t.Error("a cell with no test figure must say why, not just leave it blank")
+	}
+	if out.ComparableCells != 0 {
+		t.Errorf("ComparableCells = %d, want 0: nothing here is comparable", out.ComparableCells)
+	}
+	if out.RetentionKnown || out.RetentionPct != 0 {
+		t.Errorf("retention = %v/%v, want unknown and 0: with no comparable cells there is no "+
+			"honest ratio", out.RetentionPct, out.RetentionKnown)
+	}
+	if out.TotalTestSavingUSD != 0 || out.TotalTrainSavingUSD != 0 {
+		t.Errorf("totals = %v train / %v test, want 0 each: an uncomparable cell contributes "+
+			"to neither", out.TotalTrainSavingUSD, out.TotalTestSavingUSD)
+	}
+	// The cell is still REPORTED, with its train numbers — excluded from the totals is not
+	// the same as hidden.
+	if out.TotalCells != 1 {
+		t.Errorf("TotalCells = %d, want 1: the cell must still be reported", out.TotalCells)
+	}
+}
+
+// A cell thin on EITHER side is excluded from the totals: a train-side breach means the arm
+// was chosen from noise, a test-side one means it was scored against noise. Both are still
+// reported, flagged, so the exclusion is visible rather than silent.
+func TestKVCacheHoldoutExcludesThinCellsFromTheTotals(t *testing.T) {
+	train, test := holdoutWeeks()
+	var evs []*Event
+	// Train: 6 requests (clears the floor of 5). Test: 2 (does not).
+	trainBase := time.Date(2023, 1, 2, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		evs = append(evs, kvEvent("thin", "s1", "m",
+			trainBase.Add(time.Duration(i)*3*time.Minute).UnixMilli(), 100_000, 0))
+	}
+	testBase := time.Date(2023, 1, 9, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 2; i++ {
+		evs = append(evs, kvEvent("thin", "s2", "m",
+			testBase.Add(time.Duration(i)*3*time.Minute).UnixMilli(), 100_000, 0))
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := findHoldoutCell(out, "thin", 9)
+	if cell == nil {
+		t.Fatalf("no cell for the thin user: %+v", out.Cells)
+	}
+	if cell.TrainInsufficientData {
+		t.Error("TrainInsufficientData is true for a 6-request train side (floor is 5)")
+	}
+	if !cell.TestInsufficientData {
+		t.Error("TestInsufficientData is false for a 2-request test side")
+	}
+	if out.ComparableCells != 0 {
+		t.Errorf("ComparableCells = %d, want 0: the test side is below the floor",
+			out.ComparableCells)
+	}
+	if out.TotalCells != 1 {
+		t.Errorf("TotalCells = %d, want 1: a thin cell is excluded from the totals, not hidden",
+			out.TotalCells)
+	}
+}
+
+// The route: a malformed window is the CALLER's mistake and must answer 400, not 500 —
+// a 5xx here would fire an alert every time someone typed a bad date. A well-formed pair
+// answers 200 on an empty database, the state every new deployment is in.
+func TestKVCacheHoldoutRouteRejectsABadWindowAsA400(t *testing.T) {
+	a, _ := newTestAPI(t, Options{})
+	day := int64(86_400_000)
+	ms := func(n int64) string { return strconv.FormatInt(n*day, 10) }
+
+	for _, c := range []struct{ name, qs string }{
+		{"overlapping windows", "?train_since=" + ms(1) + "&train_until=" + ms(5) +
+			"&test_since=" + ms(4) + "&test_until=" + ms(9)},
+		{"no bounds at all", ""},
+		{"only a train window", "?train_since=" + ms(1) + "&train_until=" + ms(5)},
+	} {
+		w, _ := get(t, a, "/api/kvcache/suggest/holdout"+c.qs, "")
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s -> %d, want 400: %s", c.name, w.Code, w.Body.String())
+		}
+	}
+
+	w, body := get(t, a, "/api/kvcache/suggest/holdout?train_since="+ms(1)+"&train_until="+ms(4)+
+		"&test_since="+ms(5)+"&test_until="+ms(9), "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid windows -> %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if body == nil {
+		t.Error("the route served no JSON object")
+	}
+}

--- a/dash/kvcacheholdout_test.go
+++ b/dash/kvcacheholdout_test.go
@@ -315,3 +315,103 @@ func TestKVCacheHoldoutRouteRejectsABadWindowAsA400(t *testing.T) {
 		t.Error("the route served no JSON object")
 	}
 }
+
+// The analysis read is CAPPED at kvCacheMaxRows and the cap keeps the NEWEST rows in the
+// window (see KVCacheDataset). So a window bigger than the cap is silently reduced to its
+// own recent tail, and the single-window page shouts about it: KVCacheSuggestions carries
+// Scanned/Total/Truncated and dash/ui/kvcache.js renders a warning banner telling the
+// reader the analysis covers only the rows that were read.
+//
+// A holdout needs that louder, not quieter. The two windows are read and capped
+// INDEPENDENTLY, so a clipped train window means the arm was chosen on a slice of the
+// period the reader asked for, and RetentionPct can divide two totals whose populations
+// cover very different fractions of their windows — while every per-cell request count
+// reports only the post-cap rows, so nothing in the payload reveals it. That is the one
+// silent data loss that undermines every other honesty flag in this file.
+func TestKVCacheHoldoutReportsATruncatedWindow(t *testing.T) {
+	restore := kvCacheMaxRows
+	t.Cleanup(func() { kvCacheMaxRows = restore })
+	kvCacheMaxRows = 4
+
+	train, test := holdoutWeeks()
+	// 8 train-window requests and 6 test-window ones, all one (user, hour) cell: with the
+	// cap at 4, BOTH windows truncate and the train side loses half its rows.
+	var evs []*Event
+	for i := 0; i < 8; i++ {
+		ts := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC).
+			Add(time.Duration(i) * 3 * time.Minute).UnixMilli()
+		evs = append(evs, kvEvent("u1", "s-train", "m", ts, 100_000, 0))
+	}
+	for i := 0; i < 6; i++ {
+		ts := time.Date(2023, 1, 8, 10, 0, 0, 0, time.UTC).
+			Add(time.Duration(i) * 3 * time.Minute).UnixMilli()
+		evs = append(evs, kvEvent("u1", "s-test", "m", ts, 100_000, 0))
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !out.TrainTruncated || !out.TestTruncated {
+		t.Errorf("TrainTruncated=%v TestTruncated=%v, want both true: a reader cannot be told "+
+			"how much of each window was actually read if the payload does not carry it",
+			out.TrainTruncated, out.TestTruncated)
+	}
+	if out.TrainScanned != 4 || out.TrainTotal != 8 {
+		t.Errorf("train read %d of %d, want 4 of 8", out.TrainScanned, out.TrainTotal)
+	}
+	if out.TestScanned != 4 || out.TestTotal != 6 {
+		t.Errorf("test read %d of %d, want 4 of 6", out.TestScanned, out.TestTotal)
+	}
+	// Not just machine-readable: the notes are what the page shows a manager, and a
+	// retention figure computed over a clipped window has to say so in words too.
+	var said bool
+	for _, n := range out.Notes {
+		if strings.Contains(n, "capped") || strings.Contains(n, "truncat") {
+			said = true
+		}
+	}
+	if !said {
+		t.Errorf("no note mentions the cap; notes = %q", out.Notes)
+	}
+}
+
+// The other half of the same rule: an UNtruncated holdout must not carry a scary banner.
+// Truncated stays false and the notes stay quiet, so the flag means something when it is
+// set.
+func TestKVCacheHoldoutReportsAnUntruncatedWindowAsWhole(t *testing.T) {
+	train, test := holdoutWeeks()
+	var evs []*Event
+	for week, base := range []time.Time{
+		time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 8, 10, 0, 0, 0, time.UTC),
+	} {
+		for i := 0; i < 6; i++ {
+			ts := base.Add(time.Duration(i) * 3 * time.Minute).UnixMilli()
+			evs = append(evs, kvEvent("u1", "s-w"+strconv.Itoa(week), "m", ts, 100_000, 0))
+		}
+	}
+	db := seedKV(t, evs...)
+
+	out, err := db.KVCacheSuggestHoldout(allTenants(), KVCacheOptions{},
+		staticPricer{ibmSonnet}, KVCacheSimConfig{}, train, test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.TrainTruncated || out.TestTruncated {
+		t.Errorf("TrainTruncated=%v TestTruncated=%v, want both false on a whole window",
+			out.TrainTruncated, out.TestTruncated)
+	}
+	if out.TrainScanned != 6 || out.TrainTotal != 6 || out.TestScanned != 6 || out.TestTotal != 6 {
+		t.Errorf("train %d/%d test %d/%d, want 6/6 each",
+			out.TrainScanned, out.TrainTotal, out.TestScanned, out.TestTotal)
+	}
+	for _, n := range out.Notes {
+		if strings.Contains(n, "capped") || strings.Contains(n, "truncat") {
+			t.Errorf("an untruncated holdout carries a cap note: %q", n)
+		}
+	}
+}

--- a/dash/ui/campaigns.js
+++ b/dash/ui/campaigns.js
@@ -202,6 +202,20 @@ async function runCampHoldout() {
 }
 
 function renderCampHoldout(host, res) {
+  // Above the tiles, not below them, and worded like kvcache.js's own cap banner: a capped
+  // window is the one defect here that leaves every number below looking correct. The cap
+  // keeps each window's NEWEST rows and the two windows are capped independently, so a
+  // retention percentage over a capped pair divides two totals covering different
+  // fractions of the periods asked for.
+  if (res.train_truncated || res.test_truncated) {
+    host.appendChild(el('div', { class: 'banner warn', 'data-testid': 'camp-ho-truncated' },
+      el('strong', {}, `Capped: the train window read ${num(res.train_scanned)} of `
+        + `${num(res.train_total)} matching requests, the test window `
+        + `${num(res.test_scanned)} of ${num(res.test_total)}. `),
+      'The newest rows in each were kept, so a capped window is its own recent tail rather '
+      + 'than the period you asked for — and the two were capped independently. Narrow both '
+      + 'windows until each reads whole before comparing these totals.'));
+  }
   host.appendChild(tileGroup(null, null, [
     tile('camp-ho-train', 'Train saving (in-sample)', usd(res.total_train_saving_usd)),
     tile('camp-ho-test', 'Test saving (held out)', usd(res.total_test_saving_usd), null,

--- a/dash/ui/campaigns.js
+++ b/dash/ui/campaigns.js
@@ -40,6 +40,28 @@ const camp = {
   // source:"upload" regardless of where it came from — see createCampaignFromPending's
   // own comment for why re-fetching at commit time would be the wrong choice.
   pending: null,
+  // The preview's own filters. They narrow WHAT GETS CREATED, not just what is displayed
+  // — campFilteredCells feeds both the table and the create body, which is what makes
+  // "import this campaign for these two accounts only" a filter rather than a separate
+  // feature (see createCampaignFromPending). Every dimension here is one the payload can
+  // answer from a field it already carries; nothing is inferred.
+  filter: {
+    users: [],      // [] = every user in the payload
+    arm: '',        // '' = every best_strategy
+    hideThin: false, // drop cells the suggester itself flagged insufficient_data
+    minSaving: 0,   // predicted saving floor, in dollars
+    hourFrom: 0,
+    hourTo: 23,
+  },
+  // The holdout panel's two windows, in epoch ms, and its last result. Kept on this
+  // object rather than read back out of the inputs at render time so a re-render never
+  // silently disagrees with the numbers already on screen.
+  holdout: null,
+  holdoutGen: 0,
+  // The campaign drawer's own per-tenant filter — the overview table can run to every
+  // account this deployment has, and the owner's question of a campaign is almost always
+  // about one of them.
+  drawerTenant: '',
   // Bumped at the START of every drawer render (renderCampaignOverview,
   // renderCampaignTenantDrilldown) — not only when the drawer first opens — and checked
   // again once each one's fetch resolves, so a slow render that the manager has since
@@ -88,10 +110,171 @@ function buildCampaignsSkeleton(host) {
         onchange: onUploadSuggestFile,
       })),
     el('div', { id: 'camp-preview' })));
+  buildCampHoldoutPanel(host);
   host.appendChild(el('div', { class: 'panel' },
     el('div', { class: 'card-head' }, el('h2', {}, 'Campaigns'),
       el('span', { class: 'muted', id: 'campaigns-count' })),
     el('div', { id: 'campaigns-list' })));
+}
+
+// ── train/test holdout ─────────────────────────────────────────────────────
+//
+// The honest answer to "show me each strategy's exact and accurate prediction per hour per
+// user": a suggest cell's predicted saving is in-sample by construction (the arm is chosen
+// by maximising the very figure then presented as its prediction, over the same rows), so
+// there is no exact prediction to show — there is a fit, and there is what happens on rows
+// the choice was not made on. This panel shows both, side by side, and calls them what
+// they are. See dash/kvcacheholdout.go for why no train/test concept existed before this
+// and why it is built from the live suggester rather than a second one.
+
+/** campDefaultHoldout is two adjacent 7-day windows ending now: the split a manager almost
+ * always wants, prefilled so the panel is one click rather than four date pickers. Seven
+ * days because both windows must contain the same weekdays to be comparable at all — this
+ * suggester reads Sunday-Thursday and buckets by hour-of-day, so a train window of five
+ * days and a test window of nine would differ in which days they average over. */
+function campDefaultHoldout() {
+  const day = 86_400_000;
+  const now = Date.now();
+  return {
+    trainSince: now - 14 * day, trainUntil: now - 7 * day,
+    testSince: now - 7 * day, testUntil: now,
+  };
+}
+
+function buildCampHoldoutPanel(host) {
+  const w = campDefaultHoldout();
+  // msToLocal/localToMs are app.js's own, used by the global range control — the two
+  // `<input type="datetime-local">` are the platform's picker and need no date library,
+  // exactly as initRange's comment says.
+  const input = (id, ms) => el('input', {
+    type: 'datetime-local', id, 'data-testid': id, value: msToLocal(ms),
+  });
+  host.appendChild(el('div', { class: 'panel' },
+    el('h2', {}, 'Train / test check'),
+    el('p', { class: 'note' },
+      'Choose each cell’s strategy on a TRAIN window, then score that same strategy on a ' +
+      'disjoint TEST window it was not chosen on. Train saving is what this page’s ' +
+      'suggestions and a campaign’s frozen prediction already show; test saving is what ' +
+      'survived. The gap between them is this deployment’s own overfitting estimate — not ' +
+      'a correction to subtract from a prediction, and not a reason to distrust the ' +
+      'mechanism, just the measurement to have before committing to one. The two windows ' +
+      'must not overlap: an arm scored on rows it was chosen on is an in-sample number.'),
+    el('div', { class: 'row-actions' },
+      el('div', { class: 'field' }, el('label', { for: 'camp-train-from' }, 'Train from'),
+        input('camp-train-from', w.trainSince)),
+      el('div', { class: 'field' }, el('label', { for: 'camp-train-to' }, 'Train to'),
+        input('camp-train-to', w.trainUntil)),
+      el('div', { class: 'field' }, el('label', { for: 'camp-test-from' }, 'Test from'),
+        input('camp-test-from', w.testSince)),
+      el('div', { class: 'field' }, el('label', { for: 'camp-test-to' }, 'Test to'),
+        input('camp-test-to', w.testUntil)),
+      el('div', { class: 'field' }, el('label', {}, ' '),
+        el('button', { 'data-testid': 'camp-holdout-run', onclick: runCampHoldout }, 'Run check'))),
+    el('div', { id: 'camp-holdout' })));
+}
+
+async function runCampHoldout() {
+  const gen = ++camp.holdoutGen;
+  const btn = $('[data-testid="camp-holdout-run"]');
+  const out = clear($('#camp-holdout'));
+  const qs = {
+    train_since: localToMs($('#camp-train-from').value),
+    train_until: localToMs($('#camp-train-to').value),
+    test_since: localToMs($('#camp-test-from').value),
+    test_until: localToMs($('#camp-test-to').value),
+  };
+  btn.disabled = true;
+  loadingState(out, 4);
+  try {
+    // Two full dataset replays server-side, so this is the slowest control on the page —
+    // the button stays disabled for the duration rather than letting a second click queue
+    // another pair of them behind the first.
+    const res = await api('kvcache/suggest/holdout', qs);
+    if (gen !== camp.holdoutGen) return;
+    camp.holdout = res;
+    renderCampHoldout(clear(out), res);
+  } catch (e) {
+    if (gen !== camp.holdoutGen) return;
+    errorState(clear(out), 'Could not run the train/test check', e);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+function renderCampHoldout(host, res) {
+  host.appendChild(tileGroup(null, null, [
+    tile('camp-ho-train', 'Train saving (in-sample)', usd(res.total_train_saving_usd)),
+    tile('camp-ho-test', 'Test saving (held out)', usd(res.total_test_saving_usd), null,
+      res.total_test_saving_usd < 0 ? 'bad' : 'good'),
+    // Never a fabricated percentage: the server sets retention_known false where the ratio
+    // is undefined (no comparable cells, or a train total of exactly zero), and the tile
+    // then says so rather than showing 0%.
+    tile('camp-ho-retention', 'Predicted saving retained',
+      res.retention_known ? `${res.retention_pct.toFixed(1)}%` : 'not enough data'),
+    tile('camp-ho-cells', 'Comparable cells', `${num(res.comparable_cells)} of ${num(res.total_cells)}`),
+    tile('camp-ho-users', 'Users', num((res.users || []).length)),
+  ]));
+  for (const n of res.notes || []) {
+    host.appendChild(el('p', { class: 'muted small' }, n));
+  }
+  const cells = res.cells || [];
+  if (!cells.length) {
+    emptyState(host, 'No cells in the train window', 'Widen the train window, or pick one with traffic in it.');
+    return;
+  }
+  host.appendChild(el('p', { class: 'note' },
+    'Click a row for every candidate strategy’s train-and-test pair in that cell — which ' +
+    'answers whether the arm that won on train was anywhere near the best on test.'));
+  const tbl = el('table', { class: 'grid compact', 'data-testid': 'camp-holdout-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Tenant'), el('th', { class: 'num' }, 'Hour (UTC)'),
+      el('th', {}, 'Strategy chosen on train'),
+      el('th', { class: 'num' }, 'Train n'), el('th', { class: 'num' }, 'Train $'),
+      el('th', { class: 'num' }, 'Test n'), el('th', { class: 'num' }, 'Test $'))));
+  const body = el('tbody');
+  for (const c of cells) {
+    body.appendChild(el('tr', { class: 'click', onclick: () => openCampHoldoutCell(c) },
+      el('td', {}, el('code', { class: 'clip' }, c.user)),
+      el('td', { class: 'num' }, String(c.hour_utc)),
+      el('td', {}, c.arm),
+      el('td', { class: 'num' }, num(c.train_requests),
+        c.train_insufficient_data ? el('span', { class: 'pill neutral' }, 'thin') : null),
+      el('td', { class: 'num' }, c.train_known ? usd(c.train_saving_usd) : '—'),
+      el('td', { class: 'num' }, num(c.test_requests),
+        c.test_insufficient_data ? el('span', { class: 'pill neutral' }, 'thin') : null),
+      // A missing test figure renders as its own reason, never as $0.00 — "nothing was
+      // measured" and "this arm saved nothing" are opposite findings.
+      el('td', { class: 'num ' + (c.test_known && c.test_saving_usd < 0 ? 'bad-text' : '') },
+        c.test_known
+          ? usd(c.test_saving_usd)
+          : el('span', { class: 'pill neutral', title: c.test_note || '' }, 'no data'))));
+  }
+  tbl.appendChild(body);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
+}
+
+/** openCampHoldoutCell shows every candidate arm's train-and-test pair for one cell, so a
+ * reader can see the whole comparison the winner came out of rather than only the winner. */
+function openCampHoldoutCell(c) {
+  const body = openDrawer(`${c.user} · ${hourUTCToLocalLabel(c.hour_utc)}`, null);
+  body.appendChild(el('p', { class: 'note' },
+    `${num(c.train_requests)} train request(s), ${num(c.test_requests)} test request(s). ` +
+    `Chosen on train: ${c.arm}.` + (c.test_known ? '' : ` No test figure — ${c.test_note}`)));
+  const tbl = el('table', { class: 'grid compact', 'data-testid': 'camp-holdout-arms-table' },
+    el('thead', {}, el('tr', {},
+      el('th', {}, 'Strategy'), el('th', { class: 'num' }, 'Train $'),
+      el('th', { class: 'num' }, 'Test $'))));
+  const tbody = el('tbody');
+  for (const a of c.arms || []) {
+    tbody.appendChild(el('tr', { class: a.chosen ? 'click' : '' },
+      el('td', {}, a.strategy,
+        a.chosen ? el('span', { class: 'pill complete' }, 'chosen') : null),
+      el('td', { class: 'num' }, a.train_known ? usd(a.train_saving_usd) : '—'),
+      el('td', { class: 'num ' + (a.test_known && a.test_saving_usd < 0 ? 'bad-text' : '') },
+        a.test_known ? usd(a.test_saving_usd) : '—')));
+  }
+  tbl.appendChild(tbody);
+  body.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
 }
 
 // ── create flow: fetch or upload, preview, name, create ────────────────────
@@ -147,14 +330,173 @@ function onUploadSuggestFile(ev) {
   reader.readAsText(file);
 }
 
-/** renderSuggestPreview shows the raw suggest payload and a name field to create from it. */
+/**
+ * campNamedCells is every cell the SERVER would consider at all: one with a tenant id.
+ * A cell without one is dropped by ctlCreateCampaign regardless (an ambiguous pool —
+ * single-tenant traffic, or pre-tenancy rows), so it is excluded here before any filter
+ * runs rather than counted and then silently discarded on create.
+ */
+function campNamedCells(suggest) {
+  return (suggest.cells || []).filter((c) => c.user);
+}
+
+/**
+ * campFilteredCells applies camp.filter to a payload's named cells. This is the single
+ * definition of "the cells this campaign is about": the preview table renders it, the
+ * count reports it, and createCampaignFromPending SUBMITS it. Keeping those three on one
+ * function is what makes the filters trustworthy — a filter that changed the table but
+ * not the create body would quietly enforce hours a manager had just excluded, which is
+ * the worst possible failure for a control whose whole job is narrowing a bulk action.
+ */
+function campFilteredCells(suggest) {
+  const f = camp.filter;
+  return campNamedCells(suggest).filter((c) => {
+    if (f.users.length && !f.users.includes(c.user)) return false;
+    if (f.arm && c.best_strategy !== f.arm) return false;
+    if (f.hideThin && c.insufficient_data) return false;
+    // A cell whose saving could not be priced at all (valued false) has saving_usd 0 for
+    // want of a rate, not because it saves nothing — so a positive floor excludes it,
+    // which is the honest reading of "only cells predicted to save at least $X".
+    if (f.minSaving > 0 && !(c.saving_usd >= f.minSaving)) return false;
+    if (c.hour_utc < f.hourFrom || c.hour_utc > f.hourTo) return false;
+    return true;
+  });
+}
+
+/** campSelect builds one labelled select and wires it to a change handler — kvcache.js's
+ * kvSelect, which this page cannot import (classic scripts, one shared global scope, and
+ * that one is private to the KV-cache tab's own state). */
+function campSelect(label, value, options, onChange, testid) {
+  const sel = el('select', { 'data-testid': testid, onchange: (ev) => onChange(ev.target.value) });
+  for (const [v, text] of options) {
+    const opt = el('option', { value: v }, text);
+    if (v === value) opt.setAttribute('selected', 'selected');
+    sel.appendChild(opt);
+  }
+  return el('div', { class: 'field' }, el('label', {}, label), sel);
+}
+
+/**
+ * campNumber builds one labelled numeric input. Native type=number, min/max/step explicit,
+ * the same way every other threshold field in this dashboard is built.
+ *
+ * onChange receives the INPUT ELEMENT as well as the raw string, so a handler that
+ * normalises a value can write the normalised one back. min/max on a number input are
+ * advisory: the browser marks an out-of-range value invalid but still fires `change`
+ * carrying it, so a handler that clamped only its own state left the field displaying 99
+ * while the table filtered on 23 — a control describing a narrowing it is not performing,
+ * which is a worse outcome than either accepting or refusing the input outright.
+ */
+function campNumber(label, value, attrs, onChange, testid) {
+  const input = el('input', Object.assign({
+    type: 'number', value: String(value), 'data-testid': testid,
+    onchange: (ev) => onChange(ev.target.value, ev.target),
+  }, attrs));
+  return el('div', { class: 'field' }, el('label', {}, label), input);
+}
+
+/**
+ * renderCampFilterBar builds the preview's filter row.
+ *
+ * The user picker is a native `<select multiple>`, matching the strategy form's own
+ * account target (app.js's sf-target-ids) rather than inventing a chip widget — a manager
+ * who already picks accounts that way for a hand-made strategy picks them the same way
+ * for a bulk one. Every option carries its own cell count, so the size of what a
+ * selection is about is visible before it is made.
+ *
+ * onChange re-renders only the table and the create row, never the bar itself: rebuilding
+ * a `<select multiple>` mid-interaction would drop the selection the manager is still
+ * making, and re-rendering the bar is also what would steal focus from the number input
+ * someone is halfway through typing into.
+ */
+function renderCampFilterBar(host, suggest, onChange) {
+  const named = campNamedCells(suggest);
+  const cellsPerUser = {};
+  const arms = {};
+  for (const c of named) {
+    cellsPerUser[c.user] = (cellsPerUser[c.user] || 0) + 1;
+    arms[c.best_strategy] = (arms[c.best_strategy] || 0) + 1;
+  }
+  const users = Object.keys(cellsPerUser).sort();
+
+  const userSel = el('select', {
+    multiple: 'multiple', size: String(Math.min(6, Math.max(3, users.length))),
+    'data-testid': 'camp-filter-users',
+    onchange: (ev) => {
+      camp.filter.users = Array.from(ev.target.selectedOptions).map((o) => o.value);
+      onChange();
+    },
+  }, ...users.map((u) => {
+    const opt = el('option', { value: u }, `${u} · ${num(cellsPerUser[u])} cell(s)`);
+    if (camp.filter.users.includes(u)) opt.setAttribute('selected', 'selected');
+    return opt;
+  }));
+
+  const bar = el('div', { class: 'row-actions', 'data-testid': 'camp-filters' },
+    el('div', { class: 'field' },
+      el('label', {}, `Users (${users.length}) — none selected means all`), userSel),
+    campSelect('Best strategy', camp.filter.arm,
+      [['', 'Every strategy']].concat(Object.keys(arms).sort().map(
+        (a) => [a, `${a} · ${num(arms[a])}`])),
+      (v) => { camp.filter.arm = v; onChange(); }, 'camp-filter-arm'),
+    campNumber('Min predicted $', camp.filter.minSaving, { min: '0', step: '0.01' },
+      (v, input) => {
+        const n = Number(v);
+        camp.filter.minSaving = Number.isFinite(n) && n > 0 ? n : 0;
+        input.value = String(camp.filter.minSaving);
+        onChange();
+      }, 'camp-filter-minsaving'),
+    campNumber('Hour from (UTC)', camp.filter.hourFrom, { min: '0', max: '23', step: '1' },
+      (v, input) => {
+        camp.filter.hourFrom = campClampHour(v, 0);
+        input.value = String(camp.filter.hourFrom);
+        onChange();
+      }, 'camp-filter-hourfrom'),
+    campNumber('Hour to (UTC)', camp.filter.hourTo, { min: '0', max: '23', step: '1' },
+      (v, input) => {
+        camp.filter.hourTo = campClampHour(v, 23);
+        input.value = String(camp.filter.hourTo);
+        onChange();
+      }, 'camp-filter-hourto'),
+    el('div', { class: 'field' }, el('label', {},
+      el('input', {
+        type: 'checkbox', 'data-testid': 'camp-filter-hidethin',
+        checked: camp.filter.hideThin ? 'checked' : null,
+        onchange: (ev) => { camp.filter.hideThin = ev.target.checked; onChange(); },
+      }), ' Hide thin-data cells')),
+    el('button', {
+      class: 'ghost small', 'data-testid': 'camp-filter-reset',
+      onclick: () => {
+        camp.filter = { users: [], arm: '', hideThin: false, minSaving: 0, hourFrom: 0, hourTo: 23 };
+        // The one place the bar itself IS rebuilt, because the reset's whole purpose is to
+        // clear the controls' own displayed state — the selection it would otherwise
+        // clobber is exactly what it is meant to clear.
+        renderSuggestPreview(clear(host.parentNode), suggest);
+      },
+    }, 'Reset filters'));
+  host.appendChild(bar);
+}
+
+/** campClampHour keeps a hand-typed hour inside [0,23]. Its callers write the clamped value
+ * back into the input — see campNumber on why clamping only the state is worse than not
+ * clamping at all. An out-of-range hour would also be refused by the server
+ * (resolveCampaignCell bounds-checks it), but a filter that quietly matched nothing is a
+ * worse way to learn that than a field that corrects itself as you leave it. */
+function campClampHour(v, fallback) {
+  const n = Math.trunc(Number(v));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(23, Math.max(0, n));
+}
+
+/** renderSuggestPreview shows the suggest payload, filters over it, and a name field to
+ * create a campaign from exactly what the filters leave. */
 function renderSuggestPreview(host, suggest) {
   const cells = suggest.cells || [];
   if (!cells.length) {
     emptyState(host, 'No cells in this suggestion set', 'Nothing to campaign over.');
     return;
   }
-  const named = cells.filter((c) => c.user);
+  const named = campNamedCells(suggest);
   const unnamed = cells.length - named.length;
   host.appendChild(el('p', { class: 'note' },
     `${named.length} cell(s) across ${(suggest.users || []).length} tenant(s), baseline ` +
@@ -162,36 +504,90 @@ function renderSuggestPreview(host, suggest) {
     (unnamed ? ` ${unnamed} cell(s) with no tenant id will be excluded from the campaign.` : '') +
     ' Which of these actually activate is decided when the campaign is created — this is ' +
     'the raw recommendation, not yet resolved against what this deployment can enforce.'));
+  host.appendChild(el('p', { class: 'note' },
+    'Predicted saving is IN-SAMPLE: each cell’s strategy was chosen by replaying every ' +
+    'candidate over that cell’s own history and keeping the best, so the figure it wins ' +
+    'with measures fit, not forecast. Use the train/test panel below to see how much of it ' +
+    'survives on traffic the choice was not made on before committing to a large campaign.'));
 
+  const filterHost = el('div');
+  const tableHost = el('div');
+  const actionHost = el('div');
+  host.appendChild(filterHost);
+  host.appendChild(tableHost);
+  host.appendChild(actionHost);
+
+  const rerender = () => {
+    renderCampPreviewTable(clear(tableHost), suggest);
+    renderCampCreateRow(clear(actionHost), suggest, host);
+  };
+  renderCampFilterBar(filterHost, suggest, rerender);
+  rerender();
+}
+
+/** renderCampPreviewTable renders exactly the cells camp.filter leaves. */
+function renderCampPreviewTable(host, suggest) {
+  const named = campNamedCells(suggest);
+  const shownCells = campFilteredCells(suggest);
+  if (!shownCells.length) {
+    emptyState(host, 'No cells match these filters',
+      `All ${named.length} cell(s) were filtered out. Widen a filter, or reset them.`);
+    return;
+  }
   const SHOWN = 200;
   const tbl = el('table', { class: 'grid compact', 'data-testid': 'camp-preview-table' },
     el('thead', {}, el('tr', {},
       el('th', {}, 'Tenant'), el('th', { class: 'num' }, 'Hour (UTC)'),
       el('th', { class: 'num' }, 'Requests'), el('th', {}, 'Best strategy'),
-      el('th', { class: 'num' }, 'Predicted saving'))));
+      el('th', { class: 'num' }, 'Predicted saving'),
+      el('th', { class: 'num' }, 'Oracle ceiling'))));
   const body = el('tbody');
-  for (const c of named.slice(0, SHOWN)) {
+  for (const c of shownCells.slice(0, SHOWN)) {
     body.appendChild(el('tr', {},
       el('td', {}, el('code', { class: 'clip' }, c.user)),
       el('td', { class: 'num' }, String(c.hour_utc)),
       el('td', { class: 'num' }, num(c.requests)),
       el('td', {}, c.best_strategy,
         c.insufficient_data ? el('span', { class: 'pill neutral' }, 'thin data') : null),
-      el('td', { class: 'num' }, usd(c.saving_usd))));
+      el('td', { class: 'num' }, usd(c.saving_usd)),
+      // The exact ceiling on the same rows, already on the wire per cell — how much was
+      // there to capture, beside how much this recommendation captures. Rendered as
+      // unknown rather than 0 where the backtest could not price it.
+      el('td', { class: 'num' },
+        c.optimal_known ? usd(c.optimal_saving_usd) : el('span', { class: 'pill neutral' }, 'no rate'))));
   }
   tbl.appendChild(body);
   host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
-  if (named.length > SHOWN) {
-    host.appendChild(el('p', { class: 'muted small' }, `Showing the first ${SHOWN} of ${named.length} cells.`));
-  }
+  host.appendChild(el('p', { class: 'muted small' },
+    shownCells.length > SHOWN
+      ? `Showing the first ${SHOWN} of ${shownCells.length} matching cell(s), of ${named.length} total.`
+      : `${shownCells.length} of ${named.length} cell(s) match.`));
+}
 
+/**
+ * renderCampCreateRow builds the name field and the create button, labelled with how many
+ * cells and accounts the current filters would actually commit.
+ *
+ * The count is in the BUTTON, not only in the note above it: a manager who filtered to two
+ * accounts and then scrolled past the table needs the commit control itself to say what it
+ * is about to do, because the filters are the only thing standing between "create" and a
+ * live strategy for every account in the payload.
+ */
+function renderCampCreateRow(host, suggest, previewHost) {
+  const shownCells = campFilteredCells(suggest);
+  const users = new Set(shownCells.map((c) => c.user));
   const nameInput = el('input', {
     type: 'text', maxlength: '64', placeholder: 'Campaign name', 'data-testid': 'camp-name',
   });
   const createBtn = el('button', {
-    'data-testid': 'camp-create', onclick: () => createCampaignFromPending(nameInput, createBtn, host),
-  }, 'Create campaign');
-  host.appendChild(el('div', { class: 'row-actions', style: 'margin-top:var(--sp-3)' }, nameInput, createBtn));
+    'data-testid': 'camp-create',
+    disabled: shownCells.length ? null : 'disabled',
+    onclick: () => createCampaignFromPending(nameInput, createBtn, previewHost, suggest),
+  }, shownCells.length
+    ? `Create campaign — ${shownCells.length} cell(s), ${users.size} account(s)`
+    : 'Create campaign — nothing selected');
+  host.appendChild(el('div', { class: 'row-actions', style: 'margin-top:var(--sp-3)' },
+    nameInput, createBtn));
 }
 
 /**
@@ -215,16 +611,40 @@ function renderSuggestPreview(host, suggest) {
  * them here would wipe out work the manager has already moved on to, even though the
  * OLD campaign this call submitted was created successfully.
  */
-async function createCampaignFromPending(nameInput, createBtn, previewHost) {
+async function createCampaignFromPending(nameInput, createBtn, previewHost, previewed) {
   const name = (nameInput.value || '').trim();
   if (!name) { nameInput.focus(); return; }
   const gen = camp.previewGen;
-  const suggest = camp.pending;
+  // The payload this button was rendered against, not camp.pending: the two are normally
+  // the same object, but a fetch/upload started while this create is being clicked
+  // replaces camp.pending, and submitting THAT would create a campaign from cells nobody
+  // reviewed. previewed is captured when the row is built, so "create this" means the
+  // table above it.
+  const suggest = previewed || camp.pending;
+  const cells = campFilteredCells(suggest);
+  if (!cells.length) return;
   createBtn.disabled = true;
   try {
     const created = await ctl('/api/keepalive/campaigns', {
       method: 'POST',
-      body: JSON.stringify({ name, source: 'upload', suggest }),
+      // Only the filtered cells, with users narrowed to match — this is the whole of
+      // "import a campaign for these accounts": the server takes an uploaded suggest
+      // payload verbatim, so a narrowed payload IS a narrowed campaign, with no
+      // per-tenant import route to build or keep in step with the unfiltered one.
+      //
+      // total_saving_usd is deliberately dropped rather than carried over. Nothing on the
+      // server reads it, but it describes the UNFILTERED payload, and a stale aggregate
+      // travelling inside a narrowed one is exactly the kind of number that gets believed
+      // later by something that does start reading it.
+      body: JSON.stringify({
+        name,
+        source: 'upload',
+        suggest: Object.assign({}, suggest, {
+          cells,
+          users: Array.from(new Set(cells.map((c) => c.user))).sort(),
+          total_saving_usd: undefined,
+        }),
+      }),
     });
     if (gen === camp.previewGen) {
       camp.pending = null;
@@ -364,24 +784,46 @@ async function renderCampaignOverview(body, campaignID) {
   }
   body.appendChild(el('p', { class: 'note' }, 'Click a tenant for every hour cell’s ' +
     'historical/predicted saving alongside what actually happened.'));
-  const tbl = el('table', { class: 'grid', 'data-testid': 'camp-tenants-table' },
-    el('thead', {}, el('tr', {},
-      el('th', {}, 'Tenant'), el('th', { class: 'num' }, 'Predicted'),
-      el('th', { class: 'num' }, 'Real ping cost'), el('th', { class: 'num' }, 'Real saved'),
-      el('th', { class: 'num' }, 'Real net'))));
-  const tbody = el('tbody');
-  for (const t of tenants) {
-    tbody.appendChild(el('tr', {
-      class: 'click', onclick: () => renderCampaignTenantDrilldown(body, campaignID, t.tenant_id),
-    },
-      el('td', {}, el('code', { class: 'clip' }, t.tenant_id)),
-      el('td', { class: 'num' }, usd(t.predicted_usd)),
-      el('td', { class: 'num' }, usd(t.real_ping_usd)),
-      el('td', { class: 'num' }, usd(t.real_saved_usd)),
-      el('td', { class: 'num ' + (t.real_net_usd < 0 ? 'bad-text' : 'good-text') }, usd(t.real_net_usd))));
-  }
-  tbl.appendChild(tbody);
-  body.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
+
+  // A per-tenant filter over the rows already in hand: a campaign can target every account
+  // this deployment has, and a question about one of them should not mean reading past the
+  // other seventeen. Purely client-side — the payload is already here, so narrowing it
+  // costs no request and cannot disagree with the totals above, which deliberately keep
+  // covering the WHOLE campaign no matter what is filtered below them.
+  const tenantHost = el('div');
+  const renderRows = () => {
+    const shown = camp.drawerTenant
+      ? tenants.filter((t) => t.tenant_id === camp.drawerTenant)
+      : tenants;
+    clear(tenantHost);
+    const tbl = el('table', { class: 'grid', 'data-testid': 'camp-tenants-table' },
+      el('thead', {}, el('tr', {},
+        el('th', {}, 'Tenant'), el('th', { class: 'num' }, 'Predicted'),
+        el('th', { class: 'num' }, 'Oracle ceiling'),
+        el('th', { class: 'num' }, 'Real ping cost'), el('th', { class: 'num' }, 'Real saved'),
+        el('th', { class: 'num' }, 'Real net'))));
+    const tbody = el('tbody');
+    for (const t of shown) {
+      tbody.appendChild(el('tr', {
+        class: 'click', onclick: () => renderCampaignTenantDrilldown(body, campaignID, t.tenant_id),
+      },
+        el('td', {}, el('code', { class: 'clip' }, t.tenant_id)),
+        el('td', { class: 'num' }, usd(t.predicted_usd)),
+        el('td', { class: 'num' }, usd(t.optimal_saving_usd)),
+        el('td', { class: 'num' }, usd(t.real_ping_usd)),
+        el('td', { class: 'num' }, usd(t.real_saved_usd)),
+        el('td', { class: 'num ' + (t.real_net_usd < 0 ? 'bad-text' : 'good-text') }, usd(t.real_net_usd))));
+    }
+    tbl.appendChild(tbody);
+    tenantHost.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
+  };
+  body.appendChild(el('div', { class: 'row-actions' },
+    campSelect('Tenant', camp.drawerTenant,
+      [['', `All ${tenants.length} tenant(s)`]].concat(
+        tenants.map((t) => [t.tenant_id, t.tenant_id])),
+      (v) => { camp.drawerTenant = v; renderRows(); }, 'camp-drawer-tenant')));
+  body.appendChild(tenantHost);
+  renderRows();
 }
 
 /**

--- a/dash/uicampaigns_test.go
+++ b/dash/uicampaigns_test.go
@@ -1,0 +1,102 @@
+package dash
+
+import (
+	"strings"
+	"testing"
+)
+
+// The Campaigns tab's filters are not a display convenience — they decide what a bulk
+// create actually enforces. This pins the wiring that makes that true, because the failure
+// mode is silent and expensive: a filter bar that narrowed the TABLE but not the create
+// body would show a manager two accounts, then create live keep-alive strategies for
+// eighteen, and nothing on the page would say so.
+//
+// A static source check rather than a browser test because this repo ships no JS test
+// harness at all (no package.json, no node in `make lint`) — and because the property
+// worth protecting is a one-line one: the create call's cells come from the same function
+// the table renders from.
+func TestCampaignCreateSubmitsTheFilteredCellsNotTheWholePayload(t *testing.T) {
+	src := readUI(t, "ui/campaigns.js")
+
+	// One definition of "the cells this campaign is about", used by all three readers.
+	if !strings.Contains(src, "function campFilteredCells(") {
+		t.Fatal("campFilteredCells is gone; the filters, the count and the create body no " +
+			"longer share one definition of which cells a campaign covers")
+	}
+	create := sliceFunc(t, src, "async function createCampaignFromPending(")
+	if !strings.Contains(create, "campFilteredCells(") {
+		t.Error("createCampaignFromPending no longer builds its body from campFilteredCells: " +
+			"the preview's filters would narrow the table while the create still enforces " +
+			"every cell in the payload")
+	}
+	// The narrowed payload must carry a matching user list, since the server takes an
+	// uploaded suggest payload verbatim.
+	if !strings.Contains(create, "users:") {
+		t.Error("the create body no longer narrows `users` to the filtered cells")
+	}
+	// Guard the specific regression of submitting camp.pending wholesale again.
+	if strings.Contains(create, "suggest: camp.pending") ||
+		strings.Contains(create, "suggest }") {
+		t.Error("the create body submits the whole pending payload again, bypassing the filters")
+	}
+}
+
+// The train/test panel exists and is wired to the holdout route, and its copy says what the
+// train figure actually is. The whole reason the panel was built rather than a simple
+// "prediction window" control is that a suggest cell's predicted saving is IN-SAMPLE — a UI
+// that offered a time control over that number without saying so would be presenting a
+// measure of fit as a forecast, which this codebase's honesty convention forbids.
+func TestCampaignHoldoutPanelNamesTheInSampleFigureForWhatItIs(t *testing.T) {
+	src := readUI(t, "ui/campaigns.js")
+
+	if !strings.Contains(src, "kvcache/suggest/holdout") {
+		t.Fatal("the campaigns tab no longer calls the holdout route")
+	}
+	for _, id := range []string{
+		"camp-train-from", "camp-train-to", "camp-test-from", "camp-test-to",
+		"camp-holdout-run", "camp-holdout-table",
+	} {
+		if !strings.Contains(src, id) {
+			t.Errorf("the train/test panel is missing its %q control", id)
+		}
+	}
+	// The copy must call the train figure in-sample somewhere. Not a style preference: it
+	// is the one sentence that stops a reader treating the bigger of the two numbers as
+	// the prediction.
+	if !strings.Contains(src, "IN-SAMPLE") && !strings.Contains(src, "in-sample") {
+		t.Error("the train/test copy no longer says the train figure is in-sample; without " +
+			"that the panel reads as two equally valid predictions rather than a fit and a " +
+			"forecast")
+	}
+	// A retention percentage must never be rendered unconditionally: the server sets
+	// retention_known false where the ratio is undefined (no comparable cells, or a train
+	// total of exactly zero).
+	if !strings.Contains(src, "retention_known") {
+		t.Error("the retention tile no longer checks retention_known, so an undefined ratio " +
+			"would render as a number")
+	}
+	// A missing test figure must render as its own reason, never as $0.00 — "nothing was
+	// measured" and "this arm saved nothing" are opposite findings.
+	if !strings.Contains(src, "test_known") {
+		t.Error("the holdout table no longer checks test_known before printing a test dollar " +
+			"figure")
+	}
+}
+
+// sliceFunc returns the source of one function: from its declaration to the next top-level
+// declaration. Crude, and enough — every function in these files starts at column zero.
+func sliceFunc(t *testing.T, src, decl string) string {
+	t.Helper()
+	i := strings.Index(src, decl)
+	if i < 0 {
+		t.Fatalf("could not find %q in the source", decl)
+	}
+	rest := src[i+len(decl):]
+	// The next line that begins a new top-level declaration ends this one.
+	for _, next := range []string{"\nfunction ", "\nasync function ", "\nconst ", "\n// ──"} {
+		if j := strings.Index(rest, next); j >= 0 {
+			rest = rest[:j]
+		}
+	}
+	return rest
+}

--- a/dash/uiinventory_test.go
+++ b/dash/uiinventory_test.go
@@ -209,7 +209,11 @@ func TestNoFunctionIsDefinedTwiceInTheDashboardSource(t *testing.T) {
 	// thread is a finding that evaporates.
 	known := map[string]bool{"ui/app.js:kv": true}
 	def := regexp.MustCompile(`(?m)^function ([A-Za-z_$][\w$]*)\s*\(`)
-	for _, name := range []string{"ui/tools.js", "ui/app.js"} {
+	// Every classic script on the page, not just the two this check originally scanned.
+	// kvcache.js and campaigns.js were outside it while sharing ONE global scope with
+	// app.js — so a name either of them redefined would win or lose by load order with
+	// nothing to catch it, which is the exact failure mode the comment above describes.
+	for _, name := range []string{"ui/tools.js", "ui/app.js", "ui/kvcache.js", "ui/campaigns.js"} {
 		seen := map[string]int{}
 		for _, m := range def.FindAllStringSubmatch(readUI(t, name), -1) {
 			seen[m[1]]++

--- a/dash/uikeepalive_test.go
+++ b/dash/uikeepalive_test.go
@@ -263,7 +263,11 @@ func TestNoUIScriptShadowsAWindowMethod(t *testing.T) {
 		"getComputedStyle", "matchMedia", "getSelection", "name", "status", "length",
 	}
 	decl := regexp.MustCompile(`(?m)^(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)`)
-	for _, f := range []string{"ui/app.js", "ui/tools.js"} {
+	// Every classic script on the page: the shadow this guards against is a whole-bundle
+	// property "in any load order", so a file left out of the loop is a file that can
+	// introduce one freely. campaigns.js is the pointed case — it calls bare confirm() and
+	// alert(), both on the list below.
+	for _, f := range []string{"ui/app.js", "ui/tools.js", "ui/kvcache.js", "ui/campaigns.js"} {
 		src := stripJSComments(readUI(t, f))
 		for _, m := range decl.FindAllStringSubmatch(src, -1) {
 			for _, bad := range shadowable {

--- a/proxy/campaign.go
+++ b/proxy/campaign.go
@@ -195,6 +195,51 @@ func resolveCampaignCell(cell dash.KVCacheSuggestion, honorsHeadTTL1h func(tenan
 	return out
 }
 
+// markCampaignOverlaps turns any cell whose (tenant, hour) an ACTIVE campaign already
+// enforces into a non-activatable one, naming the campaign that holds it.
+//
+// A per-cell skip, not a refusal of the whole request. The two alternatives are both
+// worse: rejecting the campaign outright makes one already-covered hour block a batch of
+// two hundred good cells, and a manager's only recovery is to hand-edit the payload to
+// remove it — while creating the strategy anyway leaves two live strategies competing for
+// one hour, where the resolution chain silently picks one and both campaigns claim it.
+// Skipping reuses the machinery every other unenforceable cell already flows through:
+// recorded with a reason, grouped by that reason in the create result, never hidden.
+//
+// Deliberately blind to the ARM: a second campaign recommending a DIFFERENT arm for an
+// hour is still a conflict, not a refinement. Only one of the two strategies can win the
+// resolution chain, so letting the different-arm case through would recreate exactly the
+// ambiguity this gate exists to remove. Re-issuing an hour under a new arm is a real
+// need, and the honest path for it is to archive the campaign that holds it first.
+func markCampaignOverlaps(resolved []*resolvedCampaignCell, owners []tenant.CampaignCellOwner) {
+	type key struct {
+		tenantID string
+		hour     int
+	}
+	held := make(map[key]tenant.CampaignCellOwner, len(owners))
+	for _, o := range owners {
+		held[key{o.TenantID, o.HourUTC}] = o
+	}
+	for _, c := range resolved {
+		if !c.activatable {
+			continue
+		}
+		// Baseline cells ("change nothing") create no strategy at all, so they cannot
+		// collide with one — excluding them keeps a campaign whose recommendation for an
+		// hour is "keep the current policy" from being reported as conflicting with the
+		// campaign that already decided the same thing.
+		if c.config.baseline {
+			continue
+		}
+		if o, ok := held[key{c.tenantID, c.hourUTC}]; ok {
+			c.activatable = false
+			c.skipReason = fmt.Sprintf(
+				"the active campaign %q already enforces this tenant's hour %02d:00 UTC — "+
+					"archive it first to re-issue this hour", o.CampaignName, c.hourUTC)
+		}
+	}
+}
+
 // duplicateCampaignCell reports the first cell whose (tenantID, hourUTC) pair also
 // appears earlier in resolved, or nil if every pair is unique — the same key shape
 // tenant.CreateCampaign's own guard checks, run here up front so a duplicate is
@@ -612,6 +657,20 @@ func (h *Handler) ctlCreateCampaign(w http.ResponseWriter, r *http.Request) {
 			"duplicate cell for tenant %q at hour %d", dup.tenantID, dup.hourUTC))
 		return
 	}
+	// Cross-campaign overlap, checked in the same place and for the same reason the
+	// within-payload duplicate above is: before any strategy exists. A failure to READ the
+	// existing owners aborts the whole create rather than proceeding unchecked — a
+	// campaign created while this gate was blind is exactly the double-enforcement it
+	// exists to prevent, and it cannot be un-created without hunting down its strategies
+	// by hand afterwards.
+	owners, err := h.registry().ActiveCampaignCellOwners()
+	if err != nil {
+		slog.Error("context-guru: could not read active campaign cell owners", "err", err)
+		ctlErr(w, http.StatusInternalServerError,
+			"could not check this campaign against the hours already enforced")
+		return
+	}
+	markCampaignOverlaps(resolved, owners)
 
 	days := weekdaysFromNames(suggest.Weekdays)
 	groups := coalesceCampaignCells(resolved)
@@ -960,11 +1019,23 @@ func (h *Handler) ctlGetCampaignTenant(w http.ResponseWriter, r *http.Request) {
 }
 
 // campaignRealSavingsCaveat is carried on every response that includes a real-saving
-// figure, the same ceiling caveat dash.StrategyLedgerView already declares — see
-// dash/campaignsavings.go's own file doc comment for the full reasoning.
-const campaignRealSavingsCaveat = "Real saved-$ figures are a CEILING, not an exact " +
-	"per-strategy attribution: the credit lands on the tenant's whole keep-alive " +
-	"saving in that hour, not only the share this campaign's own strategies produced."
+// figure. It used to declare the figure a CEILING, on the premise that a credited request
+// carried no strategy id and so could only ever be attributed to a tenant — which was
+// already untrue when it shipped, and had the campaigns tab reporting every strategy's
+// saving under whichever campaign named the tenant. dash/campaignsavings.go now scopes the
+// credit by strategy id, so the number is exact and this says so instead.
+//
+// What replaces the old warning is the one caveat that IS still true and is easy for a
+// reader to trip over: these figures do not add up to the Keep-Alive or Overview totals,
+// because a credit whose ping matched no strategy belongs to no campaign. That is the same
+// sentence renderStrategiesList already shows for a single strategy's ledger, deliberately
+// worded the same way so the two tabs read as one product.
+const campaignRealSavingsCaveat = "Real saved-$ figures are EXACT and additive across " +
+	"campaigns: each credited request is attributed once, to whichever strategy's pings " +
+	"actually rescued it. They will not sum to the Overview or Keep-Alive tab's total, " +
+	"though — a credit whose ping matched no strategy (plain account config or a session " +
+	"override) belongs to no campaign, and neither does traffic from before this campaign " +
+	"was activated."
 
 // campaignRealSavings computes real savings for every strategy this campaign created,
 // bounded to since tenantID is only used to filter which cells to bother computing —

--- a/proxy/campaign_test.go
+++ b/proxy/campaign_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,58 @@ func TestResolveCampaignCellBaselineArmIsActivatableWithNoConfig(t *testing.T) {
 	got := resolveCampaignCell(cell, func(string) bool { return true })
 	if !got.activatable || !got.config.baseline {
 		t.Errorf("got %+v, want an activatable baseline cell", got)
+	}
+}
+
+// An (tenant, hour) an active campaign already enforces must not be enforced a second
+// time: only one of the two strategies can win the resolution chain, so the loser's
+// campaign would report a prediction for a policy that never actually ran.
+func TestMarkCampaignOverlapsSkipsHoursAnActiveCampaignAlreadyHolds(t *testing.T) {
+	held := []tenant.CampaignCellOwner{
+		{TenantID: "t1", HourUTC: 9, CampaignID: "c-old", CampaignName: "morning push"},
+	}
+	taken := &resolvedCampaignCell{tenantID: "t1", hourUTC: 9, activatable: true,
+		config: campaignArmFor(kvcache.StrategyKeepAlive5m)}
+	// Same hour, different tenant — no conflict: a strategy's Target names accounts, so
+	// t2's hour 9 is not the hour t1's strategy holds.
+	otherTenant := &resolvedCampaignCell{tenantID: "t2", hourUTC: 9, activatable: true,
+		config: campaignArmFor(kvcache.StrategyKeepAlive5m)}
+	// Same tenant, different hour — no conflict either.
+	otherHour := &resolvedCampaignCell{tenantID: "t1", hourUTC: 10, activatable: true,
+		config: campaignArmFor(kvcache.StrategyKeepAlive5m)}
+	// A baseline cell creates no strategy, so it cannot collide with one.
+	baseline := &resolvedCampaignCell{tenantID: "t1", hourUTC: 9, activatable: true,
+		config: campaignArmFor(kvcache.StrategyFixed5m)}
+
+	markCampaignOverlaps([]*resolvedCampaignCell{taken, otherTenant, otherHour, baseline}, held)
+
+	if taken.activatable || taken.skipReason == "" {
+		t.Errorf("held cell = %+v, want not activatable with a reason", taken)
+	}
+	if !strings.Contains(taken.skipReason, "morning push") {
+		t.Errorf("skip reason %q does not name the campaign holding the hour", taken.skipReason)
+	}
+	for _, c := range []*resolvedCampaignCell{otherTenant, otherHour, baseline} {
+		if !c.activatable {
+			t.Errorf("cell %+v was skipped, want still activatable", c)
+		}
+	}
+}
+
+// A DIFFERENT arm for an already-held hour is still a conflict, not a refinement — see
+// markCampaignOverlaps' own doc comment. Pinned because "the arms differ, so let it
+// through" is the plausible-looking relaxation that would silently restore two competing
+// strategies for one hour.
+func TestMarkCampaignOverlapsIsBlindToTheArm(t *testing.T) {
+	held := []tenant.CampaignCellOwner{
+		{TenantID: "t1", HourUTC: 9, CampaignID: "c-old", CampaignName: "old"},
+	}
+	differentArm := &resolvedCampaignCell{tenantID: "t1", hourUTC: 9, activatable: true,
+		arm: kvcache.StrategyStopReasonGated, config: campaignArmFor(kvcache.StrategyStopReasonGated)}
+	markCampaignOverlaps([]*resolvedCampaignCell{differentArm}, held)
+	if differentArm.activatable {
+		t.Errorf("got %+v, want not activatable: a different arm for a held hour is still a conflict",
+			differentArm)
 	}
 }
 
@@ -538,8 +591,21 @@ func TestCtlGetCampaignAggregatesPredictedAndRealPerTenant(t *testing.T) {
 		KeepAlive: true, KeepAliveStrategyID: strategyID, CostUSD: 0.02,
 		CacheRead: 40_000, Model: "aws/claude-sonnet-5", TokenAccounting: dash.AccountingComplete,
 	})
+	// The credited row carries the same strategy id its rescuing ping did — which is what
+	// makes it THIS campaign's saving rather than merely this tenant's. Before
+	// dash.CampaignRealSavings scoped the credited half by strategy id, an untagged row
+	// here was collected all the same, so this test passed while proving something weaker
+	// than it claimed: that a campaign picks up any credit its tenant happens to have.
 	f.record(t, tenantA, "s1", &dash.Event{
-		KeepAliveSavedUSD: 0.10, Model: "aws/claude-sonnet-5", TokenAccounting: dash.AccountingComplete,
+		KeepAliveSavedUSD: 0.10, KeepAliveStrategyID: strategyID,
+		Model: "aws/claude-sonnet-5", TokenAccounting: dash.AccountingComplete,
+	})
+	// A second credited row for the same tenant, under a strategy this campaign does NOT
+	// own — the manually-created strategies this deployment already runs alongside any
+	// campaign. It must not reach real_saved_usd below.
+	f.record(t, tenantA, "s1", &dash.Event{
+		KeepAliveSavedUSD: 5.00, KeepAliveStrategyID: "someone-elses-strategy",
+		Model: "aws/claude-sonnet-5", TokenAccounting: dash.AccountingComplete,
 	})
 
 	w, out := f.do(t, "GET", "/api/keepalive/campaigns/"+campaignID, "", mgrJar)
@@ -558,13 +624,14 @@ func TestCtlGetCampaignAggregatesPredictedAndRealPerTenant(t *testing.T) {
 		t.Errorf("predicted_usd = %v, want ~1.50", row["predicted_usd"])
 	}
 	if s, _ := row["real_saved_usd"].(float64); s < 0.099 || s > 0.101 {
-		t.Errorf("real_saved_usd = %v, want ~0.10", row["real_saved_usd"])
+		t.Errorf("real_saved_usd = %v, want ~0.10 — this campaign's own strategy only, not "+
+			"the $5.10 of credit this tenant has in total", row["real_saved_usd"])
 	}
 	if total, _ := out["total_predicted_usd"].(float64); total < 1.49 || total > 1.51 {
 		t.Errorf("total_predicted_usd = %v, want ~1.50", out["total_predicted_usd"])
 	}
 	if out["caveat"] == "" || out["caveat"] == nil {
-		t.Error("the ceiling caveat was not carried onto the response")
+		t.Error("the attribution caveat was not carried onto the response")
 	}
 }
 

--- a/tenant/campaign.go
+++ b/tenant/campaign.go
@@ -204,6 +204,54 @@ func (r *Registry) ArchiveCampaign(id string) error {
 	return nil
 }
 
+// CampaignCellOwner names which ACTIVE campaign already enforces one (tenant, hour) — the
+// input the create flow needs to refuse enforcing it a second time.
+type CampaignCellOwner struct {
+	TenantID     string
+	HourUTC      int
+	CampaignID   string
+	CampaignName string
+}
+
+// ActiveCampaignCellOwners returns every (tenant, hour) that an active campaign already
+// has a real strategy for.
+//
+// The campaign_cells primary key already stops one campaign from naming a (tenant, hour)
+// twice, but says nothing across campaigns — so two campaigns created from overlapping
+// suggest runs each got their own live strategy for the same tenant in the same hour.
+// Nothing crashed: the resolution chain simply picks the highest-priority match and the
+// loser never fires. But both campaigns then reported that hour as theirs, one of them
+// claiming a prediction for a strategy that never actually ran, and a manager reading
+// either one had no way to tell which. Refusing the second enforcement (see
+// proxy/campaign.go's overlap gate) is what makes "this campaign's cells" and "the
+// strategies actually running" the same set.
+//
+// ARCHIVED campaigns are excluded on purpose. Archiving does not delete the strategies a
+// campaign created (see ArchiveCampaign), so an archived campaign's hours may well still
+// be served — but archiving is exactly how a manager says "stop managing this as a group",
+// and treating it as a permanent claim on those hours would leave no way to ever re-issue
+// them short of deleting each strategy by hand. The narrower risk of an overlap with a
+// deliberately archived campaign is the better trade than an un-releasable lock.
+func (r *Registry) ActiveCampaignCellOwners() ([]CampaignCellOwner, error) {
+	rows, err := r.db.Query(`SELECT c.tenant_id, c.hour_utc, s.id, s.name
+	  FROM campaign_cells c JOIN strategy_campaigns s ON s.id = c.campaign_id
+	  WHERE s.status = ? AND c.strategy_id IS NOT NULL
+	  ORDER BY c.tenant_id, c.hour_utc`, CampaignStatusActive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []CampaignCellOwner{}
+	for rows.Next() {
+		var o CampaignCellOwner
+		if err := rows.Scan(&o.TenantID, &o.HourUTC, &o.CampaignID, &o.CampaignName); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
 // CampaignCells returns every frozen cell for one campaign, ordered by tenant then
 // hour — the same order the suggest payload it came from already used.
 func (r *Registry) CampaignCells(campaignID string) ([]CampaignCell, error) {


### PR DESCRIPTION
Reviews the Campaigns tab that #126 added, fixes two numbers that could not be
trusted, and adds the filtering, per-user import and train/test measurement the
page was asked for.

> Measurements against a copy of the live database informed this change and confirmed both
> defects below. Those production figures are deliberately **not** reproduced in this
> description; they are available internally to reviewers who need them. Everything
> asserted here is provable from the code and the tests in this PR.

## 1. The duplication question: campaign-derived strategies vs. manual ones

**The architecture stays as #126 built it, and that was the right call.** "Enforcing" a
campaign already means literally creating real `tenant.Strategy` rows through
`registry().CreateStrategy` — so the ledger, savings attribution, active/paused state
and audit trail are the Strategies tab's existing machinery, and Campaigns is the
prediction/planning layer above it. There is no second enforcement path to build, and
building one (a parallel "campaign strategy" type) would have been the mistake: two
kinds of strategy competing in one resolution chain, with two savings queries to keep in
step.

What was NOT right was the accounting, in two independent ways.

### 1a. Real saved-$ was double-counted across campaigns (the load-bearing fix)

`dash.CampaignRealSavings`' credited half was:

```sql
SELECT ... SUM(CASE WHEN keepalive_saved_usd > 0 THEN keepalive_saved_usd ELSE 0 END)
  FROM requests WHERE keepalive = 0 AND tenant_id IN (?) AND ts >= ?
```

Keyed on `tenant_id` alone. So it summed an account's **whole** keep-alive credit into
whichever campaign named that account. Its own comment explained why that was supposedly
unavoidable: the credited row carries no strategy id, only the ping does, so the figure is
"a CEILING… not an exact per-strategy attribution".

**That premise was already false when it shipped.** A credited real row *does* carry
`keepalive_strategy_id`: `keeper.arrive` returns the strategy that resolved the idle entry,
`capture` threads it onto the credited row (see `dash/schema.go`'s `keepalive_strategy_id`
comment), and `dash/keepalivestrategybackfill.go` exists for no other purpose than
recovering it on rows written before that tagging did. `StrategyLedger` was corrected to
filter on it in #131/#133 — this query was not, and the two have disagreed since.

The consequence follows from the query shape alone: **any account served by more than one
strategy has its full credit reported under each campaign that names it.** A campaign
owning one of several strategies claims all of their savings; two campaigns over one
account each claim 100% of its credit, so the campaigns sum to more money than exists.
This is not an edge case — accounts accumulate strategies over time, and nine
manually-created strategies are active on this deployment right now, so the *first*
campaign created would have absorbed their credit. Verified against production, and pinned
by `TestCampaignRealSavingsAttributesCreditToOneStrategyOnly`.

The credited half is now scoped by `keepalive_strategy_id IN (this campaign's own)`.
`SavedUSD` is exact and additive across campaigns — the same guarantee
`renderStrategiesList` already promises the reader for a single strategy.

**`Requests` and `ActiveDays` deliberately stay account-wide.** They are the denominators
for the $-per-1k-requests and $-per-active-day rates; narrowing them to the rescued rows
would divide a strategy's saving by its own successes, giving a rate that looks identical
however much traffic it missed. Both scopes now live in one conditional `SUM` inside one
scan, so the difference is visible in one place rather than split across queries.

The caveat string is rewritten rather than deleted — the *remaining* true caveat is that
these figures don't sum to the Overview/Keep-Alive totals, because a credit whose ping
matched no strategy (plain account config, or a session override) belongs to no campaign.

**Traced end to end for the double-count you asked about:** Overview and Grafana read
`SUM(requests.keepalive_saved_usd)` straight from the column, service-wide, once
(`dash/overview.go:539`, `dash/keepalive.go`). Campaigns only ever *slice* that column;
they never add to it. So there is no path by which a campaign-derived and a
manually-created strategy enter the same total twice — before or after this change. The
double-count was confined to the campaign views, and is now closed there.

### 1b. Two campaigns could enforce the same (account, hour)

`campaign_cells`' primary key stops one campaign naming an (account, hour) twice, but says
nothing across campaigns. Two campaigns built from overlapping suggest runs each got their
own live strategy for the same account in the same hour. Nothing crashed — the resolution
chain picks the highest-priority match and the loser never fires — but both campaigns then
reported that hour as theirs, one of them showing a prediction for a strategy that never
ran, with no way for a manager to tell which.

`markCampaignOverlaps` now marks any cell whose hour an **active** campaign already holds
as non-activatable, with a reason naming that campaign. Design notes:

- **A per-cell skip, not a rejected request.** One already-covered hour must not block a
  batch of two hundred good cells, and it reuses the machinery every other unenforceable
  cell already flows through (recorded with a reason, grouped in the create result, never
  hidden).
- **Blind to the arm.** A second campaign proposing a *different* arm for a held hour is
  still a conflict, not a refinement — only one strategy can win the resolution chain.
  Re-issuing an hour means archiving the campaign that holds it first. Pinned by a test,
  because "the arms differ, so let it through" is the plausible-looking relaxation that
  would restore the bug.
- **Archived campaigns don't hold hours.** Archiving doesn't delete their strategies, but
  it is exactly how a manager says "stop managing this as a group"; treating it as a
  permanent claim would leave no way to release an hour short of deleting strategies by
  hand.
- A failure to *read* the existing owners aborts the create rather than proceeding
  unchecked.

## 2. Train/test: what's real, and what I did not build

**A true train/test split did not exist anywhere in `kvcache` or `dash`.** Every
prediction on these pages is in-sample: `KVCacheSuggest` picks each cell's arm by
replaying every candidate over that cell's own rows and taking the argmax, then reports
*that replay's* saving as the cell's predicted saving. The arm is chosen to maximise the
very number then presented as its forecast, over exactly the rows it was chosen on. It is
a measure of fit, biased upward by construction, and more so as a cell thins — and
`tenant.CampaignCell` then freezes it as `PredictedUSD` and shows it beside a real, live
measurement, inviting exactly the comparison it is least able to support.

So I did not add a time control over that number. A control implying a train/test concept
that didn't exist would be the fake precision this codebase forbids. I built the split
itself.

`dash/kvcacheholdout.go` — `KVCacheSuggestHoldout` chooses each cell's arm on a train
window and scores **that same arm** on a disjoint test window, served at
`GET /api/kvcache/suggest/holdout`. Built from two calls to the existing suggester plus a
join on (user, hour, arm), because a suggest cell already carries every candidate's saving
and not just the winner's — so both halves come from the code path whose numbers a
campaign actually freezes, rather than a second simulator that could drift from it.

All four bounds are **required** and overlap is **refused**, unlike every other filter in
this package where 0 means unbounded: an unbounded train window would swallow the test
period, and an arm scored on rows it was chosen on is the single failure this view exists
to avoid — completely invisible in the output if allowed.

Run over two adjacent 7-day windows of this deployment's own traffic, **a large majority of
the in-sample predicted saving did not survive** on rows the choice was not made on, and a
material number of cells went outright negative. (Figures withheld here per the note at
the top.) That is the number to have before committing to a large campaign, and it is now
one click from the tab that creates them. It is reported as a measurement, never applied
as a correction to a prediction.

Honesty details: a cell missing a test figure carries the *reason* (`test_note`) and is
excluded from the totals, never counted as `$0.00` — "nothing was measured" and "this arm
saved nothing" are opposite findings. Cells thin on *either* side are excluded from the
totals (chosen from noise, or scored against noise) but still displayed. `retention_pct`
carries a `retention_known` flag, false where the ratio is undefined (no comparable cells,
or a train total of exactly zero — a ratio against nothing is undefined, not 0%). The
per-cell drawer shows every candidate arm's train-and-test pair, so a reader can see
whether the arm that won on train was anywhere near the best on test.

## 3. Filters, and per-user import

The preview gains a filter bar: **users** (native multi-select, matching the strategy
form's own account target), **strategy**, **minimum predicted $**, **hour range**, and
**hide thin-data**. Every dimension is one the payload can answer from a field it already
carries — nothing inferred.

**The filters decide what gets created, not just what is displayed.** `campFilteredCells`
is the single definition of "the cells this campaign is about": the table renders it, the
count reports it, and the create call *submits* it. That is the whole of "easy import of
campaigns per user" — the server already accepts an uploaded suggest payload verbatim, so
a narrowed payload **is** a narrowed campaign, with no per-account import route to build
and keep in step with the unfiltered one. A filter that narrowed the table but not the
create body would be the worst possible failure for a control whose only job is narrowing
a bulk action, so it is pinned by a test.

The cell/account count is rendered **into the create button** ("Create campaign — 2
cell(s), 1 account(s)"), because the filters are the only thing between a click and a live
strategy for every account in the payload. `total_saving_usd` is dropped from the narrowed
payload rather than carried over stale.

The campaign drawer gains a per-account filter (client-side over rows already fetched; the
totals above it deliberately keep covering the whole campaign) and surfaces the frozen
oracle-ceiling column that was already on the wire.

## Verification

Build, vet, tests and `-race` on every touched package:

```
go build ./...                            BUILD_OK
go vet ./...                              VET_OK
gofmt -l dash proxy tenant                (clean)
go test ./dash/ ./proxy/ ./tenant/        ok dash 71.9s   ok proxy 39.3s    ok tenant 8.1s
go test -race ./dash/ ./proxy/ ./tenant/  ok dash 543.2s  ok proxy 258.6s   ok tenant 42.4s
```

**One pre-existing test fails, and it is not from this change:** `TestSpendSurvivesRowEviction`
(`dash/spend_test.go:43`, `month-to-date = 1, want 10`). `spendEvents` seeds the last 10
hours, so during the first ~10 hours of any calendar month most of its rows land in the
previous month and `MonthToDateUSD` correctly omits them. Confirmed by checking out
unmodified `e88f5d8` into a clean worktree and running it there — identical failure. It
clears itself later the same day. Left alone as unrelated to this change; worth a one-line
fix in its own.

New tests, one per non-trivial behaviour: credit attributed to one strategy only (and the
denominators staying account-wide); the overlap gate, including its arm-blindness;
overlapping and under-specified holdout windows refused; the train-chosen arm scored on
test rows; a missing test cell reported rather than zeroed; thin cells excluded from the
totals; retention undefined against a zero train total; the route's 400-vs-500 split; the
create call submitting filtered cells; and the holdout copy naming the in-sample figure.

Two existing tests changed their expected *numbers* — both had encoded the double-count as
an expectation (a campaign owning no strategy still collecting an account's credit). The
properties they exist to protect are unchanged and still asserted.

Two static UI guards (duplicate top-level function, shadowed `window` method) now also
scan `kvcache.js` and `campaigns.js`, which shared one global scope with `app.js` while
sitting outside both loops — `campaigns.js` calls bare `confirm()` and `alert()`.

### Browser verification

Driven in headless Chromium through a real authenticated manager session against a
**copy** of the database on a separate port. The live `context-guru.service` was not
touched, restarted, or deployed to, and nothing was written to the live files.

Every filter exercised against a crafted 5-cell / 3-user **synthetic** payload, with zero
JS errors:

```
preview rows (all 5 cells) = 5
create label = Create campaign — 5 cell(s), 3 account(s)
after user=alice: rows = 2, create label = Create campaign — 2 cell(s), 1 account(s)
user=bob: rows = 2  →  + hide thin: rows = 1
arm=keepalive-5m: rows = 3
minSaving=2.00: rows = 2
hours 9-14: rows = 3
after reset: rows = 5
```

The holdout panel was then driven end to end over two disjoint windows and rendered
correctly: the table populated, the tiles showed the train figure labelled in-sample
beside the held-out one, the comparable-cell count read as a fraction of the total, cells
with no test traffic rendered "no data" rather than `$0.00`, and the per-cell drawer listed
every candidate arm with exactly one flagged as chosen.

That run also **caught a real bug, now fixed**: typing an out-of-range hour clamped the
filter's internal state to 23 while the input went on displaying `99` — a control
describing a narrowing it was not performing. Handlers now write the normalised value back
(`99 → 23`, `-4 → 0`, `-9 → 0`, each verified in the browser).

One environment note, not a defect: the holdout's *first* call on a cold process can return
no comparable cells, because the price list populates lazily and the earlier of its two
suggest calls sees it empty. It renders as "not enough data" with a stated reason — the
correct behaviour — and resolves on the next run. The existing `/api/kvcache/suggest`
behaves identically; this change neither introduces nor papers over it.

## Not built, deliberately

- **No campaign editing or re-run.** Archiving plus a fresh campaign already expresses it,
  and a mutable campaign would put the frozen predicted figures out of step with the
  strategies they describe.
- **No new per-account import endpoint.** A filtered upload is that feature; a second route
  would be a parallel path to keep in step for no gain.
- **No retention/overfitting correction applied to any prediction.** Measuring the gap is
  honest; adjusting a frozen number by it would invent one.
- **No `campaigns.css`.** The filter bar is built from `.field` + `.row-actions`, already
  global in `style.css`, rather than borrowing `.kv-controls` across files or adding a
  stylesheet for one row.
- **Nothing removed.** The tables that moved into their own functions render the same rows
  plus a column; archived campaigns still keep their strategies; archiving still leaves a
  campaign's strategies running.
