### PR TITLE
fix(dash): correct four money figures computed over the wrong row population, and stop activating ping schedules off partially-priced cells

### DIFF
--- a/dash/cachehistory.go
+++ b/dash/cachehistory.go
@@ -15,14 +15,29 @@ import (
 // over the stored history without touching a single stored row: history stays exactly as it was
 // recorded, and the estimate is recomputed from it on every query.
 //
-// What makes a retroactive value legitimate rather than a guess: the stable half is a property
-// of the AGENT'S SYSTEM PROMPT, not of the request, and it is measurably constant. Per model on
-// this deployment the recorded minimum and maximum are the same number (5,697 / 2,256 / 2,175 /
-// 1,634 tokens) — see CachesplitSizeSpread, which is how an operator checks that rather than
-// taking it on trust.
+// What would make a retroactive value legitimate rather than a guess: the stable half is a
+// property of the AGENT'S SYSTEM PROMPT, not of the request, so where it is measurably constant
+// for a model, the constant may stand in for the rows that never recorded it.
 //
-// Three limits, all of them in the direction of under-crediting:
+// It is NOT measurably constant. This comment used to assert that per model the recorded minimum
+// and maximum are the same number; that was checked with CachesplitSizeSpread — the very query
+// written so an operator would not have to take it on trust — and it is false on every corpus
+// large enough to test: 7 of 9 models on production traffic have a spread, the widest 5.5x
+// (1,301..7,190 tokens). So this estimate no longer values those models at all. Where the spread
+// is real the request is counted in Uncovered and skipped, which is what Uncovered is for: "we
+// cannot value this model's history" is an answer, and picking an end of a 5.5x spread is not.
 //
+// Why not simply pick the conservative end. `stable` is not only a price here, it is also the
+// GATE (read >= stable > write): a smaller constant admits far more rows, a larger one admits
+// far fewer, and the two roles want opposite ends. On production traffic the two ends differ by
+// 31x in what they credit — MIN admits 280 qualifying requests, MAX admits 11 — so any choice
+// is a 31x swing on a dollar figure resting on a premise that has been disproved. Refusing is
+// the only reading of that spread that does not invent one.
+//
+// Four limits, all of them in the direction of under-crediting:
+//
+//   - Only models whose stable half is actually CONSTANT. A model whose recorded minimum and
+//     maximum disagree has no single stable half to retro-apply, and none is guessed for it.
 //   - Only the SESSION'S FIRST request. Mid-session the credit has to know whether the snapshot
 //     had moved, and that comparison needs the tail hash these rows do not carry. A first
 //     request needs no comparison: there was nothing there to match.
@@ -39,12 +54,13 @@ type CachesplitHistorical struct {
 	// USD is the value, and Requests the number of session-first requests behind it.
 	USD      float64 `json:"usd"`
 	Requests int64   `json:"requests"`
-	// Models is how many models contributed. Zero means nothing could be valued — either no
-	// model has a measured stable half yet, or none is priced.
+	// Models is how many models contributed. Zero means nothing could be valued — no model has
+	// a measured stable half yet, none has a CONSTANT one, or none is priced.
 	Models int `json:"models"`
-	// Uncovered counts pre-instrumentation session-first requests that could NOT be valued
-	// because their model has no measured stable half. Reported so the figure is never
-	// mistaken for complete.
+	// Uncovered counts pre-instrumentation session-first requests that could NOT be valued —
+	// their model has no measured stable half, or the one it has is not a single number
+	// (recorded min != max, so there is nothing constant to retro-apply). Reported so the
+	// figure is never mistaken for complete.
 	Uncovered int64 `json:"uncovered"`
 }
 
@@ -88,11 +104,14 @@ func (d *DB) CachesplitHistoricalUSD(f Filter, p modelinfo.Pricer) (CachesplitHi
 			return out, err
 		}
 		sp, ok := sizes[model]
-		if !ok {
+		if !ok || sp[0] != sp[1] {
+			// No measured stable half, or no CONSTANT one. See the file comment: min != max
+			// on most models here, and the two ends of that spread differ by 31x in what they
+			// credit, so neither end may stand in for the rows that recorded nothing.
 			out.Uncovered++
 			continue
 		}
-		stable := int64(sp[1])
+		stable := int64(sp[0])
 		if read < stable || write >= stable {
 			continue // the stable half was not what the provider served from cache
 		}
@@ -168,11 +187,11 @@ func (d *DB) CachesplitHistoricalUSDByTenant(since int64, p modelinfo.Pricer) (m
 			seen[tenant] = map[string]bool{}
 		}
 		sp, ok := sizes[model]
-		if !ok {
-			h.Uncovered++
+		if !ok || sp[0] != sp[1] {
+			h.Uncovered++ // same refusal as CachesplitHistoricalUSD; see its file comment
 			continue
 		}
-		stable := int64(sp[1])
+		stable := int64(sp[0])
 		if read < stable || write >= stable {
 			continue // the stable half was not what the provider served from cache
 		}
@@ -211,7 +230,8 @@ func (d *DB) CachesplitHistoricalUSDByTenant(since int64, p modelinfo.Pricer) (m
 }
 
 // CachesplitSizeSpread reports the recorded minimum and maximum stable half per model. The
-// estimate above rests on those being equal; this is how that gets checked instead of assumed.
+// estimate above credits a model only where those are equal; this is where that gets checked
+// instead of assumed, and it is what decides the refusal rather than merely reporting on it.
 func (d *DB) CachesplitSizeSpread() (map[string][2]int, error) {
 	out := map[string][2]int{}
 	rows, err := d.sql.Query(`SELECT model, MIN(split_stable_tokens), MAX(split_stable_tokens)

--- a/dash/kvcachesuggest.go
+++ b/dash/kvcachesuggest.go
@@ -115,7 +115,14 @@ type KVCacheSuggestion struct {
 	SavingKnown bool    `json:"saving_known"`
 	// Valued is false where neither the baseline nor the winner could be priced — every dollar
 	// figure on this cell is then 0.00 for want of a rate, not because nothing was spent.
-	Valued bool `json:"valued"`
+	//
+	// It is a floor, not a coverage measure: kvcache.Result.Valued is `Unpriced < Requests`, so
+	// ANY one priced request in the cell sets it. UnpricedRequests is the coverage — how many of
+	// this cell's own Requests contributed nothing to SavingUSD because their model has no
+	// rates. Nonzero means SavingUSD describes only part of this cell, which is why the
+	// service-wide total refuses such a cell rather than adding it (see KVCacheSuggestions).
+	Valued           bool  `json:"valued"`
+	UnpricedRequests int64 `json:"unpriced_requests"`
 
 	// OptimalUSD and OptimalSavingUSD are the exact ceiling's own cost on this cell's rows,
 	// and its saving over Baseline — computed and frozen ALONGSIDE the winner, never as one
@@ -144,10 +151,38 @@ type KVCacheSuggestions struct {
 	// Cells is one entry per (user, hour) that had any Sunday–Thursday traffic at all, ordered
 	// by user then hour so the same window renders the same list twice.
 	Cells []KVCacheSuggestion `json:"cells"`
-	// TotalSavingUSD sums SavingUSD over the cells that both cleared MinRequests and were
-	// priced — the aggregate this deployment would have kept had every cell run its own winner
+	// TotalSavingUSD sums SavingUSD over the cells that cleared MinRequests and were priced in
+	// FULL — the aggregate this deployment would have kept had every cell run its own winner
 	// instead of the baseline, over exactly the history read.
-	TotalSavingUSD float64 `json:"total_saving_usd"`
+	//
+	// In full, because a cell's own Valued flag is `Unpriced < Requests` (kvcache/simulate.go):
+	// a cell with 99 of its 100 requests unpriced is Valued, and its SavingUSD is then measured
+	// on the one priced request while being labelled with the whole cell.
+	//
+	// The dollars themselves are not inflated by this, and it matters that the comment says so:
+	// an unpriced request contributes $0 to the baseline AND $0 to the winning arm, so a
+	// partially-priced cell UNDERSTATES its own saving. What is actually damaged is the CHOICE.
+	// BestStrategy is an argmax over the priced subset, and that ranking moves: pricing one
+	// missing model was measured to flip keepalive-5m-once from -0.07% to +1.07% and
+	// stop-reason-gated from -0.35% to +0.75%, reordering ranks 5 through 8 — and
+	// stop-reason-gated buys 249 pings. So the defect is a total that claims coverage it does
+	// not have, over cells whose winner was picked on a fraction of their own traffic.
+	//
+	// A cell therefore enters this total only when nothing in it went unpriced, which makes the
+	// figure a floor over fully-covered cells rather than a blend of two populations.
+	//
+	// TotalSavingKnown is false when NO cell qualified. The figure is then n/a, not $0.00 — a
+	// zero here would claim that switching every cell to its own winner saves nothing, which is
+	// the opposite of "we could not price it". TotalSavingCells is how many cells are behind the
+	// figure and TotalUnpricedRequests how many requests were left out of it for want of a rate,
+	// so the coverage is on the payload rather than inferred from it. Before this field existed
+	// `grep -n Unpriced dash/kvcachesuggest.go` returned nothing: no UI could disclose the
+	// coverage because the payload did not carry it, while the sibling table on the same tab
+	// does (kvcache.js:1136).
+	TotalSavingUSD        float64 `json:"total_saving_usd"`
+	TotalSavingKnown      bool    `json:"total_saving_known"`
+	TotalSavingCells      int64   `json:"total_saving_cells"`
+	TotalUnpricedRequests int64   `json:"total_unpriced_requests"`
 
 	Scanned   int64 `json:"scanned"`
 	Total     int64 `json:"total"`
@@ -223,8 +258,12 @@ func (d *DB) KVCacheSuggest(f Filter, o KVCacheOptions, p modelinfo.Pricer,
 			}
 			cell := kvSuggestCell(u, h, grp, candidates, baseName, prices, cfg)
 			out.Cells = append(out.Cells, cell)
-			if cell.Valued && !cell.InsufficientData {
+			out.TotalUnpricedRequests += cell.UnpricedRequests
+			// SavingKnown and full pricing coverage, not just Valued: see TotalSavingUSD.
+			if cell.Valued && cell.SavingKnown && cell.UnpricedRequests == 0 && !cell.InsufficientData {
 				out.TotalSavingUSD += cell.SavingUSD
+				out.TotalSavingCells++
+				out.TotalSavingKnown = true
 			}
 		}
 	}
@@ -313,5 +352,8 @@ func kvSuggestCell(user string, hour int, rows []*kvcache.Request, candidates []
 	cell.SavingPct = best.PercentUSD
 	cell.SavingKnown = best.Known
 	cell.Valued = baseline.Valued && bestResult.Valued
+	// Every arm replays the SAME rows through the same PriceList, so an unpriced request is
+	// unpriced under all of them; the baseline's count is the cell's.
+	cell.UnpricedRequests = baseline.Unpriced
 	return cell
 }

--- a/dash/moneybasis_test.go
+++ b/dash/moneybasis_test.go
@@ -46,3 +46,44 @@ func TestFrozenTokensArePricedOnlyUpToWhatTheRequestActuallyRead(t *testing.T) {
 			tc.FrozenWriteRiskUSD, 3000*spread)
 	}
 }
+
+// The "gross, of what we tried to compact" ratio summed its numerator over every row and its
+// denominator over the rows that recorded one. attempted_tokens is additive, so a row written
+// before it shipped reads 0 while still carrying a saving — 7,032 such rows on real traffic,
+// which served 2.101% where the same-basis figure is 1.824%.
+func TestAttemptedRatioCountsSavingsOnlyWhereItCountsTheDenominator(t *testing.T) {
+	db := openTestDB(t)
+	old := mkEvent(1000, "s-old", "m", 10000, 1000) // pre-column row: a saving, no denominator
+	old.AttemptedTokens = 0
+	fresh := mkEvent(2000, "s-new", "m", 3000, 1000)
+	fresh.AttemptedTokens = 4000
+	if err := db.insertBatch([]*Event{old, fresh}); err != nil {
+		t.Fatal(err)
+	}
+	o, err := db.Overview(Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got *Denominator
+	for i := range o.Denominators {
+		if o.Denominators[i].Key == "attempted" {
+			got = &o.Denominators[i]
+		}
+	}
+	if got == nil {
+		t.Fatal(`no "attempted" denominator`)
+	}
+	// Only the instrumented row may contribute to either side: 2000 saved of 4000 attempted.
+	if got.Numerator != 2000 || got.Denominator != 4000 {
+		t.Errorf("attempted ratio = %d/%d (%.3f%%), want 2000/4000 (50.000%%): the "+
+			"pre-instrumentation row's 9000-token saving has no denominator and may not "+
+			"inflate a ratio it cannot divide into", got.Numerator, got.Denominator, got.Percent)
+	}
+	if o.SavedGross != 11000 {
+		t.Errorf("SavedGross = %d, want 11000 — the all-rows figure is still reported as "+
+			"itself; only the ratio's basis changed", o.SavedGross)
+	}
+	if o.AttemptedRequests != 1 {
+		t.Errorf("AttemptedRequests = %d, want 1", o.AttemptedRequests)
+	}
+}

--- a/dash/moneybasis_test.go
+++ b/dash/moneybasis_test.go
@@ -1,0 +1,48 @@
+package dash
+
+import (
+	"testing"
+)
+
+// Four money figures on this dashboard were each computed over a population that was not the
+// population they claimed to describe. Every test here fails on the arithmetic that shipped
+// before it, and each one is written against the SAME shape the real corpus has, so a reader
+// can see which real-data condition it stands in for.
+
+// A frozen prefix is what compaction DECLINED to touch; a cache read is what the provider
+// actually served from cache. Neither bounds the other, and on 4.0% of the rows that recorded
+// a freeze (3,004 of 75,185 on real traffic) the frozen count is the larger. TierCosts prices
+// those tokens at the cache-READ rate and its own doc says they were "actually billed at" it,
+// which for the excess is false: it was billed fresh or written.
+func TestFrozenTokensArePricedOnlyUpToWhatTheRequestActuallyRead(t *testing.T) {
+	db := openTestDB(t)
+	// One row whose freeze is honest, one whose freeze exceeds its read. The second is the
+	// real corpus's 4%: the SUM over both must count 3000, not 11000.
+	honest := mkEvent(1000, "s-honest", "m", 100, 100)
+	honest.CacheRead, honest.FrozenTokens = 2000, 1000
+	over := mkEvent(2000, "s-over", "m", 100, 100)
+	over.CacheRead, over.FrozenTokens = 2000, 10000
+	if err := db.insertBatch([]*Event{honest, over}); err != nil {
+		t.Fatal(err)
+	}
+	tc, err := db.TierCosts(Filter{}, staticPricer{ibmSonnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tc == nil {
+		t.Fatal("TierCosts absent")
+	}
+	// min(1000,2000) + min(10000,2000) = 3000. The unclamped form reads 11000.
+	want := 3000 * ibmSonnet.CacheRead
+	if tc.FrozenReadUSD != want {
+		t.Errorf("FrozenReadUSD = $%.9f, want $%.9f (3000 clamped tokens, not 11000): "+
+			"tokens beyond a request's own cache_read were not read, so the cache-read rate "+
+			"is not the rate they were billed at", tc.FrozenReadUSD, want)
+	}
+	// The write-risk half is the same count times the spread, so it must inherit the clamp.
+	if spread := ibmSonnet.CacheWrite - ibmSonnet.CacheRead; tc.FrozenWriteRiskUSD != 3000*spread {
+		t.Errorf("FrozenWriteRiskUSD = $%.9f, want $%.9f — it multiplies the same count and "+
+			"must not re-import the unclamped one",
+			tc.FrozenWriteRiskUSD, 3000*spread)
+	}
+}

--- a/dash/moneybasis_test.go
+++ b/dash/moneybasis_test.go
@@ -2,6 +2,9 @@ package dash
 
 import (
 	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
 )
 
 // Four money figures on this dashboard were each computed over a population that was not the
@@ -147,5 +150,97 @@ func TestHistoricalSplitRefusesAModelWhoseStableHalfIsNotConstant(t *testing.T) 
 	if reqs != 1 || unc != 1 {
 		t.Errorf("per-tenant pass valued %d and refused %d, want 1 and 1 — it must agree with "+
 			"CachesplitHistoricalUSD, not drift from it", reqs, unc)
+	}
+}
+
+// KVCacheSuggest's headline total gated on cell.Valued, which is kvcache.Result's
+// `Unpriced < Requests` — ANY one priced request. A cell can therefore contribute a saving
+// measured on a fraction of itself while being labelled with the whole cell.
+func TestKVCacheSuggestTotalRefusesAPartiallyPricedCell(t *testing.T) {
+	start := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli() // Sunday 09:00
+	var evs []*Event
+	for i := int64(0); i < 6; i++ {
+		// One priced model, five on the model staticPricer has no rates for. Valued is true
+		// (one request priced); the coverage is 1 in 6.
+		model := "some/unmeasured-model"
+		if i == 0 {
+			model = "m"
+		}
+		evs = append(evs, kvEvent("mixed", "s1", model, start+i*600_000, 0, 100_000))
+	}
+	db := seedKV(t, evs...)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := findSuggestCell(out, "mixed", 9)
+	if c == nil {
+		t.Fatal("no cell for hour 9")
+	}
+	if c.UnpricedRequests != 5 {
+		t.Fatalf("cell reports %d unpriced of %d requests, want 5 — without this the reader "+
+			"cannot see the coverage at all", c.UnpricedRequests, c.Requests)
+	}
+	if !c.Valued {
+		t.Fatalf("fixture no longer reproduces the condition: Valued is false, so the cell " +
+			"would have been excluded by the old gate too")
+	}
+	if out.TotalSavingUSD != 0 || out.TotalSavingCells != 0 {
+		t.Errorf("total = $%.6f over %d cell(s); a cell with %d of %d requests unpriced "+
+			"describes only a sixth of itself and may not be summed into a service-wide "+
+			"headline", out.TotalSavingUSD, out.TotalSavingCells, c.UnpricedRequests, c.Requests)
+	}
+	if out.TotalSavingKnown {
+		t.Error("TotalSavingKnown is true with no qualifying cell — the figure must read n/a, " +
+			"never $0.00, which would claim that switching every cell to its winner saves nothing")
+	}
+	if out.TotalUnpricedRequests != 5 {
+		t.Errorf("TotalUnpricedRequests = %d, want 5", out.TotalUnpricedRequests)
+	}
+}
+
+// The same total still adds a cell that IS fully priced, so the gate above narrows the
+// population rather than emptying it.
+func TestKVCacheSuggestTotalStillCountsAFullyPricedCell(t *testing.T) {
+	start := time.Date(2023, 1, 1, 9, 0, 0, 0, time.UTC).UnixMilli()
+	var evs []*Event
+	for i := int64(0); i < 6; i++ {
+		evs = append(evs, kvEvent("priced", "s1", "m", start+i*600_000, 0, 100_000))
+	}
+	db := seedKV(t, evs...)
+	out, err := db.KVCacheSuggest(allTenants(), KVCacheOptions{}, staticPricer{ibmSonnet},
+		KVCacheSimConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := findSuggestCell(out, "priced", 9)
+	if c == nil {
+		t.Fatal("no cell for hour 9")
+	}
+	if c.UnpricedRequests != 0 || c.SavingUSD <= 0 {
+		t.Fatalf("fixture: unpriced=%d saving=$%.6f", c.UnpricedRequests, c.SavingUSD)
+	}
+	if !out.TotalSavingKnown || out.TotalSavingCells != 1 || out.TotalSavingUSD != c.SavingUSD {
+		t.Errorf("total = $%.6f known=%v cells=%d, want the cell's own $%.6f over 1 cell",
+			out.TotalSavingUSD, out.TotalSavingKnown, out.TotalSavingCells, c.SavingUSD)
+	}
+}
+
+// Compile-time anchor for the claim the two tests above rest on: kvcache.Result.Valued is a
+// floor ("any request priced"), never a coverage measure, so a caller that gates a total on it
+// alone is gating on the wrong thing. If this ever stops holding, the gate can be simplified.
+func TestResultValuedIsAFloorNotCoverage(t *testing.T) {
+	r := &kvcache.Result{Requests: 100, Unpriced: 99}
+	r.Valued = r.Requests > 0 && r.Unpriced < r.Requests // the expression at simulate.go:610
+	if !r.Valued {
+		t.Fatal("kvcache.Result.Valued no longer admits a 1-in-100 coverage cell; " +
+			"KVCacheSuggest's coverage gate can be reconsidered")
+	}
+	// And Savings.Known does not close the hole either: it is only "the percentage has a
+	// divisor", which one priced request is enough to give.
+	s := kvcache.Compare(&kvcache.Result{TotalUSD: 1}, &kvcache.Result{TotalUSD: 0.5})
+	if !s.Known {
+		t.Fatal("Savings.Known is no longer baseline-nonzero; recheck the gate")
 	}
 }

--- a/dash/moneybasis_test.go
+++ b/dash/moneybasis_test.go
@@ -87,3 +87,65 @@ func TestAttemptedRatioCountsSavingsOnlyWhereItCountsTheDenominator(t *testing.T
 		t.Errorf("AttemptedRequests = %d, want 1", o.AttemptedRequests)
 	}
 }
+
+// CachesplitHistoricalUSD retro-applies one model's stable half to the rows that never recorded
+// one. That is only legitimate while the stable half is CONSTANT for the model — the premise its
+// own header asserted and CachesplitSizeSpread disproves: 7 of 9 models on real traffic have a
+// spread, up to 5.5x. The two ends differ by 31x in what they credit, so a model with a spread
+// is refused into Uncovered rather than valued at either end.
+func TestHistoricalSplitRefusesAModelWhoseStableHalfIsNotConstant(t *testing.T) {
+	db := openTestDB(t)
+	// "spread" records two different stable halves; "flat" records one, twice.
+	lo := mkEvent(3000, "s-lo", "spread", 100, 100)
+	lo.SplitStableTokens = 1000
+	hi := mkEvent(4000, "s-hi", "spread", 100, 100)
+	hi.SplitStableTokens = 6000
+	f1 := mkEvent(3000, "s-f1", "flat", 100, 100)
+	f1.SplitStableTokens = 2000
+	f2 := mkEvent(4000, "s-f2", "flat", 100, 100)
+	f2.SplitStableTokens = 2000
+	// Two session-first, pre-instrumentation rows that BOTH pass the read/write gate at the
+	// smaller end of the spread — the only difference between them is the model.
+	preSpread := mkEvent(1000, "s-pre-spread", "spread", 100, 100)
+	preSpread.SplitStableTokens, preSpread.CacheRead, preSpread.CacheWrite = 0, 50000, 0
+	preFlat := mkEvent(1000, "s-pre-flat", "flat", 100, 100)
+	preFlat.SplitStableTokens, preFlat.CacheRead, preFlat.CacheWrite = 0, 50000, 0
+	if err := db.insertBatch([]*Event{lo, hi, f1, f2, preSpread, preFlat}); err != nil {
+		t.Fatal(err)
+	}
+	h, err := db.CachesplitHistoricalUSD(Filter{}, staticPricer{ibmSonnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the flat model is valued, priced at its single recorded stable half.
+	miss := ibmSonnet.CacheWrite
+	if miss < ibmSonnet.Input {
+		miss = ibmSonnet.Input
+	}
+	want := 2000 * (miss - ibmSonnet.CacheRead)
+	if h.Requests != 1 || h.Models != 1 {
+		t.Errorf("valued %d request(s) over %d model(s), want 1 and 1: the model whose "+
+			"recorded min (1000) and max (6000) disagree has no constant stable half to "+
+			"retro-apply", h.Requests, h.Models)
+	}
+	if h.USD != want {
+		t.Errorf("credit $%.9f, want $%.9f (the flat model's 2000 tokens only)", h.USD, want)
+	}
+	if h.Uncovered != 1 {
+		t.Errorf("Uncovered = %d, want 1 — a refused model must be REPORTED as unvaluable, "+
+			"not silently dropped; that is what this counter is for", h.Uncovered)
+	}
+	// Same refusal on the per-tenant pass, which is a second copy of the same arithmetic.
+	byTenant, err := db.CachesplitHistoricalUSDByTenant(0, staticPricer{ibmSonnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reqs, unc int64
+	for _, v := range byTenant {
+		reqs, unc = reqs+v.Requests, unc+v.Uncovered
+	}
+	if reqs != 1 || unc != 1 {
+		t.Errorf("per-tenant pass valued %d and refused %d, want 1 and 1 — it must agree with "+
+			"CachesplitHistoricalUSD, not drift from it", reqs, unc)
+	}
+}

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -99,6 +99,17 @@ type Overview struct {
 	AttemptedTokens int64 `json:"attempted_tokens"`
 	FrozenTokens    int64 `json:"frozen_tokens"`
 
+	// SavedGrossAttempted is SavedGross counted over ONLY the requests that recorded a nonzero
+	// attempted_tokens, and AttemptedRequests is how many those are. They exist because
+	// AttemptedTokens is not a total over the same population as SavedGross: it is an additive
+	// column, so every row written before it shipped reads 0, and cache-aware turns that were
+	// allowed to touch nothing read 0 legitimately. Summing a numerator over all rows and a
+	// denominator over that subset is the same basis mismatch the "attempted" denominator was
+	// already repaired for once (see denominators()) — repaired on the numerator's DEFINITION
+	// and not on its row population, which left the residual these two fields close.
+	SavedGrossAttempted int64 `json:"saved_gross_attempted"`
+	AttemptedRequests   int64 `json:"attempted_requests"`
+
 	FreshInput   int64 `json:"fresh_input"`
 	CacheRead    int64 `json:"cache_read"`
 	CacheWrite   int64 `json:"cache_write"`
@@ -467,6 +478,11 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 	err := d.sql.QueryRow(`SELECT COUNT(*), COUNT(DISTINCT r.session_id),
 		COALESCE(SUM(r.tokens_before),0), COALESCE(SUM(r.tokens_after),0), COALESCE(SUM(r.saved_unique),0),
 		COALESCE(SUM(r.attempted_tokens),0), COALESCE(SUM(r.frozen_tokens),0),
+		-- The gross saving over ONLY the rows that recorded an attempted_tokens denominator, so
+		-- the "gross, of what we tried to compact" ratio has one population on both sides. See
+		-- Overview.SavedGrossAttempted.
+		COALESCE(SUM(CASE WHEN r.attempted_tokens > 0 THEN r.tokens_before - r.tokens_after END),0),
+		COALESCE(SUM(CASE WHEN r.attempted_tokens > 0 THEN 1 ELSE 0 END),0),
 		COALESCE(SUM(r.fresh_input),0), COALESCE(SUM(r.cache_read),0), COALESCE(SUM(r.cache_write),0),
 		COALESCE(SUM(r.output_tokens),0),
 		COALESCE(SUM(r.cost_usd),0), COALESCE(SUM(r.baseline_cost_usd),0), COALESCE(SUM(r.cg_llm_cost_usd),0),
@@ -541,7 +557,8 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		COALESCE(SUM(r.cache_write_1h),0)
 		FROM requests r WHERE `+cond, args...).Scan(
 		&o.Requests, &o.Sessions, &o.TokensBefore, &o.TokensAfter, &o.SavedUnique,
-		&o.AttemptedTokens, &o.FrozenTokens, &o.FreshInput, &o.CacheRead, &o.CacheWrite,
+		&o.AttemptedTokens, &o.FrozenTokens, &o.SavedGrossAttempted, &o.AttemptedRequests,
+		&o.FreshInput, &o.CacheRead, &o.CacheWrite,
 		&o.OutputTokens, &o.CostUSD, &o.BaselineCostUSD, &o.CGLLMCostUSD, &o.CacheSavedUSD,
 		&o.CachesplitSavedUSD, &o.SplitRequests, &o.SplitTailMoved, &o.SplitCredited,
 		&o.SplitCreditedMoved,
@@ -909,20 +926,33 @@ func (o *Overview) denominators() []Denominator {
 		newInput = o.FreshInput + o.CacheWrite + o.SavedUnique
 	}
 	ds := []Denominator{
-		// GROSS over attempted, not unique over attempted. Both sides of this ratio are now
-		// per-turn quantities: attempted_tokens is what compaction was allowed to touch on
-		// each turn, re-counted every turn, so the numerator has to be the saving counted the
-		// same way. Dividing a numerator deduplicated ACROSS turns by a denominator recounted
-		// on every turn is a basis mismatch, and it made this ratio 13x too small (0.140%
-		// where the same-basis figure is 1.838% on production traffic) — the one bar on the
-		// page whose job is to answer "are we any good when we do have something to work
-		// with" was the one reading closest to zero. unique_whole below is still there for
-		// the conservative view.
-		denom("attempted", "gross, of what we tried to compact", o.SavedGross, o.AttemptedTokens,
+		// GROSS over attempted, not unique over attempted, and over ONE ROW POPULATION on both
+		// sides. Both sides of this ratio are per-turn quantities: attempted_tokens is what
+		// compaction was allowed to touch on each turn, re-counted every turn, so the numerator
+		// has to be the saving counted the same way. Dividing a numerator deduplicated ACROSS
+		// turns by a denominator recounted on every turn is a basis mismatch, and it made this
+		// ratio 13x too small (0.140% where the same-basis figure is 1.838% on production
+		// traffic) — the one bar on the page whose job is to answer "are we any good when we do
+		// have something to work with" was the one reading closest to zero.
+		//
+		// That repair fixed the numerator's DEFINITION and not the rows it was summed over, and
+		// the residual ran the other way. attempted_tokens is an additive column, so a row
+		// written before it shipped reads 0 while still carrying a saving, and 7,032 rows on
+		// production traffic do exactly that: they raise the numerator and cannot raise the
+		// denominator. Measured over all rows the ratio served 2.101%; over the 118,823 rows
+		// that actually recorded a denominator it is 1.824%, which is the figure the comment
+		// above independently names as the intended one. So the numerator is
+		// SavedGrossAttempted, not SavedGross.
+		//
+		// unique_whole below is still there for the conservative view.
+		denom("attempted", "gross, of what we tried to compact", o.SavedGrossAttempted, o.AttemptedTokens,
 			"GROSS savings ÷ the tokens compaction was ALLOWED to touch this turn (the "+
 				"uncached tail when cache-aware). Both sides are per-turn quantities — the "+
-				"denominator is re-counted every turn, so the numerator is too. Answers 'are "+
-				"we good when we have something to work with?' Excludes the frozen prefix we "+
+				"denominator is re-counted every turn, so the numerator is too — and both are "+
+				"summed over the SAME requests: only the ones that recorded a denominator at "+
+				"all, so a request whose attempted_tokens predates that column cannot "+
+				"contribute a saving to a ratio it has no divisor for. Answers 'are we good "+
+				"when we have something to work with?' Excludes the frozen prefix we "+
 				"deliberately never touched."),
 		denom("new_input", "of new provider-billed input", o.SavedUnique, newInput,
 			"Unique savings ÷ (fresh input + cache writes + what we removed). The most "+

--- a/dash/readvalue.go
+++ b/dash/readvalue.go
@@ -53,10 +53,18 @@ type TierCosts struct {
 	TotalUSD  float64 `json:"total_usd"`
 	StoredUSD float64 `json:"stored_usd"`
 	// FrozenReadUSD prices the tokens cache-aware compaction deliberately left alone at the
-	// cache-READ rate they were actually billed at. This is the benefit half of SafetyCost,
-	// which the panel has always promised ("its benefit is the cache reads it preserved") and
-	// never computed. FrozenWriteRiskUSD is what re-creating that same prefix instead would
-	// have ADDED — the spread between the write and read rates, i.e. what the freeze bought.
+	// cache-READ rate they were actually billed at — per row, min(frozen_tokens, cache_read).
+	// The clamp is load-bearing, not defensive: the frozen count is what compaction DECLINED to
+	// touch and cache_read is what the provider actually served from cache, and the first is not
+	// bounded by the second. On 4.0% of the rows that recorded a freeze (3,004 of 75,185) the
+	// frozen count EXCEEDS that request's cache_read, by 73.2M tokens in total; those tokens were
+	// billed fresh or written, so pricing them at the read rate prices a tier they were never
+	// charged at. Clamped rather than dropped, which is the conservative direction this file
+	// already errs in. This is the benefit half of SafetyCost, which the panel has always
+	// promised ("its benefit is the cache reads it preserved") and never computed.
+	// FrozenWriteRiskUSD is what re-creating that same prefix instead would have ADDED — the
+	// spread between the write and read rates, i.e. what the freeze bought. It is built from the
+	// same clamped count, so it inherits the clamp rather than the error.
 	FrozenReadUSD      float64 `json:"frozen_read_usd"`
 	FrozenWriteRiskUSD float64 `json:"frozen_write_risk_usd"`
 	// Requests is how many priced requests are behind these figures; Uncovered is how many
@@ -76,7 +84,8 @@ func (d *DB) TierCosts(f Filter, p modelinfo.Pricer) (*TierCosts, error) {
 	// smaller bill than the one that was billed.
 	rows, err := d.sql.Query(`SELECT r.model, COUNT(*),
 		COALESCE(SUM(r.fresh_input),0), COALESCE(SUM(r.cache_read),0), COALESCE(SUM(r.cache_write),0),
-		COALESCE(SUM(r.output_tokens),0), COALESCE(SUM(r.frozen_tokens),0), COALESCE(SUM(r.cost_usd),0)
+		COALESCE(SUM(r.output_tokens),0), COALESCE(SUM(MIN(r.frozen_tokens, r.cache_read)),0),
+		COALESCE(SUM(r.cost_usd),0)
 		FROM requests r WHERE `+cond+` AND r.token_accounting = 'complete' GROUP BY r.model`, args...)
 	if err != nil {
 		return nil, err

--- a/proxy/campaign.go
+++ b/proxy/campaign.go
@@ -190,6 +190,22 @@ func resolveCampaignCell(cell dash.KVCacheSuggestion, honorsHeadTTL1h func(tenan
 		out.skipReason = "too few requests in this cell to trust its recommendation as a pattern"
 		return out
 	}
+	// The same objection, on the other axis: too few PRICED requests. BestStrategy is an argmax
+	// over whichever of the cell's requests had rates, so a cell with unpriced traffic hands us
+	// a winner chosen on a subset of the pattern we are about to enforce. This is not about the
+	// dollars — an unpriced request contributes $0 to the baseline and $0 to every arm, so
+	// SavingUSD is understated, not inflated — it is about the ranking, which really does move:
+	// pricing one missing model reordered ranks 5 through 8 and flipped stop-reason-gated from
+	// -0.35% to +0.75%, and stop-reason-gated buys 249 pings.
+	//
+	// Baseline arms are exempt for exactly the reason InsufficientData exempts them: "change
+	// nothing" needs no evidence. Everything else here is a live ping or write-tier schedule.
+	if cell.UnpricedRequests > 0 && !a.baseline {
+		out.skipReason = fmt.Sprintf("%d of this cell's %d requests could not be priced, so its "+
+			"winning arm was chosen on a subset of its own traffic",
+			cell.UnpricedRequests, cell.Requests)
+		return out
+	}
 	out.activatable = true
 	out.config = a
 	return out

--- a/proxy/campaign_test.go
+++ b/proxy/campaign_test.go
@@ -102,6 +102,35 @@ func TestResolveCampaignCellGatesThe1hTierPerTenantModel(t *testing.T) {
 	}
 }
 
+// A cell whose winner was picked on a subset of its own traffic must not activate a live
+// schedule. BestStrategy is an argmax over the PRICED requests only, so unpriced traffic in the
+// cell means the arm about to be enforced won a comparison the rest of that cell never entered.
+// This gate is the one dash.KVCacheSuggestion.UnpricedRequests exists to make possible: before
+// that field, nothing on this path could see the condition at all.
+func TestResolveCampaignCellRefusesACellWhoseArmWasPickedOnPricedRowsOnly(t *testing.T) {
+	partial := dash.KVCacheSuggestion{User: "t1", HourUTC: 9, Requests: 36,
+		UnpricedRequests: 20, BestStrategy: kvcache.StrategyStopReasonGated}
+	got := resolveCampaignCell(partial, func(string) bool { return true })
+	if got.activatable || got.skipReason == "" {
+		t.Errorf("got %+v, want not activatable with a reason: 20 of 36 requests unpriced means "+
+			"stop-reason-gated (which buys pings) won on 16 of them", got)
+	}
+	// Fully priced, everything else equal: still activatable, so the gate narrows rather than
+	// closes the path.
+	full := partial
+	full.UnpricedRequests = 0
+	if got := resolveCampaignCell(full, func(string) bool { return true }); !got.activatable {
+		t.Errorf("got %+v, want activatable once every request in the cell is priced", got)
+	}
+	// Baseline arms are exempt for the same reason InsufficientData exempts them: enforcing
+	// "change nothing" needs no evidence about which arm won.
+	base := partial
+	base.BestStrategy = kvcache.StrategyFixed5m
+	if got := resolveCampaignCell(base, func(string) bool { return true }); !got.activatable {
+		t.Errorf("got %+v, want a baseline arm to stay activatable regardless of coverage", got)
+	}
+}
+
 func TestResolveCampaignCellBaselineArmIsActivatableWithNoConfig(t *testing.T) {
 	cell := dash.KVCacheSuggestion{User: "t1", HourUTC: 9, BestStrategy: kvcache.StrategyFixed5m}
 	got := resolveCampaignCell(cell, func(string) bool { return true })


### PR DESCRIPTION
> **One commit here changes behaviour, not just a displayed number.** `853b360` makes `proxy/campaign.go` **refuse to activate a live keep-alive ping schedule** for a cell whose winning arm was chosen on partially-priced traffic. It fails toward not acting, and it reverts cleanly on its own — see fix 5. Everything else in this PR only changes what a figure reads.

Four money figures on the dashboard were each computed over a population that was not the population they claimed to describe, plus one gate on the live ping-activation path that never checked whether the cell it was activating could be priced. Each is measured against a real corpus where one exists, and each ships with a test that fails without it.

## What a reader of the dashboard sees change

### 1. Frozen tokens are no longer priced at a rate they were not billed at — MEDIUM

`dash/readvalue.go` documents `FrozenReadUSD` as the frozen prefix priced *"at the cache-READ rate they were actually billed at"*. The frozen count is what compaction **declined to touch**; `cache_read` is what the provider **served from cache**. Neither bounds the other.

Real corpus, 133,064 requests: **3,004 of the 75,185 rows with `frozen_tokens > 0` — 4.0% — have `frozen_tokens` exceeding that same request's `cache_read`, by 73,162,809 tokens.** Those were billed fresh or written.

| | before | after |
|---|--:|--:|
| frozen tokens priced (`token_accounting = 'complete'`) | 2,535,303,824 | 2,462,141,015 |

**−2.886%** on `FrozenReadUSD` and on `FrozenWriteRiskUSD`, per model at that model's own rates. Clamped per row to `min(frozen_tokens, cache_read)` rather than dropping the rows, which is the conservative direction this file already errs in.

### 2. The "gross, of what we tried to compact" ratio is summed over one row population — MEDIUM

The numerator summed over every row, the denominator over the rows that recorded one. `attempted_tokens` is additive, so a row written before it shipped reads `0` while still carrying a saving.

Real corpus: **7,032 rows have a saving with `attempted_tokens = 0`** — they raise the numerator and cannot raise the denominator.

| | numerator | denominator | ratio |
|---|--:|--:|--:|
| served | 82,608,519 | 3,932,190,169 | **2.101%** |
| same-basis (118,823 of 133,064 rows) | 71,706,297 | 3,932,190,169 | **1.824%** |

This is the residual of a repair already made once. `dash/overview.go`'s own comment above the ratio records it being fixed from 13× too small and names the intended figure as *"1.838% on production traffic"* — which independently corroborates 1.824%. That repair fixed the numerator's **definition** and never its **row population**.

**Residual, deliberately not fixed here:** 21,321 rows (16.0%) still have `gross > attempted`, so the ratio is unbounded in principle. That is not an arithmetic problem — gross counts content saved per turn including what is re-sent, `attempted` is what compaction was allowed to touch on that turn, and clamping one to the other would discard real savings to make a ratio look tidy. The display case is **already handled on `main`**: `dash/ui/app.js:1753,1757` (from #155) renders a ratio over 100% as a multiplier rather than a percentage.

> **That guard was camouflaging this defect.** On the fixture below, the old arithmetic renders **"2.75×", not "275%"** — an honesty feature reformatted an impossible value into a plausible-looking one, and made the arithmetic bug *harder* to notice than if it had rendered raw. A guard that reformats an impossible value should also record that it fired. Named as a follow-up below rather than fixed here: it is a `dash/ui/` change and this PR deliberately touches no front-end file.

### 3. The historical cachesplit credit refuses models whose stable half is not constant — LOW (honesty)

`dash/cachehistory.go` retro-applies one model's recorded stable half to rows that predate the instrumentation. Its header asserted the premise that makes that legitimate: *"per model on this deployment the recorded minimum and maximum are the same number"*. The file also ships `CachesplitSizeSpread`, the query written so an operator would not have to take that on trust.

Run it and the premise is false. **7 of 9 models with a recorded stable half have min ≠ max, the widest spread 5.5× (1,301..7,190 tokens)**; 3 of 3 on the synthetic corpus. The code then took `MAX` while the doc said the ends coincide.

**The direction is safe, not inflationary.** `stable` gates as well as prices (`read >= stable > write`), so the larger end admits far fewer rows. Over the same 6,667 candidate requests on the real corpus:

| stable half | qualifying requests | tokens credited |
|---|--:|--:|
| `MAX` (shipped) | 11 | 49,626 |
| `MIN` | 280 | 1,565,566 |

`MAX` **under-credits ~31×**. This is an honesty defect, not an over-credit.

Refused rather than repicking an end: the doc's factual premise is disproved, so choosing either end swings a money figure 31× on an assumption just falsified; `Uncovered` already exists to report *"we cannot value this model's history"*; and `stable` serves two roles that want opposite ends, so no single constant is defensible while the spread is real. **Before/after: 11 valued requests → 2, with 6,664 candidates moving into `Uncovered`.** Applied at both sites, which are deliberate copies of the same arithmetic; the test pins that they agree. The header's false claim is corrected too — a doc comment asserting something measurably untrue is half the defect, and this one was cited as the estimate's justification.

### 4. The kv-cache headline total is gated on full pricing coverage — MEDIUM

`KVCacheSuggest` summed each cell's `SavingUSD` into a service-wide total gated on `cell.Valued`, which is `Requests > 0 && Unpriced < Requests` — **any one request priced, not all**. A cell with 99 of 100 requests unpriced is `Valued`.

**Not an inflation.** An unpriced request contributes $0 to the baseline **and** $0 to every arm, so a partially-priced cell **understates** its saving. What is damaged is the **choice of arm**: `BestStrategy` is an argmax over the priced subset, and that ranking moves. Pricing one missing model flips `keepalive-5m-once` from −0.07% to +1.07% and `stop-reason-gated` from −0.35% to +0.75%, reordering ranks 5–8. `stop-reason-gated` buys 249 pings. So the defect is a total claiming coverage it does not have, over cells whose winner was picked on a fraction of their own traffic. The gate makes the total a **floor over fully-covered cells** rather than a blend of two populations.

`cell.SavingKnown` was computed and gated nothing, so it is now in the gate — but **on its own it does not close this**, and a test says so. `Savings.Known` is `baseline.TotalUSD != 0`, i.e. "the percentage has a divisor", which one priced request is enough to give. A reviewed cell with **20 of its 36 requests unpriced reads `Valued: true` AND `SavingKnown: true`**. The gate that closes it is `UnpricedRequests == 0`.

Coverage was **absent from the payload**, not merely unrendered — before this PR `grep -n Unpriced dash/kvcachesuggest.go` returned zero hits, so no UI could disclose it however much it wanted to, while the sibling table on the same tab already carries that column (`dash/ui/kvcache.js:1136`). Added `KVCacheSuggestion.UnpricedRequests`, and `TotalSavingKnown` / `TotalSavingCells` / `TotalUnpricedRequests` on the payload.

> **No real-corpus figure for this fix, and that is unknown rather than zero.** How many requests are unpriced depends on the operator-supplied rate table, which lives with the live service and is not reachable from a development checkout. The before/after quoted in its commit — **$0.038000 over one cell → n/a over zero cells** — is on a **synthetic** 1-in-6-priced fixture. Reviewed-corpus exposure, measured separately: 5 of 19 cells contain unpriced rows carrying 16.1% of that headline.

### 5. A campaign cell whose arm won on priced rows only no longer activates a live schedule — HIGH

`proxy/campaign.go:resolveCampaignCell` is the path that activates **live ping schedules**, and it never consulted whether the cell's dollars could be priced: `grep -n 'Valued\|SavingKnown' proxy/campaign.go` returned zero hits. It gated on hour range, arm activatability, per-tenant 1h-tier honoring and `InsufficientData` — **strictly weaker than the `dash/kvcachesuggest.go` total fixed above**. The measured 20-of-36 cell passes every one of those gates and gets a real strategy created off it, and `:167` copies `predictedUSD` from the same cell with no coverage test at all.

**This is the only commit here with behavioural rather than display consequences, and it reverts cleanly on its own as `853b360`** (2 files, ~20 lines) if a reviewer prefers it split out.

The objection is `InsufficientData`'s, on the other axis: too few **priced** requests rather than too few requests. One guard in `resolveCampaignCell`, which is the single funnel — it decides activation *and* fills `predictedUSD`, so both the activation path and the `:867`/`:908` sums are covered by one predicate. Baseline arms exempt, for exactly the reason `InsufficientData` exempts them: enforcing "change nothing" needs no evidence about which arm won.

## Every fix verified to fail without itself

Each fix reverted in turn on the final tree, the rest left in place:

```
--- FAIL: TestFrozenTokensArePricedOnlyUpToWhatTheRequestActuallyRead
    moneybasis_test.go:41: FrozenReadUSD = $0.001672000, want $0.000456000 (3000 clamped
        tokens, not 11000): tokens beyond a request's own cache_read were not read, so the
        cache-read rate is not the rate they were billed at
    moneybasis_test.go:47: FrozenWriteRiskUSD = $0.019228000, want $0.005244000 — it
        multiplies the same count and must not re-import the unclamped one
--- FAIL: TestAttemptedRatioCountsSavingsOnlyWhereItCountsTheDenominator
    moneybasis_test.go:81: attempted ratio = 11000/4000 (275.000%), want 2000/4000
        (50.000%): the pre-instrumentation row's 9000-token saving has no denominator and
        may not inflate a ratio it cannot divide into
--- FAIL: TestHistoricalSplitRefusesAModelWhoseStableHalfIsNotConstant
    moneybasis_test.go:130: valued 2 request(s) over 2 model(s), want 1 and 1: the model
        whose recorded min (1000) and max (6000) disagree has no constant stable half
    moneybasis_test.go:135: credit $0.013984000, want $0.003496000 (the flat model only)
    moneybasis_test.go:138: Uncovered = 0, want 1 — a refused model must be REPORTED as
        unvaluable, not silently dropped; that is what this counter is for
    moneybasis_test.go:151: per-tenant pass valued 2 and refused 0, want 1 and 1 — it must
        agree with CachesplitHistoricalUSD, not drift from it
--- FAIL: TestKVCacheSuggestTotalRefusesAPartiallyPricedCell
    moneybasis_test.go:190: total = $0.038000 over 1 cell(s); a cell with 5 of 6 requests
        unpriced describes only a sixth of itself
    moneybasis_test.go:195: TotalSavingKnown is true with no qualifying cell — the figure
        must read n/a, never $0.00
--- FAIL: TestResolveCampaignCellRefusesACellWhoseArmWasPickedOnPricedRowsOnly
    campaign_test.go:115: got {... arm:stop-reason-gated activatable:true skipReason: ...},
        want not activatable with a reason: 20 of 36 requests unpriced means
        stop-reason-gated (which buys pings) won on 16 of them
```

`TestResultValuedIsAFloorNotCoverage` additionally pins *why* the coverage gate is not redundant, so a future reader does not simplify it back to `Valued` alone.

## Verification

```
$ CGO_ENABLED=1 go build ./... && go vet ./...      # both silent
$ CGO_ENABLED=1 go test -count=1 ./dash/ ./proxy/ ./components/... ./internal/...
ok  github.com/rossoctl/context-guru/dash                85.538s
ok  github.com/rossoctl/context-guru/proxy               48.459s
ok  github.com/rossoctl/context-guru/components           0.175s
ok  github.com/rossoctl/context-guru/components/all       0.348s
ok  github.com/rossoctl/context-guru/components/dsl       0.028s
ok  github.com/rossoctl/context-guru/components/offload   12.127s
ok  github.com/rossoctl/context-guru/components/reformat  13.447s
ok  github.com/rossoctl/context-guru/internal/cheapmodel   0.274s
ok  github.com/rossoctl/context-guru/internal/extract      0.344s
ok  github.com/rossoctl/context-guru/internal/logging      0.046s
ok  github.com/rossoctl/context-guru/internal/modelinfo    0.318s
ok  github.com/rossoctl/context-guru/internal/redact       0.027s
ok  github.com/rossoctl/context-guru/internal/skills       0.045s
ok  github.com/rossoctl/context-guru/internal/tokens       0.158s
```

## Follow-up work this PR does NOT do

- **`total_saving_known` is not read by any UI.** The payload now carries the coverage fields; nothing renders them, so the kv-cache total still displays as a number rather than `n/a`. The honesty fix is complete server-side and **unfinished end to end** — a front-end change is needed to close it.
- **The `percent > 100` render guard does not record that it fired** (`dash/ui/app.js:1753`). It silently reformats an impossible ratio into a multiplier, which is how this PR's fix 2 stayed unnoticed. It should surface that it triggered — a reformatted impossible value is a defect signal, not a display preference.
- **Nothing under `dash/ui/` is touched at all** in this PR.

## Note for branches landing beside this one

This PR **inserts two aggregate expressions** into `DB.Overview`'s main `SELECT` (`dash/overview.go:484-485`) and two matching targets into its `Scan(...)`. Two consequences for anyone rebasing onto it:

- The existing `keepalive_saved_usd` aggregates **moved from `:539-540` to `:555-556`.** No textual conflict — apply by content, not by line number.
- That `SELECT` list and its `Scan(...)` are **coupled by position.** Reshaping one without the other shifts every column silently, with no compile error and no test failure that names the cause.

## A re-pricing decision, not in this PR

`baselineDeltaUSD` prices the *unique* term at `p.CacheWrite` unconditionally while the replay term one line below correctly tests what the turn actually paid. On a turn that read cache and wrote none, the removed tail would have been billed **fresh**.

Branch: **`propose/unique-term-repricing-0901`** (one commit on top of this one). It asks for one decision: **re-pricing published savings figures downward by 0.710%** on the real corpus — the unique term moves −2.71%, and 86.4% of unique tokens sit on turns whose write did cover the prompt and do not move at all. The complete blast radius is on that branch so it can be seen at once: four copies of the formula, a fifth GROUP BY key on both read-path queries, and five test expectations updated. **That call belongs to the repo owner, not to this PR.**
