### PR TITLE
feat(dash): group the 17 dashboard tabs into 5 question-based groups

### DIFF
--- a/dash/api_test.go
+++ b/dash/api_test.go
@@ -336,6 +336,11 @@ func TestUIHasTestIDsForEveryStatTile(t *testing.T) {
 		"detail-summary", "detail-components", "live-table", "live-indicator",
 		"theme-toggle", "tab-overview", "tab-components", "tab-sessions", "tab-requests",
 		"tab-benchmarks", "tab-config", "filter-q", "filter-range", "filter-model",
+		// The nav's first level. tab-overview above is the Overview group's button: that
+		// group is also a view, so it is the one that carries data-view as well, and its
+		// testid stays the way to reach the Overview view. tab-note is the one line that
+		// says why a tab in the open group is locked.
+		"group-savings", "group-behaviour", "group-traffic", "group-admin", "tab-note",
 		"filter-provider", "filter-agent", "filter-preset", "filter-mode",
 		"filter-component", "filter-reason", "filter-accounting", "filter-clear",
 		"request-row", "diff-mode-git", "diff-mode-side", "diff-mode-orig", "diff-mode-raw",

--- a/dash/navhash.test.mjs
+++ b/dash/navhash.test.mjs
@@ -1,0 +1,255 @@
+// The dashboard's URL contract, tested against the REAL resolver in app.js.
+//
+// Every filtered view of this dashboard is a link, and those links are pasted into issues,
+// runbooks and commit messages — and two of the shapes are written by the SERVER
+// (dash/kvcache.go:510-511), so they cannot be found and updated. Adding a second nav level
+// changed the canonical hash from `#<view>` to `#/<group>/<view>`, which is precisely the
+// kind of change that silently breaks every link ever written. Hence a table rather than a
+// hand check.
+//
+// There is no bundler and no test framework in this project, on purpose: `node --test` and
+// `node:assert` ship with node. app.js is a classic script, so it is loaded the way the
+// browser loads it — as source, into a function scope, over a stub DOM small enough to read.
+// Nothing here is a second implementation of the resolver; a change to app.js changes what
+// this file tests.
+//
+//   node --test dash/navhash.test.mjs        (or: go test ./dash/ -run NavHash)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Beside dash/, not inside dash/ui/, because `//go:embed ui` (dash/ui.go:29) would
+// otherwise ship this file inside the proxy binary and serve it at /dashboard/.
+const read = (f) => readFileSync(new URL('./ui/' + f, import.meta.url), 'utf8');
+
+// ── the stub DOM ───────────────────────────────────────────────────────────
+// The nav is the only DOM the resolver touches, and it reads it through exactly one
+// selector shape. So the tab list is parsed out of index.html and the three self-mounting
+// views' own mountTab() calls, which makes this a test of the real nav rather than of a
+// hand-written copy of it: a tab moved between groups in the markup moves here too.
+function navFromSource() {
+  const groups = new Map();
+  const mounted = [];
+  const html = read('index.html');
+  for (const [, group, body] of html.matchAll(
+    /<div class="viewtabs"[^>]*data-group="([a-z]+)"[^>]*>([\s\S]*?)<\/div>/g)) {
+    groups.set(group, [...body.matchAll(/data-view="([a-z]+)"/g)].map((m) => m[1]));
+  }
+  // The self-mounters declare their own group and position; splice them in the same way
+  // mountTab does, so `after:` is exercised rather than assumed.
+  for (const f of ['tools.js', 'kvcache.js', 'campaigns.js']) {
+    const call = read(f).match(/mountTab\(\{([\s\S]*?)\}\)/);
+    assert.ok(call, `${f} no longer calls mountTab()`);
+    const field = (k) => (call[1].match(new RegExp(k + ":\\s*'([a-z]+)'")) || [])[1];
+    const [group, view, after] = [field('group'), field('view'), field('after')];
+    const list = groups.get(group);
+    assert.ok(list, `${f} mounts into group ${group}, which index.html does not define`);
+    const at = list.indexOf(after);
+    assert.ok(at >= 0, `${f} mounts after ${after}, which is not in group ${group}`);
+    list.splice(at + 1, 0, view);
+    mounted.push([view, group]);
+  }
+  return { groups, mounted };
+}
+const { groups: NAV, mounted: MOUNTED } = navFromSource();
+
+/** loadApp evaluates app.js over the stub and hands back the internals under test. */
+function loadApp() {
+  const loc = { pathname: '/dashboard/', hash: '' };
+  // Only the one selector shape the nav reads, and a tab object with only the three
+  // properties reachable() and firstView() look at. Anything else returns empty, which is
+  // what a null-DOM would do anyway.
+  const querySelectorAll = (sel) => {
+    const m = /^\.viewtabs\[data-group="([a-z]+)"\] \.tab$/.exec(sel);
+    return (m ? NAV.get(m[1]) || [] : []).map((v) => ({
+      hidden: false, dataset: { view: v }, getAttribute: () => null,
+    }));
+  };
+  const noop = () => {};
+  const stub = {
+    document: {
+      addEventListener: noop, querySelector: () => null, querySelectorAll,
+      documentElement: { getAttribute: noop, setAttribute: noop }, head: { appendChild: noop },
+      createElement: () => ({ setAttribute: noop, appendChild: noop, classList: {}, style: {} }),
+    },
+    window: { addEventListener: noop },
+    localStorage: { getItem: () => null, setItem: noop, removeItem: noop },
+    location: loc,
+    EventSource: function EventSource() {}, setInterval: noop, setTimeout: noop, fetch: noop,
+  };
+  const names = Object.keys(stub);
+  const api = new Function(...names,
+    read('app.js') + '\n;return { parseURL, urlFor, resolveNav, navPath, state, DIMS, GROUP_OF };')(
+    ...names.map((n) => stub[n]));
+  api.at = (hash) => { loc.hash = hash; return api.parseURL(); };
+  // urlFor reads `state`, so a round-trip is: parse a hash, adopt it, write it back.
+  api.roundTrip = (hash) => {
+    const w = api.at(hash);
+    Object.assign(api.state, w);
+    return api.urlFor().replace('/dashboard/', '');
+  };
+  return api;
+}
+const app = loadApp();
+// mountTab() does exactly this to GROUP_OF when a self-mounting view loads. Doing it here is
+// what makes the three appended views' hashes testable without a browser; the groups and the
+// positions come from their own mountTab() calls, not from a list in this file.
+for (const [view, group] of MOUNTED) app.GROUP_OF.set(view, group);
+
+const VIEWS = [...NAV.values()].flat().concat('overview');
+
+// ── 1. every view, by its bare legacy name and in canonical form ───────────
+test('all 17 views resolve from a bare #<view> and canonicalise to #/<group>/<view>', () => {
+  assert.equal(VIEWS.length, 17, 'the nav is no longer 17 views; update this table');
+  for (const v of VIEWS) {
+    assert.equal(app.at('#' + v).view, v, `#${v} must still resolve to ${v}`);
+    const canon = app.roundTrip('#' + v);
+    assert.equal(app.at(canon).view, v, `${canon} must resolve back to ${v}`);
+    assert.match(canon, /^#\//, `${canon} is not in canonical #/... form`);
+    // Overview is a group AND a view, so its canonical path is the one that is not doubled.
+    const want = v === 'overview' ? '#/overview' : '#/' + app.navPath(v);
+    assert.equal(canon, want);
+    assert.equal(app.at(want).view, v);
+  }
+});
+
+// ── 2. all 14 filter dimensions survive a round trip ──────────────────────
+test('all 14 filter dimensions are read and written', () => {
+  const dims = app.DIMS.map(([k]) => k);
+  assert.deepEqual(dims, ['q', 'model', 'provider', 'agent', 'preset', 'mode', 'component',
+    'reason', 'accounting', 'effort', 'thinking', 'stop_reason', 'session', 'tenant']);
+  for (const k of dims) {
+    const got = app.at(`#requests?${k}=v1`);
+    assert.equal(got.filter[k], 'v1', `${k} is not parsed out of the hash`);
+    assert.match(app.roundTrip(`#requests?${k}=v1`), new RegExp(`[?&]${k}=v1`),
+      `${k} is parsed but not written back`);
+  }
+  // And together, so no dimension is dropped when another is set.
+  const all = dims.map((k) => `${k}=${k}v`).join('&');
+  const got = app.at('#requests?' + all);
+  for (const k of dims) assert.equal(got.filter[k], k + 'v');
+});
+
+// ── 3. the time window ────────────────────────────────────────────────────
+test('from/to take a relative token or absolute ms, and `to` is omitted while now', () => {
+  assert.equal(app.at('#usage?from=now-24h').from, 'now-24h');
+  assert.equal(app.at('#usage?from=now-24h').to, 'now');
+  assert.equal(app.at('#usage?from=1700000000000').from, 1700000000000);
+  assert.equal(app.at('#usage?from=1700000000000&to=1700000900000').to, 1700000900000);
+  assert.equal(app.at('#usage?from=now-2d&to=now-1d').to, 'now-1d');
+  assert.ok(!app.roundTrip('#usage?from=now-6h').includes('to='),
+    'a live window must stay live for whoever the link is sent to');
+  assert.ok(app.roundTrip('#usage?from=now-2d&to=now-1d').includes('to=now-1d'));
+  // Junk is all-time rather than NaN, which would send `since=NaN` to the API.
+  assert.equal(app.at('#usage?from=tomorrow').from, 0);
+  assert.equal(app.at('#usage?from=-5').from, 0);
+});
+
+// ── 4. LEGACY range=<ms>. Read, never written. docs/dashboard.md documents it. ──
+test('legacy range=<ms> still maps onto the equivalent relative window', () => {
+  for (const [ms, want] of [[86400000, 'now-1d'], [3600000, 'now-1h'], [604800000, 'now-1w'],
+    [300000, 'now-5m'], [1000, 'now-1s'], [1500, 'now-2s']]) {
+    assert.equal(app.at(`#usage?range=${ms}`).from, want, `range=${ms}`);
+  }
+  // The documented example, end to end: docs/dashboard.md.
+  assert.equal(app.roundTrip('#usage?range=86400000'), '#/savings/usage?from=now-1d');
+  assert.ok(!app.roundTrip('#usage?range=86400000').includes('range='),
+    'range= is read for compatibility and never written');
+});
+
+// ── 5. sort/dir — written only on components, parsed anywhere ──────────────
+test('sort and dir parse on any view and are written only on components', () => {
+  assert.equal(app.at('#components?sort=saved&dir=asc').sort, 'saved');
+  assert.equal(app.at('#components?sort=saved&dir=asc').dir, 'asc');
+  assert.equal(app.at('#components?sort=saved').dir, 'desc', 'dir defaults to desc');
+  assert.equal(app.at('#requests?sort=saved').sort, 'saved', 'sort parses on every view');
+  assert.ok(app.roundTrip('#components?sort=saved&dir=asc').includes('sort=saved&dir=asc'));
+  assert.ok(!app.roundTrip('#requests?sort=saved').includes('sort='),
+    'a sort of another view’s table is not this view’s state');
+});
+
+// ── 6. the drawer: req | diff | acct, mutually exclusive ──────────────────
+test('the drawer keys are mutually exclusive and round-trip', () => {
+  assert.deepEqual(app.at('#requests?req=9').drawer, { req: 9 });
+  assert.deepEqual(app.at('#sessions?diff=s-1').drawer, { diff: 's-1' });
+  assert.deepEqual(app.at('#tenants?acct=a-1').drawer, { acct: 'a-1' });
+  assert.deepEqual(app.at('#requests?req=9&diff=s-1').drawer, { req: 9 }, 'req wins');
+  assert.equal(app.at('#requests').drawer, null);
+  assert.equal(app.at('#requests?req=0').drawer, null, 'req=0 is not a request');
+  assert.equal(app.roundTrip('#requests?req=9'), '#/traffic/requests?req=9');
+  assert.equal(app.roundTrip('#sessions?diff=s-1'), '#/traffic/sessions?diff=s-1');
+});
+
+// ── 7. THE TWO SHAPES THE SERVER WRITES ───────────────────────────────────
+// dash/kvcache.go:510-511 builds these, asserted in dash/kvcache_test.go:380,383, and
+// dash/uikvcache_test.go:267 asserts the UI must NOT build them — so the server stays their
+// sole author and these strings cannot be found by grepping the front end.
+test('the hashes dash/kvcache.go writes still resolve', () => {
+  const req = app.at('#requests?req=1234');
+  assert.equal(req.view, 'requests');
+  assert.deepEqual(req.drawer, { req: 1234 });
+  // A session id is client-supplied, so the server percent-escapes it; decoding is
+  // URLSearchParams' job and a `/` in the id must not read as a path separator.
+  const diff = app.at('#sessions?diff=sess%2Fwith%20space');
+  assert.equal(diff.view, 'sessions');
+  assert.deepEqual(diff.drawer, { diff: 'sess/with space' });
+});
+
+// ── 8. two-level paths ────────────────────────────────────────────────────
+test('#/group/view, #/group alone, and a stale group segment', () => {
+  assert.equal(app.at('#/behaviour/kvcache').view, 'kvcache');
+  assert.equal(app.at('#/savings/campaigns').view, 'campaigns');
+  // The leading slash is written but not required, which is what settles the ambiguity the
+  // one-level form left: the LAST segment is the view, so `savings/campaigns` cannot be
+  // read as a view literally named "savings/campaigns".
+  assert.equal(app.at('#savings/campaigns').view, 'campaigns');
+  assert.equal(app.roundTrip('#savings/campaigns'), '#/savings/campaigns');
+  // A group on its own opens its first tab.
+  assert.equal(app.at('#/savings').view, 'usage');
+  assert.equal(app.at('#/behaviour').view, 'components');
+  assert.equal(app.at('#/traffic').view, 'sessions');
+  assert.equal(app.at('#/admin').view, 'config');
+  assert.equal(app.at('#/overview').view, 'overview');
+  // A view that moved group is still found; the segment before it is only a hint.
+  assert.equal(app.at('#/admin/campaigns').view, 'campaigns');
+  assert.equal(app.roundTrip('#/admin/campaigns'), '#/savings/campaigns');
+  // A group that survived and a view name that did not.
+  assert.equal(app.at('#/savings/typo').view, 'usage');
+  // Filters ride along on both forms.
+  assert.equal(app.at('#/savings/usage?model=m1').filter.model, 'm1');
+});
+
+// ── 9. junk resolves to Overview rather than to a blank page ───────────────
+test('an unknown, empty or mis-cased hash resolves to overview', () => {
+  for (const h of ['', '#', '#/', '#nonsense', '#OVERVIEW', '#Usage', '#/no/such/thing',
+    '#view-usage', '#/nonsense/nonsense']) {
+    assert.equal(app.at(h).view, 'overview', `${JSON.stringify(h)} should fall back`);
+  }
+  // Case-sensitive on purpose: #OVERVIEW is not a near-miss to be corrected, it is a name
+  // that does not exist, and go() rewrites the address bar so it does not stay wrong.
+  assert.equal(app.roundTrip('#OVERVIEW'), '#/overview');
+  assert.equal(app.roundTrip('#nonsense'), '#/overview');
+  // Empty parameters are dropped rather than becoming empty filters.
+  const got = app.at('#requests?req=9&&&');
+  assert.equal(got.view, 'requests');
+  assert.deepEqual(got.drawer, { req: 9 });
+  assert.equal(app.roundTrip('#requests?req=9&&&'), '#/traffic/requests?req=9');
+  assert.deepEqual(app.at('#requests?model=').filter, {}, 'an empty value is not a filter');
+});
+
+// ── 10. every view in the nav is a real view, and vice versa ──────────────
+test('the nav, the loaders and the view sections agree', () => {
+  const html = read('index.html');
+  for (const v of VIEWS) {
+    assert.ok(app.GROUP_OF.has(v) || ['tools', 'kvcache', 'campaigns'].includes(v),
+      `${v} has no group`);
+  }
+  // A tab whose section is missing is a tab that switches to a blank page. The three
+  // self-mounted sections are built in JS, so they are checked in their own files.
+  for (const v of VIEWS) {
+    if (['tools', 'kvcache', 'campaigns'].includes(v)) continue;
+    assert.ok(html.includes(`id="view-${v}"`), `no section for ${v}`);
+    assert.ok(html.includes(`aria-labelledby="tab-${v}"`), `${v}'s panel names no tab`);
+    assert.ok(html.includes(`aria-controls="view-${v}"`), `${v}'s tab controls no panel`);
+  }
+});

--- a/dash/navhash_test.go
+++ b/dash/navhash_test.go
@@ -1,0 +1,104 @@
+package dash
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The URL contract is tested in JS, against the real resolver, because a second
+// implementation of it in Go would prove that the two agreed and nothing about what a
+// pasted link does. See navhash.test.mjs for the table and the reasoning; this is the
+// wrapper that makes `go test ./dash/` run it.
+//
+// node is not a build dependency of this project and never will be — the dashboard ships as
+// files in a Go binary with no bundler. So this skips when node is absent, LOUDLY, naming
+// what then goes unverified. TestTheNavHashContractIsPinned below is the part that holds
+// without node.
+func TestNavHashCompatibility(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not on PATH, so navhash.test.mjs did not run: the URL " +
+			"compatibility contract (17 bare views, 14 filter dimensions, legacy range=<ms>, " +
+			"the two hashes dash/kvcache.go writes, and #/group/view) is UNVERIFIED in this " +
+			"run. Run `node --test dash/navhash.test.mjs`.")
+	}
+	out, err := exec.Command(node, "--test", "navhash.test.mjs").CombinedOutput()
+	if err != nil {
+		t.Fatalf("node --test navhash.test.mjs failed: %v\n%s", err, out)
+	}
+	// A pass with zero tests run is not a pass.
+	if !strings.Contains(string(out), "# fail 0") || strings.Contains(string(out), "# pass 0") {
+		t.Fatalf("unexpected node --test summary:\n%s", out)
+	}
+}
+
+// What the JS table covers, asserted statically so it holds in a run with no node: the
+// pieces of the URL contract that are single strings in the source, and would each break a
+// documented or server-authored link if they went missing.
+func TestTheNavHashContractIsPinned(t *testing.T) {
+	app := readUI(t, "ui/app.js")
+	for _, want := range []struct{ needle, why string }{
+		{"function legacyFrom(", "legacy range=<ms> bookmarks (docs/dashboard.md) map onto a relative window here"},
+		{"p.get('range')", "range=<ms> is no longer read, so every pre-from/to link widens to all time"},
+		{"function resolveNav(", "the one place a hash path becomes a view"},
+		{"function navPath(", "the one place a view becomes a hash path"},
+		{`replace(/^#\/?/, '')`, "the leading slash of the canonical #/group/view form is no longer optional"},
+		{"'#/' + navPath(", "urlFor no longer writes the canonical two-level hash"},
+	} {
+		if !strings.Contains(app, want.needle) {
+			t.Errorf("app.js no longer contains %q: %s", want.needle, want.why)
+		}
+	}
+	// The 14 filter dimensions, by name. Dropping one silently narrows nothing and widens
+	// every link that set it.
+	for _, dim := range []string{"q", "model", "provider", "agent", "preset", "mode",
+		"component", "reason", "accounting", "effort", "thinking", "stop_reason", "session",
+		"tenant"} {
+		if !strings.Contains(app, "['"+dim+"',") {
+			t.Errorf("filter dimension %q is not in DIMS; links carrying it break", dim)
+		}
+	}
+	// The nav's five groups, and the fact that mountTab is the only thing that knows the
+	// nav's DOM shape.
+	for _, g := range []string{"overview", "savings", "behaviour", "traffic", "admin"} {
+		if !strings.Contains(app, "['"+g+"', [") {
+			t.Errorf("nav group %q is gone from GROUPS", g)
+		}
+	}
+	for _, f := range []string{"ui/tools.js", "ui/kvcache.js", "ui/campaigns.js"} {
+		src := readUI(t, f)
+		if !strings.Contains(src, "mountTab({") {
+			t.Errorf("%s does not mount its tab through mountTab()", f)
+		}
+		if strings.Contains(src, "$('.tabs')") {
+			t.Errorf("%s reaches into the nav itself; mountTab() is the one place that knows "+
+				"its DOM shape", f)
+		}
+	}
+}
+
+// The two hashes the SERVER writes (dash/kvcache.go:510-511) are one-level, legacy-shaped,
+// and unreachable by grepping the front end — the UI is forbidden from building them
+// (TestTheDetailTableLinksAreServerBuilt). So the resolver's one-segment branch is not a shim
+// to be tidied away later; it is what makes every row of the KV-cache table clickable.
+func TestTheServerAuthoredHashesNameViewsTheNavStillHas(t *testing.T) {
+	html := readUI(t, "ui/index.html")
+	for _, view := range []string{"requests", "sessions"} {
+		if !strings.Contains(html, `data-view="`+view+`"`) {
+			t.Errorf("dash/kvcache.go writes #%s?..., and there is no longer a %q tab for the "+
+				"resolver to find", view, view)
+		}
+	}
+	src, err := os.ReadFile("kvcache.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, shape := range []string{`"#requests?req=%d"`, `"#sessions?diff=" + url.PathEscape`} {
+		if !strings.Contains(string(src), shape) {
+			t.Errorf("kvcache.go no longer writes %s; if it moved, navhash.test.mjs "+
+				"section 7 must move with it", shape)
+		}
+	}
+}

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -6302,7 +6302,7 @@ async function loadMachines() {
       }, s.current ? 'Sign out here' : 'Revoke'))));
   }
   tbl.appendChild(body);
-  host.appendChild(tbl);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
 }
 
 /** Store this configuration as the tenant's own, or '' to go back to following the
@@ -6675,7 +6675,7 @@ async function loadTokens() {
         }, 'Revoke'))));
   }
   tbl.appendChild(body);
-  host.appendChild(tbl);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
 }
 
 async function loadAudit() {
@@ -6715,7 +6715,7 @@ async function loadAudit() {
           : null)));
     }
     tbl.appendChild(body);
-    host.appendChild(tbl);
+    host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   } catch (e) { errorState(host, 'Could not read the audit log', e); }
 }
 
@@ -6819,7 +6819,7 @@ async function loadTenants() {
           }, 'Manage')))));
     }
     tbl.appendChild(body);
-    host.appendChild(tbl);
+    host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   } catch (e) {
     clear(host);
     errorState(host, 'Could not list tenants', e);
@@ -7249,7 +7249,7 @@ async function loadVariants() {
     }
   }
   tbl.appendChild(body);
-  host.appendChild(tbl);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
 
   // The full caveat list comes from the server rather than being written twice: the API
   // decides what this comparison cannot show, and a second copy in the page would drift.
@@ -7305,7 +7305,7 @@ async function loadArchive() {
         }, 'Open'))));
     }
     tbl.appendChild(body);
-    host.appendChild(tbl);
+    host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   } catch (e) {
     clear(host);
     errorState(host, 'Could not list the archive', e);

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -159,6 +159,9 @@ function modeLabel(m) {
 // ── state ──────────────────────────────────────────────────────────────────
 const state = {
   view: 'overview',
+  // The open nav group, derived from `view` by go(). Held rather than recomputed because
+  // both nav levels read it on every switch.
+  group: 'overview',
   filter: {},
   // loadedAt is when the rollups on screen were fetched, and dirty is whether the server
   // has captured a request since. Together they are the whole freshness contract of a page
@@ -4209,6 +4212,168 @@ const loaders = {
   keepalive: loadKeepAlive,
 };
 
+// ── nav: two levels, five groups ───────────────────────────────────────────
+//
+// MODULE SEAM (app.js split, sequenced after this change): everything from here to the end
+// of `applyURL` is the SHELL + ROUTER — the nav, the hash contract and the view switch. It
+// depends on `loaders`, `DIMS`, `state` and the DOM helpers, and nothing below it depends on
+// its internals except through `go`, `mountTab` and `syncNav`. The other three seams are:
+// overview+usage+components (the rollup views), sessions+requests (the traffic views and the
+// request/diff drawer), and admin (setup/settings/tenants/strategies/archive/feedback/config).
+//
+/**
+ * GROUPS is the nav, and the ONLY place the two levels' shape is written down: the group
+ * buttons in index.html mirror it, the per-group tablists mirror it, and the hash's first
+ * path segment is a group name from it.
+ *
+ * It deliberately lists only the views index.html authors. Inventory, KV-cache and
+ * Campaigns are absent because they mount themselves (mountTab) — hardcoding them here
+ * would put back exactly the coupling that self-mounting exists to avoid.
+ */
+const GROUPS = [
+  ['overview', ['overview']],
+  ['savings', ['usage', 'benchmarks']],
+  ['behaviour', ['components', 'keepalive']],
+  ['traffic', ['sessions', 'requests']],
+  ['admin', ['config', 'strategies', 'tenants', 'setup', 'settings', 'archive', 'feedback']],
+];
+/** GROUP_OF maps a view onto its group. mountTab adds to it, which is how a self-mounted
+ *  view gets a group without this file naming it. */
+const GROUP_OF = new Map(GROUPS.flatMap(([g, views]) => views.map((v) => [v, g])));
+
+/** navTab is a view's tab button, in whichever level owns it: Overview's tab is a group
+ *  button (it is a group AND a view), every other view's tab is in a group's tablist. */
+function navTab(view) { return $(`[data-view="${view}"]`); }
+/** reachable is "this account can open it now" — the permission gate hides, the local-mode
+ *  lock only disables, and neither is navigable. */
+function reachable(tab) { return !tab.hidden && tab.getAttribute('aria-disabled') !== 'true'; }
+/** firstView is what a group opens on: its first REACHABLE tab, so Admin on a single-tenant
+ *  proxy lands on Config rather than on a locked Tenants. null = nothing in it is open to
+ *  this viewer, and the group button hides. */
+function firstView(group) {
+  if (group === 'overview') return 'overview';
+  const t = $$(`.viewtabs[data-group="${group}"] .tab`).find(reachable);
+  return t ? t.dataset.view : null;
+}
+
+/**
+ * mountTab adds one tab and its panel, and is the single place outside this section that
+ * knows the nav's DOM shape — tools.js, kvcache.js and campaigns.js each call it once.
+ *
+ * The tab button exists as soon as the caller runs, BEFORE the view's body is built, so
+ * lazy-loading those bodies later is a change to the caller and not to the nav.
+ *
+ * It returns the empty `<section class="view">`, already appended to #main and already
+ * wired as the tab's tabpanel, which is what each caller then fills.
+ */
+function mountTab({ group, after, view, label, manager }) {
+  const list = $(`.viewtabs[data-group="${group}"]`);
+  if (!list) throw new Error('mountTab: no such group: ' + group);
+  const tab = el('button', {
+    role: 'tab', class: 'tab', id: 'tab-' + view, 'data-view': view,
+    'data-testid': 'tab-' + view, 'aria-controls': 'view-' + view,
+    'aria-selected': 'false', tabindex: '-1',
+    // `manager` is the only gate any self-mounting view has needed. data-local-ok and
+    // data-account are markup-only for that reason; add a flag the day a caller wants one.
+    'data-manager': manager ? '' : null,
+    // A gated tab mounts hidden and applyAccount reveals it, exactly like the ones in the
+    // markup: a manager tab that is visible for the moment before /api/whoami answers is a
+    // manager tab a non-manager can click.
+    hidden: manager ? 'hidden' : null,
+  }, label);
+  const sib = after && $(`.tab[data-view="${after}"]`, list);
+  list.insertBefore(tab, sib ? sib.nextSibling : null);
+  GROUP_OF.set(view, group);
+  const panel = el('section', {
+    class: 'view', id: 'view-' + view, role: 'tabpanel',
+    'aria-labelledby': 'tab-' + view, hidden: 'hidden',
+  });
+  $('#main').appendChild(panel);
+  return panel;
+}
+
+/**
+ * syncNav makes both nav levels match state: which group is open, which of its tabs is
+ * selected, which groups this viewer has anything in, and ONE tab stop per level.
+ *
+ * That last part is the fix for a measured defect: seventeen `role="tab"` buttons were
+ * seventeen Tab stops, so reaching the filter bar by keyboard meant seventeen presses. The
+ * WAI-ARIA tabs pattern is one stop per tablist with the arrows moving inside it — navKeys.
+ */
+function syncNav() {
+  const group = state.group || 'overview';
+  for (const b of $$('.groups .tab')) {
+    b.hidden = !firstView(b.dataset.group);
+    const on = b.dataset.group === group;
+    b.setAttribute('aria-selected', String(on));
+    b.tabIndex = on ? 0 : -1;
+  }
+  const panel = $(`#subnav .grouppanel[data-group="${group}"]`);
+  for (const p of $$('#subnav .grouppanel')) p.hidden = p !== panel;
+  // Overview is a group with one view, so it has no second level at all rather than a
+  // sub-nav row holding a single tab that repeats the label above it. And nothing in the
+  // nav means anything while the gate is up — a stray sub-nav bar over a login form is
+  // worse than no nav, which is why showGate calls back into here.
+  $('#subnav').hidden = !panel || gated();
+  for (const t of $$('.viewtabs .tab')) {
+    const on = t.dataset.view === state.view;
+    t.setAttribute('aria-selected', String(on));
+    t.tabIndex = on ? 0 : -1;
+  }
+  // A tablist whose selected tab is not in it (mid-switch) would have no tab stop at all.
+  if (panel && !$('.tab[tabindex="0"]', panel)) {
+    const t = $$('.tab', panel).find(reachable) || $('.tab', panel);
+    if (t) t.tabIndex = 0;
+  }
+  renderTabNote(panel);
+}
+
+/**
+ * lockTab marks a tab present-but-not-now instead of hiding it. NN/g `empty-nav-state`: an
+ * unavailable destination should say why, and on a default single-tenant proxy only nine of
+ * the seventeen tabs are open, so silently hiding the rest makes the product look half its
+ * size and reads as a broken build. A locked tab keeps its place and stays focusable.
+ */
+function lockTab(tab, why) {
+  if (why) { tab.setAttribute('aria-disabled', 'true'); tab.dataset.why = why; } else { tab.removeAttribute('aria-disabled'); delete tab.dataset.why; }
+}
+
+/** renderTabNote is the one line under a group's tabs naming what is locked and why. All
+ *  current locks share one reason, so the note states it once; give it a per-reason split
+ *  the day a second reason exists. */
+function renderTabNote(panel) {
+  const note = $('#tab-note');
+  const locked = panel ? $$('.tab[aria-disabled="true"]', panel) : [];
+  note.hidden = !locked.length;
+  if (!locked.length) return;
+  const names = locked.map((t) => t.textContent);
+  const list = names.length > 1
+    ? names.slice(0, -1).join(', ') + ' and ' + names[names.length - 1] + ' need'
+    : names[0] + ' needs';
+  note.textContent = list + ' ' + locked[0].dataset.why + '.';
+}
+
+/**
+ * navKeys is arrow-key movement inside a tablist, with MANUAL activation: the arrows move
+ * focus and Enter/Space (the button's own behaviour) opens it. Automatic activation is the
+ * pattern's default, but every tab here fires a data fetch, so scrubbing across Admin's
+ * seven tabs would issue seven queries nobody asked for.
+ */
+function navKeys(ev) {
+  const from = ev.target.closest('[role="tab"]');
+  if (!from) return;
+  const tabs = $$('[role="tab"]', ev.currentTarget).filter((t) => !t.hidden);
+  const i = tabs.indexOf(from);
+  const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 }[ev.key];
+  let j = -1;
+  if (step) j = (i + step + tabs.length) % tabs.length;
+  else if (ev.key === 'Home') j = 0;
+  else if (ev.key === 'End') j = tabs.length - 1;
+  if (j < 0 || j === i) return;
+  ev.preventDefault();
+  tabs[j].focus();
+}
+
 /**
  * DIMS is every filter dimension, and it is the single list the whole filter layer
  * reads: the URL, the chips, the facet dropdowns and the "why is this empty" copy.
@@ -4278,11 +4443,14 @@ function go(view, push = true) {
   if (!$('#gate').hidden) return;
   if (!Object.prototype.hasOwnProperty.call(loaders, view)) view = 'overview';
   // A view whose tab this account is not entitled to is not reachable by typing its
-  // hash either: its loader would 401/403 and paint an error nobody can act on.
-  const tab = $(`.tab[data-view="${view}"]`);
-  if (tab && tab.hidden) view = 'overview';
+  // hash either: its loader would 401/403 and paint an error nobody can act on. That
+  // covers a LOCKED tab as well as a hidden one — the lock says "not with this sign-in",
+  // and a 403 is not a better way to say it.
+  const tab = navTab(view);
+  if (tab && !reachable(tab)) view = 'overview';
   state.view = view;
-  for (const t of $$('.tab')) t.setAttribute('aria-selected', String(t.dataset.view === view));
+  state.group = GROUP_OF.get(view) || 'overview';
+  syncNav();
   for (const s of $$('.view')) s.hidden = s.id !== 'view-' + view;
   // A filter bar over a view with nothing to filter is thirteen controls inviting clicks
   // that change nothing — and on Settings it sat directly above a form, so the two read as
@@ -4493,7 +4661,34 @@ function urlFor() {
   // send each other, and Back must close the panel rather than undo a filter change.
   if (state.drawer && state.drawer.acct) p.set('acct', state.drawer.acct);
   const q = p.toString();
-  return location.pathname + '#' + state.view + (q ? '?' + q : '');
+  return location.pathname + '#/' + navPath(state.view) + (q ? '?' + q : '');
+}
+/**
+ * navPath is the canonical hash path for a view: `<group>/<view>`, collapsed to just the
+ * name when a group is also a view (Overview). So `#/savings/usage`, and `#/overview`.
+ *
+ * THE RULE, stated once: the LAST path segment is the view; anything before it is a group
+ * hint and is ignored whenever the view is known. That is what makes the old one-level
+ * `#usage` and the new `#/savings/usage` the same link, and it is decidable without a
+ * lookahead because no view name contains a slash. The leading slash is written, not
+ * required — `#savings/usage` resolves identically and is rewritten.
+ */
+function navPath(view) {
+  const g = GROUP_OF.get(view) || 'overview';
+  return g === view ? view : g + '/' + view;
+}
+/**
+ * resolveNav turns a hash path into a view name. Every link this dashboard has ever
+ * written is one segment, including the two the SERVER writes (dash/kvcache.go:510-511),
+ * so that branch is not a compatibility shim to be removed later — it is half the traffic.
+ */
+function resolveNav(path) {
+  const seg = String(path || '').split('/').filter(Boolean);
+  const view = seg[seg.length - 1] || '';
+  if (GROUP_OF.has(view)) return view;
+  // Only a group name survived (`#/admin`, or `#/savings/typo`): open its first tab.
+  const g = GROUPS.find(([n]) => n === seg[0]);
+  return (g && firstView(g[0])) || 'overview';
 }
 function syncURL(replace) {
   const url = urlFor();
@@ -4502,7 +4697,7 @@ function syncURL(replace) {
   else history.pushState(null, '', url);
 }
 function parseURL() {
-  const [view, query] = (location.hash || '').replace(/^#/, '').split('?');
+  const [path, query] = (location.hash || '').replace(/^#\/?/, '').split('?');
   const p = new URLSearchParams(query || '');
   const filter = {};
   for (const [k] of DIMS) if (p.get(k)) filter[k] = p.get(k);
@@ -4515,7 +4710,7 @@ function parseURL() {
   let from = p.get('from') || (legacy ? 'now-' + legacy + 'ms' : 0);
   if (legacy) from = legacyFrom(legacy);
   return {
-    view: view || 'overview', filter,
+    view: resolveNav(path), filter,
     from: numish(from), to: numish(p.get('to') || 'now'),
     sort: p.get('sort') || '', dir: p.get('dir') === 'asc' ? 'asc' : 'desc',
     drawer: req ? { req } : diff ? { diff } : acct ? { acct } : null,
@@ -4795,7 +4990,21 @@ function initTheme() {
 
 function init() {
   initTheme();
-  for (const t of $$('.tab')) t.addEventListener('click', () => go(t.dataset.view));
+  // Delegated, not one listener per tab: the three self-mounting views add their tabs
+  // while this file is still being parsed, so a per-tab loop here would either miss them
+  // or have to be re-run. A group button opens that group's first usable tab.
+  $('.groups').addEventListener('click', (ev) => {
+    const b = ev.target.closest('[data-group]');
+    if (b) go(firstView(b.dataset.group) || 'overview');
+  });
+  $('#subnav').addEventListener('click', (ev) => {
+    const t = ev.target.closest('.tab');
+    // A locked tab is inert; #tab-note beside it already says why, so a click that
+    // bounced to Overview would be a worse answer than no click at all.
+    if (t && reachable(t)) go(t.dataset.view);
+  });
+  $('.groups').addEventListener('keydown', navKeys);
+  $('#subnav').addEventListener('keydown', navKeys);
   // One control changes one filter. Nothing else in state.filter is touched, which is
   // what stops a filter with no control (session, tenant) from being wiped — or kept
   // invisibly — by a change to an unrelated dropdown.
@@ -5267,10 +5476,13 @@ function showGate(show) {
   // form invites clicking things that will 401 — and the TABS did exactly that, each
   // click firing a data fetch that answered 401 and logged a console error.
   $('#main').hidden = show;
-  for (const sel of ['.filters', '.tabs', '.live']) {
+  for (const sel of ['.filters', '.groups', '.live']) {
     const n = $(sel);
     if (n) n.hidden = show;
   }
+  // The second level is syncNav's, because whether it is shown at all depends on the open
+  // group as well as on the gate.
+  syncNav();
 }
 
 /** Reflect who is signed in, and which tabs that entitles them to. */
@@ -5287,9 +5499,18 @@ function applyAccount() {
   // fine on a single-tenant proxy, where there is no principal and nothing to scope:
   // /api/benchmarks is manager-gated in hosted mode but open locally, and hiding the tab
   // there would break the local dev path.
-  for (const el of $$('[data-manager]')) {
-    el.hidden = account.hosted ? !(t && t.role === 'manager') : !el.hasAttribute('data-local-ok');
+  //
+  // In HOSTED mode a non-manager still sees nothing: that is a permissions boundary over
+  // somebody else's data. In single-tenant local mode there is no other tenant to protect,
+  // so the manager-only tabs are LOCKED rather than hidden — see lockTab.
+  for (const b of $$('[data-manager]')) {
+    const ok = account.hosted ? !!(t && t.role === 'manager') : b.hasAttribute('data-local-ok');
+    b.hidden = account.hosted && !ok;
+    lockTab(b, ok || account.hosted ? '' : 'a manager sign-in');
   }
+  // data-account tabs stay silently hidden. A signed-out viewer has no use for a tab they
+  // cannot enable from here, which is the whole difference from the manager case above.
+  syncNav();
   loadTenantOptions();
 }
 function isManager() { return !!(account.tenant && account.tenant.role === 'manager'); }

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -4307,6 +4307,9 @@ function syncNav() {
     const on = b.dataset.group === group;
     b.setAttribute('aria-selected', String(on));
     b.tabIndex = on ? 0 : -1;
+    // Level 1 scrolls sideways below 900px rather than wrapping to a second 44px row, so
+    // the open group can be half off the edge. A no-op when it is already fully visible.
+    if (on) b.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   }
   const panel = $(`#subnav .grouppanel[data-group="${group}"]`);
   for (const p of $$('#subnav .grouppanel')) p.hidden = p !== panel;

--- a/dash/ui/campaigns.js
+++ b/dash/ui/campaigns.js
@@ -15,20 +15,17 @@
 'use strict';
 
 // ── mount ──────────────────────────────────────────────────────────────────
-// Right after Strategies: a campaign is a bulk way to create the same rows that tab
-// edits by hand.
-(function mountCampaignsTab() {
-  const tabs = $('.tabs');
-  const tab = el('button', {
-    role: 'tab', class: 'tab', 'data-view': 'campaigns', 'data-testid': 'tab-campaigns',
-    'data-manager': '', hidden: 'hidden', 'aria-selected': 'false',
-  }, 'Campaigns');
-  const after = $('.tab[data-view="strategies"]', tabs);
-  tabs.insertBefore(tab, after ? after.nextSibling : null);
-})();
-
-const campView = el('section', { class: 'view', id: 'view-campaigns', hidden: 'hidden' });
-$('#main').appendChild(campView);
+// Savings, right after Usage. A campaign is a bulk way to create the rows the Strategies
+// tab edits by hand, which is why it used to sit next to it — but what a reader comes here
+// to see is money it did or did not save, so it belongs beside the evidence for the
+// headline number rather than beside the editor. Still manager-only.
+//
+// mountTab (app.js) is the single place that knows the nav's DOM shape; it returns the
+// section, already appended to #main and wired as this tab's tabpanel.
+const campView = mountTab({
+  group: 'savings', after: 'usage', view: 'campaigns', label: 'Campaigns',
+  manager: true,
+});
 
 // ── local state ────────────────────────────────────────────────────────────
 // Its own object, not app.js's shared filter state: this view is in UNFILTERED_VIEWS,

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -10,26 +10,34 @@
 <body>
 <a class="skip" href="#main">Skip to content</a>
 
+<!-- One sticky box for the whole chrome. Three separately-stuck elements needed the
+     next one's height as a magic `top` offset (.filters was `top: 41px`), which a second
+     nav level breaks. Sticking the wrapper instead makes the offsets the browser's
+     problem. -->
+<div class="chrome">
 <header class="topbar">
   <h1 class="brand">
     <svg class="logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 18 L10 6 L14 14 L20 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
     <span>context-guru</span>
   </h1>
-  <nav class="tabs" role="tablist" aria-label="Views">
-    <button role="tab" class="tab" data-view="overview" data-testid="tab-overview" aria-selected="true">Overview</button>
-    <button role="tab" class="tab" data-view="usage" data-testid="tab-usage">Usage</button>
-    <button role="tab" class="tab" data-view="keepalive" data-testid="tab-keepalive">Keep-alive</button>
-    <button role="tab" class="tab" data-view="components" data-testid="tab-components" data-manager data-local-ok>Components</button>
-    <button role="tab" class="tab" data-view="sessions" data-testid="tab-sessions">Sessions</button>
-    <button role="tab" class="tab" data-view="requests" data-testid="tab-requests">Requests</button>
-    <button role="tab" class="tab" data-view="benchmarks" data-testid="tab-benchmarks" data-manager data-local-ok>Benchmarks</button>
-    <button role="tab" class="tab" data-view="archive" data-testid="tab-archive" data-account hidden>Archive</button>
-    <button role="tab" class="tab" data-view="setup" data-testid="tab-setup" data-account hidden>Setup</button>
-    <button role="tab" class="tab" data-view="settings" data-testid="tab-settings" data-account hidden>Settings</button>
-    <button role="tab" class="tab" data-view="feedback" data-testid="tab-feedback" data-account hidden>Feedback</button>
-    <button role="tab" class="tab" data-view="tenants" data-testid="tab-tenants" data-manager hidden>Tenants</button>
-    <button role="tab" class="tab" data-view="strategies" data-testid="tab-strategies" data-manager hidden>Strategies</button>
-    <button role="tab" class="tab" data-view="config" data-testid="tab-config" data-manager data-local-ok>Config</button>
+  <!-- Level 1: five groups, one per question a viewer arrives with. A flat list of
+       seventeen co-equal tabs was a hierarchy in name only — every viewer scanned all
+       seventeen labels to find one, and the manager got no signal about which three
+       mattered. Group order is also the manager→operator gradient: a manager stops after
+       Savings, an operator carries on, and nobody is denied anything.
+
+       Both levels are real tablists, related the way nested tabs are meant to be: a group
+       tab controls the .grouppanel holding that group's tablist, and each view tab controls
+       its own .view section. Overview is the one group that is also a view — it answers a
+       question rather than naming a category, so it gets no sub-nav and its tab points
+       straight at #view-overview. That is why this button carries data-view as well, and
+       why tab-overview is still the testid for reaching the Overview view. -->
+  <nav class="groups tabs" role="tablist" aria-label="Sections">
+    <button role="tab" class="tab" id="tab-overview" data-group="overview" data-view="overview" data-testid="tab-overview" aria-controls="view-overview" aria-selected="true">Overview</button>
+    <button role="tab" class="tab" id="grp-savings" data-group="savings" data-testid="group-savings" aria-controls="grp-savings-panel" aria-selected="false" tabindex="-1">Savings</button>
+    <button role="tab" class="tab" id="grp-behaviour" data-group="behaviour" data-testid="group-behaviour" aria-controls="grp-behaviour-panel" aria-selected="false" tabindex="-1">Behaviour</button>
+    <button role="tab" class="tab" id="grp-traffic" data-group="traffic" data-testid="group-traffic" aria-controls="grp-traffic-panel" aria-selected="false" tabindex="-1">Traffic</button>
+    <button role="tab" class="tab" id="grp-admin" data-group="admin" data-testid="group-admin" aria-controls="grp-admin-panel" aria-selected="false" tabindex="-1">Admin</button>
   </nav>
   <div class="topbar-right">
     <span class="live" data-testid="live-indicator" title="Live event stream"><i class="dot"></i><span id="live-label">connecting…</span></span>
@@ -39,6 +47,50 @@
     <button id="theme" class="ghost small" data-testid="theme-toggle" aria-label="Colour theme">Auto</button>
   </div>
 </header>
+
+<!-- Level 2: the open group's views. One tablist per group rather than one tablist whose
+     membership changes, so each carries its own accessible name and each group tab has a
+     real panel to control. The three self-mounting views (Inventory, KV-cache, Campaigns)
+     splice themselves in here via mountTab() — do not hardcode them, that is what keeps
+     them independently loadable.
+
+     One tab per line, deliberately: dash/api_test.go's gating check reads the last line
+     carrying data-testid="tab-<name>" and requires data-manager / data-local-ok on that
+     same line. -->
+<div id="subnav" hidden>
+  <div class="grouppanel" role="tabpanel" id="grp-savings-panel" data-group="savings" aria-labelledby="grp-savings" hidden>
+    <div class="viewtabs" role="tablist" data-group="savings" aria-label="Savings views">
+      <button role="tab" class="tab" id="tab-usage" data-view="usage" data-testid="tab-usage" aria-controls="view-usage" aria-selected="false" tabindex="-1">Usage</button>
+      <button role="tab" class="tab" id="tab-benchmarks" data-view="benchmarks" data-testid="tab-benchmarks" aria-controls="view-benchmarks" aria-selected="false" tabindex="-1" data-manager data-local-ok>Benchmarks</button>
+    </div>
+  </div>
+  <div class="grouppanel" role="tabpanel" id="grp-behaviour-panel" data-group="behaviour" aria-labelledby="grp-behaviour" hidden>
+    <div class="viewtabs" role="tablist" data-group="behaviour" aria-label="Behaviour views">
+      <button role="tab" class="tab" id="tab-components" data-view="components" data-testid="tab-components" aria-controls="view-components" aria-selected="false" tabindex="-1" data-manager data-local-ok>Components</button>
+      <button role="tab" class="tab" id="tab-keepalive" data-view="keepalive" data-testid="tab-keepalive" aria-controls="view-keepalive" aria-selected="false" tabindex="-1">Keep-alive</button>
+    </div>
+  </div>
+  <div class="grouppanel" role="tabpanel" id="grp-traffic-panel" data-group="traffic" aria-labelledby="grp-traffic" hidden>
+    <div class="viewtabs" role="tablist" data-group="traffic" aria-label="Traffic views">
+      <button role="tab" class="tab" id="tab-sessions" data-view="sessions" data-testid="tab-sessions" aria-controls="view-sessions" aria-selected="false" tabindex="-1">Sessions</button>
+      <button role="tab" class="tab" id="tab-requests" data-view="requests" data-testid="tab-requests" aria-controls="view-requests" aria-selected="false" tabindex="-1">Requests</button>
+    </div>
+  </div>
+  <div class="grouppanel" role="tabpanel" id="grp-admin-panel" data-group="admin" aria-labelledby="grp-admin" hidden>
+    <div class="viewtabs" role="tablist" data-group="admin" aria-label="Admin views">
+      <button role="tab" class="tab" id="tab-config" data-view="config" data-testid="tab-config" aria-controls="view-config" aria-selected="false" tabindex="-1" data-manager data-local-ok>Config</button>
+      <button role="tab" class="tab" id="tab-strategies" data-view="strategies" data-testid="tab-strategies" aria-controls="view-strategies" aria-selected="false" tabindex="-1" data-manager hidden>Strategies</button>
+      <button role="tab" class="tab" id="tab-tenants" data-view="tenants" data-testid="tab-tenants" aria-controls="view-tenants" aria-selected="false" tabindex="-1" data-manager hidden>Tenants</button>
+      <button role="tab" class="tab" id="tab-setup" data-view="setup" data-testid="tab-setup" aria-controls="view-setup" aria-selected="false" tabindex="-1" data-account hidden>Setup</button>
+      <button role="tab" class="tab" id="tab-settings" data-view="settings" data-testid="tab-settings" aria-controls="view-settings" aria-selected="false" tabindex="-1" data-account hidden>Settings</button>
+      <button role="tab" class="tab" id="tab-archive" data-view="archive" data-testid="tab-archive" aria-controls="view-archive" aria-selected="false" tabindex="-1" data-account hidden>Archive</button>
+      <button role="tab" class="tab" id="tab-feedback" data-view="feedback" data-testid="tab-feedback" aria-controls="view-feedback" aria-selected="false" tabindex="-1" data-account hidden>Feedback</button>
+    </div>
+  </div>
+  <!-- Why a tab in this group is there but not usable. One line for the group, not a badge
+       per tab: the locked tabs share a reason and three copies of it is noise. -->
+  <p class="tab-note" id="tab-note" data-testid="tab-note" role="status" hidden></p>
+</div>
 
 <section class="filters" aria-label="Filters">
   <input id="f-q" type="search" placeholder="Search session, model, agent…" data-testid="filter-q" aria-label="Search">
@@ -116,6 +168,7 @@
        filter is one only "Clear" can undo. -->
   <div id="f-active" class="chips" data-testid="filter-chips" role="group" aria-label="Active filters" hidden></div>
 </section>
+</div><!-- .chrome -->
 
 <div id="capture-warning" class="banner warn" hidden data-testid="capture-warning"></div>
 <!-- Observe mode: above the fold, before any number, because in that mode every figure
@@ -233,7 +286,7 @@
 <main id="main">
 
 <!-- ── Overview ───────────────────────────────────────────────────────────── -->
-<section class="view" id="view-overview">
+<section class="view" id="view-overview" role="tabpanel" aria-labelledby="tab-overview"None>
   <!-- The freshness bar. This page used to repaint itself every ten seconds, which made
        every figure on it unreadable and every open explanation close under the reader.
        Now it refreshes when the reader asks, or when the SSE stream says a request was
@@ -391,7 +444,7 @@
      Spent against saved, three ways of cutting it: by day, and by any one dimension of
      the request — including the metadata the request itself carried. Both panels read the
      filter bar above, so the time range is the range selected there. -->
-<section class="view" id="view-usage" hidden>
+<section class="view" id="view-usage" role="tabpanel" aria-labelledby="tab-usage" hidden>
   <div class="panel">
     <h2>Per day <span class="section-note">UTC</span></h2>
     <!-- Two dollar figures, and they are NOT either of the token savings ratios above: this
@@ -444,7 +497,7 @@
 </section>
 
 <!-- ── Components ─────────────────────────────────────────────────────────── -->
-<section class="view" id="view-components" hidden>
+<section class="view" id="view-components" role="tabpanel" aria-labelledby="tab-components" hidden>
   <div class="panel">
     <h2>Per-component economics</h2>
     <p class="note">Which components earn their place. A row opens that component's requests.</p>
@@ -501,7 +554,7 @@
 </section>
 
 <!-- ── Sessions ───────────────────────────────────────────────────────────── -->
-<section class="view" id="view-sessions" hidden>
+<section class="view" id="view-sessions" role="tabpanel" aria-labelledby="tab-sessions" hidden>
   <div class="panel">
     <h2>Sessions</h2>
     <p class="note">A row opens its requests; <strong>Diff</strong> opens what compaction
@@ -534,7 +587,7 @@
      the 119 sessions this mechanism touched on our own traffic lost money, funding a large
      rebate on 34, and the requirement is to save money rather than to raise the bill. A page
      that led with the calculator would be selling. -->
-<section class="view" id="view-keepalive" hidden>
+<section class="view" id="view-keepalive" role="tabpanel" aria-labelledby="tab-keepalive" hidden>
   <div class="panel">
     <h2>Verdict</h2>
     <p class="note">What the idle keep-alive has spent on your traffic and what it has
@@ -667,7 +720,7 @@
 </section>
 
 <!-- ── Requests ───────────────────────────────────────────────────────────── -->
-<section class="view" id="view-requests" hidden>
+<section class="view" id="view-requests" role="tabpanel" aria-labelledby="tab-requests" hidden>
   <div class="panel">
     <h2>Requests</h2>
     <div class="tblwrap" tabindex="0">
@@ -690,7 +743,7 @@
 </section>
 
 <!-- ── Benchmarks ─────────────────────────────────────────────────────────── -->
-<section class="view" id="view-benchmarks" hidden>
+<section class="view" id="view-benchmarks" role="tabpanel" aria-labelledby="tab-benchmarks" hidden>
   <div class="panel">
     <h2>Benchmark runs</h2>
     <p class="note">From the harness artifacts. Reward sits beside cost on purpose: an arm
@@ -704,7 +757,7 @@
 <!-- Archive: what has moved to cold storage. The list comes from a LOCAL index, so it
      renders instantly and works even when the remote is unreachable; only opening one
      session costs a network round trip. -->
-<section class="view" id="view-archive" hidden>
+<section class="view" id="view-archive" role="tabpanel" aria-labelledby="tab-archive" hidden>
   <div class="card">
     <div class="card-head">
       <h2>Cold storage</h2>
@@ -717,7 +770,7 @@
 </section>
 
 <!-- Setup: the copy-paste block a user needs, with their own token substituted. -->
-<section class="view" id="view-setup" hidden>
+<section class="view" id="view-setup" role="tabpanel" aria-labelledby="tab-setup" hidden>
   <div class="card">
     <div class="card-head"><h2>Point Claude Code at context-guru</h2></div>
     <div id="setup-token-banner" class="banner" hidden data-testid="setup-token-banner"></div>
@@ -733,7 +786,7 @@
 </section>
 
 <!-- Settings: the tenant's own configuration and tokens. -->
-<section class="view" id="view-settings" hidden>
+<section class="view" id="view-settings" role="tabpanel" aria-labelledby="tab-settings" hidden>
   <div class="card">
     <div class="card-head"><h2>Compaction</h2><span class="muted" id="settings-saved" data-testid="settings-saved"></span></div>
     <div id="settings-form" data-testid="settings-form"></div>
@@ -767,7 +820,7 @@
      carry data-manager, so a plain account sees the form and nothing else. The form
      itself is built in JS (buildFeedbackForm) from the questions the server serves, so
      there is one copy of the keys and one copy of the wording. -->
-<section class="view" id="view-feedback" hidden>
+<section class="view" id="view-feedback" role="tabpanel" aria-labelledby="tab-feedback" hidden>
   <div class="card">
     <div class="card-head"><h2>How is context-guru working for you?</h2></div>
     <p class="muted small">Answers go to whoever runs this deployment. Nobody else can
@@ -825,7 +878,7 @@
 </section>
 
 <!-- Tenants: the manager's roster. -->
-<section class="view" id="view-tenants" hidden>
+<section class="view" id="view-tenants" role="tabpanel" aria-labelledby="tab-tenants" hidden>
   <div class="card">
     <div class="card-head"><h2>A/B variants</h2>
       <select id="ab-range" data-testid="ab-range" aria-label="Comparison window">
@@ -862,7 +915,7 @@
      the Tenant editor are — an empty mount point here, so the fields, the window
      builder and the account picker cannot drift from the validation the control route
      itself enforces. -->
-<section class="view" id="view-strategies" hidden>
+<section class="view" id="view-strategies" role="tabpanel" aria-labelledby="tab-strategies" hidden>
   <div class="panel">
     <h2 id="strategy-form-title">New strategy</h2>
     <p class="note">A durable rule: "only during Israel business hours", or a service-wide
@@ -877,7 +930,7 @@
   </div>
 </section>
 
-<section class="view" id="view-config" hidden>
+<section class="view" id="view-config" role="tabpanel" aria-labelledby="tab-config" hidden>
   <!-- YOUR configuration first. The complaint this answers: a change saved on the Settings
        page never appeared here, because this tab only ever rendered the PROXY PROCESS's
        startup-resolved config while Settings writes the ACCOUNT's document — two different

--- a/dash/ui/kvcache.js
+++ b/dash/ui/kvcache.js
@@ -32,20 +32,13 @@
 document.head.appendChild(el('link', { rel: 'stylesheet', href: 'kvcache.css' }));
 
 // ── mount ──────────────────────────────────────────────────────────────────
-// Next to Keep-alive: both are about what a cached prefix costs to hold, and this one is the
-// measurement the other one's calculator is an application of.
-(function mountKVCacheTab() {
-  const tabs = $('.tabs');
-  const tab = el('button', {
-    role: 'tab', class: 'tab', 'data-view': 'kvcache', 'data-testid': 'tab-kvcache',
-    'aria-selected': 'false',
-  }, 'KV-cache');
-  const after = $('.tab[data-view="keepalive"]', tabs);
-  tabs.insertBefore(tab, after ? after.nextSibling : null);
-})();
-
-const kvView = el('section', { class: 'view', id: 'view-kvcache', hidden: 'hidden' });
-$('#main').appendChild(kvView);
+// Behaviour, next to Keep-alive: both are about what a cached prefix costs to hold, and this
+// one is the measurement the other one's calculator is an application of. mountTab (app.js)
+// is the single place that knows the nav's DOM shape; it returns the section, already
+// appended to #main and wired as this tab's tabpanel.
+const kvView = mountTab({
+  group: 'behaviour', after: 'keepalive', view: 'kvcache', label: 'KV-cache',
+});
 
 // ── local state ────────────────────────────────────────────────────────────
 // Its own state object, NOT app.js's: the shared one is mirrored into the URL for the views

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -1046,7 +1046,10 @@ table.grid tr.revoked { opacity: 0.55; }
 }
 @media (max-width: 900px) {
   .topbar { gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); }
-  .tabs { order: 3; width: 100%; overflow-x: auto; padding-bottom: 2px; }
+  /* nowrap so the existing overflow-x actually does something: five groups wrapped to two
+     44px rows, and the group names are a fixed set of five that a reader learns, which is
+     what makes a scroller acceptable here and not on the second level. */
+  .tabs { order: 3; width: 100%; overflow-x: auto; padding-bottom: 2px; flex-wrap: nowrap; }
   /* 44px is the floor for a target you hit with a thumb, and these were 28 at every
      width — nothing about the nav reflowed at 390px, it just got narrower. Applied only
      here so the desktop topbar stays one 41px row. */

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -198,12 +198,16 @@ code, kbd { font-family: var(--mono); font-size: 0.92em; }
 .bad-text  { color: var(--bad); }
 
 /* ── top bar ──────────────────────────────────────────────────────────── */
+/* The whole chrome sticks as one box. It used to be three separately-stuck elements, each
+   needing the previous one's height as a magic `top` (.filters was `top: 41px`) — which a
+   second nav level breaks, and which nothing kept honest. Sticking the wrapper makes the
+   offsets the browser's arithmetic instead of ours. */
+.chrome { position: sticky; top: 0; z-index: 20; }
 .topbar {
   display: flex; align-items: center; gap: var(--sp-4); flex-wrap: wrap;
   padding: var(--sp-2) var(--sp-4);
   background: var(--bg-raised);
   border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 20;
 }
 .brand {
   display: flex; align-items: center; gap: var(--sp-2);
@@ -225,6 +229,33 @@ code, kbd { font-family: var(--mono); font-size: 0.92em; }
   box-shadow: inset 0 -2px 0 var(--accent);
   border-radius: var(--r-sm) var(--r-sm) 0 0;
 }
+/* A tab that exists but is not open to this sign-in. NOT `opacity`, which would take the
+   label to 1.2:1 against this surface — the muted foreground is a real token that passes,
+   and the padlock carries the same fact without relying on the colour (DESIGN 2.5). */
+.tab[aria-disabled="true"] { color: var(--fg-faint); cursor: default; font-weight: 500; }
+.tab[aria-disabled="true"]:hover { background: none; color: var(--fg-faint); }
+.tab[aria-disabled="true"]::after { content: " \1F512"; font-size: 0.85em; }
+
+/* ── the second nav level ──────────────────────────────────────────────────
+   A quieter bar than the topbar it hangs off: one level has to read as subordinate to the
+   other or two rows of buttons are just a longer flat list. */
+#subnav {
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: 2px var(--sp-4);
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border);
+}
+/* min-width:0 so the group's tablist can shrink below its own content and wrap; a flex
+   item's default min-width:auto refuses to, which is what pushed the body 133px wider than
+   a 390px viewport on Admin's seven tabs. Same fix, same reason, as .topbar-right above. */
+.grouppanel { min-width: 0; }
+/* Wrapping rather than a horizontal scroller: seven tabs at 390px cost a second 44px row,
+   and a scroller costs a tab nobody can see is there. */
+.viewtabs { display: flex; gap: 1px; flex-wrap: wrap; }
+#subnav .tab { font-size: var(--t-small); }
+/* Why a tab in this group is locked. Beside the tabs rather than under them: it is one
+   short line and the bar is otherwise half empty. */
+.tab-note { color: var(--fg-muted); font-size: var(--t-small); }
 /* min-width:0 and wrap: this group's own content (an email, two buttons and the live
    pill) has a min-content width of ~260px, and without these it refused to shrink or
    break — which is what pushed the body 17px wider than a 360px viewport. */
@@ -280,7 +311,6 @@ button.subtle:hover { text-decoration: underline; }
   padding: var(--sp-2) var(--sp-4);
   background: var(--bg);
   border-bottom: 1px solid var(--border);
-  position: sticky; top: 41px; z-index: 19;
 }
 .filters input, .filters select {
   background: var(--bg-raised); color: var(--fg);
@@ -1017,6 +1047,13 @@ table.grid tr.revoked { opacity: 0.55; }
 @media (max-width: 900px) {
   .topbar { gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); }
   .tabs { order: 3; width: 100%; overflow-x: auto; padding-bottom: 2px; }
+  /* 44px is the floor for a target you hit with a thumb, and these were 28 at every
+     width — nothing about the nav reflowed at 390px, it just got narrower. Applied only
+     here so the desktop topbar stays one 41px row. */
+  .tab { min-height: 44px; display: inline-flex; align-items: center; }
+  #subnav { padding: 0 var(--sp-3); flex-wrap: wrap; }
+  /* The note goes under the tabs rather than competing with them for a 390px row. */
+  .tab-note { flex: 1 0 100%; padding-bottom: var(--sp-1); }
   .filters { padding: var(--sp-2) var(--sp-3); position: static; }
   .filters input, .filters select { max-width: none; flex: 1 1 140px; }
   main { padding: var(--sp-3) var(--sp-3) var(--sp-5); }

--- a/dash/ui/tools.js
+++ b/dash/ui/tools.js
@@ -35,22 +35,18 @@
 document.head.appendChild(el('link', { rel: 'stylesheet', href: 'tools.css' }));
 
 // ── mount ──────────────────────────────────────────────────────────────────
-// The tab goes next to Usage: both answer "where is the money", and this one is
-// actionable, so it does not belong at the far end behind the account tabs.
-(function mountToolsTab() {
-  const tabs = $('.tabs');
-  const tab = el('button', {
-    role: 'tab', class: 'tab', 'data-view': 'tools', 'data-testid': 'tab-tools',
-    'aria-selected': 'false',
-  }, 'Inventory');
-  const after = $('.tab[data-view="usage"]', tabs);
-  tabs.insertBefore(tab, after ? after.nextSibling : null);
-})();
-
-// The section is built here too, in DOM rather than markup, because every part of it is
-// conditional on what the report says can be answered.
-const toolsView = el('section', { class: 'view', id: 'view-tools', hidden: 'hidden' });
-$('#main').appendChild(toolsView);
+// Behaviour, right after Components: all four tabs in that group answer "what did the
+// proxy do to my traffic", and this is the actionable one. It used to sit after Usage
+// because that was the sibling this file happened to name — an implementation artefact,
+// not an IA decision.
+//
+// mountTab (app.js) is the single place that knows the nav's DOM shape, and it returns the
+// empty section already appended to #main and already wired as this tab's tabpanel. The
+// section is still built from JS rather than markup because every part of it is conditional
+// on what the report says can be answered.
+const toolsView = mountTab({
+  group: 'behaviour', after: 'components', view: 'tools', label: 'Inventory',
+});
 
 // ── local state ────────────────────────────────────────────────────────────
 // Its own sort state, NOT app.js's state.sort: that one is the components table's and is

--- a/dash/uikvcache_test.go
+++ b/dash/uikvcache_test.go
@@ -207,11 +207,17 @@ func TestTheKVCacheTabRespectsTheTimeRange(t *testing.T) {
 		t.Error("the KV-cache view has no loader")
 	}
 	// The tab and the section mount themselves, so the shared page has one line about it.
-	if !strings.Contains(src, `'data-view': 'kvcache'`) {
-		t.Error("the KV-cache view does not mount its own tab")
+	// It goes through mountTab (app.js), which is the only place that knows the nav's DOM
+	// shape — this file used to reach into `.tabs` and insertBefore a named sibling itself,
+	// and three copies of that were three things to fix when the nav grew a second level.
+	if !strings.Contains(src, "mountTab({") || !strings.Contains(src, "view: 'kvcache'") {
+		t.Error("the KV-cache view does not mount its own tab via mountTab()")
 	}
-	if !strings.Contains(src, `id: 'view-kvcache'`) {
-		t.Error("the KV-cache view does not mount its own section")
+	if !strings.Contains(src, "group: 'behaviour'") {
+		t.Error("the KV-cache tab does not name its nav group; mountTab would throw")
+	}
+	if strings.Contains(src, "$('.tabs')") || strings.Contains(src, "insertBefore(tab") {
+		t.Error("the KV-cache view builds the nav itself instead of calling mountTab()")
 	}
 	if !strings.Contains(readUI(t, "ui/index.html"), `<script src="kvcache.js">`) {
 		t.Error("kvcache.js is not loaded by the shared page")

--- a/docs/dashboard-kvcache-page.md
+++ b/docs/dashboard-kvcache-page.md
@@ -19,7 +19,7 @@ line about it (`<script src="kvcache.js"></script>` in `dash/ui/index.html`). No
 ## Opening it
 
 The tab sits next to **Keep-alive** — both answer "what is the prompt cache doing to my bill" —
-at `/dashboard/#kvcache`. It respects the shared filter bar above it: every figure is "over this
+at `/dashboard/#/behaviour/kvcache` (and at `/dashboard/#kvcache`, which is rewritten to it). It respects the shared filter bar above it: every figure is "over this
 window", so the time range, the model, the agent and the account selector all narrow it. Three
 narrowings exist only here (time-of-day band, observed TTL tier, and whether a request has a
 successor at all) because all three are derived rather than columns. The tier one is deliberately

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -21,6 +21,74 @@ route, including [`/stats`](reference/routes.md), is byte-for-byte unchanged.
     hand-drawn SVG — no chart library, no framework, no npm. The page fetches nothing
     off-origin, so it works in a VPC or fully air-gapped, and a test asserts that.
 
+## Navigation — five groups, two levels
+
+Seventeen co-equal top-level tabs was a flat list pretending to be a hierarchy: every viewer
+scanned all seventeen labels to find one, and the manager got no signal about which three
+mattered. The nav is now two levels and five groups, chunked by **the question the viewer
+arrived with** rather than by subsystem — which is what puts the manager and the operator on
+one nav instead of two products.
+
+| Group | Views, in order | Answers |
+|---|---|---|
+| **Overview** | *(a single view, no sub-nav)* | what is this saving us, and what should I do about it |
+| **Savings** | `usage` · `campaigns` · `benchmarks` | where the money went, and the evidence for the headline |
+| **Behaviour** | `components` · `tools` (Inventory) · `keepalive` · `kvcache` | what the proxy did to my traffic |
+| **Traffic** | `sessions` · `requests` | what happened on this request |
+| **Admin** | `config` · `strategies` · `tenants` · `setup` · `settings` · `archive` · `feedback` | how this is tuned and who can see it |
+
+Group order is also the split between the two audiences: a manager stops after Savings, an
+operator carries on, and nobody is denied anything. Each group opens on its first tab, and
+each group's first tab is the manager-legible one — depth is the second tab onward. Overview
+gets no sub-nav because a sub-nav would make it read as a category rather than an answer.
+
+Both levels are real ARIA tablists, and there is **one Tab stop per level** with the arrow
+keys moving inside it — seventeen tab buttons used to be seventeen Tab stops, so reaching the
+filter bar by keyboard took seventeen presses. Activation is manual (arrows move focus,
+Enter/Space opens), because every tab fires a data fetch and scrubbing across Admin's seven
+would issue seven queries nobody asked for.
+
+### A tab you cannot open says why
+
+On a **single-tenant local proxy** the manager-gated tabs without `data-local-ok` are rendered
+disabled with a one-line reason under the tab row, not hidden. Only nine of the seventeen tabs
+are otherwise reachable there, so hiding the rest made the product look half its size and read
+as a broken build. The `data-account` tabs stay silently hidden: a signed-out viewer has no use
+for a tab they cannot enable from here, which is the whole difference between the two cases.
+
+A group whose every tab is unavailable to this viewer hides its group button too, rather than
+opening onto nothing.
+
+### The URL carries both levels
+
+The canonical hash is `#/<group>/<view>[?<filters>]` — `#/savings/usage`, `#/traffic/requests?req=9`
+— collapsed to `#/overview` for the one group that is also a view.
+
+**The rule, once: the last path segment is the view; anything before it is a group hint, and it
+is ignored whenever the view is known.** That is what makes the one-level `#usage` this
+dashboard has always written and the new `#/savings/usage` the same link, and it is decidable
+without a lookahead because no view name contains a slash. So all of these resolve, and the
+first three are rewritten in place with `replaceState`:
+
+| Written | Resolves to |
+|---|---|
+| `#usage` — every link ever pasted into an issue | `#/savings/usage` |
+| `#savings/usage` — the leading slash is written, not required | `#/savings/usage` |
+| `#/admin/campaigns` — a view that changed group | `#/savings/campaigns` |
+| `#/admin` — a group on its own | its first available tab, `#/admin/config` |
+| `#nonsense`, `#OVERVIEW` (case-sensitive), `#` | `#/overview` |
+
+Two of those one-level shapes are written by the **server**, not the UI — `dash/kvcache.go`
+builds `#requests?req=<id>` and `#sessions?diff=<escaped id>` for every row of the KV-cache
+table, and `dash/uikvcache_test.go` asserts the UI must *not* build them, so the server stays
+their sole author and they cannot be found by grepping the front end. The one-segment branch is
+therefore not a compatibility shim to be tidied away later.
+
+The whole contract — seventeen bare view names, all fourteen filter dimensions, `from`/`to`,
+`sort`/`dir`, the three drawer keys, legacy `range=<ms>`, the two server-authored shapes and
+every rewrite case — is a table in `dash/navhash.test.mjs`, run against the **real** resolver
+in `app.js` (`go test ./dash/ -run NavHash`, or `node --test dash/navhash.test.mjs`).
+
 ## What it shows
 
 ### Overview
@@ -892,9 +960,10 @@ Why a pair rather than one duration:
 
 On the wire this is `?since=`/`?until=` — `requests.ts` is epoch milliseconds UTC, `since`
 inclusive, `until` exclusive, both covered by `idx_requests_ts`. In the URL it is
-`#requests?from=now-24h&to=now`. Old `range=<ms>` bookmarks are still parsed and mapped to
-the nearest relative token, so a link pasted into an issue last month does not silently
-widen to all time.
+`#/traffic/requests?from=now-24h&to=now`. Old `range=<ms>` bookmarks are still parsed and
+mapped to the nearest relative token, so a link pasted into an issue last month does not
+silently widen to all time — `#usage?range=86400000` becomes `#/savings/usage?from=now-1d`,
+which is pinned in `dash/navhash.test.mjs`. `range=` is read and never written.
 
 The range params are written inside `qs()` rather than passed through its `extra` argument,
 because `extra` drops any value that is `''`, `0` or `undefined` — so `until: 0` could never


### PR DESCRIPTION
Seventeen co-equal top-level tabs was a flat list pretending to be a hierarchy: every viewer scanned all seventeen labels to find one, and the manager got no signal about which three mattered. This is two levels and five groups, chunked by **the question the viewer arrived with**.

| Group | Views, in order |
|---|---|
| **Overview** | *(one view, no sub-nav)* |
| **Savings** | `usage` · `campaigns` · `benchmarks` |
| **Behaviour** | `components` · `tools` (Inventory) · `keepalive` · `kvcache` |
| **Traffic** | `sessions` · `requests` |
| **Admin** | `config` · `strategies` · `tenants` · `setup` · `settings` · `archive` · `feedback` |

Group order is the manager→operator gradient: a manager stops after Savings, an operator carries on, nobody is denied anything. Each group's first tab is the manager-legible one.

## Accessibility — the headline

Measured over 34 tab×theme combinations per viewport, `origin/main` vs this branch, both sides fully populated:

| | 1440 before → after | 390 before → after |
|---|---|---|
| **Tab stops** | 1334 → **792** | 1346 → **803** |
| **`role="tabpanel"`** | 0 → **17** | 0 → **17** |
| **Contrast failures** | 0/216/11204 → **0/221/11526** | 0/216/11168 → **0/222/11540** |
| **Missing focus rings** | 0 → **0** | 0 → **0** |
| **Nav elements <44×44** | 34 → 42 † | 34 → **0** |
| **Body scrolls X** | 0 → **0** | 8 → **8**, identical set |
| **Chrome height (Admin)** | 3 rows → 2 | 228px → **217px** |

Seventeen `role="tab"` buttons were seventeen Tab stops, so reaching the filter bar by keyboard took seventeen presses. Now it is a roving tabindex per level with arrows/Home/End, and **manual activation** — automatic is the pattern's default, but every tab fires a data fetch and scrubbing across Admin's seven would issue seven queries nobody asked for.

† **Deliberate, not an oversight.** The 44px floor is applied only below 900px, so the desktop topbar stays one 41px row on a pointer-fine surface. The two-level nav adds buttons at 1440, all 28px tall, which is why that one number rises.

Contrast denominators are stated because `0/0/0` is a scan that found nothing, not a pass.

**And the Admin group's zeros are thinner than they look.** All seven Admin tabs audited at 23-75 visible text nodes, five of them under 50 — `tenants` at **27**, which is its empty state. @impl-tabs's cookie-carrying harness renders **27 rows** there. So `0 contrast failures` and `0 missing focus rings` are true of every page this harness can reach, but the Admin group was measured near-empty on both sides of the comparison: it is **unaudited, not clean**. Supporting that reading: the first two genuine contrast failures ever found on this product (`feedback`, `strategies`, in #173) surfaced the moment the harness could carry a session. The nav numbers above — tab stops, tabpanels, touch targets — are structural and unaffected; the colour and focus zeros for Admin need a re-run behind auth.

## The hash contract

Canonical form is `#/<group>/<view>`, collapsed to `#/overview` for the one group that is also a view.

**The rule: the last path segment is the view; anything before it is a group hint, ignored whenever the view is known.** That makes the one-level `#usage` this dashboard has always written and the new `#/savings/usage` the same link, and it is decidable without a lookahead because no view name contains a slash. `#/admin/campaigns` (stale group) resolves and rewrites to `#/savings/campaigns`.

Two of those one-level shapes are written by the **server** — `dash/kvcache.go:510-511` builds `#requests?req=<id>` and `#sessions?diff=<escaped id>` for every KV-cache row, and `dash/uikvcache_test.go` forbids the UI from building them. So the one-segment branch is not a shim to tidy away later; it is half the traffic. No Go change was needed.

`dash/navhash.test.mjs` runs the **real** resolver out of `app.js` in a function scope over a ~12-line stub DOM — no second implementation, no proxy, no port, no HTTP, no 5s response cache, 0.2s. 10 tests: 17 bare views + canonical round-trip · all 14 filter dimensions individually and together · `from`/`to` relative and absolute, `to` omitted while `now`, junk→0 not NaN · `range=<ms>` over 6 durations including the documented `86400000`→`now-1d` · `sort`/`dir` written only on components · `req|diff|acct` exclusivity · the two server-authored shapes including `sess%2Fwith%20space` → `sess/with space` · `#/group`, `#/group/typo`, two-segment without a leading slash · 9 junk hashes → `#/overview` · nav/loader/section agreement. The tab table is parsed from `index.html` plus the three `mountTab({...})` call sites, so a tab moved between groups moves the test with it.

`go test ./dash/ -run NavHash` runs it under node and **skips loudly** naming what went unverified when node is absent; `TestTheNavHashContractIsPinned` holds either way.

## How much to trust the numbers above

**I threw out a set of figures that favoured this branch.** A re-run reported `bodyScrollsX 8 → 5` and `clipped 14 → 7`. Both were fake:

```
kvcache|dark|390    2038 visible text nodes  ->    43
kvcache|light|390   2038                     ->    43
tools|dark|1440     1164                     ->    16
tools|light|1440    1164                     ->  1156   <- same build, populated
```

Same build, same viewport, different theme, opposite outcomes → a race, not a defect. `shots.mjs` has no per-tab ready selector: it waits for `[data-view]` (the nav, which exists immediately) at `:227`/`:244` and then a fixed 1400 ms, and these are the two heaviest queries on a 16,444-request corpus. **Those views "stopped overflowing" by being empty.** The rows quoted above are off real content on both sides — verified by text-node count, since a skeleton reads as ~15 nodes and a rendered table as 1156+. `perf.mjs` is unaffected; it has a real ready selector per tab. The table above is from the run where kvcache is 2038→2030 and tools 1164→1156 in all four combos.

**`clipped` is struck entirely.** `span.comp-name.trunc` is the only element that ever appeared in it across five runs, and that truncation is deliberate and non-lossy (`style.css:598-602` `text-overflow: ellipsis`, `tools.js:957`/`:1069` carry `title: t.name`). The metric carries no signal on this corpus. Thanks to @impl-perf for catching it before anyone "fixed" working code.

## The eight combos still scrolling at 390px are unchanged by this branch

Identical set before and after — `keepalive`, `kvcache`, `strategies`, `tools`, each in both themes. **Not caused here and not fixed here:** all four are addressed in #169 (`perf/dash-load-0901`, which reports keepalive +753px, strategies +183px, kvcache +16px → zero). `tools` also carries pre-existing `mcp__*` name truncation routed to `impl-inventory`. The `1440 → 0` result above is a clean one and should not be read as covering the mobile situation.

## Also here

- **`mountTab({ group, after, view, label })`** replaces three copies of "reach into `.tabs` and `insertBefore` a named sibling" in `tools.js`, `kvcache.js` and `campaigns.js`. One place knows the nav's DOM shape. The tab button exists **before** the view body is built, so lazy-loading those bodies stays a change to the caller and not to the nav. The three are deliberately absent from `GROUPS` in `app.js` — hardcoding them would restore the coupling self-mounting exists to avoid.
- **Locked, not hidden.** On a single-tenant local proxy the manager-gated tabs without `data-local-ok` render `aria-disabled` with one line under the tab row (*"Strategies and Tenants need a manager sign-in."*) instead of vanishing. Only nine of seventeen tabs were otherwise reachable there, so hiding the rest made the product look half its size and read as a broken build. Visible tabs go 9 → 12. `data-account` tabs stay silently hidden: a signed-out viewer has no use for a tab they cannot enable from here. A group with nothing reachable hides its group button.
- **One sticky box for the chrome.** Three separately-stuck elements each needed the previous one's height as a magic `top` (`.filters` was `top: 41px`), which a second nav level breaks and nothing kept honest. `.chrome` sticks instead. That makes it a containing block for absolutely-positioned descendants, so: enumerated all five `position: absolute` rules, established only `.filters details.more > .more-body` is inside it, then measured the popover against its own `<summary>` on both builds — **identical to the pixel at both widths**. Below 620px `style.css:371-373` makes it `static` (not a popover at all on a phone); at 1440 `details.more { position: relative }` stops the chain. There is no width at which `.chrome` is its containing block.
- **Six bare tables wrapped** in the existing `.tblwrap` idiom: `loadMachines`, `loadTokens`, `loadAudit`, `loadTenants`, `loadVariants`, `loadArchive`. A table with no scroll container is only *visibly* broken once its content is wide enough, so "none overflows today" is a claim about the data, not the code — `tools` audited clean at 14,876 requests and failed at 16,444. The `tabindex="0"` is not decoration (axe `scrollable-region-focusable`).
- **Docs:** a `## Navigation` section in `docs/dashboard.md` with the group table, the hash rule and the rewrite cases; `docs/dashboard.md:895` and `docs/dashboard-kvcache-page.md:22` updated.

## Known gap, on purpose

**A static "every `appendChild(tbl)` is wrapped" check would fail on this branch today**, which is why it is not here. Three of the nine sites — `toggleBenchTasks` (4028), `loadKAArmed` (8533), `loadKABehaviour` (8623) — sit inside functions `impl-tabs` is rewriting, so they go with that work rather than conflicting with it. The check becomes addable once those land.

## Benchmarks moves under Savings — and can now say why it is empty

Benchmarks moves under **Savings** as evidence for the Overview claim, which makes it more prominent. It could not previously say **why** it was empty: `dash/api.go`'s `?refresh=1` returned `{ingested_runs, ingested_tasks}` and the click handler discarded the body, so a wrong `--dashboard-bench-dirs` and a correct scan of an empty directory rendered identically. I was going to file that as a follow-up needing a new payload field.

**No longer needed — @impl-tabs took both halves** on `fix/tab-verdicts-and-denominators-0901`: `?refresh=1` now also returns `dirs`, and the handler distinguishes all three outcomes (scanned N dirs / no flag configured / scanned but no run directory found). The empty state's instruction, which named the non-existent `--dash-bench-dirs`, is fixed there too. So this PR does not promote a tab that cannot explain itself — but that fix lands in **their** PR, not this one, and both branches are independent. Nothing here depends on it.

## Verification

```
CGO_ENABLED=1 go build ./...   BUILD ok
CGO_ENABLED=1 go vet ./...     VET ok
go test -count=1 ./dash/       ok  85.113s
go test -count=1 ./schema/ ./config/ ./apply/    ok (rebased base)
node --test dash/navhash.test.mjs               # tests 10  # pass 10  # fail 0
```

Live in Chromium, 29 hash cases resolving with exactly one visible view each, 17 tabpanels, 1+1 tab stops. Both proxies verified by pid+exe before measuring (`/healthz` returns 200 from a *sibling's* proxy if your own bind failed), and `--dashboard-retention 0 --dashboard-max-bytes 0` on both with `grep -c pruned` = 0 — corpus 16,444 requests / 53,627 tool_declarations, unchanged end to end.

**Tests updated, none deleted:** `dash/uikvcache_test.go` asserted the literals `'data-view': 'kvcache'` / `id: 'view-kvcache'`, which now live in the `mountTab` call — rewritten to assert `mountTab({`, `view: 'kvcache'`, `group: 'behaviour'` **and** that the file no longer contains `$('.tabs')`/`insertBefore(tab`, which is stronger than what it replaced. `dash/api_test.go` gained the four group testids and `tab-note`; all six original `tab-*` literals kept, and one tab per line preserved for the gating check at `:371`.

## Module seams for the `app.js` split

`app.js` carries a comment naming them: shell+router (`GROUPS` through `applyURL`, exporting only `go`/`mountTab`/`syncNav`, depending only on `loaders`/`DIMS`/`state`/DOM helpers), overview+usage+components, sessions+requests+drawer, and admin.
