### PR TITLE
fix(dash): report unpriced components in tokens, state the cache-frozen ceiling, and export the counters that only reached /stats

### DIFF
--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -505,7 +505,10 @@ function barRows(host, rows, opts = {}) {
       onclick: r.onclick || null,
     },
       el('div', { class: 'bar-label', text: r.label }),
-      el('div', { class: 'bar-track' }, el('div', {
+      // `ratio` drops the fill: a figure over 100% is not a share, and this track is a 100%
+      // scale, so any bar drawn for it is a bar that disagrees with its own label. The empty
+      // track keeps the three-column grid intact.
+      el('div', { class: 'bar-track' + (r.ratio ? ' none' : '') }, r.ratio ? null : el('div', {
         class: 'bar-fill' + (r.value < 0 ? ' neg' : '') + (r.value === 0 ? ' zero' : ''),
         style: 'width:' + width + '%' + (r.color ? ';background:' + r.color : ''),
       })),
@@ -1741,9 +1744,17 @@ function renderTiles(o) {
 function renderDenominators(o) {
   barRows($('#denominators'), (o.denominators || []).map((d) => ({
     label: d.label,
+    // Over 100% the figure is a RATIO, not a share, and the track is a share scale by
+    // construction — so the bar pinned full while the number beside it said 158.17%, each
+    // contradicting the other. The arithmetic is right (see the gross-over-attempted
+    // description: the denominator is re-counted every turn), so only the presentation
+    // changes: no track, and a multiple rather than a percentage. The three ratios that ARE
+    // shares keep their bar.
+    ratio: d.available && d.percent > 100,
     value: d.available ? d.percent : 0,
     max: 100,
-    display: d.available ? pct(d.percent, 2) : 'n/a',
+    display: !d.available ? 'n/a'
+      : d.percent > 100 ? (d.percent / 100).toFixed(2) + '×' : pct(d.percent, 2),
     available: d.available,
     // The divisor is what makes these four bars four different measurements, so it is the
     // half that stays visible. The prose folds.
@@ -1753,6 +1764,41 @@ function renderDenominators(o) {
     desc: d.description,
     descSummary: 'Why this denominator',
   })), { emptyDetail: 'No requests match the filter.' });
+  renderFrozenCeiling(o);
+}
+
+/**
+ * renderFrozenCeiling states the cache-frozen share as what it is: the explanation for the
+ * savings percentages directly above it. ~86% of a warm agent transcript sits in the prompt
+ * prefix the provider already cached, and compaction is forbidden to touch it (invariant 5) —
+ * which is why those bars read as low as they do. Until now that share appeared only as a
+ * COST row in the safety panel, with nothing connecting it to the ratios it caps.
+ *
+ * No new capture: both figures already ride on /api/overview and are already tiled under
+ * "What compaction could reach". This is the same quotient, named as a ceiling.
+ *
+ * Zero frozen tokens is NOT rendered as "0% frozen". A window can read zero either because
+ * nothing was frozen or because the requests were not cache-aware at all (compaction is then
+ * allowed the whole request), and /api/overview carries no cache-awareness aggregate that
+ * would separate them — so it says it cannot compute the ceiling instead of claiming there
+ * is none.
+ */
+function renderFrozenCeiling(o) {
+  const host = $('#frozen-ceiling');
+  if (!host) return;
+  const reach = (o.attempted_tokens || 0) + (o.frozen_tokens || 0);
+  if (!reach || !o.frozen_tokens) {
+    host.textContent = reach
+      ? 'No tokens were frozen in this window, so no cache-safety ceiling is computable — '
+        + 'either nothing was frozen or these requests did not run cache-aware.'
+      : 'No cache-safety ceiling computable: this window records neither attempted nor frozen '
+        + 'tokens.';
+    return;
+  }
+  const touchable = (100 * o.attempted_tokens) / reach;
+  host.textContent = `Compaction was allowed to touch ${pct(touchable, 1)} of these tokens; the `
+    + `other ${pct(100 - touchable, 1)} sat in the already-cached prefix `
+    + `(${compact(o.frozen_tokens)} frozen ÷ ${compact(reach)} attempted + frozen).`;
 }
 
 function renderWaterfall(o) {
@@ -2017,8 +2063,14 @@ async function loadValueBreakdown() {
       return;
     }
     panel.hidden = false;
-    const tiles = active.map((c) => tile('vb-' + c.component, c.component,
-      usd(c.net_usd_with_estimate), num(c.runs) + ' runs', c.net_usd_with_estimate < 0 ? 'bad' : 'good'));
+    // Same priced-ness fallback as the declaration-filter tile below: an unpriced model must
+    // not make a real saving read as "$0.00" in --good. A component with unpriceable rows
+    // states the tokens it removed, with no tone — "unknown" is not "worthless".
+    const tiles = active.map((c) => (c.saved_usd_unpriced_rows > 0
+      ? tile('vb-' + c.component, c.component, compact(c.saved_unique) + ' tok',
+        num(c.runs) + ' runs', '')
+      : tile('vb-' + c.component, c.component, usd(c.net_usd_with_estimate),
+        num(c.runs) + ' runs', c.net_usd_with_estimate < 0 ? 'bad' : 'good')));
     if (hasKeepAlive) {
       tiles.push(tile('vb-keepalive', 'Keep-alive (net)', usd(o.keepalive_net_usd),
         num(o.keepalive_pings) + ' pings', o.keepalive_net_usd < 0 ? 'bad' : 'good'));
@@ -2300,10 +2352,10 @@ function activitySummary(gates, events) {
  * a column with nothing orderable in it (the gate summary, the verdict prose).
  */
 const COMPONENT_SORT = ['component', 'kind', 'runs', 'acted_tokens', 'acted_structural',
-  'act_rate', 'reverted',
+  'act_rate', null, 'reverted',
   'saved_unique', 'saved_gross', 'overcount_ratio', 'duration_ms_total', 'duration_ms_avg',
   'llm_calls', 'llm_cost_usd', 'saved_usd', 'net_usd_with_estimate',
-  'net_usd_first_removal', 'replay_multiple', 'errors', null, null];
+  'net_usd_first_removal', 'replay_multiple', 'errors', null];
 
 /**
  * renderNetReconcile prints the two verdicts side by side, and the one step between them.
@@ -2541,6 +2593,10 @@ async function loadComponents() {
             + 'markers, breakpoints. Not a failure to act.',
         }, num(c.acted_structural) || '—'),
         el('td', { class: 'num', text: pct(c.act_rate * 100, 1) }),
+        // Beside the act rate, not twenty columns to its right. This is the cell that makes a
+        // 0.0% act rate falsifiable (docs/dashboard.md), and at 1600px wide it sat at x=2087
+        // in a 2628px table — off-screen for the reader who needs it most.
+        el('td', {}, activitySummary(c.gates, c.events)),
         el('td', { class: 'num', text: num(c.reverted) }),
         // An unkeyed component's `unique` is identically its `gross`, so the cell is marked:
         // without it the column reads as "this component never repeated a removal", which is a
@@ -2619,7 +2675,6 @@ async function loadComponents() {
               + 'there is no repeat business to amortize.',
         }, c.replay_multiple ? c.replay_multiple.toFixed(1) + '×' : '—'),
         el('td', { class: 'num', text: num(c.errors) }),
-        el('td', {}, activitySummary(c.gates, c.events)),
         el('td', {}, el('span', { class: 'pill ' + vcls, text: vtext }))));
     }
     renderNetReconcile(components);
@@ -3309,7 +3364,7 @@ async function openRequest(id, fromURL) {
           el('th', { text: '#' }), el('th', { text: 'Component' }), el('th', { text: 'Kind' }),
           el('th', { class: 'num', text: 'Saved' }), el('th', { class: 'num', text: 'Unique' }),
           el('th', { class: 'num', text: 'Latency' }), el('th', { text: 'Outcome' }),
-          el('th', { text: 'Why declined' }))));
+          el('th', { text: 'Why / what happened' }))));
       const tb = el('tbody');
       e.components.forEach((c, i) => {
         const outcome = c.reverted ? ['reverted', 'missing'] : c.skipped ? ['skipped', 'neutral']

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -281,6 +281,10 @@
          .bar-formula) and only the prose folds away. -->
     <p class="note">Four denominators, four questions. Missing inputs read <em>n/a</em>, never 0.</p>
     <div id="denominators" data-testid="denominators"></div>
+    <!-- The ceiling those four ratios are measured against. It was on the page only as a COST
+         row in the safety panel, so nothing told a reader that the frozen prefix is the
+         EXPLANATION for the numbers directly above. renderFrozenCeiling fills it. -->
+    <p class="note" id="frozen-ceiling" data-testid="frozen-ceiling"></p>
   </div>
 
   <div class="panel">
@@ -472,13 +476,13 @@
         <thead><tr>
           <th>Component</th><th>Kind</th><th class="num">Runs</th><th class="num">Acted</th>
           <th class="num">Structural</th>
-          <th class="num">Act rate</th><th class="num">Reverted</th>
+          <th class="num">Act rate</th><th>Why / what happened</th><th class="num">Reverted</th>
           <th class="num">Unique saved</th><th class="num">Gross saved</th><th class="num">Overcount</th>
           <th class="num">Own latency</th><th class="num">Avg ms</th>
           <th class="num">LLM calls</th><th class="num">LLM cost</th>
           <th class="num">Saved $</th><th class="num">Net $</th>
           <th class="num">Net $ (counted once)</th><th class="num">Replay ×</th>
-          <th class="num">Errors</th><th>Why declined</th><th>Verdict</th>
+          <th class="num">Errors</th><th>Verdict</th>
         </tr></thead>
         <tbody id="components-body"></tbody>
       </table>

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -99,7 +99,16 @@
 /* Dark mode. Tokens only. Applies to an explicit choice and to the system
    preference, so the toggle wins in both directions. The series steps are a
    SEPARATE validated set against the dark surface, not an automatic lightening —
-   flipping the light steps puts them outside the dark lightness band. */
+   flipping the light steps puts them outside the dark lightness band.
+
+   --good/--bad are re-stepped for the same reason, and they are the one pair a reader is
+   asked to TELL APART as adjacent bars (the waterfall's reductions vs its penalties). The
+   previous pair (#3fbe7f / #ef6f63) failed twice on #0d1117: deutan ΔE 4.1 against each
+   other, and L 0.716 / 0.693 above the dark band's 0.48–0.67 ceiling. These measure deutan
+   ΔE 9.7 with L 0.650 / 0.663, and hold 4.5:1 on --bg, --bg-raised and their own soft tint
+   (they are used as TEXT, not just as fills). Re-run the dataviz palette validator before
+   touching either — the light pair sits at ΔE 6.4, legal only because every waterfall row
+   also carries a signed value, so nothing here is colour-alone. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) { color-scheme: dark; }
   :root:not([data-theme="light"]) {
@@ -107,9 +116,9 @@
     --border: #2a313c; --border-soft: #21272f;
     --fg: #e8ebf0; --fg-muted: #9aa4b2; --fg-faint: #8792a1;
     --accent: #4f96f6; --accent-soft: #14243b; --on-accent: #08111e;
-    --good: #3fbe7f; --good-soft: #10301f;
+    --good: #52a27a; --good-soft: #10301f;
     --warn: #dba43c; --warn-soft: #2f2510;
-    --bad: #ef6f63; --bad-soft: #351815;
+    --bad: #f84e3a; --bad-soft: #351815;
     --info: #6ba3ec; --info-soft: #13223a;
     --s1: #4a90e2; --s2: #d9703c; --s3: #1ba676; --s4: #9a68d6;
     /* Stepped for the dark surface rather than flipped: 4.59:1 against --bg-raised. */
@@ -123,9 +132,9 @@
   --border: #2a313c; --border-soft: #21272f;
   --fg: #e8ebf0; --fg-muted: #9aa4b2; --fg-faint: #8792a1;
   --accent: #4f96f6; --accent-soft: #14243b; --on-accent: #08111e;
-  --good: #3fbe7f; --good-soft: #10301f;
+  --good: #52a27a; --good-soft: #10301f;
   --warn: #dba43c; --warn-soft: #2f2510;
-  --bad: #ef6f63; --bad-soft: #351815;
+  --bad: #f84e3a; --bad-soft: #351815;
   --info: #6ba3ec; --info-soft: #13223a;
   --s1: #4a90e2; --s2: #d9703c; --s3: #1ba676; --s4: #9a68d6;
   --s-mute: #7a8496;
@@ -479,6 +488,8 @@ details.why dd { margin: 0; }
 /* Rounded on the data end only, square against the baseline: a pill-shaped bar
    reads as shorter than it is at small values. */
 .bar-fill { height: 100%; background: var(--s1); border-radius: 0 var(--r-sm) var(--r-sm) 0; min-width: 2px; }
+/* A ratio over 100% gets no track at all — see barRows(): a 100% scale cannot draw it. */
+.bar-track.none { background: none; }
 .bar-fill.neg { background: var(--bad); }
 .bar-val {
   font-variant-numeric: tabular-nums; font-size: var(--t-small); font-weight: 600;

--- a/proxy/compactpreset_test.go
+++ b/proxy/compactpreset_test.go
@@ -1,0 +1,94 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/config"
+	"github.com/rossoctl/context-guru/dash"
+	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// TestCompactRowNamesThePresetThatRan.
+//
+// Observed live: POST /compact?preset=codesafe ran codesafe's pipeline — `collapse` fired,
+// and collapse is in no other preset — while both /api/requests and the request drawer
+// labelled the row "codesmart", the process default. /compact is THE offline replay and
+// eval endpoint (deploy/harbor/replay.py drives it), and the point of an eval sweep is
+// comparing presets, so every row carrying the default silently blended an A/B into one
+// bucket with nothing to show it had.
+func TestCompactRowNamesThePresetThatRan(t *testing.T) {
+	agg := metrics.NewAggregator()
+	cfg, err := config.LoadBytes([]byte("preset: codesafe\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pipe, err := cfg.Build(agg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := dash.NewRecorder(dash.Options{DBPath: t.TempDir() + "/d.db",
+		BatchSize: 1, FlushInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rec.Close() })
+	h := New(pipe, store.NewMemory(store.Options{}), agg, Options{
+		Preset: cfg.Preset, Dashboard: rec, Prices: fixedPricer{},
+		// Mirrors cmd/context-guru-proxy's builder, names before preset.
+		PipelineFor: func(preset string, names []string) (*components.Pipeline, error) {
+			doc := "preset: " + preset + "\n"
+			if len(names) > 0 {
+				doc = "pipeline: [" + strings.Join(names, ",") + "]\n"
+			}
+			c, err := config.LoadBytes([]byte(doc))
+			if err != nil {
+				return nil, err
+			}
+			return c.Build(agg)
+		},
+	})
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	// One request per override shape, each tagged by its model so the rows can be told
+	// apart without depending on insertion order.
+	want := map[string]string{
+		"m-default": "codesafe",  // no override: the tenant default stands
+		"m-preset":  "codesmart", // ?preset= actually swapped the pipeline
+		"m-header":  "custom",    // an explicit list has no preset name
+		"m-unknown": "codesafe",  // build failed => the configured pipeline ran, and IS the label
+	}
+	for _, tc := range []struct{ model, query, header string }{
+		{"m-default", "", ""},
+		{"m-preset", "&preset=codesmart", ""},
+		{"m-header", "", "format,textclean"},
+		{"m-unknown", "&preset=nosuchpreset", ""},
+	} {
+		req, _ := http.NewRequest(http.MethodPost,
+			srv.URL+"/compact?provider=anthropic"+tc.query,
+			strings.NewReader(string(anthropicRequest(tc.model))))
+		if tc.header != "" {
+			req.Header.Set("x-context-guru-pipeline", tc.header)
+		}
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	waitForRows(t, rec, int64(len(want)))
+
+	page, _ := rec.DB().Requests(dash.Filter{}, 0, 10)
+	for _, e := range page.Requests {
+		if got := e.Preset; got != want[e.Model] {
+			t.Errorf("%s: row preset = %q; want %q — the dashboard names a pipeline that did not run",
+				e.Model, got, want[e.Model])
+		}
+	}
+}

--- a/proxy/dashcapture.go
+++ b/proxy/dashcapture.go
@@ -77,7 +77,11 @@ func (h *Handler) newCapture(r *http.Request, provider, route string, tn *Tenanc
 	}
 	// The preset comes from the TENANCY, not from Options: in a hosted deployment
 	// the configuration in effect is the tenant's, and labelling every row with the
-	// server default would make the dashboard's preset comparison a lie.
+	// server default would make the dashboard's preset comparison a lie. That is the
+	// DEFAULT, not the last word: /compact lets one request swap the pipeline, and a
+	// row labelled with the tenant default while another preset ran is the same lie a
+	// level down — so the handler overrides this label via notePreset once the
+	// override has resolved.
 	return &capture{
 		rec: h.rec, pricer: h.opts.Prices, preset: tn.Preset, tenant: tn.ID,
 		route: route, provider: provider,
@@ -85,6 +89,21 @@ func (h *Handler) newCapture(r *http.Request, provider, route string, tn *Tenanc
 		llm:    &cheapmodel.Sink{},
 		unique: map[string]int{},
 	}
+}
+
+// notePreset relabels the row with the pipeline this ONE request ran, for /compact's
+// per-request override (?preset=<name>, or x-context-guru-pipeline with an explicit
+// component list, which is labelled "custom" because it has no preset name). The
+// dashboard's preset facet is the whole point of an eval sweep across presets, and it can
+// only compare configurations if each row names the one that actually ran.
+//
+// An empty name means no override took effect, so the tenancy's default — the label
+// newCapture set — is the honest one and stays.
+func (c *capture) notePreset(name string) {
+	if c == nil || name == "" {
+		return
+	}
+	c.preset = name
 }
 
 // llmCtx scopes context-guru's own cheap-model accounting to THIS request. Every

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/rossoctl/context-guru/components/offload"
+	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/internal/cheapmodel"
 	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/store"
 )
 
 // Prometheus exposition at /metrics, for Grafana.
@@ -388,11 +390,44 @@ func (h *Handler) renderMetrics() string {
 		promHeaderProc(&b, "cg_wasted_tokens_total", "Tokens spent recovering offloaded content.", "counter")
 		promLine(&b, "cg_wasted_tokens_total", "", float64(s.WastedTokens))
 
-		promHeaderProc(&b, "cg_frozen_decisions_total", "Freeze-replay outcomes for compaction decisions.", "counter")
-		promLine(&b, "cg_frozen_decisions_total", `outcome="hit"`, float64(s.FrozenHits))
-		promLine(&b, "cg_frozen_decisions_total", `outcome="miss"`, float64(s.FrozenMisses))
-		promLine(&b, "cg_frozen_decisions_total", `outcome="dropped"`, float64(s.FrozenDropped))
-		promLine(&b, "cg_frozen_decisions_total", `outcome="repaired"`, float64(s.FrozenRepaired))
+		// Beside the bounces, because this is the failure the bounces CANNOT show: a bounce
+		// is a successful recovery, so a broken stash and an agent that never asked read
+		// identically there. The two causes are split because they call for opposite
+		// responses, and only one of them is ours.
+		//
+		// Read from expand's own counters, like the cg_llm_* family reads offload's, and NOT
+		// off the Snapshot: Snapshot.ExpandUnresolved* are host-filled and the only host that
+		// fills them is the /stats handler, so a promLine off `s` here would export a
+		// hard-wired 0 forever. (cg_frozen_decisions_total has exactly that bug today.)
+		malformed, missing := expand.Unresolved()
+		promHeaderProc(&b, "cg_expand_unresolved_total",
+			`Expand attempts that recovered nothing, by cause. reason="missing" is the ALERTABLE one: an id this proxy could have minted resolved to no stash, so a cut advertised as reversible was not and content the agent asked back for is gone. reason="malformed" means the model invented a marker id and there is nothing to fix. Neither is visible in cg_expand_bounces_total, which counts SUCCESSFUL re-serves.`, "counter")
+		promLine(&b, "cg_expand_unresolved_total", `reason="malformed"`, float64(malformed))
+		promLine(&b, "cg_expand_unresolved_total", `reason="missing"`, float64(missing))
+
+		// Same rule as the unresolved counters above, and it bit this family first: all four
+		// outcomes used to read s.Frozen*, which nothing fills here, so the series exported a
+		// hard-wired 0 on every scrape however badly freeze-replay was doing. Sourced now
+		// exactly as the /stats handler sources it.
+		promHeaderProc(&b, "cg_frozen_decisions_total",
+			`Freeze-replay outcomes for compaction decisions. hit/miss count the replay path and are complete. dropped/repaired are counted by the STORE that owns the frozen set, so they are present only where this process holds it: on a hosted deployment each tenant has its own store and those two outcomes are ABSENT here rather than 0 — read them per tenant from the dashboard. An absent series is "this process cannot tell you"; a 0 would claim no frozen decision was lost.`, "counter")
+		hits, misses := offload.FrozenStats()
+		promLine(&b, "cg_frozen_decisions_total", `outcome="hit"`, float64(hits))
+		promLine(&b, "cg_frozen_decisions_total", `outcome="miss"`, float64(misses))
+		// A failed cast means NOT COMPUTABLE HERE, not zero — which is why these two lines are
+		// inside it and not defaulted. The drop/repair counters live in the store instance,
+		// and a hosted deployment gives each tenant its own, so this process's store knows
+		// nothing about them; emitting 0 would assert the one thing an operator watches this
+		// series for ("no frozen decision was lost") on no evidence. Absence is the `n/a` the
+		// exposition format does not have. hit/miss above need no such guard: they are
+		// package-level counters in offload, incremented on every replay in the process
+		// whatever the tenant, so they are complete under exactly the procCaveat already
+		// attached — process-wide, summed over tenants, reset on restart.
+		if fl, ok := h.store.(*store.Memory); ok {
+			dropped, repaired := fl.FrozenLossStats()
+			promLine(&b, "cg_frozen_decisions_total", `outcome="dropped"`, float64(dropped))
+			promLine(&b, "cg_frozen_decisions_total", `outcome="repaired"`, float64(repaired))
+		}
 
 		promHeaderProc(&b, "cg_sse_streams_total", "Responses by streaming path.", "counter")
 		promLine(&b, "cg_sse_streams_total", `path="streamed"`, float64(s.SSEStreamed))

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -1,0 +1,183 @@
+package proxy
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/metrics"
+)
+
+// TestEverySnapshotFieldIsExportedOrExempt.
+//
+// promexport.go is a hand-written list of promLine calls and nothing made it keep up with
+// metrics.Snapshot, so fields fell out silently. expand_unresolved_malformed / _missing
+// did: metrics.go calls the second one "the ALERTABLE one" and it reached /stats and the
+// dashboard but never Prometheus, which is the only one of the three an operator can page
+// on. The gap was invisible because a metric that was never added looks exactly like a
+// metric nobody wanted.
+//
+// So: every field of Snapshot must either be read by the exporter or be listed in
+// notExportedWhy with a reason. Adding a field to Snapshot without doing one of the two
+// FAILS THE BUILD.
+//
+// EXPECTED TO FAIL ON PR #137, and that is the test working as intended: that PR adds an
+// `adjudicate_stray` field to Snapshot and exports it nowhere. The fix is to export it, or
+// to list it below with an honest reason — not to delete this test.
+//
+// What it checks is that the exporter READS the field, not that a particular series
+// renders, and NOT that the value is real: `s` in renderMetrics is the bare aggregator
+// snapshot, so any field the /stats handler fills afterwards is zero there and a promLine
+// off it exports a permanent 0. Reflection CANNOT see that: a field read from `s` passes
+// this test whatever the value. cg_frozen_decisions_total was exactly that bug — all four
+// outcomes read s.Frozen*, which renderMetrics never fills, so the series exported 0 on
+// every scrape (fixed in this change by sourcing it as /stats does; a test that catches the
+// class would have to render against a snapshot with a distinct value per field, which
+// needs a seam renderMetrics does not have). Rendered shape is covered by
+// promexport_help_test.go, promexport_components_test.go and TestExpandUnresolvedSeriesRender.
+func TestEverySnapshotFieldIsExportedOrExempt(t *testing.T) {
+	src, err := os.ReadFile("promexport.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := reflect.TypeOf(metrics.Snapshot{})
+	for i := range rt.NumField() {
+		name := rt.Field(i).Name
+		read := regexp.MustCompile(`\bs\.` + name + `\b`).Match(src)
+		why, exempt := notExportedWhy[name]
+		switch {
+		case read && exempt:
+			t.Errorf("Snapshot.%s IS read by the exporter now, so its entry (%q) is stale — "+
+				"delete it from notExportedWhy", name, why)
+		case !read && !exempt:
+			t.Errorf("Snapshot.%s reaches /stats but no promLine in promexport.go reads it, "+
+				"so it never reaches Prometheus. Export it, or add it to notExportedWhy with "+
+				"a reason it should not be a cg_* series.", name)
+		}
+	}
+}
+
+// notExportedWhy is why a Snapshot field is not read by the exporter. One line each, and
+// the honest reason: an entry here is a claim that /metrics loses nothing by it, so "not
+// exported yet" is spelled out as such rather than dressed up as a decision.
+var notExportedWhy = map[string]string{
+	// Derived: PromQL computes these from series that ARE exported, and a second series
+	// would be a number that can disagree with its own inputs.
+	"AdjustedSaved":  "cg_saved_tokens_total - cg_wasted_tokens_total",
+	"FrozenFlips":    `cg_frozen_decisions_total{outcome="dropped"} - {outcome="repaired"}`,
+	"SSEBufferedPct": "a ratio of the two cg_sse_streams_total paths",
+
+	// Exported, but read live from the counter's owner instead of off the Snapshot — same
+	// numbers, and /stats prices them identically on purpose. For a field the /stats
+	// handler fills AFTER taking the snapshot this is required rather than a preference:
+	// renderMetrics holds the bare aggregator snapshot, where those fields are zero.
+	"ExpandUnresolvedMalformed": `cg_expand_unresolved_total{reason="malformed"}, from expand.Unresolved()`,
+	"ExpandUnresolvedMissing":   `cg_expand_unresolved_total{reason="missing"}, from expand.Unresolved()`,
+	"LLMCalls":                  "cg_llm_calls_total, from cheapmodel.Usage()",
+	"LLMInputTokens":            `cg_llm_tokens_total{direction="input"}, from cheapmodel.Usage()`,
+	"LLMOutputTokens":           `cg_llm_tokens_total{direction="output"}, from cheapmodel.Usage()`,
+	"LLMTimeouts":               `cg_llm_failures_total{kind="timeout"}, from offload.LLMTimeouts()`,
+	"LLMErrors":                 `cg_llm_failures_total{kind="error"}, from offload.LLMErrors()`,
+	"FrozenHits":                `cg_frozen_decisions_total{outcome="hit"}, from offload.FrozenStats()`,
+	"FrozenMisses":              `cg_frozen_decisions_total{outcome="miss"}, from offload.FrozenStats()`,
+	"FrozenDropped":             `cg_frozen_decisions_total{outcome="dropped"}, from store.Memory.FrozenLossStats()`,
+	"FrozenRepaired":            `cg_frozen_decisions_total{outcome="repaired"}, from store.Memory.FrozenLossStats()`,
+	"Extract":                   "the cg_extract_* family, from metrics.ExtractSnapshot()",
+
+	// Not numbers. Prometheus has no string sample, and a list of names would have to
+	// become a label — which is what the cg_component_* family already is.
+	"Mode":             "a string; the operating mode is a label, not a measurement",
+	"ObserveNotice":    "prose banner for /stats readers",
+	"ObserveLLMNotice": "prose banner for /stats readers",
+	"TopPassthrough":   `component NAMES; the counts are cg_component_runs_total{outcome="mutated"}`,
+	"TopDiscarded":     `component NAMES; the count is cg_component_runs_total{outcome="discarded"}`,
+	"KeepAlive":        "typed `any`; the host fills it with a ledger this package cannot name",
+
+	// Configured budgets, not measurements: constant for the process's life, so a series
+	// would only ever restate a flag. Read them off /stats when a *_timeouts is non-zero.
+	"LLMCallTimeoutMs":       "configured budget, not a measurement",
+	"SummarizeCallTimeoutMs": "configured budget, not a measurement",
+	"AgentDietCallTimeoutMs": "configured budget, not a measurement",
+
+	// cmdfilter attribution is keyed by filter and by output SELECTOR, and the selector set
+	// is open by design (it is the backlog of filters worth writing) — not a bounded label
+	// set the way the component names are.
+	"CmdfilterFamilies": "unbounded label set; dashboard-only",
+	"CmdfilterFilters":  "unbounded label set; dashboard-only",
+	"CmdfilterMisses":   "unbounded label set; dashboard-only",
+
+	// Observe mode's HYPOTHETICALS. metrics.go keeps them in a namespace that shares no key
+	// with an enforced metric so nothing can sum a projection into a saving; as cg_* series
+	// they would sit beside the enforced ones in the same metric browser, which is the
+	// confusion that invariant exists to prevent.
+	"ObserveRequests":          "observe-mode hypothetical",
+	"ActualBaselineTokens":     "observe-mode hypothetical",
+	"ProjectedOptimizedTokens": "observe-mode hypothetical",
+	"PotentialSavedTokens":     "observe-mode hypothetical",
+	"PotentialSavingsPct":      "observe-mode hypothetical",
+	"PotentialComponents":      "observe-mode hypothetical",
+	"PotentialOverheadMsAvg":   "observe-mode hypothetical",
+	"ObserveQueue":             "observe-mode off-path pool; its drops undercount the hypotheticals, so they belong with them",
+
+	// NOT EXPORTED YET, and each of these arguably should be. Listed rather than left
+	// silent: this change deliberately adds ONE family (cg_expand_unresolved_total, the
+	// alertable one) instead of growing the exposition by fourteen series inside a
+	// dashboard PR. Moving any entry out of this map is a small, self-contained change.
+	"LLMTruncated":          "NOT EXPORTED YET — full price, zero result; a real alert candidate",
+	"SummarizeTimeouts":     "NOT EXPORTED YET — summarize's fail-open path is invisible in Prometheus",
+	"SummarizeErrors":       "NOT EXPORTED YET — as above",
+	"AgentDietTimeouts":     "NOT EXPORTED YET — agentdiet's fail-open path, same gap",
+	"AgentDietErrors":       "NOT EXPORTED YET — as above",
+	"SyncEnforced":          "NOT EXPORTED YET — the machine-readable 'we did modify requests'",
+	"CompactionResets":      "NOT EXPORTED YET — agent self-compaction restarting the cached prefix",
+	"UpstreamMsAvgBypassed": "NOT EXPORTED YET — the bypassed baseline half of cg_upstream_latency_ms",
+	"SSETTFBMsAvgBuf":       "NOT EXPORTED YET — buffered responses' time-to-last-byte",
+	"SSEExpandAfterStream":  "NOT EXPORTED YET — the SSE peek's price; alert candidate",
+	"AttemptedTokens":       "NOT EXPORTED YET — the honest savings denominator",
+	"FrozenTokens":          "NOT EXPORTED YET — what cache-awareness left alone",
+	"SavingsPctAttempted":   "NOT EXPORTED YET — saved/attempted, the ratio that does not trend to 0",
+	"SavingsPctNewInput":    "NOT EXPORTED YET — saved/(fresh+cache_write+saved)",
+}
+
+// TestExpandUnresolvedSeriesRender: both reasons are present with a value even at zero (a
+// family that appears only once something breaks renders "No data" in Grafana, which reads
+// as healthy — the same argument as refusalReasons), and both track the real counter.
+func TestExpandUnresolvedSeriesRender(t *testing.T) {
+	h := New(nil, nil, metrics.NewAggregator(), Options{})
+	zero := []string{
+		`cg_expand_unresolved_total{reason="malformed"} 0`,
+		`cg_expand_unresolved_total{reason="missing"} 0`,
+	}
+	for _, want := range zero {
+		if !containsLine(h.renderMetrics(), want) {
+			t.Errorf("/metrics is missing the line %q", want)
+		}
+	}
+	if help := helpLine(h.renderMetrics(), "cg_expand_unresolved_total"); !strings.Contains(help, "ALERTABLE") {
+		t.Errorf("HELP does not say which of the two reasons to page on:\n  %s", help)
+	}
+
+	// And the values move. A 16-hex id is one this proxy mints, so it classifies as
+	// `missing` — the alertable case; "nothex" cannot be one, so it is `malformed`.
+	expand.NoteUnresolved("0123456789abcdef")
+	expand.NoteUnresolved("nothex")
+	body := h.renderMetrics()
+	for _, still := range zero {
+		if containsLine(body, still) {
+			t.Errorf("still reads 0 after a recorded failure: %q — the series is not reading "+
+				"expand's counters (Snapshot.ExpandUnresolved* are filled only by /stats)", still)
+		}
+	}
+}
+
+func containsLine(body, line string) bool {
+	for _, ln := range strings.Split(body, "\n") {
+		if ln == line {
+			return true
+		}
+	}
+	return false
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -569,6 +569,10 @@ func (h *Handler) compact(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pipe := tn.Pipe
+	// effPreset is what the captured row must be LABELLED with: the pipeline that actually
+	// ran on this request. Empty means no override took effect, so the tenant default
+	// newCapture already recorded stands. See capture.notePreset.
+	effPreset := ""
 	if h.opts.PipelineFor != nil {
 		preset := r.URL.Query().Get("preset")
 		var names []string
@@ -579,6 +583,14 @@ func (h *Handler) compact(w http.ResponseWriter, r *http.Request) {
 			// ponytail: rebuild per override request; add an LRU cache if override QPS ever matters.
 			if p, err := h.opts.PipelineFor(preset, names); err == nil {
 				pipe = p
+				// Same precedence PipelineFor itself applies: an explicit component list wins
+				// over ?preset=. Such a list has no preset name, so it is labelled "custom",
+				// exactly as a configuration document with a bare `pipeline:` is (see
+				// buildTenantConfig) — never the preset name that did NOT run.
+				effPreset = preset
+				if len(names) != 0 {
+					effPreset = "custom"
+				}
 			} // build error => fall back to the configured pipeline (fail open)
 		}
 	}
@@ -615,6 +627,7 @@ func (h *Handler) compact(w http.ResponseWriter, r *http.Request) {
 	// divergence as the window this handler used to hard-code as unknown, a few lines above —
 	// and it went unnoticed for the same reason, because both are silent.
 	cp := h.newCapture(r, string(provider), "/compact", tn)
+	cp.notePreset(effPreset)
 	cp.noteModel(gjson.GetBytes(body, "model").String())
 	start := time.Now()
 	// cp.llmCtx: our own compaction-model spend under this context is charged to THIS


### PR DESCRIPTION
Eight fixes to the dashboard's honesty surface, found by driving the live UI in a real browser
rather than by reading it. Every one is a place where the page either asserted a number it could
not compute, or hid one it already had.

## ⚠️ One operational note, up front

**`cg_frozen_decisions_total` steps from a hard-wired `0` to real values.** All four outcomes were
reading `Snapshot` fields that only the `/stats` handler fills, while `renderMetrics` holds the bare
snapshot — so the series reported `0` on every scrape regardless of state, and the observability for
the freeze-replay mechanism read permanently healthy. Anyone alerting on it was alerting on a
constant and **will see a step change at deploy**. That is the fix landing, not an incident. Filed
separately as #154.

## The UI fixes

| # | What was wrong | Fix |
|---|---|---|
| 1 | The value-breakdown panel rendered every unpriced component as a **green `$0`** under the heading *"Where the value comes from"*. On `/compact` traffic that is all of them — `collapse` had removed **112,151 unique tokens** and its tile said `$0`, while the Cost tiles eight lines above honestly read `unknown`. | Reuse the sibling declaration-filter tile's priced-ness check, which already had the rule written out: *"an unpriced model must not make a real saving read as $0.00"*. Now `60k tok` in neutral tone. A component that genuinely saved nothing still reads `$0` — that zero is a computed truth, not an unknown. |
| 2 | The first savings bar drew a **ratio on a share scale**: gross-over-attempted is correctly >100% (`attempted_tokens` is re-counted every turn) but rendered as `158.17%` pinned full inside a track that is 100% by construction, as the first figure on the page. | Render a bare multiple with no track. **The arithmetic is untouched** — only the presentation lied. The other three denominators are shares and are unchanged, and the *"Missing inputs read n/a, never 0"* contract still holds. |
| 3 | **New:** nothing on the page told a reader that the cache-frozen prefix is *the explanation* for the four ratios above it. `frozen_tokens` was present only as a **cost** row in the safety panel. | One caption: *"Compaction was allowed to touch 29.2% of these tokens; the other 70.8% sat in the already-cached prefix (616k frozen ÷ 869k attempted + frozen)."* Uses the same top-level fields the "What compaction could reach" tiles already read, so caption and tiles cannot drift. Reports **"no ceiling computable"** rather than 0% when nothing was frozen. |
| 4 | Dark-mode `--good`/`--bad` — the pair the waterfall asks a reader to distinguish as adjacent bars — **failed deuteranopia separation** and sat outside the dark lightness band. | Re-stepped in-band with separation restored. These tokens are also **text ink** (`.good-text`, `.tile.good .v`, `.banner.ok`), so ≥4.5:1 AA against all three dark grounds was a hard constraint — which is why separation had to come from hue and chroma rather than a lightness gap. Light pair and the four categorical series steps untouched. |
| 5 | `collapse`'s `char_window` is an **event, not a gate**, and rendered under a header reading *"Why declined"* on rows that had acted. | Header now reads **"Why / what happened"**. The cell stays merged — `dash/event.go:417` records that the merge fixed a real empty-cell bug; only the header was never revisited. |
| 6 | That column sat at **x=2087 in a 2628px table** — off-screen at 1600px — though `docs/dashboard.md:325` calls it *"the column to read when act rate is 0%… without it a table of zeros is unfalsifiable."* Six of eleven components had a 0.0% act rate on the observed traffic. | Moved to immediately after **Act rate** (now `thLeft=613`, visible). The `<th>`, the `COMPONENT_SORT` key array and the row builder all shifted together, so the table stays 21 headers to 21 cells with each row's data under its own header. |

**Palette validation** (checker, not eyeballed):

```
BEFORE  dark  #3fbe7f <-> #ef6f63   deutan dE 4.1  FAIL   L 0.716/0.693 vs band 0.48-0.67  FAIL
AFTER   dark  #52a27a <-> #f84e3a   deutan dE 9.7  PASS   L 0.650/0.663                    PASS
                                    chroma PASS · normal dE 28.4 PASS · contrast PASS
```

The new green sits closer to the `--s3` series step (normal ΔE 3.4, was 7.4). Verified by grepping
usage that the collision is unreachable: `--s3` reaches the DOM only through `SERIES`/`SERIES_SAVED`
(legended line charts and one paired bar), never as status ink; `--good` is a chart mark in exactly
one place (the waterfall, `app.js:1815`), whose neighbours are `--bad` and `SERIES[0]`. No chart
draws both in the same mark set.

## The metrics fixes

**`/compact?preset=` rows were labelled with the wrong preset.** The capture recorded the tenant's
preset, but a per-request `?preset=` (or `x-context-guru-pipeline`) actually swaps the pipeline —
and `proxy.go:594` documents `/compact` as *the* endpoint for offline replay and evaluation, where
the whole point is comparing presets. So every row carried the process default and the dashboard's
preset facet silently collapsed an A/B into one bucket. The tenant default remains the fallback (that
reasoning is still correct for hosted deployments). A raw pipeline header records `custom` — the
label `main.go:756` already uses for exactly that — never a preset name that did not run.

```
model=m-default  preset=codesmart  components=[... extract_llm extract linecap cachesplit]
model=m-preset   preset=codesafe   components=[... extract collapse linecap cachesplit]
model=m-header   preset=custom     components=[format textclean]
```

`collapse` appears only in the `codesafe` row and `extract_llm` only in `codesmart`, so the label
names the pipeline that ran. Before the fix all three read `codesmart`.

**`cg_expand_unresolved_total` is now exported**, with `reason="malformed"` / `reason="missing"`.
`metrics/metrics.go` calls it *"the ALERTABLE one"* and it reached `/stats` only, while
`cg_expand_bounces_total` sitting directly beside it worked — which is what made the gap hard to
spot by reading.

**And the reason both gaps survived:** `promexport.go` is a hand-maintained list of `promLine` calls
with nothing asserting that every `Snapshot` field is either exported or deliberately exempt.
`promexport_coverage_test.go` now reflects over all 66 fields and requires each to be exported or
listed with an honest reason. Stale entries fail too, so the list cannot rot.

**Fourteen fields are recorded there as genuine unexported gaps** rather than exempted to make the
test pass — including `Summarize{Timeouts,Errors}` and `AgentDiet{Timeouts,Errors}` (how you would
notice an LLM component silently failing) and `AttemptedTokens`/`FrozenTokens` (two of the four
savings denominators). Tracked separately rather than expanded into this diff.

**The test's limits are stated in its own comment.** It cannot detect a field that is exported but
hard-wired to a constant — a field read from `s` passes whatever it renders — so it would **not**
have caught the frozen-decisions bug above. Catching that class needs a render seam `renderMetrics`
does not have, and inventing one for a test hook was out of scope. Better to state the boundary than
to imply coverage that isn't there.

## Verification

```
CGO_ENABLED=1 go build ./...                      exit=0
CGO_ENABLED=0 go build ./cmd/context-guru-proxy   exit=0   (the configuration that ships)
go vet ./dash/... ./proxy/...                     exit=0
go test -count=1 ./proxy/... ./metrics/... ./dash/... ./config/...
  ok proxy 44.6s · ok metrics 0.014s · ok dash 79.3s · ok config 8.4s
```

- UI driven in headless Chromium on a live proxy with real traffic, **both themes, zero JS console
  errors** on every view (`console`, `pageerror` and `requestfailed` all captured).
- The `n/a` branch of the new caption forced with **real traffic** (`CACHE_MODE=off` → `frozen 0`),
  not a stub, and confirmed to render the ambiguity honestly rather than pick a story: there is no
  cache-aware aggregate on the wire, so it says nothing-was-frozen *or* not-cache-aware.
- The frozen-metric fix proven with a **paired before/after on identical traffic** — `0/0` → `2`
  hits / `10` misses, matching `/stats` in the same process. No golden file needed regenerating.

No new dependency, no build step, no CDN reference — `dash/ui/` stays hand-written and air-gapped.
