### PR TITLE
fix(dash): page the session transcript, and stop the Diff view crashing the tab

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -1146,10 +1146,23 @@ type Change struct {
 	Components []string `json:"components,omitempty"`
 }
 
+// TraceTextCap bounds Change.Before/After — the copy of the text that goes into a trace
+// or a dashboard row. It is NOT a cap on the message: the pipeline rewrote the whole
+// thing, and BeforeTokens/AfterTokens are counted on the FULL string, so a Change can
+// legitimately report 2,658 tokens next to 4,000 bytes of text. clip() appends a visible
+// "…[+N bytes]" so a reader is told, and the original is recoverable through the expand
+// tool when the after-text carries a <<cg:HASH>> marker.
+//
+// It is exported because it is the cap that actually binds. apply is an importable
+// library — the bifrost plugin embeds it and has its own reason to bound trace size — so
+// an embedder that stores these rows must be able to report the EFFECTIVE limit rather
+// than assert its own, larger one. dash does exactly that for content_cap_bytes.
+const TraceTextCap = 4000
+
 func mkChange(path, before, after string, comps []string) Change {
 	return Change{
 		Path: path, BeforeTokens: schema.TextTokens(before), AfterTokens: schema.TextTokens(after),
-		Before: clip(before, 4000), After: clip(after, 4000), Components: comps,
+		Before: clip(before, TraceTextCap), After: clip(after, TraceTextCap), Components: comps,
 	}
 }
 

--- a/dash/api.go
+++ b/dash/api.go
@@ -388,6 +388,17 @@ const (
 	TranscriptUnknownSession = "unknown_session"
 )
 
+// transcriptPageSize is how many TURNS one page of the compaction-diff view carries.
+// It is a render budget, not a taste: blocks-per-turn measured max 24 / avg 7.9 on our
+// own corpus, and the client crosses a second of synchronous work somewhere past ~2,000
+// blocks, so 50 turns is ~400 blocks typical and ~1,200 worst case. transcriptPageMax is
+// what an explicit ?limit= may ask for — a caller may choose to wait, but not to ask for
+// 78 MB.
+const (
+	transcriptPageSize = 50
+	transcriptPageMax  = 200
+)
+
 // sessionTranscript serves one session's before/after content for the compaction-diff
 // view: every message context-guru rewrote in the session, oldest first, with the
 // component rows that ran on each request.
@@ -419,11 +430,21 @@ func (a *API) sessionTranscript(w http.ResponseWriter, r *http.Request) {
 		visible = p.Manager || (!f.TenantAll && f.Tenant == p.TenantID)
 	}
 
-	evs, err := a.rec.DB().SessionEvents(f, session, visible)
+	// PAGED, and the cap is not optional. The worst session in our own corpus holds
+	// 1,310 turns / 31,425 rewritten messages / ~78 MB of JSON; serving that in one
+	// response killed the renderer in 1.9 s. Keyset, exactly as /api/requests does it.
+	limit := transcriptPageSize
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = min(n, transcriptPageMax)
+		}
+	}
+	tp, err := a.rec.DB().SessionEventsPage(f, session, visible, r.URL.Query().Get("after"), limit)
 	if err != nil {
 		httpErr(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	evs := tp.Requests
 	// A session id is unique per ACCOUNT, not per service, so under a manager's
 	// service-wide scope SessionEvents matches the id in every account that has one —
 	// interleaving two people's code into a single diff. Pin the view to the account
@@ -455,13 +476,9 @@ func (a *API) sessionTranscript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hot := false
-	for _, e := range evs {
-		if len(e.Content) > 0 {
-			hot = true
-			break
-		}
-	}
+	// Session-wide, from the DB, NOT from this page: a first page of unstored turns in a
+	// partially-stored session must not report "storage is off" for the whole session.
+	hot := tp.HasContent
 	inCold := arch != nil && (arch.ContentPath != "" || arch.FullPath != "")
 
 	// The EFFECTIVE decision for the tenant whose transcripts these are, not the process
@@ -495,11 +512,23 @@ func (a *API) sessionTranscript(w http.ResponseWriter, r *http.Request) {
 		state = TranscriptNotCaptured
 	}
 
+	// A FULL archive left no local metric rows, so the fetched events are the whole
+	// session and SessionEventsPage had nothing to cap. Apply the same window in memory
+	// rather than handing back every turn through the one path that skipped the LIMIT.
+	if len(tp.Requests) == 0 && len(evs) > 0 {
+		evs, tp.NextCursor, tp.Total = windowEvents(evs, r.URL.Query().Get("after"), limit)
+	}
+
 	writeJSON(w, map[string]any{
 		"session":         session,
 		"state":           state,
 		"requests":        evs,
 		"content_visible": visible,
+		// The page's own coordinates. `total` is the session's turn count so the panel can
+		// say which slice of what it is showing; `next_cursor` is "" on the last page.
+		"next_cursor": tp.NextCursor,
+		"total":       tp.Total,
+		"page_size":   limit,
 		// The effective decision, plus WHICH party's gate is off when it is false. The UI
 		// used to read the process flag and tell a user to enable a setting they had
 		// already enabled, because the operator's gate was the one that was closed.
@@ -1177,4 +1206,25 @@ func (a *API) capture(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, map[string]any{"capture": s, "description": description})
+}
+
+// windowEvents applies the transcript route's keyset window to events that came from
+// cold storage rather than from SQL — the full-archive case, where there is no local row
+// to page over. Same cursor format, same (ts, id) order, so the client cannot tell the
+// two sources apart.
+func windowEvents(evs []*Event, after string, limit int) ([]*Event, string, int64) {
+	total := int64(len(evs))
+	if ts, id, ok := parseTranscriptCursor(after); ok {
+		i := 0
+		for i < len(evs) && !(evs[i].TS > ts || (evs[i].TS == ts && evs[i].ID > id)) {
+			i++
+		}
+		evs = evs[i:]
+	}
+	next := ""
+	if limit > 0 && len(evs) > limit {
+		evs = evs[:limit]
+		next = strconv.FormatInt(evs[limit-1].TS, 10) + ":" + strconv.FormatInt(evs[limit-1].ID, 10)
+	}
+	return evs, next, total
 }

--- a/dash/api.go
+++ b/dash/api.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rossoctl/context-guru/apply"
 	"github.com/rossoctl/context-guru/internal/modelinfo"
 	"golang.org/x/sync/errgroup"
 )
@@ -534,7 +535,7 @@ func (a *API) sessionTranscript(w http.ResponseWriter, r *http.Request) {
 		// already enabled, because the operator's gate was the one that was closed.
 		"content_captured":   captured,
 		"capture_blocked_by": blockedBy,
-		"content_cap_bytes":  a.rec.Opts().ContentCap,
+		"content_cap_bytes":  effectiveContentCap(a.rec.Opts().ContentCap),
 		"archive":            arch,
 		"remote":             a.rec.RemoteName(),
 		"reachable":          a.rec.RemoteReachable(),
@@ -948,7 +949,7 @@ func (a *API) request(w http.ResponseWriter, r *http.Request) {
 		"content_visible":    trusted,
 		"content_captured":   captured,
 		"capture_blocked_by": blockedBy,
-		"content_cap_bytes":  a.rec.Opts().ContentCap,
+		"content_cap_bytes":  effectiveContentCap(a.rec.Opts().ContentCap),
 		"content_archived":   archived,
 	})
 }
@@ -1227,4 +1228,16 @@ func windowEvents(evs []*Event, after string, limit int) ([]*Event, string, int6
 		next = strconv.FormatInt(evs[limit-1].TS, 10) + ":" + strconv.FormatInt(evs[limit-1].ID, 10)
 	}
 	return evs, next, total
+}
+
+// effectiveContentCap is the cap that actually binds on captured text, which is not the
+// one this package configures. apply clips Change.Before/After to apply.TraceTextCap
+// before a row ever reaches capture, and that is 4,000 bytes against a --dashboard-content-cap
+// that defaults to 16 KiB — so the dashboard's own cap could never bind, and serving it as
+// content_cap_bytes told a reader a number no truncation had ever used. Report the minimum.
+func effectiveContentCap(dashCap int) int {
+	if dashCap <= 0 {
+		return apply.TraceTextCap
+	}
+	return min(dashCap, apply.TraceTextCap)
 }

--- a/dash/query.go
+++ b/dash/query.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -324,46 +325,128 @@ func (d *DB) Request(id int64, withContent bool) (*Event, error) {
 	return e, trows.Err()
 }
 
-// SessionEvents returns one session's requests oldest-first, scoped by f — so a
-// hosted caller can only ever name a session that is theirs, and a session id
-// belonging to somebody else comes back as zero rows rather than as a 403 that
-// confirms it exists.
-//
-// withContent=false skips the transcript blobs entirely, which is what the list
-// views and the metrics-only states want: the content columns are the bulk of the
-// bytes and gunzipping a whole session to render a token count is pure waste.
+// TranscriptPage is one page of a session's turns plus the cursor for the next one.
+type TranscriptPage struct {
+	Requests []*Event `json:"requests"`
+	// NextCursor is the `after` value for the following page; "" = no more turns.
+	NextCursor string `json:"next_cursor"`
+	// Total is the turn count for the WHOLE session, so a page can say which slice of
+	// what it is showing rather than presenting a page as if it were the session.
+	Total int64 `json:"total"`
+	// HasContent answers "does this session have stored before/after text ANYWHERE",
+	// not "on this page". The state machine above this needs the session's answer: a
+	// first page of unstored turns would otherwise render "transcript storage is off"
+	// over a session whose later turns ARE stored, which is exactly the wrong answer
+	// that sends a user to switch on a setting they already have on.
+	HasContent bool `json:"has_content"`
+}
+
+// transcriptCursor encodes one keyset boundary. The sort is (ts, id) and the cursor
+// carries both: ts alone is not unique within a session and id alone is not the sort
+// key, so either half on its own can skip or repeat a turn.
+func parseTranscriptCursor(s string) (ts, id int64, ok bool) {
+	before, after, found := strings.Cut(s, ":")
+	if !found {
+		return 0, 0, false
+	}
+	ts, err := strconv.ParseInt(before, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	id, err = strconv.ParseInt(after, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return ts, id, true
+}
+
+// SessionEvents returns ALL of one session's requests oldest-first, scoped by f. It is
+// the ARCHIVE path's read: an upload has to carry the whole session, or the object it
+// writes misreports what was captured. Anything user-facing wants SessionEventsPage —
+// one session in this corpus reaches 31,425 diff blocks and ~78 MB of JSON, which is a
+// browser crash rather than a page.
 func (d *DB) SessionEvents(f Filter, sessionID string, withContent bool) ([]*Event, error) {
-	cond, args := f.where()
-	rows, err := d.sql.Query(`SELECT r.id FROM requests r WHERE `+cond+
-		` AND r.session_id = ? ORDER BY r.ts ASC, r.id ASC`, append(args, sessionID)...)
+	p, err := d.SessionEventsPage(f, sessionID, withContent, "", 0)
 	if err != nil {
 		return nil, err
 	}
-	var ids []int64
+	return p.Requests, nil
+}
+
+// SessionEventsPage returns one page of a session's requests oldest-first, scoped by f
+// — so a hosted caller can only ever name a session that is theirs, and a session id
+// belonging to somebody else comes back as zero rows rather than as a 403 that
+// confirms it exists.
+//
+// Pagination is KEYSET, the same shape Requests already uses: `after` is the last
+// (ts, id) seen, not an OFFSET, so page 50 of a long session costs what page 1 costs
+// and no turn is skipped or repeated while the session is still being written to.
+// limit <= 0 means unlimited, and is for the archive path only.
+func (d *DB) SessionEventsPage(f Filter, sessionID string, withContent bool, after string, limit int) (*TranscriptPage, error) {
+	cond, args := f.where()
+	sessArgs := append(append([]any(nil), args...), sessionID)
+
+	q := `SELECT r.id, r.ts FROM requests r WHERE ` + cond + ` AND r.session_id = ?`
+	pageArgs := append([]any(nil), sessArgs...)
+	if ts, id, ok := parseTranscriptCursor(after); ok {
+		q += ` AND (r.ts > ? OR (r.ts = ? AND r.id > ?))`
+		pageArgs = append(pageArgs, ts, ts, id)
+	}
+	q += ` ORDER BY r.ts ASC, r.id ASC`
+	if limit > 0 {
+		// One extra row, as in Requests: it says whether another page exists without a
+		// second COUNT against a table that is still being written to.
+		q += ` LIMIT ?`
+		pageArgs = append(pageArgs, limit+1)
+	}
+	rows, err := d.sql.Query(q, pageArgs...)
+	if err != nil {
+		return nil, err
+	}
+	type key struct{ id, ts int64 }
+	var keys []key
 	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
+		var k key
+		if err := rows.Scan(&k.id, &k.ts); err != nil {
 			rows.Close()
 			return nil, err
 		}
-		ids = append(ids, id)
+		keys = append(keys, k)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	out := make([]*Event, 0, len(ids))
-	for _, id := range ids {
+
+	page := &TranscriptPage{Requests: []*Event{}}
+	if limit > 0 && len(keys) > limit {
+		keys = keys[:limit]
+		last := keys[limit-1]
+		page.NextCursor = strconv.FormatInt(last.ts, 10) + ":" + strconv.FormatInt(last.id, 10)
+	}
+	for _, k := range keys {
 		// Reusing Request rather than a bespoke join: it is the tested path that
 		// assembles an Event with its components and content, and a second parallel
 		// query is one that can quietly diverge from what the request view shows.
-		e, err := d.Request(id, withContent)
+		e, err := d.Request(k.id, withContent)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, e)
+		page.Requests = append(page.Requests, e)
 	}
-	return out, nil
+
+	if err := d.sql.QueryRow(`SELECT COUNT(*) FROM requests r WHERE `+cond+
+		` AND r.session_id = ?`, sessArgs...).Scan(&page.Total); err != nil {
+		return nil, err
+	}
+	// Session-wide, not page-wide, and cheap: idx_content_request makes it an index
+	// probe and EXISTS stops at the first hit.
+	if err := d.sql.QueryRow(`SELECT EXISTS(SELECT 1 FROM requests r
+		JOIN request_content c ON c.request_id = r.id
+		WHERE `+cond+` AND r.session_id = ?)`, sessArgs...).Scan(&page.HasContent); err != nil {
+		return nil, err
+	}
+	return page, nil
 }
 
 // SessionRow is one row of the session list — the view neither reference

--- a/dash/transcript_test.go
+++ b/dash/transcript_test.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -296,4 +297,253 @@ func TestSessionEventsIsOldestFirst(t *testing.T) {
 			t.Fatalf("row %d (ts %d) precedes row %d (ts %d)", i, got[i].TS, i-1, got[i-1].TS)
 		}
 	}
+}
+
+// The transcript route used to have no LIMIT: one session in the production corpus is
+// 1,310 turns / 31,425 rewritten messages / ~78 MB of JSON, and rendering it killed the
+// browser tab. Paging is the fix, so the page has to be exact — walking every page must
+// visit every turn once, in order, and never twice.
+func TestSessionEventsPageWalksEveryTurnExactlyOnce(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Now().UnixMilli()
+	const n = 37
+	var evs []*Event
+	for i := 0; i < n; i++ {
+		// Two turns share a ts on purpose: a keyset on ts alone would skip or repeat here,
+		// which is exactly the bug a naive cursor introduces.
+		ts := base + int64(i/2)*1000
+		e := mkEvent(ts, "s", "m", 100, 90)
+		e.Content = []ContentRow{{Path: "messages.0", Before: "b", After: "a"}}
+		evs = append(evs, e)
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[int64]int{}
+	var order []int64
+	cursor, pages := "", 0
+	for {
+		p, err := db.SessionEventsPage(Filter{TenantAll: true}, "s", false, cursor, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.Total != n {
+			t.Fatalf("page %d: Total = %d, want %d (the session's turn count, not the page's)", pages, p.Total, n)
+		}
+		if len(p.Requests) > 10 {
+			t.Fatalf("page %d returned %d rows, over the limit of 10", pages, len(p.Requests))
+		}
+		for _, e := range p.Requests {
+			seen[e.ID]++
+			order = append(order, e.TS)
+		}
+		pages++
+		if p.NextCursor == "" {
+			break
+		}
+		cursor = p.NextCursor
+		if pages > 10 {
+			t.Fatal("cursor never terminated")
+		}
+	}
+	if pages != 4 {
+		t.Errorf("walked %d pages of 10 over %d turns, want 4", pages, n)
+	}
+	if len(seen) != n {
+		t.Errorf("saw %d distinct turns, want %d", len(seen), n)
+	}
+	for id, c := range seen {
+		if c != 1 {
+			t.Errorf("turn %d returned %d times", id, c)
+		}
+	}
+	for i := 1; i < len(order); i++ {
+		if order[i] < order[i-1] {
+			t.Errorf("turn %d (ts %d) precedes turn %d (ts %d) across the page boundary",
+				i, order[i], i-1, order[i-1])
+		}
+	}
+}
+
+// limit <= 0 is the archive path: an upload that carried one page would misreport what
+// was captured, so the unlimited wrapper must stay unlimited.
+func TestSessionEventsIsStillUnlimited(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Now().UnixMilli()
+	var evs []*Event
+	for i := 0; i < 120; i++ {
+		evs = append(evs, mkEvent(base+int64(i), "s", "m", 100, 90))
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.SessionEvents(Filter{TenantAll: true}, "s", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 120 {
+		t.Fatalf("SessionEvents returned %d of 120 turns — the archive would upload a page", len(got))
+	}
+}
+
+// HasContent answers the SESSION's question, not the page's. A first page of turns with
+// no stored text over a session whose later turns ARE stored used to make the route say
+// "transcript storage is off", i.e. tell a user to switch on a setting they already have on.
+func TestSessionEventsPageHasContentIsSessionWide(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Now().UnixMilli()
+	var evs []*Event
+	for i := 0; i < 12; i++ {
+		e := mkEvent(base+int64(i)*1000, "s", "m", 100, 90)
+		if i >= 10 { // only the LAST page carries text
+			e.Content = []ContentRow{{Path: "messages.0", Before: "b", After: "a"}}
+		}
+		evs = append(evs, e)
+	}
+	if err := db.insertBatch(evs); err != nil {
+		t.Fatal(err)
+	}
+	p, err := db.SessionEventsPage(Filter{TenantAll: true}, "s", true, "", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Requests) != 5 {
+		t.Fatalf("page 1 has %d rows, want 5", len(p.Requests))
+	}
+	for _, e := range p.Requests {
+		if len(e.Content) != 0 {
+			t.Fatal("fixture assumption: page 1 was supposed to have no stored text")
+		}
+	}
+	if !p.HasContent {
+		t.Error("HasContent = false on a session with stored text on a later page")
+	}
+
+	// And it stays false when the session really has none.
+	empty := openTestDB(t)
+	if err := empty.insertBatch([]*Event{mkEvent(base, "s", "m", 100, 90)}); err != nil {
+		t.Fatal(err)
+	}
+	q, err := empty.SessionEventsPage(Filter{TenantAll: true}, "s", true, "", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.HasContent {
+		t.Error("HasContent = true on a session with no stored text")
+	}
+}
+
+// A garbage cursor must be ignored (page 1), never turned into a SQL error or an empty
+// page — a stale link is not an error the reader caused.
+func TestTranscriptCursorGarbageFallsBackToPageOne(t *testing.T) {
+	for _, bad := range []string{"", "abc", "abc:def", "12", ":", "1:", ":2"} {
+		if _, _, ok := parseTranscriptCursor(bad); ok {
+			t.Errorf("parseTranscriptCursor(%q) accepted it", bad)
+		}
+	}
+	if ts, id, ok := parseTranscriptCursor("1700000000000:42"); !ok || ts != 1700000000000 || id != 42 {
+		t.Errorf("parseTranscriptCursor round trip = %d,%d,%v", ts, id, ok)
+	}
+}
+
+// The route's own contract: default page size, an explicit ?limit=, and the cap.
+func TestTranscriptRouteIsCapped(t *testing.T) {
+	a, rec, _ := transcriptAPI(t, Options{CaptureContent: true})
+	base := time.Now().UnixMilli()
+	var evs []*Event
+	for i := 0; i < transcriptPageSize+7; i++ {
+		e := mkEvent(base+int64(i)*1000, "s", "m", 100, 90)
+		e.Content = []ContentRow{{Path: "messages.0", Before: "b", After: "a"}}
+		evs = append(evs, e)
+	}
+	seed(t, rec, evs...)
+
+	var page struct {
+		Requests   []*Event `json:"requests"`
+		NextCursor string   `json:"next_cursor"`
+		Total      int64    `json:"total"`
+		PageSize   int      `json:"page_size"`
+	}
+	w, _ := get(t, a, "/api/sessions/s/transcript", "127.0.0.1:1")
+	if w.Code != 200 {
+		t.Fatalf("status %d", w.Code)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Requests) != transcriptPageSize {
+		t.Errorf("default page served %d turns, want %d", len(page.Requests), transcriptPageSize)
+	}
+	if page.Total != int64(transcriptPageSize+7) {
+		t.Errorf("total = %d, want %d", page.Total, transcriptPageSize+7)
+	}
+	if page.NextCursor == "" {
+		t.Error("no next_cursor with 7 turns left to read")
+	}
+
+	// The last page: the cursor resolves and the walk terminates.
+	w2, _ := get(t, a, "/api/sessions/s/transcript?after="+page.NextCursor, "127.0.0.1:1")
+	var p2 = page
+	if err := json.Unmarshal(w2.Body.Bytes(), &p2); err != nil {
+		t.Fatal(err)
+	}
+	if len(p2.Requests) != 7 || p2.NextCursor != "" {
+		t.Errorf("last page: %d turns, next_cursor %q; want 7 and \"\"", len(p2.Requests), p2.NextCursor)
+	}
+
+	// An explicit ?limit= is honoured, and cannot ask for the whole 78 MB.
+	w3, _ := get(t, a, "/api/sessions/s/transcript?limit=3", "127.0.0.1:1")
+	var p3 = page
+	if err := json.Unmarshal(w3.Body.Bytes(), &p3); err != nil {
+		t.Fatal(err)
+	}
+	if len(p3.Requests) != 3 || p3.PageSize != 3 {
+		t.Errorf("?limit=3 served %d turns (page_size %d)", len(p3.Requests), p3.PageSize)
+	}
+	w4, _ := get(t, a, "/api/sessions/s/transcript?limit=100000", "127.0.0.1:1")
+	var p4 = page
+	if err := json.Unmarshal(w4.Body.Bytes(), &p4); err != nil {
+		t.Fatal(err)
+	}
+	if p4.PageSize != transcriptPageMax {
+		t.Errorf("?limit=100000 gave page_size %d, want the cap %d", p4.PageSize, transcriptPageMax)
+	}
+}
+
+// windowEvents is the cold-storage half of the same cap: a FULL archive leaves no local
+// row for SQL to page over, so without this the one path that skipped the LIMIT would
+// still hand back every turn.
+func TestWindowEventsPagesArchivedTurns(t *testing.T) {
+	mk := func(ts, id int64) *Event { return &Event{ID: id, TS: ts} }
+	all := []*Event{mk(10, 1), mk(10, 2), mk(20, 3), mk(30, 4), mk(30, 5)}
+
+	got, next, total := windowEvents(all, "", 2)
+	if total != 5 || len(got) != 2 || got[1].ID != 2 || next != "10:2" {
+		t.Fatalf("page 1 = %d rows, next %q, total %d", len(got), next, total)
+	}
+	// Two turns share ts 10, so a cursor on ts alone would drop or repeat one.
+	got, next, _ = windowEvents(all, next, 2)
+	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 4 || next != "30:4" {
+		t.Fatalf("page 2 = %v, next %q", eventIDs(got), next)
+	}
+	got, next, _ = windowEvents(all, next, 2)
+	if len(got) != 1 || got[0].ID != 5 || next != "" {
+		t.Fatalf("page 3 = %v, next %q; want [5] and \"\"", eventIDs(got), next)
+	}
+	// Unlimited and a garbage cursor both mean "everything, from the start".
+	if got, next, _ = windowEvents(all, "", 0); len(got) != 5 || next != "" {
+		t.Errorf("limit 0 = %d rows, next %q", len(got), next)
+	}
+	if got, _, _ = windowEvents(all, "nonsense", 2); len(got) != 2 || got[0].ID != 1 {
+		t.Errorf("garbage cursor did not fall back to page 1: %v", eventIDs(got))
+	}
+}
+
+func eventIDs(evs []*Event) []int64 {
+	out := make([]int64, 0, len(evs))
+	for _, e := range evs {
+		out = append(out, e.ID)
+	}
+	return out
 }

--- a/dash/transcript_test.go
+++ b/dash/transcript_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/rossoctl/context-guru/apply"
 )
 
 // countingRemote records how many times the transcript route reached for cold storage.
@@ -546,4 +548,51 @@ func eventIDs(evs []*Event) []int64 {
 		out = append(out, e.ID)
 	}
 	return out
+}
+
+// content_cap_bytes used to serve the dashboard's own --dashboard-content-cap, which
+// could never bind: apply clips Change.Before/After to apply.TraceTextCap (4,000 bytes)
+// before a row reaches capture, and the dashboard default is 16 KiB. So the API asserted
+// a number no truncation had ever used. It must report the cap that actually binds.
+func TestContentCapReportsTheCapThatBinds(t *testing.T) {
+	if apply.TraceTextCap >= defaultContentCap {
+		t.Skipf("fixture assumption: apply's clip (%d) is the tighter of the two (dash %d)",
+			apply.TraceTextCap, defaultContentCap)
+	}
+	for _, tc := range []struct {
+		name    string
+		dashCap int
+		want    int
+	}{
+		{"default 16 KiB is not the cap", defaultContentCap, apply.TraceTextCap},
+		{"a dash cap tighter than apply's does bind", 512, 512},
+		{"unset means apply's", 0, apply.TraceTextCap},
+	} {
+		if got := effectiveContentCap(tc.dashCap); got != tc.want {
+			t.Errorf("%s: effectiveContentCap(%d) = %d, want %d", tc.name, tc.dashCap, got, tc.want)
+		}
+	}
+
+	// And the route serves it, on both the transcript and the single request.
+	a, rec, _ := transcriptAPI(t, Options{CaptureContent: true, ContentCap: defaultContentCap})
+	e := mkEvent(time.Now().UnixMilli(), "s", "m", 100, 90)
+	e.Content = []ContentRow{{Path: "messages.0", Before: "b", After: "a"}}
+	seed(t, rec, e)
+
+	for _, url := range []string{"/api/sessions/s/transcript", "/api/requests/1"} {
+		w, _ := get(t, a, url, "127.0.0.1:1")
+		if w.Code != 200 {
+			t.Fatalf("%s: status %d", url, w.Code)
+		}
+		var body struct {
+			Cap int `json:"content_cap_bytes"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Cap != apply.TraceTextCap {
+			t.Errorf("%s served content_cap_bytes = %d, want the binding cap %d",
+				url, body.Cap, apply.TraceTextCap)
+		}
+	}
 }

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -2745,7 +2745,16 @@ async function loadSessions() {
         el('td', { text: firstOf(s.presets) }),
         el('td', { class: 'num', text: num(s.turns) }),
         el('td', { class: 'num', text: compact(s.tokens_before) }),
-        el('td', { class: 'num', text: compact(s.saved) }),
+        // BOTH denominators, in one cell rather than a 16th column, and in the order the
+        // <details> above the table explains them. Gross alone was the only savings figure
+        // on this row and it overstates by 27.7x overall / up to 572.9x on one session.
+        el('td', {
+          class: 'num',
+          title: 'gross ' + num(s.saved) + ' tokens: a removed span counted once per turn it '
+            + 'was absent from. unique ' + num(s.saved_unique) + ' tokens: the same text '
+            + 'counted once. Gross is the size of every request we sent; unique is how much '
+            + 'distinct text was dropped.',
+        }, compact(s.saved) + ' / ' + compact(s.saved_unique)),
         // A dollar figure over a session whose turns are not all priced is a figure with
         // a different denominator from the token columns beside it: it covers the priced
         // turns only. The dagger says so rather than letting the two read as one total.

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -2994,9 +2994,12 @@ function renderSide(host, rows) {
   host.appendChild(el('div', { class: 'side-scroll', tabindex: '0' }, grid));
 }
 
-function renderDiff(host, before, after, mode) {
+/** `rows` lets a caller hand in the diff it already computed. Every block used to run
+ *  the LCS TWICE — once for the toolbar tally, once here — so a large session paid for
+ *  two quadratic passes per block and got one rendering out of it. */
+function renderDiff(host, before, after, mode, rows) {
   clear(host);
-  const rows = withHunks(diffLines((before || '').split('\n'), (after || '').split('\n')));
+  rows = rows || withHunks(diffLines((before || '').split('\n'), (after || '').split('\n')));
   if (mode === 'orig') { renderOneSide(host, rows, 'a'); return; }
   if (mode === 'raw') { renderOneSide(host, rows, 'b'); return; }
   if (mode === 'side') { renderSide(host, rows); return; }
@@ -3017,10 +3020,17 @@ function renderDiff(host, before, after, mode) {
   host.appendChild(frag);
 }
 
-/** Count added/removed lines, for the toolbar's tally. */
-function diffTally(before, after) {
+/** Count added/removed lines, for the toolbar's tally, from rows the caller already has.
+ *
+ *  It counts the LCS result rather than deriving anything from before_tokens/after_tokens:
+ *  those are a different unit and do not track the line counts at all. Measured over 300
+ *  content rows, 0 of 300 had `(lines removed − lines added) == (before_tokens −
+ *  after_tokens)`, and the median ratio between the two is 0.0 — the common case is one
+ *  long line replaced by a marker plus a note, i.e. +1 line net for several hundred tokens
+ *  saved. So there is no arithmetic shortcut here; the saving is one pass instead of two. */
+function diffTally(rows) {
   let add = 0, del = 0;
-  for (const r of diffLines((before || '').split('\n'), (after || '').split('\n'))) {
+  for (const r of rows) {
     if (r.op === '+') add++;
     else if (r.op === '-') del++;
   }
@@ -3173,46 +3183,65 @@ function kvBand(title, testid, ...pairs) {
  */
 function diffBlock(c, components, opts = {}) {
   const saved = c.before_tokens - c.after_tokens;
-  const t = diffTally(c.before, c.after);
   const det = el('details', { class: 'diff', 'data-testid': 'diff-block' });
-  if (opts.open) det.open = true;
   det.appendChild(el('summary', {
     text: `${opts.prefix || ''}${c.path} — ${compact(c.before_tokens)} → ${compact(c.after_tokens)} tokens ` +
           (saved > 0 ? `(saved ${compact(saved)})` : '(rewritten, no token saving)'),
   }));
 
-  // tabindex: this box scrolls, and a scroll region a keyboard user cannot focus is a
-  // part of the diff they cannot reach at all (axe scrollable-region-focusable). Same
-  // reason .tblwrap carries one.
-  const bodyHost = el('div', { class: 'diffbody', tabindex: '0', role: 'group',
-    'aria-label': 'Diff of ' + c.path });
   let mode = opts.mode || 'git';
+  let bodyHost = null, rows = null;
   const buttons = [];
-  const bar = el('div', { class: 'difftoolbar' });
+
+  // Everything below the summary is built ON FIRST OPEN, not up front. A closed <details>
+  // shows none of it — not the tally, not the chips, not the diff — so building it eagerly
+  // bought nothing and cost one LCS pass plus a few hundred DOM nodes per block. On the
+  // worst session in this corpus that was 31,425 blocks × (2 LCS + ~30 nodes each), which
+  // killed the renderer in 1.9 s. Deferring it makes an unopened block a summary line.
+  const build = () => {
+    if (bodyHost) return;
+    // The ONE LCS pass. The tally and every view mode read the same rows.
+    rows = withHunks(diffLines((c.before || '').split('\n'), (c.after || '').split('\n')));
+    const t = diffTally(rows);
+    const bar = el('div', { class: 'difftoolbar' });
+    for (const [m, label, testid] of DIFF_MODES) {
+      const b = el('button', {
+        class: 'ghost small', 'data-testid': testid, 'data-mode': m,
+        'aria-pressed': String(m === mode), onclick: () => setMode(m),
+      }, label);
+      buttons.push(b);
+      bar.appendChild(b);
+    }
+    bar.appendChild(el('span', { class: 'spacer' }));
+    bar.appendChild(el('span', { class: 'tally' },
+      el('span', { class: 'del', text: '−' + num(t.del) }), ' / ',
+      el('span', { class: 'add', text: '+' + num(t.add) }), ' lines'));
+    det.appendChild(bar);
+
+    const chips = attributionChips(c, components);
+    if (chips) det.appendChild(el('div', { class: 'difftoolbar' }, chips));
+
+    // tabindex: this box scrolls, and a scroll region a keyboard user cannot focus is a
+    // part of the diff they cannot reach at all (axe scrollable-region-focusable). Same
+    // reason .tblwrap carries one.
+    bodyHost = el('div', { class: 'diffbody', tabindex: '0', role: 'group',
+      'aria-label': 'Diff of ' + c.path });
+    det.appendChild(bodyHost);
+    renderDiff(bodyHost, c.before, c.after, mode, rows);
+  };
+
   const setMode = (next) => {
     mode = next;
+    // A session-wide toolbar sets .open and calls this in the same tick, and `toggle`
+    // fires asynchronously — so build here rather than trusting the event to have landed.
+    if (det.open) build();
+    if (!bodyHost) return;
     for (const b of buttons) b.setAttribute('aria-pressed', String(b.dataset.mode === next));
-    renderDiff(bodyHost, c.before, c.after, next);
+    renderDiff(bodyHost, c.before, c.after, next, rows);
   };
-  for (const [m, label, testid] of DIFF_MODES) {
-    const b = el('button', {
-      class: 'ghost small', 'data-testid': testid, 'data-mode': m,
-      'aria-pressed': String(m === mode), onclick: () => setMode(m),
-    }, label);
-    buttons.push(b);
-    bar.appendChild(b);
-  }
-  bar.appendChild(el('span', { class: 'spacer' }));
-  bar.appendChild(el('span', { class: 'tally' },
-    el('span', { class: 'del', text: '−' + num(t.del) }), ' / ',
-    el('span', { class: 'add', text: '+' + num(t.add) }), ' lines'));
-  det.appendChild(bar);
 
-  const chips = attributionChips(c, components);
-  if (chips) det.appendChild(el('div', { class: 'difftoolbar' }, chips));
-
-  det.appendChild(bodyHost);
-  renderDiff(bodyHost, c.before, c.after, mode);
+  det.addEventListener('toggle', () => { if (det.open) build(); });
+  if (opts.open) { det.open = true; build(); }
   det.setMode = setMode;
   return det;
 }
@@ -3651,22 +3680,42 @@ function dismissDrawer() {
 
 /** transcriptURL builds the route, carrying only the manager's tenant selector — never
  *  the view filters, which would silently drop turns out of the middle of a session. */
-function transcriptURL(session, fetchCold) {
+function transcriptURL(session, fetchCold, after) {
   const p = new URLSearchParams();
   if (state.filter.tenant) p.set('tenant', state.filter.tenant);
   if (fetchCold) p.set('fetch', '1');
+  if (after) p.set('after', after);
   const q = p.toString();
   return '/api/sessions/' + encodeURIComponent(session) + '/transcript' + (q ? '?' + q : '');
 }
 
-async function openSessionDiff(session, fetchCold, fromURL) {
+/**
+ * The diff drawer's pager. One session at a time, in memory.
+ *
+ * `pages[i]` is the keyset cursor for page i plus the 0-based turn number it starts at,
+ * so "turn 3" keeps meaning the third turn of the CONVERSATION on page 7, and Previous
+ * is a step back to a cursor already seen rather than a re-page from the start.
+ *
+ * ponytail: not in the URL. The router lives in another file, and a cursor pasted into a
+ * shared link would pin the reader to a page boundary of a session that has since grown —
+ * a link to a session is the honest thing to share. Move it into the hash if someone
+ * actually asks to deep-link a page.
+ */
+let diffPager = { session: null, pages: [{ cursor: '', offset: 0 }], page: 0 };
+
+async function openSessionDiff(session, fetchCold, fromURL, page) {
   // Linkable, like the request drawer: this view is the one people want to send someone.
   if (!fromURL) { state.drawer = { diff: session }; syncURL(false); }
+  // A different session resets the pager; a re-open of the same one (the cold-storage
+  // fetch button re-enters here) keeps the page you were on.
+  if (diffPager.session !== session) diffPager = { session, pages: [{ cursor: '', offset: 0 }], page: 0 };
+  if (page != null) diffPager.page = page;
+  const at = diffPager.pages[diffPager.page] || diffPager.pages[0];
   const body = openDrawer('Compaction diff · ' + (session || '(no session id)'), null);
   loadingState(body, 5);
   let out;
   try {
-    const res = await fetch(transcriptURL(session, fetchCold), { headers: { accept: 'application/json' } });
+    const res = await fetch(transcriptURL(session, fetchCold, at.cursor), { headers: { accept: 'application/json' } });
     if (!res.ok) {
       let msg = res.status + ' ' + res.statusText;
       let j = null;
@@ -3682,10 +3731,17 @@ async function openSessionDiff(session, fetchCold, fromURL) {
     errorState(clear(body), 'Could not load this session', err);
     return;
   }
-  renderSessionDiff(body, session, out);
+  // Learn the NEXT page's coordinates from the answer we just got: keyset pagination has
+  // no page numbers, so the only way forward is the cursor the server handed back.
+  if (out.next_cursor) {
+    diffPager.pages[diffPager.page + 1] = {
+      cursor: out.next_cursor, offset: at.offset + (out.requests || []).length,
+    };
+  }
+  renderSessionDiff(body, session, out, at.offset);
 }
 
-function renderSessionDiff(body, session, out) {
+function renderSessionDiff(body, session, out, offset = 0) {
   clear(body);
   if (out.state === 'unknown_session') {
     contentBlockedState(body, 'unknown_session');
@@ -3722,16 +3778,26 @@ function renderSessionDiff(body, session, out) {
   const storedTurns = reqs.filter((e) => (e.content || []).length).length;
   const partial = storedTurns < rewrittenTurns;
 
+  // The route is paged, so every total above is a total over THIS PAGE. Saying so is not a
+  // nicety: an unlabelled "Tokens before → after" over 50 of 1,310 turns is a wrong number
+  // about the session, which is the level at which the reader is asking.
+  const total = out.total || reqs.length;
+  const paged = total > reqs.length;
+  const from = reqs.length ? offset + 1 : 0;
+  const to = offset + reqs.length;
+  const per = paged ? ' (turns ' + num(from) + '–' + num(to) + ')' : '';
+
   body.appendChild(el('div', { class: 'kv', 'data-testid': 'session-diff-summary' },
     kv('Session', session || '(none)'),
-    kv('Turns in this session', num(reqs.length)),
-    kv('Turns rewritten', num(rewrittenTurns)),
-    kv('Turns with stored text', storedTurns + ' of ' + rewrittenTurns + ' rewritten'),
-    kv('Messages rewritten' + (partial ? ' (stored turns only)' : ''), num(changed)),
-    kv('Tokens before → after', compact(before) + ' → ' + compact(after)),
-    kv('Saved (gross / unique)', compact(before - after) + ' / ' + compact(unique)),
-    kv('context-guru latency', dur(cgMs)),
-    kv('Window', reqs.length
+    kv('Turns in this session', num(total)
+      + (paged ? ' — showing ' + num(from) + '–' + num(to) : '')),
+    kv('Turns rewritten' + per, num(rewrittenTurns)),
+    kv('Turns with stored text' + per, storedTurns + ' of ' + rewrittenTurns + ' rewritten'),
+    kv('Messages rewritten' + per + (partial ? ' (stored turns only)' : ''), num(changed)),
+    kv('Tokens before → after' + per, compact(before) + ' → ' + compact(after)),
+    kv('Saved (gross / unique)' + per, compact(before - after) + ' / ' + compact(unique)),
+    kv('context-guru latency' + per, dur(cgMs)),
+    kv('Window' + per, reqs.length
       ? when(reqs[0].ts) + ' → ' + when(reqs[reqs.length - 1].ts)
       : (out.archive ? when(out.archive.first_ts) + ' → ' + when(out.archive.last_ts) : '—'))));
 
@@ -3778,7 +3844,9 @@ function renderSessionDiff(body, session, out) {
   }
 
   if (compTotals.size) {
-    body.appendChild(el('h2', { text: 'Components, across the session' }));
+    body.appendChild(el('h2', { text: paged
+      ? 'Components, across turns ' + num(from) + '–' + num(to)
+      : 'Components, across the session' }));
     const rows = Array.from(compTotals.entries()).sort((a, b) => b[1].saved - a[1].saved);
     const tbl = el('table', { class: 'tbl compact', 'data-testid': 'session-diff-components' },
       el('thead', {}, el('tr', {},
@@ -3839,6 +3907,33 @@ function renderSessionDiff(body, session, out) {
     'not a reconstructed transcript: the messages we left alone were never captured, so ' +
     'stitching them into a whole conversation would be inventing the parts we did not store.' }));
 
+  // Say the size BEFORE rendering it. A block count is the one number that predicts what
+  // this panel is about to cost, and the page it belongs to is the answer to "where is the
+  // rest of it" — a session in this corpus reaches 31,425 blocks, and the panel used to
+  // open on all of them at once with no warning and no way out.
+  const blockCount = withContent.reduce((n, e) => n + e.content.length, 0);
+  body.appendChild(el('p', { class: 'note', 'data-testid': 'diff-scale', text:
+    num(blockCount) + ' block(s) on this page, from ' + num(storedTurns) + ' stored turn(s)'
+    + (paged ? ' of ' + num(total) + ' in the session. Blocks are collapsed until you open '
+      + 'one — expanding all of them renders every line of all ' + num(blockCount) + '.'
+      : '. Blocks are collapsed until you open one.') }));
+
+  const pager = () => {
+    if (!paged) return null;
+    const prev = el('button', {
+      class: 'ghost', disabled: diffPager.page === 0,
+      onclick: () => openSessionDiff(session, false, true, diffPager.page - 1),
+    }, 'Previous turns');
+    const next = el('button', {
+      class: 'ghost', disabled: !out.next_cursor,
+      onclick: () => openSessionDiff(session, false, true, diffPager.page + 1),
+    }, 'Next turns');
+    return el('div', { class: 'pager', 'data-testid': 'diff-pager' }, prev,
+      el('span', { text: 'Turns ' + num(from) + '–' + num(to) + ' of ' + num(total) }), next);
+  };
+  const topPager = pager();
+  if (topPager) body.appendChild(topPager);
+
   // One toolbar drives every block, which is what makes (a) "the session before
   // compaction" and (b) "after" single clicks rather than N expansions.
   const blocks = [];
@@ -3859,14 +3954,17 @@ function renderSessionDiff(body, session, out) {
   bar.appendChild(el('span', { class: 'spacer' }));
   bar.appendChild(el('button', {
     class: 'ghost small',
+    title: 'Renders every line of all ' + num(blockCount) + ' blocks on this page',
     onclick: () => { for (const blk of blocks) blk.open = !blk.open; },
-  }, 'Expand / collapse all'));
+  }, 'Expand / collapse all ' + num(blockCount)));
   body.appendChild(bar);
 
   // Turn numbers come from the position in the FULL request list, not in the filtered
   // one: "turn 3" has to mean the third turn of the conversation, not the third turn
   // that happened to be rewritten.
-  const turnOf = new Map(reqs.map((e, i) => [e, i + 1]));
+  // `offset` is this page's first turn, so a turn number is the conversation's, not the
+  // page's: on page 7 the first block is "turn 301", not "turn 1".
+  const turnOf = new Map(reqs.map((e, i) => [e, offset + i + 1]));
   for (const e of withContent) {
     for (const c of e.content) {
       const blk = diffBlock(c, e.components, {
@@ -3877,6 +3975,10 @@ function renderSessionDiff(body, session, out) {
       body.appendChild(blk);
     }
   }
+  // A second pager at the bottom: the top one is 400 blocks up by the time you have read
+  // the page, and scrolling back to find Next is not a feature.
+  const botPager = pager();
+  if (botPager) body.appendChild(botPager);
 }
 
 // ── benchmarks ─────────────────────────────────────────────────────────────

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -3020,6 +3020,45 @@ function renderDiff(host, before, after, mode, rows) {
   host.appendChild(frag);
 }
 
+/**
+ * CLIPPED matches the truncation sentinel apply.clip() appends to a trace text:
+ * "…[+2559 bytes]" at the very end of the LAST line. It means the pipeline rewrote the
+ * whole message but only the first apply.TraceTextCap bytes were captured — so the token
+ * counts in the block summary are for the full message while the text below is a prefix.
+ */
+const CLIPPED = /…\[\+(\d+) bytes\]$/;
+
+/**
+ * markClipped turns each truncation sentinel into its own `gap` row — the same op the
+ * elided-unchanged-run marker already uses, so all three renderers style it as a notice
+ * instead of tinting it like a line of transcript. Runs AFTER the diff, on the rows, so
+ * the diff itself is byte-for-byte what it was before.
+ *
+ * Returns the bytes not captured per side, for the block-level note.
+ */
+function markClipped(rows) {
+  const missing = { a: 0, b: 0 };
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const r = rows[i];
+    if (r.op === 'gap') continue;
+    const m = CLIPPED.exec(r.text || '');
+    if (!m) continue;
+    const n = Number(m[1]);
+    // op ' ' means the sentinel survived as an unchanged line, i.e. both sides carry it.
+    if (r.op === '-' || r.op === ' ') missing.a = Math.max(missing.a, n);
+    if (r.op === '+' || r.op === ' ') missing.b = Math.max(missing.b, n);
+    r.text = r.text.slice(0, -m[0].length);
+    rows.splice(i + 1, 0, { op: 'gap', text:
+      `… truncated here: ${num(n)} more bytes were not captured (the diff shows the first ` +
+      `${num(CONTENT_CAP)} bytes; token counts above are for the whole message) …` });
+  }
+  return missing;
+}
+
+/** The cap the server says actually binds, from any transcript/request answer. Defaults to
+ *  apply.TraceTextCap so a notice reads correctly before the first answer lands. */
+let CONTENT_CAP = 4000;
+
 /** Count added/removed lines, for the toolbar's tally, from rows the caller already has.
  *
  *  It counts the LCS result rather than deriving anything from before_tokens/after_tokens:
@@ -3202,6 +3241,7 @@ function diffBlock(c, components, opts = {}) {
     if (bodyHost) return;
     // The ONE LCS pass. The tally and every view mode read the same rows.
     rows = withHunks(diffLines((c.before || '').split('\n'), (c.after || '').split('\n')));
+    const missing = markClipped(rows);
     const t = diffTally(rows);
     const bar = el('div', { class: 'difftoolbar' });
     for (const [m, label, testid] of DIFF_MODES) {
@@ -3220,6 +3260,26 @@ function diffBlock(c, components, opts = {}) {
 
     const chips = attributionChips(c, components);
     if (chips) det.appendChild(el('div', { class: 'difftoolbar' }, chips));
+
+    // The header/body disagreement, said out loud: the token counts in the summary are the
+    // whole message's, the text below is a prefix. Without this the only signal was a
+    // sentinel tinted like an ordinary transcript line.
+    if (missing.a || missing.b) {
+      det.appendChild(el('div', { class: 'state blocked', 'data-testid': 'diff-truncated',
+        role: 'note' },
+        el('div', { class: 'state-body' },
+          el('strong', { text: 'Only the first ' + num(CONTENT_CAP) + ' bytes were captured' }),
+          el('span', { text:
+            [missing.a && num(missing.a) + ' bytes of the before-text',
+              missing.b && num(missing.b) + ' bytes of the after-text'].filter(Boolean).join(' and ')
+            + ' are not in this diff. The token counts in the heading above cover the whole '
+            + 'message, so they will not match the text you can see here. '
+            + (MARKER.test(c.after || '')
+              ? 'The after-text carries a <<cg:HASH>> marker, so the full original is still '
+                + 'recoverable through the expand tool.'
+              : 'This is a capture limit, not a rewrite: nothing was lost from what was sent '
+                + 'upstream.') }))));
+    }
 
     // tabindex: this box scrolls, and a scroll region a keyboard user cannot focus is a
     // part of the diff they cannot reach at all (axe scrollable-region-focusable). Same
@@ -3305,7 +3365,9 @@ async function openRequest(id, fromURL) {
     // capture_blocked_by names WHICH party's gate is shut, so the empty-diff panel can
     // stop telling people to change a setting that is not theirs.
     const { request: e, content_visible: visible, content_captured: captured,
-      content_archived: archived, capture_blocked_by: blockedBy } = await res.json();
+      content_archived: archived, capture_blocked_by: blockedBy,
+      content_cap_bytes: cap } = await res.json();
+    if (cap) CONTENT_CAP = cap;
     clear(body);
 
     // Four captioned bands rather than twenty-four pairs in one grid. Same data, same
@@ -3743,6 +3805,7 @@ async function openSessionDiff(session, fetchCold, fromURL, page) {
 
 function renderSessionDiff(body, session, out, offset = 0) {
   clear(body);
+  if (out.content_cap_bytes) CONTENT_CAP = out.content_cap_bytes;
   if (out.state === 'unknown_session') {
     contentBlockedState(body, 'unknown_session');
     return;

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -511,12 +511,22 @@
         <strong>&dagger;</strong> means some of that session's turns carried no usable provider
         usage data, so the dollar figure covers its priced turns only — while the token
         columns beside it cover every turn.</p>
+      <p><strong>Saved tokens carries two denominators, and on some sessions they are
+        orders of magnitude apart.</strong> <em>Gross</em> counts a removed span once per turn
+        it was absent from: an agent re-sends its whole transcript every turn, so one removal
+        keeps being counted for the rest of the session. <em>Unique</em> counts that same text
+        once. On a short session the two agree; on a long one gross can be hundreds of times
+        larger, and which is "the saving" depends on the question — <em>gross</em> answers
+        "how much smaller was every request we sent", <em>unique</em> answers "how much
+        distinct text did we drop". Both are shown because a single unlabelled figure here
+        reads correctly right up to the session where it is wrong by a factor of 500.</p>
     </details>
     <div class="tblwrap" tabindex="0">
       <table class="tbl" data-testid="sessions-table">
         <thead><tr>
           <th>Session</th><th data-scope-col hidden>Account</th><th>Model</th><th>Agent</th><th>Preset</th>
-          <th class="num">Turns</th><th class="num">Before</th><th class="num">Saved (gross)</th>
+          <th class="num">Turns</th><th class="num">Before</th>
+          <th class="num">Saved tokens<br><span class="hint">gross / unique</span></th>
           <th class="num">Net saved $</th><th class="num">Cache r/w</th>
           <th class="num">Keep-alive net</th><th class="num">Expands</th>
           <th class="num">CG ms</th><th>Started</th><th><span class="vh">Row actions</span></th>

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -694,6 +694,13 @@ details.why dd { margin: 0; }
 .diff {
   border: 1px solid var(--border-soft); border-radius: var(--r);
   margin-bottom: var(--sp-3); overflow: hidden; background: var(--bg-raised);
+  /* A session page is hundreds of these and an expand-all opens every one, so layout and
+     paint for the blocks off screen are work nobody asked for. `auto` on the intrinsic
+     size means the placeholder height (a collapsed summary row) applies only until the
+     block has been rendered once; after that the browser remembers its real size, so
+     scrollbar length and in-page find stay honest. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 44px;
 }
 .diff > summary {
   padding: var(--sp-2) var(--sp-3); cursor: pointer; font-size: var(--t-small);

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -698,9 +698,11 @@ details.why dd { margin: 0; }
      paint for the blocks off screen are work nobody asked for. `auto` on the intrinsic
      size means the placeholder height (a collapsed summary row) applies only until the
      block has been rendered once; after that the browser remembers its real size, so
-     scrollbar length and in-page find stay honest. */
+     scrollbar length and in-page find stay honest. 37px is the measured height of a
+     collapsed block (summary row + border + margin) at this type scale — guessing high
+     makes the scrollbar claim a longer page than there is. */
   content-visibility: auto;
-  contain-intrinsic-size: auto 44px;
+  contain-intrinsic-size: auto 37px;
 }
 .diff > summary {
   padding: var(--sp-2) var(--sp-3); cursor: pointer; font-size: var(--t-small);


### PR DESCRIPTION
One click on **Diff** in the Sessions table could kill the browser tab. Both sides were
unbounded: `SessionEvents` had no `LIMIT`, and the client looped every content row of every
turn with no slice. This fixes that, the double LCS pass behind it, and two honesty defects
found in the same panel.

## The crash

Worst session in our own corpus: **1,310 turns / 31,425 rewritten messages / ~78 MB of
JSON**. Measured with synthetic content of that shape (`impl-traffic-scale.mjs`, derived
from `rev-traffic-scale.mjs`), Chromium 1440×900, loopback.

Settle is **two consecutive equal samples of `[blocks, dl]`** — a block-count-only settle
stops measuring the right thing once rendering is deferred.

| blocks | BEFORE | AFTER, paged | AFTER, unbounded payload |
|---|---|---|---|
| 504 | 516 ms · 58,810 nodes · 12,111 `.dl` | 191 ms · 2,551 · 52 | 198 ms · 2,507 · 40 |
| 2,016 | 1,731 ms · 231,178 · 48,399 | 385 ms · 3,951 · 52 | 511 ms · 5,531 · 40 |
| 8,016 | 6,971 ms · 915,130 · 192,387 | 363 ms · 3,951 · 52 | 1,949 ms · 17,531 · 40 |
| 31,440 | **RENDERER CRASHED @ 1,816 ms** | **367 ms · 3,903 · 39** | **RENDERER CRASHED @ 2,071 ms** |

**Read the third column: client hardening alone does not survive 31,440 blocks.** A 105 MB
response still kills the tab, because the cost is parsing the JSON, not building the DOM.
The server cap is the load-bearing half; the client work buys 8,016 blocks and no more.

**The two columns that changed meaning, said plainly.** `BEFORE settled` includes building
all 192,387 `.dl` nodes. `AFTER settled` cannot, because only the one auto-open block is
built. Same user-visible measure, different work by design. The cost moved, so here is
where it went:

| | BEFORE | AFTER |
|---|---|---|
| open one closed block | 0.7–0.8 ms (already built) | **1.2–2.4 ms** |
| expand-all, side-by-side, **2,016 blocks both sides** | **4,865 ms** | **1,611 ms** |

The second row is the apples-to-apples one, and it is the interaction a user reaches by
curiosity rather than by having a pathological session.

## A pagination PR's real question is *which* query to cap. There were four; one should be.

Three of these are bugs the obvious implementation ships:

1. **`SessionEvents` stays unlimited** — it is the **archive upload** path (`archive.go:170`),
   which must carry the whole session or the object it writes misreports what was captured.
   Capping it would have silently truncated cold-storage archives: data loss, no error,
   found months later. Its signature is unchanged; `SessionEventsPage` is a new sibling.
2. **A full archive has no local rows**, so `mergeArchivedContent` returned everything and
   skipped the `LIMIT` entirely. `windowEvents` applies the same window in memory.
3. **`hot` was derived from the served page**, so a first page of unstored turns would report
   "transcript storage is off" for a session whose later turns *are* stored — sending a user
   to switch on a setting they already have on. It is now a session-wide `EXISTS`.

**Keyset is on the `(ts, id)` tuple, not `id` alone.** Ties on `ts` are real in this data;
an id-only cursor silently skips or repeats rows across a page boundary. That is exactly the
"0 duplicates, 0 gaps" property measured below.

Default 50 turns, `?limit=` up to 200, `next_cursor` / `total` / `page_size` in the response.

## Server paging without client paging would be a worse bug

A capped endpoint alone gives 50 turns and no way to reach turn 51 — trading a visible crash
for silent truncation of the one view whose purpose is completeness. Both halves ship here.
`transcriptURL(session, fetchCold, after)` sends `?after=`; the pager renders above **and**
below the block list; turn numbers are the conversation's, so page 7 opens at "turn 301";
page-scoped figures in the summary carry `(turns X–Y)` rather than reading as session totals.

Walked every page of the worst-shaped session: **27 pages in 6,977 ms, 1,310 of 1,310
distinct turns, 0 duplicates, 0 gaps**, ending on `Turns 1,301–1,310 of 1,310`.

The pager is deliberately **not** in the URL hash. A cursor in a shared link pins a reader to
a page boundary of a session that has since grown; `state.drawer = { diff: session }` keeps
meaning "this session's diff". Agreed with `impl-nav`, who also notes it would widen the
`urlFor`/`parseURL` compatibility contract for state not worth linking.

## The double LCS pass: deleting work that was never used

`diffBlock` built its whole body — toolbar, tally, attribution chips, the diff — for every
block whether or not the `<details>` was open, and ran the LCS **twice** per block
(`diffTally` called `diffLines`, then `renderDiff` called it again).

**A closed `<details>` never showed the tally, the chips or the diff, so eager construction
bought nothing.** The body is now built on first open from **one** `diffLines` pass shared by
the tally and every view mode. That reframes the change: not an optimisation, just deleting
work that was never on screen. It is where the 915k → 17.5k node drop comes from.

**The originally-suggested fix was rejected on measurement.** Deriving the tally from
`before_tokens - after_tokens` does not work: over 300 content rows, **0 of 300** had
`(lines removed − lines added) == (before_tokens − after_tokens)`; median ratio 0.0, p90 0.37.
The common shape is one long line replaced by a marker plus a note — +1 line net for several
hundred tokens saved. Different units, no shortcut. Shipping it would have shipped a wrong
number.

## `content-visibility` — measured separately, because node count is the wrong metric for it

It skips layout and paint, **not DOM construction**, so it cannot move node counts and must
be judged on time. Paired A/B in one page (rule overridden via `insertRule` — `addStyleTag`
is blocked by the dashboard's `style-src 'self'`), 3 runs each, full 1,200-block page,
expand-all:

```
content-visibility: auto      1,022 / 957 / 997 ms     domNodes 86,327
content-visibility: visible   3,175 / 3,130 / 3,248 ms domNodes 86,327
```

Identical node counts, ~3.2× on time. **The node drop in the table above is entirely the
deferred build, not this property** — worth stating so two branches cannot both claim it.

**Convention for `contain-intrinsic-size`, agreed with `impl-perf`:** `auto <measured
at-rest height>`. The `auto` keyword so the placeholder applies only until first render,
after which the browser remembers the real size and the scrollbar stays honest. Here that is
the **measured** 37px collapsed block — an earlier guessed 44px inflated `drawerScrollH` by
~18%. `impl-perf` is shipping no `content-visibility` rule (on `hidden` views it is inert —
`display: none` generates no box), so this is the only one on the branch.

## Sessions table: one savings column that overstated by up to 572.9×

`Saved (gross)` was the only savings figure on the row, and `saved_unique` was already in the
same JSON object, unrendered — the Overview tile and the Components table both use it.

Gross counts a removed span once per turn it was absent from; the agent re-sends its whole
transcript every turn, so one removal keeps being re-counted. Unique counts it once. The two
differ by **27.7× in total, median 1.0×, p90 17.4×, max 572.9× (n=1,735)** — the worst
distribution for a single unlabelled column, because it looks right until it is off by 500×.

Both now render as `gross / unique` in **one** cell, reusing the `Cache r/w` pattern already
in that table rather than adding a 16th column to a table at 15, with the unit in the header
and the explanation in the panel's existing `<details>`. Neither is dropped — they answer
different questions.

## The content cap that could never bind

`apply.mkChange` clips `Change.Before/After` to 4,000 bytes while `--dashboard-content-cap`
defaults to 16 KiB, so for any proxy-written row the operative limit was always the
hardcoded one — and `content_cap_bytes` served `16384`, a number no truncation had ever used.
The 4,000 is now the exported `apply.TraceTextCap`, and `dash` reports
`min(its own cap, that)`. `dash/event.go` already imported `apply`, so no new dependency edge.

**Not done: making the clip limit a parameter.** `apply.Opts` already exists, so the plumbing
is ~3 lines and clean *in code*. Skipped because the only value worth passing is dash's
16 KiB default, which **quadruples every deployment's stored content blobs** — an operator's
decision, not a bug fix. (The layering also argues for restraint: `apply` is embedded by the
bifrost plugin and must not learn about `dash`'s configuration.) Three lines away if wanted.

**Truncation now reads as a notice, not as content.** `clip()` appends `…[+N bytes]` to the
*end of the last line*, and in "Before" mode that was tinted like an ordinary transcript
line. `markClipped` splits it into its own `op:'gap'` row **after** the diff is computed — so
the diff is byte-identical and all three renderers use the elided-run notice idiom they
already have, no renderer changes — plus a `role="note"` panel giving the missing byte count,
saying the heading's token counts cover the whole message, and naming the expand tool when
the after-text carries a marker.

Measured, 2,016 blocks all expanded side-by-side, 1 block in 7 clipped:

```
BEFORE  sentinel rendered as a transcript line 288   block notices   0
AFTER   sentinel rendered as a transcript line   0   block notices 288   notice rows 576
```

Attribution is untouched: `rev-traffic` verified it live (`c.components` accurate, `expand`
byte-exact at 6,559 bytes in and out). Nothing here keys on `<<cg:HASH>>` uniqueness — two
blocks legitimately share a marker when their content is byte-identical, and the only
`MARKER.test()` is a per-block property check for the notice wording, not an identity claim.

## Verification

```
CGO_ENABLED=1 go build ./...        BUILD OK
CGO_ENABLED=1 go vet ./...          VET OK
CGO_ENABLED=1 go test -count=1 ./dash/    ok  83.212s
CGO_ENABLED=1 go test ./apply/            ok   1.301s
```

Eight new tests: keyset walk (37 turns, two sharing a `ts`, 4 pages, 0 dupes, order held
across boundaries), `SessionEvents` still unlimited, session-wide `HasContent`, cursor
parsing, route cap / `?limit=` / clamp, `windowEvents`, `effectiveContentCap` on both routes.

Sessions-tab layout audit, `shots.mjs --tabs sessions`, both themes, 1440 + 390:

```
BEFORE  clippedOff 0  bodyScrollsX no  textClip 0  contrast 0/5/377  focusMissing 0
AFTER   clippedOff 0  bodyScrollsX no  textClip 0  contrast 0/5/379  focusMissing 0
```

The text-node denominator is 377 → 379 (the two new header words), i.e. the same population —
so the zeros are a genuine pass, not the "view had not finished loading" artefact that
produced fake improvements elsewhere on this sweep. No new CSS hex outside the token blocks.
No CDN, npm, bundler or build step; `go build` alone still produces a working air-gapped
dashboard.

## Co-edited regions and land order

Rebased on `origin/main` (`3697f3c`). Overlaps, all confirmed non-conflicting by direct
coordination:

- **`impl-nav`** (`feat/nav-groups-0901`) — `app.js`: their edits are `state` (~160), a nav
  block above the `DIMS` comment, `go()`/`urlFor()`/`parseURL()`/`showGate()`/`applyAccount()`/
  `init()`, and `.tblwrap` wrappers at 6305-7308. Mine are ~2745, 2994-3030, 3183, 3680-3990.
  No overlap. `index.html`: they change only each `<section class="view">` **opening tag**
  (adding `role="tabpanel" aria-labelledby="tab-…"`, asserted by `dash/navhash.test.mjs` §10);
  my edit is strictly inside the Sessions panel below that line. **Either order works** —
  whoever lands second rebases. My branch adds ~120 lines to `app.js`, so line offsets past
  the old 3873 have shifted; address hunks by content, not by number.
- **`impl-perf`** (`perf/dash-load-0901`) — `style.css` at ~537, ~940, ~1165; mine at 694.
  No overlap, and they ship no `content-visibility` rule.
- **`impl-tabs`** — landing a shared `usdOrNA` helper. I render no dollar cell here; the two
  `—`-for-unknown dollar cells in my line range are theirs to convert in one place. **They
  land first**, I adopt it in a follow-up.

## Known gaps

- `components: ['dedup', 'extract']` on one block has never been observed end to end. This
  change does not touch chip rendering, so no fixture was constructed for it.
- Cold-storage paths are unit-tested (`windowEvents`); `?fetch=1` against a real remote is not
  exercised here.
- 50 turns/page is derived from measured blocks-per-turn (max 24 / avg 7.9) against the
  ~2,000-block knee, not A/B'd against 25 or 100.
- The `--paged` figures come from a route stub mirroring the server's cursor semantics; the Go
  side is separately tested to its last page. No single run drove both halves, because the
  seeded corpus has no 1,310-turn session to point a browser at.

All content in every measurement, screenshot and fixture is synthetic, of the measured
production *shape*. No production text appears anywhere in this branch.
