### PR TITLE
fix(deploy): self-heal rclone.conf ownership/mode drift on re-run

### DIFF
--- a/deploy/service/install.sh
+++ b/deploy/service/install.sh
@@ -164,7 +164,18 @@ cmd_install() {
 
   say "rclone config for cold storage"
   if [ -f "$STATE/rclone.conf" ]; then
-    ok "$STATE/rclone.conf exists (left alone)"
+    # CONTENTS left alone — this holds a live Box credential nobody wants regenerated. The
+    # OWNERSHIP and the mode are not content, and the same argument write_local_dropin
+    # makes for its chmod applies here with more at stake: the service opens this file as
+    # $SVC_USER, so once the owner or the mode has drifted (a manual edit, a restore from
+    # backup, an install predating the 0600 below) every start logs "permission denied",
+    # cold storage silently switches off, and the eviction path DELETES idle sessions
+    # instead of archiving them to Box. Only a re-run of this installer can put it back, so
+    # re-assert both unconditionally rather than treating "the file exists" as "the file
+    # works".
+    chown "$SVC_USER:$SVC_USER" "$STATE/rclone.conf"
+    chmod 0600 "$STATE/rclone.conf"
+    ok "$STATE/rclone.conf exists (contents left alone, 0600 $SVC_USER)"
   elif [ -n "$RCLONE_SRC" ] && [ -f "$RCLONE_SRC" ]; then
     install -m0600 -o "$SVC_USER" -g "$SVC_USER" "$RCLONE_SRC" "$STATE/rclone.conf"
     ok "copied $RCLONE_SRC -> $STATE/rclone.conf (0600, $SVC_USER)"
@@ -386,8 +397,17 @@ cmd_preflight() {
     warn "MANAGER_EMAIL is empty in the unit — no account will be able to administer others"
   fi
 
-  if [ -f "$STATE/rclone.conf" ]; then
-    ok "rclone config for cold storage"
+  # Existence is not access. This file is read by the service AS $SVC_USER, so a `-f` test
+  # here reports a green check for a file that is about to fail with "permission denied" on
+  # every restart — the only evidence being a journal line nobody is reading, while
+  # eviction quietly deletes what it should have archived. Ask the question the service
+  # asks: can $SVC_USER actually read it? -n so a sudo that wants to prompt fails instead
+  # of hanging a diagnostic.
+  if [ -f "$STATE/rclone.conf" ] && sudo -u "$SVC_USER" -n test -r "$STATE/rclone.conf" 2>/dev/null; then
+    ok "rclone config for cold storage (readable by $SVC_USER)"
+  elif [ -f "$STATE/rclone.conf" ]; then
+    warn "$STATE/rclone.conf exists but $SVC_USER cannot read it — check ownership/mode/SELinux context"
+    warn "cold storage is therefore OFF at runtime and eviction DELETES instead of archiving; fix with: sudo $0 install"
   else
     warn "no $STATE/rclone.conf — cold storage disabled, so eviction DELETES instead of archiving"
   fi


### PR DESCRIPTION
Closes #153.

## The symptom

Every restart of the live `context-guru.service` logs:

```
Failed to load config file "/var/lib/context-guru/rclone.conf": open /var/lib/context-guru/rclone.conf: permission denied
```

Cold storage is therefore off, and with the archiver unavailable the disk/quota
eviction path in `dash/janitor.go` deletes idle sessions rather than migrating
them to Box first. So this is not a cosmetic log line — it is old sessions going
away instead of moving. It is pre-existing (present on restarts well before the
recent redeploys), and the only place it was ever visible was the journal.

## What we are not doing

We are deliberately not diagnosing which drift produced it. Wrong owner, wrong
mode, a stale SELinux label, a manual edit, a restore from backup — the fix
should be the same one either way, and a fix that requires first knowing which
one it was is a fix that has to be re-derived by hand the next time. Nothing on
the live host was touched by this change.

## The actual bug: an idempotent installer that wasn't

`install.sh` documents itself as safe to re-run, and re-running it is the
standing answer to "the box has drifted". For `rclone.conf` that answer was
false. The rclone step tested `-f` and, on an existing file, left it entirely
alone — never re-asserting `cg:cg` or `0600`:

```bash
if [ -f "$STATE/rclone.conf" ]; then
  ok "$STATE/rclone.conf exists (left alone)"
```

`write_local_dropin` in the same file already learned this exact lesson for
`20-local.conf`, and its comment says it better than a new one would: *"CONTENTS
left alone; the mode is not content ... skipping the chmod here would mean the
fix never reaches the boxes that actually have the problem."* The convention was
just never extended to the other credential-adjacent file — the one that holds an
actual live credential. So the install step now re-asserts owner and mode on the
existing file. Contents are still never touched; nobody wants the Box token
regenerated by an installer run.

## The reason nobody found out: a preflight that checked the wrong thing

`cmd_preflight` also tested only `-f`, which means a file that exists and cannot
be opened by `cg` produced a green ✓. An operator running `sudo ./install.sh
preflight` got a written all-clear for precisely the state that silently breaks
archiving, and the next restart's journal was the only other notification. It now
asks the question the service asks, as the service user
(`sudo -u cg -n test -r`), and distinguishes the three states — readable,
present-but-unreadable, absent — naming ownership/mode/SELinux context in the
failure so the message points at the problem instead of restating the
consequence.

Severity stays a `!` rather than a `✗`, matching the existing "no rclone.conf"
branch: cold storage is an optional feature and `cmd_start` should not begin
refusing to start a service over it.

## Verification

`bash -n` clean; `shellcheck` is not installed in the environment this was
written in, so it was not run. The two new branches were exercised against
fixtures in a scratch directory: an existing `0644` file comes back `0600` with
its contents intact, and the preflight check flips correctly across a readable
file, a `chmod 000` file, and a missing file. No new dependency — `sudo` is how
this script is invoked in the first place, and both install and preflight already
require root.

Known ceiling, stated rather than papered over: `chown`/`chmod` heal DAC drift,
not an SELinux relabel, and a readability probe run from an unconfined root shell
answers for DAC rather than for the unit's own domain. If a label turns out to be
the cause, the preflight message says to check it. Adding `restorecon` here would
be guessing at a cause nobody has established.
