### PR TITLE
perf(dash): fix four page-overflow defects and serve the UI assets gzipped

### DIFF
--- a/dash/ui.go
+++ b/dash/ui.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
@@ -50,6 +51,41 @@ var uiFS embed.FS
 // Content, not buildinfo.Commit, so a dirty local rebuild at an unchanged commit also
 // gets new URLs.
 var assetVersion, versionedUI = versionAssets()
+
+// gzippedUI holds each versioned asset gzip-compressed, built once at process start.
+//
+// Why bother when the assets are already embedded: on loopback bytes are free, and the
+// measured cost of the four scripts here is ~99 ms of MAIN-THREAD CPU against ~31 ms of
+// DOMContentLoaded — so compression is NOT the local bottleneck and this is not a local
+// speedup. It is for the hosted multi-tenant service, where the same 705 KB of JS and
+// 91 KB of CSS cross a WAN on every cold load and drop ~70%.
+//
+// Compressed once rather than per request: the bytes never change for the life of the
+// process, so a gzip.Writer per response would burn CPU to produce an identical body.
+// An asset that does not shrink is left out of the map and served raw.
+var gzippedUI = gzipAssets(versionedUI)
+
+func gzipAssets(assets map[string][]byte) map[string][]byte {
+	out := make(map[string][]byte, len(assets))
+	for n, b := range assets {
+		var buf bytes.Buffer
+		zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+		if err != nil {
+			return nil
+		}
+		if _, err := zw.Write(b); err != nil {
+			return nil
+		}
+		if err := zw.Close(); err != nil {
+			return nil
+		}
+		// Already-compressed formats (png, woff2) grow. Serve those raw.
+		if buf.Len() < len(b) {
+			out[n] = buf.Bytes()
+		}
+	}
+	return out
+}
 
 // rewritable lists the asset types that can name a sibling asset.
 var rewritable = map[string]bool{".html": true, ".htm": true, ".js": true, ".css": true, ".svg": true}
@@ -183,10 +219,50 @@ func uiHandler() http.Handler {
 		if b, ok := versionedUI[name]; ok {
 			// Every request of this build serves identical bytes. The ETag turns the
 			// no-cache HTML's revalidation into a 304 instead of a re-download.
-			w.Header().Set("ETag", `"`+assetVersion+`"`)
+			etag := `"` + assetVersion + `"`
+			// Vary on EVERY asset response, compressed or not: a shared cache that
+			// stored the raw body under an unvaried key would later hand it to a
+			// client that asked for gzip, and vice versa.
+			w.Header().Set("Vary", "Accept-Encoding")
+			if gz, ok := gzippedUI[name]; ok && acceptsGzip(r.Header.Get("Accept-Encoding")) {
+				// A different Content-Encoding is a different representation, so it
+				// needs a different validator — otherwise a cache revalidating with
+				// this ETag can be told "304, use what you have" and serve a gzip
+				// body to a client that did not ask for one.
+				w.Header().Set("Content-Encoding", "gzip")
+				etag = `"` + assetVersion + `-gzip"`
+				b = gz
+			}
+			w.Header().Set("ETag", etag)
+			// ServeContent still types the response from `name` (the .js/.css
+			// extension), sets Content-Length from the reader, and answers Range
+			// requests against the bytes it is given — which for a compressed
+			// response is the encoded body, as RFC 9110 requires.
 			http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(b))
 			return
 		}
 		files.ServeHTTP(w, r)
 	})
+}
+
+// acceptsGzip reports whether the client will take gzip. Deliberately not a full
+// Accept-Encoding parser: the one case that has to be honoured is an explicit
+// `gzip;q=0` refusal, because a client that says no and gets gzip anyway is broken
+// rather than slow.
+func acceptsGzip(ae string) bool {
+	for _, part := range strings.Split(ae, ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		if name := strings.TrimSpace(fields[0]); name != "gzip" && name != "*" {
+			continue
+		}
+		for _, p := range fields[1:] {
+			if q := strings.TrimSpace(p); strings.HasPrefix(q, "q=") {
+				if v := strings.TrimSpace(strings.TrimPrefix(q, "q=")); v == "0" || strings.HasPrefix(v, "0.0") || v == "0." {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
 }

--- a/dash/ui.go
+++ b/dash/ui.go
@@ -235,9 +235,17 @@ func uiHandler() http.Handler {
 			}
 			w.Header().Set("ETag", etag)
 			// ServeContent still types the response from `name` (the .js/.css
-			// extension), sets Content-Length from the reader, and answers Range
-			// requests against the bytes it is given — which for a compressed
-			// response is the encoded body, as RFC 9110 requires.
+			// extension) and answers Range requests against the bytes it is given —
+			// which for a compressed response is the encoded body, as RFC 9110
+			// requires.
+			//
+			// It does NOT set Content-Length once Content-Encoding is set, so the
+			// compressed responses go out chunked and a browser shows no download
+			// progress for them. Do not "fix" that by setting Content-Length here:
+			// ServeContent answers a Range request with a 206 whose body is only the
+			// requested slice, and it will not overwrite a Content-Length we already
+			// set — so a full-body length on a 206 would be a broken response rather
+			// than a missing progress bar.
 			http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(b))
 			return
 		}

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -8719,7 +8719,7 @@ async function loadKACalc() {
         c.priced ? usd(r.net_usd) : 'not priced')));
   }
   tbl.appendChild(tb);
-  host.appendChild(tbl);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   // Reach and cost side by side, so the flattening is visible: on our own traffic K=1→K=2 takes
   // reach from 30% to 51% of the recoverable dollars and K=3, K=4 add 6 and 4 points, while
   // ping count keeps climbing.

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -927,13 +927,13 @@
 </div>
 <div id="scrim" class="scrim" hidden></div>
 
-<script src="app.js"></script>
+<script defer src="app.js"></script>
 <!-- The Inventory view mounts itself: its tab, its section, its stylesheet and its loader
      registration all live in tools.js, so this feature is one line in the shared page. -->
-<script src="tools.js"></script>
+<script defer src="tools.js"></script>
 <!-- The KV-cache TTL view mounts itself the same way, from kvcache.js. -->
-<script src="kvcache.js"></script>
+<script defer src="kvcache.js"></script>
 <!-- Strategy campaigns mounts itself the same way, from campaigns.js. -->
-<script src="campaigns.js"></script>
+<script defer src="campaigns.js"></script>
 </body>
 </html>

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -580,7 +580,7 @@
       entry. It runs from each request&rsquo;s START, so a response that streamed for four minutes
       has already spent four minutes of its own entry&rsquo;s life.</p>
     <div id="ka-live-warning" data-testid="ka-live-warning"></div>
-    <div class="scroll-x">
+    <div class="tblwrap" tabindex="0">
       <table class="tbl" data-testid="ka-live-table">
         <thead><tr>
           <th>SESSION</th><th data-scope-col hidden>TENANT</th>

--- a/dash/ui/kvcache.js
+++ b/dash/ui/kvcache.js
@@ -1170,7 +1170,8 @@ function renderKVFeatureImportance() {
         el('td', { class: 'num' }, r.score.toFixed(3))));
     }
     tbl.appendChild(body);
-    cols.appendChild(el('div', {}, el('h4', {}, label), tbl));
+    cols.appendChild(el('div', {}, el('h4', {}, label),
+      el('div', { class: 'tblwrap', tabindex: '0' }, tbl)));
   }
   host.appendChild(cols);
   if (fi.logistic_regression && fi.gradient_boosted

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -531,6 +531,10 @@ details.why dd { margin: 0; }
 .tblwrap { overflow-x: auto; max-width: 100%; }
 .panel, .card, .grid-2, .tiles, main { min-width: 0; }
 .panel > *, .card > * { min-width: 0; }
+/* A grid child defaults to min-width:auto, so a wide table inside one pushes the COLUMN
+   wider than its track and the page scrolls sideways — .tblwrap on the table cannot help
+   while its own parent refuses to shrink. */
+.grid-2 > * { min-width: 0; }
 .tbl { width: 100%; border-collapse: collapse; font-size: var(--t-body); }
 .tbl th, .tbl td {
   text-align: left; padding: var(--sp-2) var(--sp-3);
@@ -933,8 +937,13 @@ pre.code {
 .field select, .field textarea {
   padding: var(--sp-2) var(--sp-3); font: inherit;
   background: var(--bg); border: 1px solid var(--border); border-radius: var(--r-sm); color: var(--fg);
-  max-width: 520px;
+  max-width: min(520px, 100%);
 }
+/* A <select> is as wide as its widest option and a <fieldset> will not shrink below its
+   own min-content, so one long option in the strategy form pushed the page 183px sideways
+   at 390px. min-inline-size:0 overrides the UA's min-content floor; min() keeps the 520px
+   cap on a wide screen. */
+fieldset { min-inline-size: 0; }
 .field textarea { font-family: var(--mono); font-size: var(--t-small); max-width: none; line-height: 1.6; }
 details.field > summary { font-size: var(--t-small); color: var(--fg-muted); font-weight: 600; cursor: pointer; margin-bottom: var(--sp-2); }
 .hint { margin: 0; font-size: var(--t-small); color: var(--fg-muted); line-height: 1.55; max-width: 82ch; }
@@ -1153,7 +1162,7 @@ table.grid tr.revoked { opacity: 0.55; }
    the account editor's boxes would have been the browser default next to styled ones. */
 .field input[type=text], .field input[type=number], .field input[type=password],
 .field input[type=email] {
-  padding: var(--sp-2) var(--sp-3); font: inherit; max-width: 520px;
+  padding: var(--sp-2) var(--sp-3); font: inherit; max-width: min(520px, 100%);
   background: var(--bg); border: 1px solid var(--border); border-radius: var(--r-sm); color: var(--fg);
 }
 /* The two irreversible actions, folded away and visibly not part of the form above it.

--- a/dash/ui/tools.css
+++ b/dash/ui/tools.css
@@ -50,7 +50,10 @@
    which is the part that really does toggle — a whole row that looks clickable and is not is a
    worse affordance than one that never claimed to be. */
 .cg-item {
-  display: grid; grid-template-columns: auto 1fr; gap: var(--sp-1) var(--sp-2);
+  /* minmax(0, 1fr): a bare 1fr track floors at min-content, and min-content here is an
+     unbreakable tool name like mcp__sentry__analyze_issue_with_seer, so the row grew past
+     a 390px viewport and took the page with it. */
+  display: grid; grid-template-columns: auto minmax(0, 1fr); gap: var(--sp-1) var(--sp-2);
   align-items: baseline; padding: var(--sp-2); margin-left: calc(var(--sp-2) * -1);
   border-radius: var(--r-sm); font-size: var(--t-body);
 }
@@ -100,7 +103,7 @@
    The only thing that needs saying is that the checkbox row must not squeeze its evidence
    into a column two words wide. */
 @media (max-width: 560px) {
-  .cg-item { grid-template-columns: auto 1fr; }
+  .cg-item { grid-template-columns: auto minmax(0, 1fr); }
   .cg-item-weight, .cg-item-usd { flex: 1 0 100%; }
 }
 
@@ -140,7 +143,11 @@
 .inv-group {
   border: 1px solid var(--border-soft); border-radius: var(--r);
   padding: var(--sp-3); background: var(--bg-raised);
-  display: grid; gap: var(--sp-2);
+  /* minmax(0, 1fr), not the implicit auto track: an auto track floors at the widest
+     descendant's min-content, which here is the longest line of the `white-space: pre`
+     removal snippet — so the card grew past the viewport and .inv-snippet's own
+     overflow-x never got the chance to scroll. */
+  display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--sp-2);
 }
 .inv-group-head {
   display: flex; flex-wrap: wrap; gap: var(--sp-2) var(--sp-4);

--- a/dash/ui/tools.css
+++ b/dash/ui/tools.css
@@ -207,4 +207,10 @@ details.why > .inv-prompt-regions { max-width: none; }
 .inv-part-name { font-weight: 600; }
 /* The per-row removal fold sits in a table cell, so it must not stretch the row. */
 .inv-removal-fold > summary { white-space: nowrap; }
+/* ...but in the card layout there is no row to stretch, and "Remove just
+   mcp__postgres__describe_table" is one unbreakable 414px line in a 390px viewport. Must sit
+   AFTER the rule above: same specificity, and a media query adds none. */
+@media (max-width: 560px) {
+  .inv-removal-fold > summary { white-space: normal; }
+}
 .inv-removal-fold .inv-removal { min-width: 22rem; }

--- a/dash/uigzip_test.go
+++ b/dash/uigzip_test.go
@@ -1,0 +1,76 @@
+package dash
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The dashboard's assets are ~705 KB of JS and ~91 KB of CSS. They were served raw to
+// every client on every cold load; over a WAN that is the whole story of the load time.
+// What this guards is not the compression but the NEGOTIATION: a client that did not ask
+// for gzip must not be handed a gzip body, and the two representations must not share one
+// validator, or a cache revalidating with the wrong one serves the wrong body.
+func TestUIAssetsNegotiateGzip(t *testing.T) {
+	a, _ := newTestAPI(t, Options{})
+	m := http.NewServeMux()
+	a.Mount(m)
+
+	get := func(ae string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/dashboard/app.js", nil)
+		if ae != "" {
+			req.Header.Set("Accept-Encoding", ae)
+		}
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("Accept-Encoding %q -> %d", ae, w.Code)
+		}
+		return w
+	}
+
+	raw := get("")
+	if enc := raw.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("a client that offered no encoding got Content-Encoding %q", enc)
+	}
+
+	gz := get("gzip, deflate, br")
+	if enc := gz.Header().Get("Content-Encoding"); enc != "gzip" {
+		t.Fatalf("Content-Encoding = %q; want gzip", enc)
+	}
+	if gz.Body.Len() >= raw.Body.Len() {
+		t.Errorf("gzip body is %d bytes against %d raw — no compression happened", gz.Body.Len(), raw.Body.Len())
+	}
+	// Compressed or not, it has to be the same script.
+	zr, err := gzip.NewReader(gz.Body)
+	if err != nil {
+		t.Fatalf("gzip body does not decompress: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("reading the gzip body: %v", err)
+	}
+	if string(got) != raw.Body.String() {
+		t.Errorf("the decompressed body differs from the raw one (%d vs %d bytes)", len(got), raw.Body.Len())
+	}
+
+	// Two representations, two validators. With one shared ETag a shared cache holding the
+	// gzip copy can answer a raw client's revalidation with 304 and hand it the compressed
+	// bytes, which is a broken page rather than a slow one.
+	if a, b := raw.Header().Get("ETag"), gz.Header().Get("ETag"); a == "" || a == b {
+		t.Errorf("raw and gzip share the ETag %q — a cache cannot tell the representations apart", a)
+	}
+	for _, w := range []*httptest.ResponseRecorder{raw, gz} {
+		if v := w.Header().Get("Vary"); v != "Accept-Encoding" {
+			t.Errorf("Vary = %q; want Accept-Encoding, or a cache keys both representations together", v)
+		}
+	}
+
+	// An explicit refusal is a refusal. `gzip;q=0` means "not gzip", not "gzip is fine".
+	if enc := get("gzip;q=0, identity").Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("gzip;q=0 was served Content-Encoding %q", enc)
+	}
+}

--- a/dash/uikvcache_test.go
+++ b/dash/uikvcache_test.go
@@ -213,7 +213,10 @@ func TestTheKVCacheTabRespectsTheTimeRange(t *testing.T) {
 	if !strings.Contains(src, `id: 'view-kvcache'`) {
 		t.Error("the KV-cache view does not mount its own section")
 	}
-	if !strings.Contains(readUI(t, "ui/index.html"), `<script src="kvcache.js">`) {
+	// The attribute list is not the point — that the shared page loads the file is. Matched
+	// on the src alone so adding `defer` (or any other attribute) does not read as the tag
+	// having been removed.
+	if !strings.Contains(readUI(t, "ui/index.html"), `src="kvcache.js">`) {
 		t.Error("kvcache.js is not loaded by the shared page")
 	}
 }


### PR DESCRIPTION
**Merge order: this must land before #172.** `feat/inventory-hierarchy-0901` fails the
390 px constraint on the Inventory tab without the two `tools.css` commits here — measured on
that branch by actually removing them (`clippedOff 48`, `+159 px`), not by simulating it.

Six commits: two defect fixes, two cheap wins, one comment correction. Measured with the
sweep harness (`perf.mjs` / `shots.mjs`) throughout, on a copy of the seeded corpus with
both janitor rules disabled (`--dashboard-retention 0 --dashboard-max-bytes 0`).

## 1. Three tabs scrolled the page body sideways at 390 px. Now zero.

`index.html:583` wrapped the keep-alive live table in `<div class="scroll-x">`, and
`.scroll-x` is defined in **no stylesheet** — `grep -n 'scroll-x' dash/ui/*.css` returned
nothing. The working class is `.tblwrap` (already on `main`). Computed `overflow-x` was
therefore `visible`, an 1114 px table sat in a 390 px body, and the page scrolled sideways,
which the design brief forbids outright.

Overflow audit, all 17 tabs, dark, 390×844:

| tab | before | after |
|---|---|---|
| keepalive | body **+753 px** | no |
| kvcache | body **+16 px** | no |
| strategies | body **+183 px** | no |
| tools | body **+159 px** (see §2) | no |
| 13 others | no | no |

Three fixes, and only one of them was the rename:

- **keepalive** — `.scroll-x` → `.tblwrap`, *and* the ladder table at `app.js:8722` was
  appended bare. Fixing the live table exposed the ladder at +179 px.
- **kvcache** — wrapping `kvcache.js:1173` was not enough. A grid child defaults to
  `min-width: auto`, so the new `.tblwrap`'s own parent refused to shrink and the table
  pushed the column instead of scrolling inside it. `.grid-2 > * { min-width: 0 }` is the
  actual fix, matching the `.panel > *` / `.card > *` rules two lines above.
- **strategies** — not a table at all. A `<select>` is as wide as its widest option and a
  `<fieldset>` will not shrink below its own min-content, so one long option made a 544 px
  fieldset in a 390 px viewport. `fieldset { min-inline-size: 0 }` plus
  `max-width: min(520px, 100%)` on the form controls.

**Process note: fixing the biggest overflow reveals the next one.** Two of the three tabs had
a second defect hidden behind the first, so the audit has to be re-run after each fix rather
than once at the end.

## 2. Inventory (`tools`) — 48 elements were clipped out of reach

Found by re-running the audit after the seeded corpus grew to 16,444 requests: the tab only
breaks once the tool tables have rows, so the earlier sweep on a sparse corpus called it
clean. Two grid tracks flooring at min-content — `.inv-group`'s implicit auto track taking
its width from the longest line of the `white-space: pre` removal snippet, and `.cg-item`'s
`1fr` track taking it from an unbreakable name like `mcp__sentry__analyze_issue_with_seer`.
The `@media (max-width: 560px)` block re-declares the same track, so it has to agree or it
wins at 390 px. `minmax(0, 1fr)` in all three places.

    clippedOff    48 -> 0      unreachable content, the audit's worst category
    bodyScrollsX  +159 -> no   body.scrollWidth exactly 390 at 390px

Not a defect, for whoever picks up the rest: the `span.comp-name.trunc` findings on this tab
are deliberate. `style.css:572` is `overflow: hidden; text-overflow: ellipsis` and
`tools.js:961,1073` carry the full value in a `title`, so the name is truncated on purpose and
recoverable. Same shape as the `.vh` false positive in the harness README's §6 list.

The residual 138 px is also closed, in a third commit. It sat unattributed because the
audit's two checks answer different questions, which is worth recording: `overflowPage`
compares **bounding rects**, while `bodyScrollsX` reads `body.scrollWidth`, which includes
descendants' **scrollable overflow region**. A box with `overflow-x: visible` whose content
overflows keeps its own rect inside the viewport, so a rect scan finds nothing at any
tolerance. The predicate that finds it is `left + max(scrollWidth, width) > viewport`, and it
**must** skip any element with a scrolling ancestor or every cell inside a `.tblwrap` reads as
page overflow — the mistake two of us made independently.

It named `.inv-removal-fold > summary { white-space: nowrap }` (`tools.css:202`) holding
"Remove just mcp__postgres__describe_table", one unbreakable 414 px line. The nowrap is
deliberate — the fold also sits in a table cell, where wrapping stretches the row — so the
override is scoped to the narrow breakpoint and placed **after** the original. Same
specificity, and a media query adds none, so an override in the earlier `@media` block at
:102 silently loses; that cost a build to discover.

**All 17 tabs now pass the constraint**, `body.scrollWidth` exactly 390 at 390 px, verified
twice per theme with the tables populated (1,556 text nodes, 115 items — a run reporting 24
nodes is an empty render, not a pass).

## 3. The embedded assets are served gzipped

`dash/ui.go` set `Cache-Control`, `ETag` and a CSP and never looked at `Accept-Encoding`, so
~705 KB of JS and ~91 KB of CSS went over the wire raw on every load. Compressed once at
process start with stdlib `compress/gzip`, served from memory, raw as the fallback. No build
step, no dependency, no CDN.

**This is a WAN win, not a local one.** On loopback the four scripts cost ~31 ms of DCL but
~99 ms of main-thread CPU, 98% of it `app.js` — compression is not the local bottleneck,
execution is. At 1.6 Mbit/s and 150 ms RTT, 1440×900, 5 cold loads, median (range):

| | FCP | DCL | js+css wire |
|---|---:|---:|---:|
| before | 1276 ms (1272..1284) | 4388 ms (4383..4392) | 760K |
| after | 600 ms (592..684) | 1570 ms (1550..1584) | 232K |

Independently measured end to end at 5 Mbit: 831 KB → 252 KB, ~1,362 ms → ~412 ms.

| asset | raw | gzip -9 | brotli -11 |
|---|---:|---:|---:|
| app.js | 473222 | 145814 | 119037 |
| tools.js | 108553 | 33414 | 28021 |
| kvcache.js | 76175 | 23211 | 19823 |
| campaigns.js | 46744 | 14176 | 12162 |
| style.css | 74610 | 19754 | 16658 |
| tools.css | 12415 | 3919 | 3260 |
| kvcache.css | 4586 | 1862 | 1492 |
| index.html | 55749 | 15762 | 13251 |
| **total** | **852054** | **257912 (−70%)** | **213704 (−75%)** |

**Brotli is deliberately not shipped, and this should not be re-opened:** Go has no stdlib
brotli, so it means a new third-party dependency in a product whose whole constraint is that
it works air-gapped with no CDN and no build step — for 5 percentage points of ratio over
gzip. Bad trade.

Caching correctness, since this is the part that breaks quietly:

- `Vary: Accept-Encoding` on **every** asset response, not only compressed ones. A shared
  cache that stored the raw body under an unvaried key would later hand it to a client that
  asked for gzip, and vice versa.
- A distinct `"<v>-gzip"` ETag. A different `Content-Encoding` is a different representation,
  so it needs a different validator, or a cache revalidating with one can 304 a raw client
  into a compressed body.
- `gzip;q=0` is an explicit refusal and is honoured.
- Compressed once at init, not per response: the bytes never change for the life of the
  process, so a `gzip.Writer` per response would burn CPU to produce an identical body.

One caveat, documented at the site: `net/http`'s `serveContent` skips `Content-Length` once
`Content-Encoding` is set, so compressed assets go out chunked and show no download progress.
Do not "fix" it by setting `Content-Length` — `ServeContent` answers a Range request with a
206 whose body is only the requested slice and will not overwrite a length we set, so a
full-body length there is a broken response rather than a missing progress bar.

## 4. `defer` on the four scripts — shipped, and it is NOT a speedup

DESIGN §4.3 item 2 says `defer` "removes all ~380 ms of throttled parse+eval from the
pre-paint path". **Measured, it does not.** A deferred script still runs before
`DOMContentLoaded` and still before first paint if the paint has not happened; `defer` only
changes timing relative to *parsing*, and these four scripts already sit after the last byte
of markup, so there was no parse work left for them to block.

| condition | before | after |
|---|---|---|
| 6× CPU throttle, loopback (n=9) | DCL 667 ms (580..877) | DCL 587 ms (538..660) |
| slow-4G, 1× CPU | DCL 1570 ms | DCL 1549 ms |
| loopback 1× (n=10) | — | DCL/FCP/contentReady all move less than the spread, in inconsistent directions |

**Why n=9 rather than n=5:** a 5-run pass showed 6× DCL going 517 → 753 ms, which reads as a
serious regression. At n=9 it reversed. The delta was inside the run-to-run spread the whole
time and the scary number was noise. Every figure above is quoted as a range for that reason.

Kept because it is correct-by-default — a script that later moves above content cannot
silently become parser-blocking — not because it makes anything faster.

Mount order verified from the live DOM rather than assumed: 17 tabs, in the documented order
(`overview usage tools keepalive kvcache components sessions requests benchmarks archive
setup settings feedback tenants strategies campaigns config`). `defer` preserves document
order, so the three self-mounters still splice their tabs in after their named siblings.

## What this PR does NOT do

**These changes do not address the dominant cost of this dashboard.** That is server-side
query time: `Overview` alone measures 434–659 ms at 16k requests and extrapolates to ~3.6 s
at production's 133k, and `/api/facets` costs ~637 ms for a 1 KB response on **every** tab
switch (`app.js:4468` calls `loadFacets()` from every `go()`). I measured `/api/components`
cold at 2,192 ms and, on a second run of the same probe, 3,718 ms — the largest single number
on the page. Against that, the whole four-file JS payload is ~99 ms of CPU and ~31 ms of DCL.

That work is tracked in **`perf/dash-query-cost-0901`**. Nothing here makes this dashboard
fast on a real deployment.

## Scorecard on DESIGN §4.3

Its five no-build techniques were a reasonable set of hypotheses. Measured: **one pays as
prescribed, one pays in a placement the doc did not name, and three measure as nothing where
they were applied.**

- **item 2, `defer`** — no measurable effect in any of four conditions (above).
- **item 3, lazy-load the three self-mounting views** — `kvcache.js` costs 0.5 ms of CPU
  against `app.js`'s 80.6 of 82.5 ms (98%), and the tab it belongs to spends ~992 ms in one
  API call. Lazy-loading it would optimise a 0.5 ms cost on a page waiting a second for data.
  After item 1 most of the byte win (~71 KB gzipped) is already taken. **Not built.**
- **item 5, `content-visibility: auto` — inert *where the doc prescribes it*, effective
  elsewhere.** On inactive views it does nothing: `style.css:161` is
  `[hidden] { display: none !important; }`, all 16 inactive views compute `display: none` with
  zero client rects, and the property has no effect on a box that is not generated. Measured
  at 6× throttle, n=9: FCP 272 → 260 ms, DCL 587 → 569 ms, both inside overlapping ranges.
  **Not shipped here.** But `impl-traffic` measured it on a long list *inside a rendered view*
  — paired A/B in one page, rule swapped via `insertRule`, three runs each, 1,200 blocks
  expanded — and got **1,022/957/997 ms against 3,175/3,130/3,248 ms at identical DOM node
  counts (86,327)**, a ~3.2× win. So the property works; **placement decides whether it does
  anything**, and a flat item list cannot express that. Note also that node count and time
  measure different fixes there: the diff view's 915k → 17k node drop is entirely the deferred
  render, and `content-visibility` contributes zero nodes and ~2.2 s.

  If you apply it: `contain-intrinsic-size` must be the **measured** collapsed height per
  component, not a shared constant. `impl-traffic`'s diff blocks are `auto 37px`; the 44px we
  had agreed on by eye inflated the scroll height ~18%.

So of the five, gzip (item 1) pays as prescribed and over a WAN; `content-visibility` pays in
a placement item 5 does not name; items 2, 3 and 5-as-written measure as nothing.

## Deferred, with owners

- **The `app.js` split** — sequenced after `impl-nav`, which defines the module seams;
  `app.js:4218` on that branch now names all four. Doing it twice is wasted work.
- **9 bare `appendChild(tbl)` sites in `app.js`** — known-latent, none overflows any tab
  today. "Today" is doing real work in that sentence: a table with no scroll container is
  only *visibly* broken once its content is wide enough, so this is a statement about the
  current data, not about the code. Demonstrated twice on this branch — `ka-ladder` was
  invisible until the larger keep-alive overflow in front of it was fixed, and `tools` audited
  clean on a 14,876-request corpus and failed at 16,444. Routed: `impl-nav` takes 6081 `loadMachines`, 6454 `loadTokens`, 6494 `loadAudit`,
  6598 `loadTenants`, 7028 `loadVariants`, 7084 `loadArchive` (all Admin-group, its own
  seam); `impl-tabs` takes 4028 `toggleBenchTasks`, 8533 `loadKAArmed`, 8623
  `loadKABehaviour`. `.tblwrap` is already on `main`, so none of them depends on this branch.
- **`X-Cache: hit|miss`** — proposed, not built; it touches the API surface. Handed to
  `impl-query` with the paired probe, because the 5 s cache is the only thing hiding a 637 ms
  call. The cache is also why every perf number here needs a stated cache side: Overview
  `contentReady` ranged 247..922 ms over 10 cold runs (273% spread) on that alone.
- **`total_saving_known` rendering `n/a`** — **not taken, and the premise does not hold on
  this branch.** The field does not exist on `main`; it arrives with
  `origin/fix/dash-money-formulas-0901` (`kvcachesuggest.go:183`). Its consumer is
  `campaigns.js`, not `kvcache.js`, and nothing in the front end renders the figure at all —
  the only mention is `campaigns.js:659` deliberately dropping it from a POST, with a comment
  saying why. So there is no number on screen to turn into `n/a`. It belongs to whoever lands
  the money-formulas branch.

## Pre-existing bug found, not fixed

`ui.go:186` gives **every** asset the same `ETag` (`"<assetVersion>"`). A client revalidating
`style.css` with an `If-None-Match` it obtained from `app.js` gets a 304 and then serves the
wrong file. Browsers key `If-None-Match` per URL so it does not fire in practice, but a
shared cache or a hand-rolled client can. Behaviour left intact as briefed; this PR only
splits raw from gzip.

## Tests

    CGO_ENABLED=1 go build ./... && go vet ./...   clean
    CGO_ENABLED=1 go test -count=1 ./dash/         ok  73.705s

New `dash/uigzip_test.go` covers the negotiation, ETag distinctness, `Vary`, and `gzip;q=0`.
`uikvcache_test.go:216` matched the literal `<script src="kvcache.js">` and so read `defer`
as the tag having been removed; it now matches the `src` alone, which is what it meant.

## Process note — why every figure here is a range

Six instruments produced confident wrong answers during this sweep: a 5-run `defer`
"regression" of 517 → 753 ms that reversed at n=9; a `min-width: 0` fix that "worked" on a run
which had rendered an empty table; a probe of mine that counted elements inside a `.tblwrap`
scroller as page overflow; a sibling's `14 → 7` clip improvement that was two tabs failing to
render; a harness selector returning five elements with four `undefined`; and a warm-switch
figure that was a 300 ms give-up constant reported as a measurement. **Every one was caught by
re-running, not by reasoning in advance**, and five of the six presented as a confident zero
or improvement rather than an error. The seeded corpus also grew mid-sweep and broke a tab
(`tools`) that had audited clean an hour earlier.

Hence: ranges not point estimates, `n/a` rather than `0` for anything uncomputable, and a
stated cache side on every API number. A reviewer should trust the ranges here and distrust
any single number in this area that does not come with one.

## Not verified

Whether the 9 latent `app.js` tables overflow at viewports
other than 390×844. Real network conditions — slow-4G is Chromium's emulator, not anyone's
connection; the byte counts are real, the millisecond counts are an emulation.
