### PR TITLE
fix(dashboard): stop reporting unmeasured values as measurements on Overview, Components, Keep-alive and Benchmarks

### DIFF
--- a/dash/api.go
+++ b/dash/api.go
@@ -1112,8 +1112,12 @@ func (a *API) benchmarks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Query().Get("refresh") == "1" {
-		runs, tasks := a.rec.DB().IngestBenchRoots(a.rec.Opts().BenchDirs)
-		writeJSON(w, map[string]any{"ingested_runs": runs, "ingested_tasks": tasks})
+		// The DIRS go back with the counts. Without them a re-scan of a mistyped path and a
+		// correct scan of an empty directory are the same response — and the UI reported both
+		// as "nothing happened" because it discarded the body entirely.
+		dirs := a.rec.Opts().BenchDirs
+		runs, tasks := a.rec.DB().IngestBenchRoots(dirs)
+		writeJSON(w, map[string]any{"ingested_runs": runs, "ingested_tasks": tasks, "dirs": dirs})
 		return
 	}
 	runs, err := a.rec.DB().BenchRuns()

--- a/dash/bench.go
+++ b/dash/bench.go
@@ -192,6 +192,17 @@ type BenchArm struct {
 	CacheHitRate     float64 `json:"cache_hit_rate"`
 	MeanWallS        float64 `json:"mean_wall_s"`
 	Exceptions       int64   `json:"exceptions"`
+	// CostRows is how many of this arm's tasks carry a non-zero cost, and it exists so the UI
+	// can tell "this arm was free" apart from "the ingester could not find a cost in the file".
+	//
+	// harborRow.AgentCost binds to `agent_cost`. A rows file that names its cost anything else
+	// unmarshals to the zero value silently, every task lands at 0, and the arm then renders
+	// $0 / $0 / $0 and sorts as the CHEAPEST — a flattering lie with no way for a reader to see
+	// it. A float64 cannot express absence, and making the column nullable would spread that
+	// through five call sites; counting the rows that priced is the same information one join
+	// cheaper. An arm that ran tasks and cost exactly nothing on every one of them is not a
+	// measurement either, so `n/a` is the honest render in both cases.
+	CostRows int64 `json:"cost_rows"`
 }
 
 // BenchRuns returns every ingested run with its per-arm aggregates.
@@ -230,7 +241,8 @@ func (d *DB) benchArms(runID int64) ([]BenchArm, error) {
 		SUM(CASE WHEN reward >= 1 THEN 1 ELSE 0 END),
 		AVG(reward), AVG(steps), SUM(cost_usd), AVG(cost_usd), SUM(norm_cost_usd),
 		SUM(cache_read), SUM(cache_write), SUM(fresh_input), SUM(completion_tokens),
-		AVG(wall_s), SUM(exception)
+		AVG(wall_s), SUM(exception),
+		SUM(CASE WHEN cost_usd > 0 THEN 1 ELSE 0 END)
 		FROM bench_tasks WHERE run_id = ? GROUP BY arm ORDER BY arm`, runID)
 	if err != nil {
 		return nil, err
@@ -242,7 +254,7 @@ func (d *DB) benchArms(runID int64) ([]BenchArm, error) {
 		if err := rows.Scan(&a.Arm, &a.Tasks, &a.Scored, &a.Solved, &a.MeanReward, &a.MeanSteps,
 			&a.TotalCostUSD, &a.MeanCostUSD, &a.TotalNormCostUSD,
 			&a.CacheRead, &a.CacheWrite, &a.FreshInput, &a.Completion,
-			&a.MeanWallS, &a.Exceptions); err != nil {
+			&a.MeanWallS, &a.Exceptions, &a.CostRows); err != nil {
 			return nil, err
 		}
 		if a.Scored > 0 {

--- a/dash/overview.go
+++ b/dash/overview.go
@@ -336,6 +336,20 @@ type Overview struct {
 	// over message text only — a different unit, roughly a third the size, and the reason no
 	// token figure on this page may be read as a billed-token figure. See the tile.
 	BilledInputTokens int64 `json:"billed_input_tokens"`
+	// TokensBeforeBilled and BilledInputRows are the DENOMINATOR and the POPULATION for
+	// BilledInputTokens, and they exist because the browser was dividing by the wrong thing.
+	//
+	// BilledInputTokens is fresh + cache_read + cache_write, which is identically 0 on a row
+	// where the provider reported no usage. TokensBefore is our own tokenizer and is non-zero on
+	// every row. So `billed_input_tokens / tokens_before` is a ratio across two populations: a
+	// numerator contributed only by rows with provider usage over a denominator summed across
+	// all of them. It understates the ratio by exactly the share of unmeasured rows, and it
+	// printed "the provider bills LESS than we count" 0 px above a tooltip saying the opposite.
+	//
+	// Restricting the DENOMINATOR to the same rows makes it one population, and BilledInputRows
+	// is that population's size so the ratio can state its own denominator (DESIGN §3.4).
+	TokensBeforeBilled int64 `json:"tokens_before_billed"`
+	BilledInputRows    int64 `json:"billed_input_rows"`
 
 	CGLatencyMsAvg float64 `json:"cg_latency_ms_avg"`
 	UpstreamMsAvg  float64 `json:"upstream_ms_avg"`
@@ -525,6 +539,13 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		COALESCE(SUM(CASE WHEN r.cache_bp_system + r.cache_bp_tools
 			+ r.cache_bp_messages + r.cache_bp_blocks > 0 THEN 1 ELSE 0 END),0),
 		COALESCE(SUM(r.fresh_input + r.cache_read + r.cache_write),0),
+		-- Our own count over the SAME rows that contributed the figure above, plus how many
+		-- rows those are. See Overview.TokensBeforeBilled: a ratio of the two sums is only a
+		-- ratio if both come from one population.
+		COALESCE(SUM(CASE WHEN r.fresh_input + r.cache_read + r.cache_write > 0
+			THEN r.tokens_before ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN r.fresh_input + r.cache_read + r.cache_write > 0
+			THEN 1 ELSE 0 END),0),
 		-- Coverage for the two new columns. A streaming request that carries neither a TTFB
 		-- nor the buffered flag predates the capture; counting those apart is what keeps a
 		-- history of zeros from reading as a measurement of zero.
@@ -551,6 +572,7 @@ func (d *DB) Overview(f Filter) (*Overview, error) {
 		&o.SSEStreamed, &o.SSEBuffered, &ttfbAvg, &upBufAvg,
 		&o.Breakpoints.System, &o.Breakpoints.Tools, &o.Breakpoints.Messages,
 		&o.Breakpoints.Blocks, &o.Breakpoints.Requests, &o.BilledInputTokens,
+		&o.TokensBeforeBilled, &o.BilledInputRows,
 		&o.SSERecorded, &o.SSEStreamRows, &o.CacheTTLRecorded,
 		&o.KeepAliveSavedUSD, &o.KeepAliveMissesAvoided, &o.CacheWrite1h)
 	if err != nil {

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -2988,7 +2988,14 @@ async function loadSessions() {
         // A dollar figure over a session whose turns are not all priced is a figure with
         // a different denominator from the token columns beside it: it covers the priced
         // turns only. The dagger says so rather than letting the two read as one total.
-        el('td', { class: 'num' }, s.baseline_cost_usd ? usd(s.saved_usd) : '—',
+        // `—` was standing in for an uncomputable value, which DESIGN §3.6 rule 3 rules out the
+        // same way it rules out `$0`: neither carries a reason, and a dash reads as "nothing
+        // here" rather than "we cannot say". Routed through the same helper as the Components
+        // dollar cells so there is one answer to this in the codebase.
+        el('td', { class: 'num' },
+          usdOrNA(s.saved_usd, !!s.baseline_cost_usd,
+            'no turn in this session reported the provider usage a baseline cost needs, so there '
+            + 'is nothing to subtract an actual cost from'),
           s.baseline_cost_usd && s.incomplete_rows > 0
             ? el('span', {
               class: 'na small',
@@ -2998,15 +3005,19 @@ async function loadSessions() {
             }, ' †')
             : null),
         el('td', { class: 'num', text: compact(s.cache_read) + ' / ' + compact(s.cache_write) }),
-        // The keep-alive's net for this session, from its own ping rows. Blank rather than $0
-        // where it never ran: a zero would read as "it broke even here", which it did not do.
+        // The keep-alive's net for this session, from its own ping rows. `n/a` rather than $0
+        // where it never ran — a zero would read as "it broke even here", which it did not do —
+        // and rather than the `—` that was here, which carried the reason only in a title.
         el('td', {
           class: 'num ' + (s.keepalive_net_usd < 0 ? 'bad-text' : s.keepalive_net_usd > 0 ? 'good-text' : ''),
           title: s.keepalive_pings || s.keepalive_saved_usd
             ? `${num(s.keepalive_pings)} pings cost ${usd(s.keepalive_ping_usd)}; `
               + `${usd(s.keepalive_saved_usd)} of re-creations avoided (a ceiling)`
-            : 'the keep-alive did not run on this session',
-        }, s.keepalive_pings || s.keepalive_saved_usd ? usd(s.keepalive_net_usd) : '—'),
+            : '',
+        }, usdOrNA(s.keepalive_net_usd,
+          !!(s.keepalive_pings || s.keepalive_saved_usd),
+          'the keep-alive did not run on this session, so it neither spent nor avoided anything '
+          + 'here — this is an absence, not a break-even')),
         el('td', { class: 'num', text: num(s.expands) }),
         el('td', { class: 'num', text: ms(s.cg_latency_ms_avg) }),
         el('td', { text: when(s.start) }),
@@ -4434,7 +4445,7 @@ async function toggleBenchTasks(sec, runID, arm) {
             : el('span', { class: 'pill neutral', text: 'unsolved' }))));
     }
     tbl.appendChild(tb);
-    host.appendChild(tbl);
+    host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   } catch (err) {
     errorState(host, 'Could not load tasks', err);
   }
@@ -8302,11 +8313,18 @@ function npsBar(host, nps) {
     el('span', {}, el('i', { class: 'sw ' + cls }), `${label}: ${n}`))));
 }
 
-/** starText renders a stored rating as filled and empty stars plus its number. */
+/**
+ * starText renders a stored rating as filled and empty stars plus its number.
+ *
+ * The empty half is U+2606 WHITE STAR (an outline), not a recoloured U+2605. Both halves were
+ * the same filled glyph separated only by colour, which fails WCAG 1.4.1 / DESIGN §2.5 for a
+ * colour-blind reader even after the unfilled colour was fixed — and at the old 1.32:1 it was
+ * invisible outright, so the SCALE of the rating was unreadable.
+ */
 function starText(v) {
   return el('span', { class: 'star-read', title: `${v} of 5` },
     el('span', { class: 'on', text: '★'.repeat(v) }),
-    el('span', { class: 'off', text: '★'.repeat(5 - v) }),
+    el('span', { class: 'off', text: '☆'.repeat(5 - v) }),
     el('span', { class: 'vh', text: ` ${v} of 5` }));
 }
 
@@ -9022,7 +9040,7 @@ async function loadKAArmed() {
       }, 'Disarm'))));
   }
   tbl.appendChild(tb);
-  host.appendChild(tbl);
+  host.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
 }
 
 /** loadKABehaviour fills panels 3a–3e. */
@@ -9112,7 +9130,7 @@ async function loadKABehaviour() {
         el('td', {}, g.median_hours.toFixed(2) + ' h'), el('td', {}, g.max_hours.toFixed(2) + ' h')));
     }
     tbl.appendChild(tb);
-    gaps.appendChild(tbl);
+    gaps.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
   }
 }
 

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -8310,7 +8310,7 @@ Object.assign(loaders, { feedback: loadFeedback });
 // to an entity and never to a rank.
 
 /** kaState holds the tab's loaded payloads, so a control redraw need not refetch. */
-const kaState = { ledger: null, behaviour: null, sessions: [], calc: null, armed: [], live: null,
+const kaState = { ledger: null, recommend: null, behaviour: null, sessions: [], calc: null, armed: [], live: null,
   x: 280, k: 2,
   // canArm is false on a single-tenant deployment, which mounts no control plane at all — so
   // there is nothing to POST an arm to. Drawing the button anyway would put an affordance on the
@@ -8330,6 +8330,10 @@ async function loadKeepAlive() {
   try {
     kaState.ledger = await api('keepalive');
     renderKAVerdict(kaState.ledger);
+    // The decision row paints immediately with the ledger half, and again when the
+    // counterfactual lands. The ledger must not wait on a window function; the row must not
+    // wait on the ledger either, or the two halves flash in a different order every load.
+    renderKADecision(kaState.ledger, kaState.recommend);
     renderKADownside(kaState.ledger);
   } catch (e) {
     if (aborted(e)) return;
@@ -8370,20 +8374,102 @@ function renderKACoverage(o) {
   }
 }
 
+/**
+ * renderKADecision reconciles the THREE verdicts this tab used to give on one window, all of
+ * them reachable without touching a filter, two of them right, none of them labelled as the
+ * decision:
+ *
+ *   - the `ka-net` tile:      +$99.79, green, "Winner"
+ *   - the K ladder, rung 2:   −$83.33, and all four rungs negative
+ *   - "What should I set?":   "this would COST you money … entirely below zero"
+ *
+ * They are not contradictory measurements. They are three different questions and the tab never
+ * said so:
+ *
+ *   the LEDGER is retrospective and SELECTED — what the shipped policy did on the 36 sessions
+ *   it actually fired on, and its saving half is explicitly a CEILING (content-keyed cache);
+ *   the LADDER and the RECOMMENDATION are counterfactual over the WHOLE window — every ping the
+ *   gated policy would have sent across all 173 sessions with an expiry, 3,323 of them at K=2
+ *   against the 544 really sent.
+ *
+ * The decision "should this stay on across my traffic" is the counterfactual one, so that is the
+ * decision number, it is named as such, and the ledger is subordinate to it — still at full
+ * size, because a negative net is never demoted (DESIGN §3.7) and neither is an inconvenient
+ * positive one.
+ *
+ * It renders in the Verdict panel, ADJACENT to the ledger tiles, not 2,900 px below them: cost
+ * belongs beside its benefit. The counterfactual arrives from a slower endpoint, so the row is
+ * built with a placeholder and filled when that lands — the ledger must never wait on it
+ * (see loadKeepAlive).
+ */
+function renderKADecision(o, rec) {
+  const host = clear($('#ka-decision'));
+  const ledgerNet = o && o.keepalive_recorded_from ? o.net_usd : null;
+  // The three-part row: benefit, cost, signed net. A renderer that can emit one without the
+  // other is a bug, so all three come from one call.
+  const rows = [];
+  if (rec && !rec.refused && rec.lo_usd !== undefined) {
+    const mid = (rec.lo_usd + rec.hi_usd) / 2;
+    rows.push(['DECISION — expected across all your traffic',
+      usd(rec.lo_usd) + ' to ' + usd(rec.hi_usd),
+      '90% interval over ' + num(rec.n) + ' expiries in ' + num(rec.sessions) + ' sessions, at '
+      + rec.idle_seconds + 's / ' + rec.max_pings + ' pings',
+      mid < 0 ? 'bad' : 'good']);
+  } else if (rec && rec.refused) {
+    rows.push(['DECISION — expected across all your traffic',
+      rec.service_lo_usd !== undefined && rec.n
+        ? 'below zero'
+        : 'not computable',
+      rec.refused, 'bad']);
+  }
+  if (ledgerNet !== null) {
+    rows.push(['Measured on the sessions it already fired on', usd(ledgerNet),
+      num(o.sessions_touched) + ' of the sessions in this window · the saving half is a CEILING, '
+      + 'so this is an upper bound and it is not the decision',
+      '']);
+  }
+  if (!rows.length) { host.hidden = true; return; }
+  host.hidden = false;
+  host.appendChild(el('div', { class: 'panel', 'data-testid': 'ka-decision-panel' },
+    el('h2', {}, 'Which number is the decision?'),
+    el('p', { class: 'note' },
+      'These two answer different questions and the tab used to show them 2,900 px apart with '
+      + 'nothing saying which to act on. The ', el('strong', {}, 'first'), ' is the one a '
+      + 'decision rests on: it replays the gated policy over ',
+      el('strong', {}, 'every'), ' session in this window. The second is what the policy '
+      + 'actually did on the subset of sessions it fired on, which is a selected population and '
+      + 'a ceiling. The K ladder further down is the same counterfactual, per rung.'),
+    // Inside its own overflow-x wrapper: the third column is a sentence, and at 390 px an
+    // unwrapped 3-column table pushed the BODY sideways (DESIGN §3.1 — the page body never
+    // scrolls horizontally, the table does).
+    el('div', { class: 'tblwrap', tabindex: '0' },
+    el('table', { class: 'grid', 'data-testid': 'ka-decision-table' },
+      el('tbody', {}, ...rows.map(([label, value, note, cls]) => el('tr', {},
+        el('td', {}, el('strong', {}, label)),
+        el('td', { class: 'num ' + (cls === 'bad' ? 'bad-text' : cls === 'good' ? 'good-text' : ''),
+          style: 'font-weight:600' }, value),
+        el('td', { class: 'small' }, note))))))));
+}
+
 /** renderKAVerdict is panel 1: a handful of headline numbers, as tiles. Not a bar chart of four
  *  numbers — four values with different units are four figures, not a comparison. */
 function renderKAVerdict(o) {
   renderKACoverage(o);
   const host = clear($('#ka-tiles'));
   const ran = !!o.keepalive_recorded_from;
-  const position = !ran || !o.pings ? 'No pings yet' : (o.net_usd < 0 ? 'Losing' : 'Winner');
-  const cls = position === 'Winner' ? 'good' : position === 'Losing' ? 'bad' : '';
+  // "Winner" was decided by the LEDGER's sign alone, so this tab called a policy a winner on a
+  // window where its own ladder said every rung loses money and its own recommendation refused
+  // it outright. The position now states which population it describes, and the judgement — the
+  // --good/--bad colour — is deferred to the decision row above, which has the counterfactual.
+  const position = !ran || !o.pings ? 'No pings yet' : (o.net_usd < 0 ? 'Behind' : 'Ahead');
   host.appendChild(tileGroup(null, null, [
     // The words are beside the colour, always: a status must never rest on hue alone.
-    tile('ka-position', 'Your position', position,
-      ran ? num(o.sessions_touched) + ' sessions touched' : 'nothing to judge yet', cls),
-    tile('ka-net', 'Keep-alive net', ran ? usd(o.net_usd) : '—',
-      'avoided − spent', ran ? (o.net_usd < 0 ? 'bad' : 'good') : ''),
+    tile('ka-position', 'Where it stands so far', position,
+      ran ? num(o.sessions_touched) + ' sessions touched — see the decision row above'
+        : 'nothing to judge yet', ran ? 'accent' : ''),
+    tile('ka-net', 'Keep-alive net, measured', ran ? usd(o.net_usd) : '—',
+      'avoided − spent, on the sessions it fired on — an upper bound, not the decision',
+      ran ? (o.net_usd < 0 ? 'bad' : '') : ''),
     tile('ka-pings', 'Pings sent', ran ? num(o.pings) : '—',
       ran ? usd(o.ping_usd) + ' spent on your key' : 'none'),
     tile('ka-saved', 'Re-creations avoided', ran ? usd(o.saved_usd) : '—',

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -99,6 +99,32 @@ function usd(v) {
   return (v < 0 ? '-' : '') + '$' + nf.format(Math.round(a));
 }
 function pct(v, digits = 1) { return v === null || v === undefined ? '—' : v.toFixed(digits) + '%'; }
+/**
+ * usdOrNA renders a dollar figure, or `n/a` WITH ITS REASON when the figure is not a
+ * measurement.
+ *
+ * It exists because usd(0) returns '$0' and a $0 is a CLAIM (BRIEF conventions, DESIGN §3.6).
+ * searchfold removed 1.76M tokens on this corpus with every one of its 488 acted rows
+ * unpriceable, and the cell read `$0` in the ordinary colour with a tooltip that said
+ * "recorded per request" — a confident zero standing in for an unknown, which is the single
+ * thing this dashboard exists to refuse. cachesplit is the same shape inverted: 8,906
+ * structural mutations, no content removed, and a `$0` that reads as "saved nothing" while
+ * /api/stats credits it separately.
+ *
+ * `known` is the CALLER's assertion that the number was computed from something, and it is a
+ * required argument rather than a defaulted one so that a new dollar cell cannot inherit the
+ * lie by omitting it. `reason` is required for the same purpose: an unreasoned `n/a` is
+ * indistinguishable from a bug and will be filed as one (DESIGN §3.6 rule 4).
+ *
+ * Returns a Node, not a string, because the reason has to reach a screen reader as well as a
+ * pointer.
+ */
+function usdOrNA(v, known, reason) {
+  if (known) return document.createTextNode(usd(v));
+  if (!reason) throw new Error('usdOrNA(): an n/a without a reason is indistinguishable from a bug');
+  return el('span', { class: 'na', title: 'not available: ' + reason,
+    'aria-label': 'not available: ' + reason }, 'n/a');
+}
 function ms(v) {
   if (!v) return '0 ms';
   return v >= 1000 ? (v / 1000).toFixed(2) + ' s' : v.toFixed(v < 10 ? 1 : 0) + ' ms';
@@ -2161,15 +2187,59 @@ function renderSeries(buckets) {
 
 // ── components ─────────────────────────────────────────────────────────────
 /**
- * verdict summarises whether a component earns its place, from what it saved
- * against what it cost. Order matters: a component that burned real wall time for
- * nothing is a worse finding than one that simply never fired, so the cost test
- * comes FIRST — otherwise extract_llm's 15 s of model calls for zero savings reads
- * as a bland "inert here".
+ * ERROR_RATE_BAD is the rate at which a component's own failures outrank its economics.
+ *
+ * There used to be no threshold at all: `if (c.errors > 0)` sat above every economic test, and
+ * because fail-open logs an error for each reverted run, EVERY component in a real window has
+ * some. On the 15,900-request corpus the worst rate is 0.39% (toolschema, 9 of 2,314) and all
+ * 14 rows rendered the red `errors` pill — so on a deployment saving $174 no component could
+ * ever read "earning its place", and extract_llm's $2.15 loss was indistinguishable from
+ * dedup's $66 gain. 5% is where "this component is broken" becomes the headline; below it the
+ * rate is noise and belongs in the Errors column, with its denominator, not in the verdict.
+ */
+const ERROR_RATE_BAD = 0.05;
+
+/** errRate is errors per run — the only form in which an error count is a finding. */
+function errRate(c) { return c.runs > 0 ? (c.errors || 0) / c.runs : 0; }
+
+/**
+ * actedStructuralOnly is a component that mutated requests without removing any content.
+ *
+ * cachesplit is the whole reason this predicate exists: its job is WHERE the cache breakpoint
+ * goes, so `acted_tokens` and `saved_unique` are 0 by construction and every content-shaped
+ * test below reads it as inert. Its dollars are recorded per REQUEST (`cachesplit_saved_usd`,
+ * $60.33 on this window from /api/stats) and never reach /api/components at all, so this
+ * column cannot judge it and must not try.
+ */
+function actedStructuralOnly(c) {
+  return (c.acted_structural || 0) > 0 && (c.acted_tokens || 0) === 0;
+}
+
+/**
+ * verdict summarises whether a component earns its place, from what it saved against what it
+ * cost. The precedence, in order, and every step of it was a defect once:
+ *
+ *   1. never ran            — nothing to judge.
+ *   2. error RATE over 5%   — a component failing on one request in twenty is worse news than
+ *                             any dollar figure. Thresholded, and stated WITH the rate; an
+ *                             unthresholded bare `errors` here defeated steps 3-5 for all 14
+ *                             components.
+ *   3. DOLLARS              — a component that makes LLM calls is the only kind that can be
+ *                             net-negative, and that is the most valuable thing this column
+ *                             can say. It comes before latency so extract_llm's 1h 2m of
+ *                             hot-path time for $0.09 of savings reads as `underwater -$2.15`
+ *                             rather than as a bland "inert here".
+ *   4. STRUCTURAL           — before every content test, because "removed no tokens" is
+ *                             cachesplit's normal state, not a failure. Reversed, this branch
+ *                             was unreachable and the third-largest saving on the deployment
+ *                             read `costly and inert`.
+ *   5. content economics    — latency against tokens, then act rate.
  */
 function verdict(c) {
   if (c.runs === 0) return ['—', 'neutral'];
-  if (c.errors > 0) return ['errors', 'missing'];
+  if (errRate(c) >= ERROR_RATE_BAD) {
+    return ['errors on ' + pct(errRate(c) * 100, 1) + ' of runs', 'missing'];
+  }
   // DOLLARS FIRST, where there are any. A component that makes LLM calls is the only kind
   // that can be net-negative, and until the per-call records existed this function had no
   // money to reason with — so it judged the one component that can lose money on tokens and
@@ -2185,6 +2255,11 @@ function verdict(c) {
     if (net < -0.01) return ['underwater ' + usd(net), 'missing'];
     if (net <= 0) return ['break-even', 'partial'];
     return ['net ' + usd(net), 'complete'];
+  }
+  // Consulted BEFORE the latency test below, which is what "costly and inert" is: that test
+  // asks "spent time, removed nothing", and removing nothing is this component's job.
+  if (actedStructuralOnly(c)) {
+    return [num(c.acted_structural) + ' structural mutations', 'partial'];
   }
   // Spent >1s of hot-path time and returned nothing: paid for, unused.
   if (c.saved_unique === 0 && c.duration_ms_total > 1000) return ['costly and inert', 'missing'];
@@ -2561,6 +2636,114 @@ const UNIQUE_MARK = { fabricated: '*', unknown: '?', measured: '', none: '' };
  *  every cell says how much of it is which. */
 function compSaved(c) { return (c.saved_usd || 0) + (c.saved_usd_estimated || 0); }
 
+/**
+ * savedKnown is whether this component's dollar saving is a MEASUREMENT rather than an
+ * unpriceable or inapplicable zero. Three cases, and only the last is a real $0:
+ *
+ *   - a non-zero figure                  → measured.
+ *   - zero with unpriceable rows         → the rows exist and could not be valued. searchfold
+ *                                          removed 1.76M tokens over 488 acted rows, every one
+ *                                          of them on a model with no price, and the cell read
+ *                                          `$0`.
+ *   - zero on a structural-only component→ this column does not measure what it does at all
+ *                                          (see actedStructuralOnly). `$0` there asserts
+ *                                          "saved nothing" about the third-largest saving on
+ *                                          the deployment.
+ *   - zero, priced, and it did act        → a genuine $0.
+ */
+function savedKnown(c) {
+  if (compSaved(c) !== 0) return true;
+  if (c.saved_usd_unpriced_rows > 0) return false;
+  return !actedStructuralOnly(c);
+}
+
+/** savedNAReason is why the saving is not a number, in the words the reader needs. */
+function savedNAReason(c) {
+  if (actedStructuralOnly(c)) {
+    return c.component + ' removes no content, so this column cannot value it. It mutated '
+      + num(c.acted_structural) + ' requests structurally — cache placement — and its saving is '
+      + 'recorded per request instead, as the prefix-cache figure on Overview.';
+  }
+  return num(c.saved_usd_unpriced_rows) + ' of this component\u2019s acted rows ran on a model '
+    + 'with no entry in the operator\u2019s price list, so their saving could not be valued. '
+    + 'It is missing from this figure, not zero.';
+}
+
+/**
+ * savedTitle names which parts of the figure are recorded, valued on read, and unpriceable.
+ *
+ * The unpriced clause used to be NESTED inside the `saved_usd_estimated` branch, and that field
+ * is 0 across this entire corpus — so the one disclosure that says "some of these rows could
+ * not be priced at all" was unreachable on every row that needed it. It is now a clause of its
+ * own, appended whenever there are unpriced rows, whether or not anything was estimated.
+ */
+function savedTitle(c) {
+  const parts = [c.saved_usd_estimated
+    ? usd(c.saved_usd) + ' recorded + ' + usd(c.saved_usd_estimated) + ' valued on read over '
+      + num(c.saved_usd_estimated_rows) + ' rows written before the column existed'
+    : usd(c.saved_usd) + ' recorded per request'];
+  if (c.saved_usd_unpriced_rows) {
+    parts.push(num(c.saved_usd_unpriced_rows) + ' row'
+      + (c.saved_usd_unpriced_rows === 1 ? '' : 's') + ' could not be priced at all — no model '
+      + 'price for the model they ran on, so their saving is MISSING from this figure, not zero');
+  }
+  return parts.join(' · ');
+}
+
+/** partly lists components with their unpriced row count, for the note above the table. */
+function partly(cs) {
+  return cs.map((c) => c.component + ' (' + num(c.saved_usd_unpriced_rows) + ' of '
+    + num(c.acted_tokens) + ' acted rows)').join(', ');
+}
+
+/**
+ * renderUnpricedNote is the ONE explanation a column of `n/a` is allowed to have (DESIGN §3.6
+ * rule 5) — the per-cell reasons are for detail, not for the fact that unpriced rows exist.
+ *
+ * It is level-1 visible rather than behind a `<details>`, because a missing denominator is a
+ * CAVEAT and disclosure hides derivation, never caveats (DESIGN §3.3).
+ */
+function renderUnpricedNote(components) {
+  const host = $('#components-unpriced');
+  if (!host) return;
+  clear(host);
+  const unpriced = components.filter((c) => c.saved_usd_unpriced_rows > 0);
+  const structural = components.filter((c) => actedStructuralOnly(c));
+  if (!unpriced.length && !structural.length) { host.hidden = true; return; }
+  host.hidden = false;
+  if (unpriced.length) {
+    const rows = unpriced.reduce((n, c) => n + c.saved_usd_unpriced_rows, 0);
+    // Two different outcomes and they must not be conflated. A component with SOME unpriceable
+    // rows still shows a figure — it is a lower bound, and calling it n/a would throw away a
+    // real measurement. A component with no priceable row at all has no figure to show.
+    const partial = unpriced.filter((c) => savedKnown(c));
+    const total = unpriced.filter((c) => !savedKnown(c));
+    host.appendChild(el('div', {},
+      el('strong', {}, num(rows) + ' acted rows across ' + unpriced.length + ' component'
+        + (unpriced.length === 1 ? '' : 's') + ' could not be priced'),
+      ' — the model they ran on has no entry in the operator’s price list, so their saving is '
+      + 'absent from the dollar columns rather than zero. Set MODEL_PRICES to value them.'));
+    if (partial.length) {
+      host.appendChild(el('div', {},
+        'Partly unpriced, so the dollar figure shown is a ', el('strong', {}, 'lower bound'),
+        ': ' + partly(partial) + '.'));
+    }
+    if (total.length) {
+      host.appendChild(el('div', {},
+        'No priceable row at all, so the dollar cells read ', el('span', { class: 'na' }, 'n/a'),
+        ' rather than $0: ' + partly(total) + '.'));
+    }
+  }
+  if (structural.length) {
+    host.appendChild(el('div', {},
+      el('strong', {}, structural.map((c) => c.component).join(', ')
+        + (structural.length === 1 ? ' removes' : ' remove') + ' no content'),
+      ' — ' + (structural.length === 1 ? 'its' : 'their') + ' work is where the cache breakpoint '
+      + 'goes, which this table measures in the Structural column and cannot value in dollars. '
+      + 'The saving is recorded per request and appears on Overview as the prefix-cache figure.'));
+  }
+}
+
 async function loadComponents() {
   const body = clear($('#components-body'));
   loadingRows(body, COMPONENT_SORT.length);
@@ -2624,7 +2807,7 @@ async function loadComponents() {
         // gap is named in the tooltip rather than hidden by the choice.
         el('td', {
           class: 'num',
-          title: !c.llm_calls ? '' : llmCostTitle(c),
+          title: !c.llm_calls ? 'this component makes no model calls of its own' : llmCostTitle(c),
         }, c.llm_calls ? usd(c.llm_cost_usd) + (llmCostGap(c) ? '‡' : '') : '—'),
         // A cost never travels alone. saved_usd is what this component's removals were
         // worth over the window — summed per turn, so a frozen reduction replaying across a
@@ -2636,34 +2819,36 @@ async function loadComponents() {
         // — 6 populated rows out of 100,579 on production — and the most-read tab in the
         // dashboard therefore said the product was worthless. The dagger says how much of the
         // figure is valued rather than recorded; it is never silently merged.
+        el('td', { class: 'num', title: savedKnown(c) ? savedTitle(c) : '' },
+          usdOrNA(compSaved(c), savedKnown(c), savedNAReason(c)),
+          savedKnown(c) && c.saved_usd_estimated ? '†' : null),
+        // A net whose benefit half is unknown is unknown too: subtracting a real cost from an
+        // unpriceable saving produced `$0` for searchfold and `-$0.00` for anything with a
+        // sliver of LLM cost, both of which read as measurements.
         el('td', {
-          class: 'num',
-          title: c.saved_usd_estimated
-            ? usd(c.saved_usd) + ' recorded + ' + usd(c.saved_usd_estimated) + ' valued on read '
-              + 'over ' + num(c.saved_usd_estimated_rows) + ' rows written before the column existed'
-              + (c.saved_usd_unpriced_rows
-                ? ' · ' + num(c.saved_usd_unpriced_rows) + ' rows unpriceable' : '')
-            : 'recorded per request',
-        }, usd(compSaved(c)) + (c.saved_usd_estimated ? '†' : '')),
-        el('td', {
-          class: 'num' + (c.net_usd_with_estimate < 0 ? ' warn-text' : ''),
-          title: 'AMORTIZED verdict: saved ' + usd(compSaved(c)) + ' across every turn those '
-            + 'removals stayed removed for, − own LLM cost ' + usd(c.llm_cost_usd || 0)
+          class: 'num' + (savedKnown(c) && c.net_usd_with_estimate < 0 ? ' warn-text' : ''),
+          title: !savedKnown(c) ? '' : 'AMORTIZED verdict: saved ' + usd(compSaved(c))
+            + ' across every turn those removals stayed removed for, − own LLM cost '
+            + usd(c.llm_cost_usd || 0)
             + '. The per-turn column beside this one is the same verdict without the repeat '
             + 'business, and it can have the opposite sign.',
-        }, usd(c.net_usd_with_estimate)),
+        }, usdOrNA(c.net_usd_with_estimate, savedKnown(c),
+          'the saving half of this net is not a number — ' + savedNAReason(c))),
         // The same verdict with replay excluded — the number /stats reports. It is here
         // BESIDE the amortized one, not instead of it, because the two answer different
         // questions and a component can be genuinely positive on one and negative on the
         // other. Showing only whichever is flattering is the failure mode this column exists
         // to prevent.
         el('td', {
-          class: 'num' + (c.net_usd_first_removal < 0 ? ' warn-text' : ''),
-          title: 'PER-TURN verdict: each piece of content credited ONCE at the rate it would '
-            + 'have entered the prompt at (' + usd(c.saved_usd_first_removal || 0) + ') − own '
-            + 'LLM cost ' + usd(c.llm_cost_usd || 0) + '. This is what the proxy\'s /stats '
-            + 'endpoint reports.',
-        }, c.saved_gross ? usd(c.net_usd_first_removal) : '—'),
+          class: 'num' + (savedKnown(c) && c.net_usd_first_removal < 0 ? ' warn-text' : ''),
+          title: !savedKnown(c) ? '' : 'PER-TURN verdict: each piece of content credited ONCE at '
+            + 'the rate it would have entered the prompt at ('
+            + usd(c.saved_usd_first_removal || 0) + ') − own LLM cost '
+            + usd(c.llm_cost_usd || 0) + '. This is what the proxy\'s /stats endpoint reports.',
+        }, c.saved_gross
+          ? usdOrNA(c.net_usd_first_removal, savedKnown(c),
+            'the saving half of this net is not a number — ' + savedNAReason(c))
+          : '—'),
         el('td', {
           class: 'num',
           title: c.replay_multiple > 1
@@ -2674,9 +2859,22 @@ async function loadComponents() {
             : 'Every removal this component made was of content it had not removed before, so '
               + 'there is no repeat business to amortize.',
         }, c.replay_multiple ? c.replay_multiple.toFixed(1) + '×' : '—'),
-        el('td', { class: 'num', text: num(c.errors) }),
+        // The count AND its rate. The verdict column no longer shouts `errors` below the 5%
+        // threshold (see ERROR_RATE_BAD), so this is where a sub-threshold rate stays visible —
+        // and a bare count over an unstated denominator was never a finding anyway: 41 errors
+        // means nothing until you know it is 41 of 14,057.
+        el('td', {
+          class: 'num' + (errRate(c) >= ERROR_RATE_BAD ? ' warn-text' : ''),
+          title: c.errors
+            ? num(c.errors) + ' of ' + num(c.runs) + ' runs = ' + pct(errRate(c) * 100, 2)
+              + '. Fail-open reverts the component and logs one of these per affected run, so a '
+              + 'low rate is the mechanism working, not a defect. The verdict column names '
+              + 'errors only above ' + pct(ERROR_RATE_BAD * 100, 0) + '.'
+            : 'no run of this component failed in this window',
+        }, c.errors ? num(c.errors) + ' (' + pct(errRate(c) * 100, 2) + ')' : '0'),
         el('td', {}, el('span', { class: 'pill ' + vcls, text: vtext }))));
     }
+    renderUnpricedNote(components);
     renderNetReconcile(components);
     // One measure (unique tokens saved) across up to twelve components: a magnitude
     // comparison, so ONE hue. Colouring bar N by N implied each component was a

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -1420,6 +1420,34 @@ function tileGroup(label, note, tiles, cls) {
   return frag;
 }
 
+/**
+ * costCoverage is the share of the window that actually contributed to a dollar figure.
+ *
+ * Every dollar sum on this page is unrestricted by `token_accounting`, so a row with no
+ * provider usage contributes $0 to it — and `costKnown` used to be `complete > 0`, meaning ONE
+ * priced request in a window unlocked five tiles presented as totals. On a 40-row window with 8
+ * complete rows, 32 rows contributed nothing to a figure labelled "Total dollars avoided".
+ *
+ * The fix is not to hide the number: a partial total is still the best available figure and
+ * hiding it would be its own dishonesty. The fix is that it never renders without saying what
+ * share of the window it covers (DESIGN §3.4 rule 1 — a figure carries its denominator, in the
+ * same block, not in a tooltip).
+ */
+function costCoverage(o) {
+  const complete = (o.accounting && o.accounting.complete) || 0;
+  const requests = o.requests || 0;
+  return { complete, requests, pct: requests > 0 ? (100 * complete) / requests : 0 };
+}
+
+/** costNote appends the coverage to a dollar tile's sub-line. Kept as a suffix rather than a
+ *  separate line so the qualifier cannot be laid out away from the number it qualifies. */
+function costNote(o, sub) {
+  const c = costCoverage(o);
+  if (!c.requests) return sub;
+  return sub + ' · priced on ' + num(c.complete) + ' of ' + num(c.requests) + ' requests ('
+    + pct(c.pct, 1) + ')';
+}
+
 function renderTiles(o) {
   const host = clear($('#tiles'));
   const exact = (o.accounting && o.accounting.complete) || 0;
@@ -1454,7 +1482,7 @@ function renderTiles(o) {
     // NOT in here — it was, under the label "compaction + provider cache", and a headline
     // number that mostly measures somebody else's mechanism is not a headline number.
     tile('total-saved-usd', 'Total dollars avoided', costKnown ? usd(o.total_saved_usd) : 'unknown',
-      'compaction + prefix cache + keep-alive + declarations dropped',
+      costNote(o, 'compaction + prefix cache + keep-alive + declarations dropped'),
       costKnown ? (o.total_saved_usd < 0 ? 'bad' : 'good') : ''),
     // The second total, beside the first and only when they differ. It is the SAME money plus
     // what the account removed itself — an MCP server they dropped, a skill they switched off.
@@ -1463,11 +1491,12 @@ function renderTiles(o) {
     // work into the figure we claim credit for would be taking it.
     costKnown && Math.abs(o.total_reduced_usd - o.total_saved_usd) > 0.00005
       ? tile('total-reduced-usd', 'Total the bill came down', usd(o.total_reduced_usd),
-        'ours + ' + usd(o.self_removed_usd) + ' you removed yourself',
+        costNote(o, 'ours + ' + usd(o.self_removed_usd) + ' you removed yourself'),
         o.total_reduced_usd < 0 ? 'bad' : 'good')
       : null,
     tile('saved-usd', 'Net dollars saved', costKnown ? usd(o.net_saved_usd) : 'unknown',
-      'baseline − actual − our spend', costKnown ? (o.net_saved_usd < 0 ? 'bad' : 'good') : ''),
+      costNote(o, 'baseline − actual − our spend'),
+      costKnown ? (o.net_saved_usd < 0 ? 'bad' : 'good') : ''),
     tile('saved-unique', 'Tokens saved (unique)', compact(o.saved_unique),
       compact(o.replay_tokens) + ' re-earned on later turns', 'accent'),
     // Risk beside value, at the SAME altitude, because on this traffic it is 22x larger than
@@ -1477,7 +1506,7 @@ function renderTiles(o) {
     // and a $157 exposure in a folded footnote is not honest about which number is bigger.
     tile('prefix-change-exposure', 'Prefix-change exposure',
       costKnown ? usd(o.prefix_change_cost_all_usd) : 'unknown',
-      num(o.prefix_change_requests_all) + ' turns re-billed · not netted',
+      costNote(o, num(o.prefix_change_requests_all) + ' turns re-billed · not netted'),
       o.prefix_change_cost_all_usd > 0 ? 'bad' : ''),
     tile('requests', 'Requests', num(o.requests), num(o.sessions) + ' sessions'),
   ], 'headline'));
@@ -1497,10 +1526,17 @@ function renderTiles(o) {
     // no JSON envelope — and the provider bills a superset with its own tokenizer. Measured on
     // this corpus the two differ by 3.2x. Without this tile beside them, four token counts and
     // a "% saved" invite being read against an invoice they are not denominated in.
+    // ONE POPULATION, and the sub-line says which. The numerator is contributed only by rows
+    // where the provider reported usage — it is identically 0 elsewhere — so dividing it by
+    // tokens_before summed over ALL rows invented a ratio across two populations and understated
+    // it by exactly the share of unmeasured rows. It printed "0.6× our count", i.e. "the
+    // provider bills LESS than we count", directly above a tooltip in the same tile saying the
+    // figure is "about three times larger". Both server sums were individually correct.
     tile('billed-input', 'Provider-billed input', compact(o.billed_input_tokens),
-      o.tokens_before > 0
-        ? (o.billed_input_tokens / o.tokens_before).toFixed(1) + '× our count'
-        : 'fresh + cache reads + writes'),
+      o.tokens_before_billed > 0
+        ? (o.billed_input_tokens / o.tokens_before_billed).toFixed(2) + '× our count, on the '
+          + num(o.billed_input_rows) + ' requests reporting provider usage'
+        : 'fresh + cache reads + writes — no request in this window reported provider usage'),
     // The check itself, as a figure rather than a footnote. A ratio of sums (the tile to the
     // left) is dominated by the largest requests; this is the median per-request ratio over the
     // only population where the two counts describe the SAME prompt — requests where nothing
@@ -1559,7 +1595,12 @@ function renderTiles(o) {
         : '', 'accent'),
   ]));
 
-  host.appendChild(tileGroup('Cost', costKnown ? 'billed, and the counterfactual' : 'no priced requests in this window', [
+  // The whole group's coverage in the group note rather than five identical tile suffixes:
+  // every figure below is summed over the window unrestricted, so each of them is a partial
+  // total and the share is the same for all of them.
+  host.appendChild(tileGroup('Cost', costKnown
+    ? costNote(o, 'billed, and the counterfactual')
+    : 'no priced requests in this window', [
     tile('cost-baseline', 'Baseline cost', costKnown ? usd(o.baseline_cost_usd) : 'unknown',
       costKnown ? 'without context-guru' : 'needs all four tiers'),
     tile('cost-actual', 'Actual cost', costKnown ? usd(o.cost_usd) : 'unknown',

--- a/dash/ui/app.js
+++ b/dash/ui/app.js
@@ -4110,6 +4110,73 @@ function renderSessionDiff(body, session, out) {
 }
 
 // ── benchmarks ─────────────────────────────────────────────────────────────
+/** BENCH_BASELINE is the harness's name for the no-compaction arm, in every run dir it
+ *  writes (`rows-off.json`). It is the arm every delta on this tab is measured against. */
+const BENCH_BASELINE = 'off';
+
+/** benchOrder puts the baseline first and leaves the rest alphabetical. A comparison table
+ *  whose reference row sorts into the middle makes the reader do the subtraction. */
+function benchOrder(arms) {
+  return arms.slice().sort((a, b) => (a.arm === BENCH_BASELINE ? -1 : b.arm === BENCH_BASELINE ? 1
+    : a.arm < b.arm ? -1 : a.arm > b.arm ? 1 : 0));
+}
+
+/** benchCostKnown: did the ingester find a cost on ANY of this arm's tasks? See
+ *  BenchArm.CostRows — a zero here is an unparsed key far more often than a free run. */
+function benchCostKnown(a) { return (a.cost_rows || 0) > 0; }
+
+function benchCostNAReason(a) {
+  return 'none of this arm’s ' + num(a.tasks) + ' task rows carried a cost the ingester could '
+    + 'read. It reads the per-task cost from an "agent_cost" key; a rows file naming it '
+    + 'otherwise parses to zero, which would render this arm as the cheapest in the study.';
+}
+
+/**
+ * benchDeltaCell is the signed difference from the baseline arm, in the cell (docs/RESULTS.md's
+ * own shape). Solve rate in percentage POINTS, cost as a percentage of the baseline's own cost —
+ * two different units, so the caller names which, and a `pt`/`%` suffix is on the value.
+ *
+ * A sign and an arrow, never colour alone (DESIGN §2.5). Direction is per-measure: more solves
+ * is good, more dollars is not.
+ */
+function benchDeltaCell(a, base, isBase, key, unit) {
+  if (isBase) return el('td', { class: 'num muted', text: '—' });
+  if (!base) {
+    return el('td', { class: 'num' }, el('span', {
+      class: 'na', title: 'not available: this run has no "' + BENCH_BASELINE + '" arm, so there '
+        + 'is nothing to compare against',
+      'aria-label': 'not available: this run has no baseline arm to compare against',
+    }, 'n/a'));
+  }
+  const costLike = unit === '%';
+  if (costLike && !(benchCostKnown(a) && benchCostKnown(base))) {
+    return el('td', { class: 'num' }, el('span', {
+      class: 'na', title: 'not available: a cost delta needs a parseable cost on both this arm '
+        + 'and the baseline',
+      'aria-label': 'not available: a cost delta needs a parseable cost on both arms',
+    }, 'n/a'));
+  }
+  let d, txt;
+  if (costLike) {
+    const b = base[key] || 0;
+    if (!b) return el('td', { class: 'num muted', text: '—' });
+    d = (100 * ((a[key] || 0) - b)) / b;
+    txt = (d > 0 ? '+' : '−') + Math.abs(d).toFixed(2) + '%';
+  } else {
+    d = 100 * ((a[key] || 0) - (base[key] || 0));
+    txt = (d > 0 ? '+' : '−') + Math.abs(d).toFixed(1) + ' pt';
+  }
+  // Cheaper is better; more solved is better. One flag, both directions.
+  const good = costLike ? d < 0 : d > 0;
+  const arrow = d === 0 ? '' : d > 0 ? ' ▲' : ' ▼';
+  return el('td', {
+    class: 'num ' + (Math.abs(d) < 0.005 ? '' : good ? 'good-text' : 'bad-text'),
+    title: 'against the "' + base.arm + '" baseline' + (costLike
+      ? ' (normalised cost basis)' : ' (percentage points of solve rate)'),
+    text: Math.abs(d) < 0.005 ? '±0' : txt + arrow,
+  });
+}
+
 async function loadBenchmarks() {
   const host = clear($('#bench-list'));
   loadingState(host, 3);
@@ -4117,8 +4184,15 @@ async function loadBenchmarks() {
     const { runs } = await api('benchmarks');
     clear(host);
     if (!runs || !runs.length) {
+      // The flag is --dashboard-bench-dirs (cmd/context-guru-proxy/main.go:166). This string
+      // said --dash-bench-dirs, which does not exist anywhere in the repo, and an unknown flag
+      // makes the proxy EXIT — so the tab's only instruction killed the process of anyone who
+      // followed it. This empty state is the tab's primary surface: bench_runs is 0 on a
+      // 133k-request production deployment.
       emptyState(host, 'No benchmark runs ingested',
-        'Point --dash-bench-dirs at a harness jobs root (a directory of runs, each with summary.json and rows-*.json) and re-scan.');
+        'Point --dashboard-bench-dirs at a harness jobs root (a directory of runs, each with '
+        + 'summary.json and rows-*.json), restart, and press Re-scan. Re-scan reports what it '
+        + 'found, including the directories it looked in.');
       return;
     }
     // 42 ingested runs rendered flat is 40k pixels of table. Collapse each run and
@@ -4132,34 +4206,92 @@ async function loadBenchmarks() {
         '  ' + [run.dataset, run.model, armNames && 'arms: ' + armNames,
           when(run.ts)].filter(Boolean).join(' · ')));
       const inner = el('div', { style: 'padding:12px 14px' });
+      // BASELINE FIRST, and the delta column exists. The server orders by arm name
+      // (dash/bench.go benchArms), so `off` sorted third of four alphabetically and a reader had
+      // to compute the one number this tab exists to produce — the difference from baseline —
+      // in their head across four rows. docs/RESULTS.md:11-14 puts baseline first with the
+      // deltas in-cell; this matches it.
+      const arms = benchOrder(run.arms || []);
+      const base = arms.find((a) => a.arm === BENCH_BASELINE) || null;
       const tbl = el('table', { class: 'tbl' }, el('thead', {}, el('tr', {},
         el('th', { text: 'Arm' }), el('th', { class: 'num', text: 'Tasks' }),
-        el('th', { class: 'num', text: 'Solved' }), el('th', { class: 'num', text: 'Solve rate' }),
+        // Scored is the DENOMINATOR of Solve rate, and it was in BenchArm without being a
+        // column. Four arms printed rates off four different denominators (60, 59, 57, 57) with
+        // Tasks — which is not the denominator — beside them, and the only clue was Exceptions,
+        // eleven columns right and off-screen below 1100 px. Both now sit next to the rate.
+        el('th', { class: 'num', title: 'tasks that produced a score: tasks − exceptions. This '
+          + 'is the denominator of Solve rate; Tasks is not.', text: 'Scored' }),
+        el('th', { class: 'num', text: 'Exceptions' }),
+        el('th', { class: 'num', text: 'Solved' }),
+        el('th', { class: 'num', text: 'Solve rate' }),
+        el('th', { class: 'num', text: 'vs baseline' }),
         el('th', { class: 'num', text: 'Mean reward' }), el('th', { class: 'num', text: 'Mean steps' }),
-        el('th', { class: 'num', text: 'Total cost' }), el('th', { class: 'num', text: 'Cost / task' }),
+        // Two bases, both named. bench.go computes TotalNormCostUSD and the UI rendered
+        // neither basis by name — `grep -n norm_cost dash/ui/app.js` was zero hits, so the tab
+        // showed the agent-reported basis while the published claim (docs/RESULTS.md) is the
+        // normalised one, unlabelled and differing by over a point.
+        el('th', { class: 'num', title: 'as the agent harness reported it', text: 'Total cost (agent)' }),
+        el('th', { class: 'num', title: 'every arm re-priced from its own token counts at one '
+          + 'rate card — the basis docs/RESULTS.md quotes', text: 'Total cost (normalised)' }),
+        el('th', { class: 'num', text: 'vs baseline' }),
+        el('th', { class: 'num', text: 'Cost / task' }),
         el('th', { class: 'num', text: '$ per solve' }),
-        el('th', { class: 'num', text: 'Cache hit' }), el('th', { class: 'num', text: 'Mean wall' }),
-        el('th', { class: 'num', text: 'Exceptions' }))));
+        el('th', { class: 'num', text: 'Cache hit' }), el('th', { class: 'num', text: 'Mean wall' }))));
       const tb = el('tbody');
-      for (const a of run.arms || []) {
-        const perSolve = a.solved > 0 ? a.total_cost_usd / a.solved : null;
-        tb.appendChild(el('tr', { class: 'click', onclick: () => toggleBenchTasks(inner, run.id, a.arm) },
-          el('td', {}, el('code', { text: a.arm })),
+      for (const a of arms) {
+        const isBase = base && a.arm === base.arm;
+        const known = benchCostKnown(a);
+        const perSolve = a.solved > 0 && known ? a.total_cost_usd / a.solved : null;
+        tb.appendChild(el('tr', { class: 'click' + (isBase ? ' is-current' : ''),
+          onclick: () => toggleBenchTasks(inner, run.id, a.arm) },
+          el('td', {}, el('code', { text: a.arm }),
+            isBase ? el('span', { class: 'pill neutral', text: 'baseline' }) : null),
           el('td', { class: 'num', text: num(a.tasks) }),
+          el('td', { class: 'num', text: num(a.scored) }),
+          el('td', { class: 'num', text: num(a.exceptions) }),
           el('td', { class: 'num', text: num(a.solved) }),
-          el('td', { class: 'num', text: pct(a.solve_rate * 100) }),
+          // The denominator travels with the rate, in the same cell. codesmart 40/60 and rtk
+          // 38/57 both print 66.7% and are not the same measurement.
+          el('td', { class: 'num', title: num(a.solved) + ' of ' + num(a.scored) + ' scored tasks'
+            + (a.exceptions ? ' (' + num(a.exceptions) + ' excluded as infrastructure exceptions)' : '') },
+          a.scored > 0 ? pct(a.solve_rate * 100) + ' of ' + num(a.scored) : 'n/a'),
+          benchDeltaCell(a, base, isBase, 'solve_rate', 'pt'),
           el('td', { class: 'num', text: a.mean_reward.toFixed(3) }),
           el('td', { class: 'num', text: a.mean_steps.toFixed(1) }),
-          el('td', { class: 'num', text: usd(a.total_cost_usd) }),
-          el('td', { class: 'num', text: usd(a.mean_cost_usd) }),
-          el('td', { class: 'num', text: perSolve === null ? '—' : usd(perSolve) }),
-          el('td', { class: 'num', text: pct(a.cache_hit_rate * 100, 2) }),
-          el('td', { class: 'num', text: dur(a.mean_wall_s * 1000) }),
-          el('td', { class: 'num', text: num(a.exceptions) })));
+          el('td', { class: 'num', title: known ? '' : '' },
+            usdOrNA(a.total_cost_usd, known, benchCostNAReason(a))),
+          el('td', { class: 'num' },
+            usdOrNA(a.total_norm_cost_usd, known, benchCostNAReason(a))),
+          benchDeltaCell(a, base, isBase, 'total_norm_cost_usd', '%'),
+          el('td', { class: 'num' }, usdOrNA(a.mean_cost_usd, known, benchCostNAReason(a))),
+          el('td', { class: 'num', text: perSolve === null ? (known ? '—' : 'n/a') : usd(perSolve) }),
+          // Same shape as the cost cells: BenchArm.CacheHitRate is left at 0 when the arm
+          // reported no token counts at all (benchArms guards `total > 0`), and `0.00%` there is
+          // a claim about a cache that was never measured. The token sums are already on the
+          // wire, so the distinction costs nothing.
+          el('td', { class: 'num' }, a.cache_read + a.cache_write + a.fresh_input > 0
+            ? pct(a.cache_hit_rate * 100, 2)
+            : el('span', {
+              class: 'na',
+              title: 'not available: this arm’s rows carry no cache_read / cache_write / '
+                + 'fresh_input counts, so its cache behaviour was not measured',
+              'aria-label': 'not available: this arm reported no token counts, so its cache '
+                + 'hit rate was not measured',
+            }, 'n/a')),
+          el('td', { class: 'num', text: dur(a.mean_wall_s * 1000) })));
       }
       tbl.appendChild(tb);
       inner.appendChild(el('div', { class: 'tblwrap', tabindex: '0' }, tbl));
-      inner.appendChild(el('p', { class: 'note', text: 'Cost per solve is the number that matters: an arm that spends less by solving fewer tasks has not saved anything. Click an arm for its per-task rows.' }));
+      inner.appendChild(el('p', { class: 'note', text: 'Cost per solve is the number that matters: an arm that spends less by solving fewer tasks has not saved anything. Solve rate is over SCORED tasks, so two arms with the same rate off different denominators are not the same measurement — the denominator is in the cell. Click an arm for its per-task rows.' }));
+      if (arms.some((a) => !benchCostKnown(a))) {
+        inner.appendChild(el('p', { class: 'hint' },
+          el('strong', {}, 'One or more arms report no cost on any task. '),
+          'Those cells read ', el('span', { class: 'na' }, 'n/a'),
+          ' rather than $0, because the ingester reads the per-task cost from an ',
+          el('code', {}, 'agent_cost'),
+          ' key and a rows file naming it something else parses to zero silently — which would '
+          + 'render as the cheapest arm in the study. Check the rows file’s cost key.'));
+      }
       // Cost-vs-reward scatter: the visualization the issue asks for.
       inner.appendChild(el('h2', { text: 'Cost vs reward, by arm' }));
       const scatter = el('div', { class: 'chart', 'data-testid': 'bench-scatter' });
@@ -4171,6 +4303,44 @@ async function loadBenchmarks() {
   } catch (err) {
     if (aborted(err)) return;
     errorState(host, 'Could not load benchmarks', err);
+  }
+}
+
+/**
+ * rescanBenchmarks fires the re-scan and SAYS WHAT IT FOUND.
+ *
+ * The click handler used to `await fetch(...)` and discard the response, so a mistyped path and
+ * a correct scan of an empty directory rendered identically — the tab simply stayed empty —
+ * while the server was returning real counts the whole time. It now also reports the
+ * directories, because "scanned nothing because none are configured" is a different problem
+ * from "scanned two and found no runs" and only one of them is fixed by editing a path.
+ */
+async function rescanBenchmarks() {
+  const host = $('#bench-list');
+  try {
+    const r = await fetch('/api/benchmarks?refresh=1');
+    if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + r.statusText);
+    const out = await r.json();
+    const dirs = out.dirs || [];
+    if (out.ingested_runs > 0) {
+      $('#bench-scan').textContent = 'Scanned ' + dirs.length + ' director'
+        + (dirs.length === 1 ? 'y' : 'ies') + ': ingested ' + num(out.ingested_runs)
+        + ' run' + (out.ingested_runs === 1 ? '' : 's') + ', ' + num(out.ingested_tasks)
+        + ' task rows.';
+    } else if (!dirs.length) {
+      $('#bench-scan').textContent = 'Nothing was scanned: no --dashboard-bench-dirs is '
+        + 'configured on this proxy, so Re-scan has no directory to look in. Restart with the '
+        + 'flag pointing at a jobs root.';
+    } else {
+      $('#bench-scan').textContent = 'Scanned ' + dirs.join(', ') + ' and found no run '
+        + 'directory (a run needs summary.json and at least one rows-*.json). 0 runs, 0 tasks '
+        + 'ingested.';
+    }
+    $('#bench-scan').hidden = false;
+    loadBenchmarks();
+  } catch (err) {
+    if (aborted(err)) return;
+    errorState(host, 'Re-scan failed', err);
   }
 }
 
@@ -5068,10 +5238,7 @@ function init() {
   });
   $('#sess-prev').addEventListener('click', () => { state.sessOffset = Math.max(0, state.sessOffset - 25); loadSessions(); });
   $('#sess-next').addEventListener('click', () => { state.sessOffset += 25; loadSessions(); });
-  $('#bench-refresh').addEventListener('click', async () => {
-    await fetch('/api/benchmarks?refresh=1');
-    loadBenchmarks();
-  });
+  $('#bench-refresh').addEventListener('click', rescanBenchmarks);
   $('#drawer-close').addEventListener('click', closeDrawer);
   // Forward wrap: reaching the sentinel means the last real stop is behind us.
   $('#drawer-end').addEventListener('focus', () => { $('#drawer-close').focus(); });
@@ -9092,6 +9259,11 @@ async function loadKARecommend() {
     errorState(host, 'Could not work out a recommendation', e);
     return;
   }
+  kaState.recommend = rec;
+  // Same payload, two places: the decision row above (which is what a reader acts on) and the
+  // detail below. Rendering it only here is how the refusal came to sit 2,900 px under a green
+  // "Winner" tile that contradicted it.
+  renderKADecision(kaState.ledger, rec);
   clear(host);
   if (rec.refused) {
     // Two different refusals, and only one of them is about thin history: "your own gaps are

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -704,6 +704,9 @@
     <p class="note">From the harness artifacts. Reward sits beside cost on purpose: an arm
       that saves money by failing tasks is not saving money.</p>
     <button id="bench-refresh" class="ghost" data-testid="bench-refresh">Re-scan run directories</button>
+    <!-- What the re-scan actually found. The click handler used to discard the server's counts,
+         so a wrong path and a correct scan of an empty directory looked identical. -->
+    <p class="hint" id="bench-scan" data-testid="bench-scan" role="status" hidden></p>
     <div id="bench-list" data-testid="bench-list"></div>
   </div>
 </section>

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -487,6 +487,10 @@
         <tbody id="components-body"></tbody>
       </table>
     </div>
+    <!-- ONE explanation for a column of n/a, above nothing and beside the table, rather than
+         forty tooltips (DESIGN §3.6 rule 5). Filled by loadComponents only when this window
+         actually contains unpriceable rows; a `hidden` empty paragraph the rest of the time. -->
+    <p class="hint" id="components-unpriced" data-testid="components-unpriced" hidden></p>
     <!-- The two verdicts, reconciled. This dashboard and the proxy's /stats endpoint report
          OPPOSITE SIGNS for the same component, and until now neither surface admitted the
          other existed: a reader here saw extract_llm green and positive, an operator running

--- a/dash/ui/index.html
+++ b/dash/ui/index.html
@@ -545,6 +545,10 @@
       avoided, over the window selected above. The <strong>net</strong> is the only one of
       these figures worth a decision.</p>
     <div id="ka-coverage"></div>
+    <!-- The reconciliation of the three verdicts this tab gives on one window, ABOVE the tiles
+         and above the fold: cost belongs beside its benefit (DESIGN §3.7), not 2,900 px below
+         it. Filled by renderKADecision from the ledger and the recommendation. -->
+    <div id="ka-decision" data-testid="ka-decision" hidden></div>
     <div id="ka-tiles"></div>
   </div>
 

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -188,6 +188,12 @@ code, kbd { font-family: var(--mono); font-size: 0.92em; }
   color: var(--fg-muted); font-style: normal;
   border-bottom: 1px dotted var(--border); cursor: help;
 }
+/* The dotted rule works because "n/a" is a WORD wide enough to carry one. On the `†` footnote
+   mark (`.na small`, ~10px including its leading space) it renders as a four-dot fragment offset
+   under the space and reads as dirt on the screen rather than as "a reason exists here".
+   Measured at deviceScaleFactor 6. The upright weight, --fg-muted and cursor:help all stay --
+   `cursor: pointer` had implied the dagger was clickable, which it is not. */
+.na.small { border-bottom: 0; }
 /* Screen-reader-only. Used for the action columns' headers: a th with no text is a
    column with no name, and aria-label on a th is not a name a table walker reports. */
 /* No position:absolute here: inside a horizontally scrolling table an absolutely

--- a/dash/ui/style.css
+++ b/dash/ui/style.css
@@ -180,7 +180,14 @@ code, kbd { font-family: var(--mono); font-size: 0.92em; }
    here is emitted by index.html or app.js; three unused ones were deleted. */
 .muted { color: var(--fg-muted); }
 .small { font-size: var(--t-small); }
-.na { color: var(--fg-faint); font-style: italic; }
+/* DESIGN §3.6 rules 1-2: an `n/a` is the same size as the number it replaces, and it is ink
+   (--fg-muted) rather than faint italic, which reads as a rendering failure. The dotted
+   underline is what tells the reader a reason exists in the title/aria-label. --fg-faint was
+   already legal (4.64-6.00:1); --fg-muted is 5.46-7.50:1. */
+.na {
+  color: var(--fg-muted); font-style: normal;
+  border-bottom: 1px dotted var(--border); cursor: help;
+}
 /* Screen-reader-only. Used for the action columns' headers: a th with no text is a
    column with no name, and aria-label on a th is not a name a table walker reports. */
 /* No position:absolute here: inside a horizontally scrolling table an absolutely
@@ -290,6 +297,11 @@ button.subtle:hover { text-decoration: underline; }
 }
 .filters input[type="search"] { min-width: 200px; flex: 1 1 200px; max-width: 320px; }
 .filters select:hover, .filters input:hover { border-color: var(--fg-faint); }
+/* An <option> in the popup list does NOT inherit its select's color: the UA paints it with its
+   own default, measured 3.68:1 (#808080 on --bg) in the tenant picker in light mode. Both halves
+   set explicitly, on bare `option` rather than per-select, so every dropdown in the app is
+   covered once. --fg on --bg-raised is 18.13:1 light / 14.49:1 dark. */
+option { color: var(--fg); background: var(--bg-raised); }
 /* The filter bar is hidden on the views that have nothing to filter (Setup, Settings,
    Tenants, Archive, Config). Fourteen dropdowns over a settings form invite clicks that
    change nothing. */
@@ -1133,7 +1145,13 @@ table.grid tr.revoked { opacity: 0.55; }
 .score-dim { color: var(--fg-muted); }
 .star-read { white-space: nowrap; letter-spacing: 0.5px; }
 .star-read .on { color: var(--accent); }
-.star-read .off { color: var(--border); }
+/* --fg-muted, not --border. The hairline measures 1.22-1.44:1 against every surface it can
+   land on, in both themes, which makes an unfilled star invisible: a 3-of-5 rating read as a
+   3-star rating with no sign that 5 was possible, 41 times over on Feedback. --fg-muted is
+   5.46-7.50:1 on all four surfaces in both themes. The glyph also changes from a filled star
+   to an outline one (starText), so the two states differ in SHAPE as well as hue and the row
+   survives greyscale and CVD (DESIGN §2.5). */
+.star-read .off { color: var(--fg-muted); }
 .answer-block { margin-top: var(--sp-2); }
 .answer-block h4 {
   margin: 0 0 2px; font-size: var(--t-micro); font-weight: 600; color: var(--fg-muted);


### PR DESCRIPTION
Four tabs reported numbers that were not measurements. Eleven display fixes plus two real contrast failures, on the seed v2 corpus (15,900 requests, 200 sessions, 4 bench runs). Every claim below is rendered text, not a screenshot description.

## The one fix that prevents a class rather than an instance

`usdOrNA(v, known, reason) -> Node` (`dash/ui/app.js`, beside `usd()`). `known` and `reason` are **required** arguments, and it throws on a missing reason. Every other fix here prevents one instance of a defect; this signature makes the honest path the only path — a new dollar cell cannot silently omit its coverage, because there is no argument-shape in which it can.

This is DESIGN §3.4 rule 1's shape applied to coverage rather than to a denominator — *"make the denominator a required argument of the render function, so an omitted denominator is a crash, not a confident number."* The throw is that rule enforced, not defensive coding.

It exists because `usd(0)` returns `'$0'` and a `$0` is a claim. `searchfold` removed 1.76M tokens over 488 acted rows, every one on a model with no price, and three cells read `$0` with a tooltip saying "recorded per request".

## Keep-alive gave three incompatible verdicts on one window

All three reachable without touching a filter, none labelled as the decision:

| | |
|---|---|
| `ka-net` tile | **+$99.79**, green, "Winner" |
| K ladder, rung marked current | **−$83.33**, all four rungs negative |
| "What should I set?" | "this would **COST** you money … entirely below zero" |

Not resolved by picking one. They differ because they answer different questions: the **ledger is retrospective and selected** — what the shipped policy did on the 36 of 200 sessions it fired on, with a saving half that is explicitly a ceiling (the provider's cache is content-keyed) — while the **ladder and recommendation are counterfactual** over all 173 sessions with an expiry, 3,323 pings at K=2 against the 544 actually sent.

The decision "should this stay on across my traffic" is the counterfactual one. So it is named as the decision, in a row **above** the tiles rather than 2,900 px below them (DESIGN §3.7: cost beside its benefit; a negative net is never demoted), and the measured tile is relabelled as an upper bound:

```
Which number is the decision?
DECISION — expected across all your traffic | below zero | …the 90% interval is
  $-88.37 to $-75.61, entirely below zero…
Measured on the sessions it already fired on | $99.79 | 36 of the sessions in this
  window · the saving half is a CEILING, so this is an upper bound and it is not the decision

Your position | Winner            →  Where it stands so far   | Ahead
Keep-alive net | $99.79           →  Keep-alive net, measured | $99.79 | …an upper bound, not the decision
```

The row paints from whichever half has arrived and repaints when the other lands, so the ledger still never waits on the slow window function. The honesty costs nothing in latency.

## Components: the verdict the code's own comment was written to produce was unreachable

`if (c.errors > 0)` gated the column with no rate threshold, above every economic test — and fail-open logs an error per reverted run, so every component in a real window has some. Worst rate in the corpus is 0.39% (`toolschema`, 9 of 2,314), and **14 of 14 rows rendered the red `pill missing`**. On a window saving $351, no component could read "earning its place".

```
extract_llm  verdict  errors            → underwater -$2.15
cachesplit   verdict  costly and inert  → 8,906 structural mutations
cachesplit   Saved $  $0                → n/a
searchfold   Saved $ / Net $  $0 / $0   → n/a / n/a
dedup        verdict  errors            → earning its place
dedup        Errors   31                → 31 (0.22%)
```

Distribution over the 14 components: **13 `errors` + 1 `costly and inert` → 5 `earning its place`, 6 `expensive for its yield`, 1 `underwater`, 1 `structural`, 0 `errors`.**

`underwater -$2.15` is what `verdict()`'s own docstring said it existed to produce. The errors gate one line above defeated it. Showing the cell as `31 (0.22%)` rather than `31` is what stops the bug recurring: a bare count invites a threshold-free gate, a rate does not.

`cachesplit` was the inverse shape — 8,906 structural mutations, `Saved $ $0`, red pill, while `/api/stats` credits it $60.33 on the same window. A reader acting on that row switches off the third-largest saving on the deployment.

### The unpriced note separates two things that get conflated

Conflating them is what produced the green `$0` in the first place. **Partly** unpriced means the figure shown is a lower bound and must still be shown; **no priceable row at all** means there is no figure and the cells read `n/a`:

> **2,959 acted rows across 4 components could not be priced** … Partly unpriced, so the dollar figure shown is a **lower bound**: format (1,196 of 11,391 acted rows), toon (486 of 4,171), textclean (789 of 6,527). No priceable row at all, so the dollar cells read *n/a* rather than $0: searchfold (488 of 488).

One explanation above the table rather than forty tooltips (DESIGN §3.6 rule 5).

## Benchmarks: `59.6% of 57` is the whole fix

Four arms printed rates off four different denominators in one column with no flag. `Scored = tasks − exceptions` was in `BenchArm` without being a column; `Tasks`, which looks like the denominator, is not; the only clue was `Exceptions`, eleven columns right and off-screen below 1100 px.

```
before  Arm       Tasks Solved Solve rate  Total cost  … Exceptions
        codesmart 60    40     66.7%       $27.59        0     ← 40/60
        rtk       60    38     66.7%       $26.26        3     ← 38/57

after   off [baseline] 60 57 3 34 59.6% of 57  —          $29.59  $29.59  —
        codesmart      60 60 0 40 66.7% of 60  +7.0 pt ▲  $27.59  $27.59  −6.77% ▼
        headroom       60 59 1 39 66.1% of 59  +6.5 pt ▲  $19.10  $19.10  −35.45% ▼
        rtk            60 57 3 38 66.7% of 57  +7.0 pt ▲  $26.26  $26.26  −11.24% ▼
```

Baseline pinned first with a pill (was third of four, alphabetically); signed deltas with arrows, never colour alone; both cost bases rendered and named (`bench.go` computed `TotalNormCostUSD` and `grep -n norm_cost dash/ui/app.js` was zero hits).

Plus: the empty state named `--dash-bench-dirs`, which does not exist — an unknown flag makes the proxy **exit**, so the tab's only instruction killed the process of anyone who followed it. Real flag is `--dashboard-bench-dirs`. And Re-scan discarded the response body, so a wrong path and a correct scan of an empty directory rendered identically; it now reports all three outcomes, and `?refresh=1` returns the directories it looked in.

An arm whose rows file names cost differently ingested as `$0` and sorted as the **cheapest**. `benchArms` now counts rows that priced, and the UI refuses to render a cost it could not parse. Verified against a run whose rows file uses `bob_cost`: `$0/$0/$0/$0/0.00%` → `n/a` throughout.

## Overview

Both server sums were individually correct; the ratio was invented in the browser. `billed_input_tokens / tokens_before` divided a numerator contributed only by rows reporting provider usage by a denominator summed over all of them. Now `tokens_before_billed` + `billed_input_rows`, same population, and the tile names it. And `costKnown = complete > 0` let **one** priced request unlock five tiles presented as totals; each now states its coverage (`priced on 14,259 of 15,900 requests (89.7%)`).

## Two contrast failures, the first real ones found on this product

Measured with the bundled `validate_palette.js` `contrast()`, not eyeballed:

```
unfilled star .star-read .off      BEFORE var(--border)      AFTER var(--fg-muted)
  light  --bg / raised / sunken / hover   1.34 1.43 1.23 1.29   5.92 6.34 5.46 5.71
  dark   --bg / raised / sunken / hover   1.44 1.32 1.39 1.22   7.50 6.87 7.21 6.35
<option> text                      BEFORE UA #808080         AFTER --fg on --bg-raised
  light on --bg #f6f7f9                    3.68  FAIL          18.13  PASS
  dark  on --bg #0d1117                    4.79  PASS          14.49  PASS
```

At 1.32:1 an unfilled star is invisible, so a 3-of-5 rating read as a 3-star rating with no sign that 5 was possible, across 84 rendered rows. **Gate chosen: 4.5:1, not the 3:1 non-text gate** — these are text glyphs in a `<span>`, so SC 1.4.3 applies on its own terms and the stricter gate needs no argument about whether a star is a graphic.

The more serious half was §2.5: both states were the *same filled glyph* separated only by colour, which fails 1.4.1 for a colour-blind reader even at passing contrast. The empty half is now U+2606 `☆`, so they differ in shape: `★★★★★` / `★★★☆☆` / `★★☆☆☆`.

Paired runs, dc29f22 vs this branch, same corpus and cookie:

| tab | contrastFail/pairs/nodes | |
|---|---|---|
| `feedback` | **1**/11/408 → **0**/10/408 | 1.32 dark, 1.43 light |
| `strategies` | **1**/7/122 → **0**/6/122 | 3.68 light |

The pair *count* drops with the failure count, so the failing pair is gone rather than merely passing. Zero contrast failures across all 32 combinations after.

## Known limitation of the evidence in this PR

**`shots.mjs` could not authenticate to a hosted proxy when this work started**, so every manager-gated tab screenshotted as `Could not load — sign in at /dashboard/`, and the audit passed that empty table as clean (`0/4/50`). Several fixes here are on gated surfaces. The earlier screenshots in `before-local/` were therefore taken in single-tenant local mode, where `requireManager` short-circuits.

`infra-harness` has since added `--cookie-file`, and the `before-auth/` and `after-auth/` sets are behind a real session.

**A second instrument caveat, and why the contrast claim survives it.** `shots.mjs` has no per-tab ready selector — it waits for `[data-view]` (the nav, present immediately) then a fixed delay, so it can audit a loading skeleton and manufacture an improvement out of a tab that simply had not rendered yet (`impl-nav` saw exactly that: a `bodyScrollsX 8 → 5` "win" off `kvcache` dropping from 2038 visible text nodes to 43). The text-node denominator is the tell, so both my runs were checked against each other before any claim was made:

| tab·theme·vw | textNodes before/after | pairs | fail |
|---|---|---|---|
| `feedback` (all 4) | **408 / 408** | 11 → 10 | 1 → 0 |
| `strategies` (all 4) | **122 / 122** | 7 → 6 | 1 → 0 |

Both contrast fixes are measured on an **identical denominator**, so they are not a render-state artefact, and the pair count falls by exactly one alongside the failure — the failing pair vanished from a scan of the same size. Across all 32 combinations, 0 showed a denominator shift outside 0.85–1.25×; every movement that did occur is content this PR adds (benchmarks +3 columns 88→103, components +note 360→371, keep-alive +decision row 309→319, sessions +2 `n/a` spans 376→396). This matters beyond this PR: **the two contrast failures above were only findable once the harness could carry a session**, and anything still unreachable is unaudited rather than clean. `tenants`, `strategies` and `campaigns` have no `data-local-ok`, so they were invisible to every prior audit on this product.

## Not fixed, deliberately

- **The Verdict column sits 1,116 px off-screen at 1440 px.** Table width 2,732 px, `Verdict` header left edge 2,556 px, 21 columns against DESIGN §3.1's 7-plus-a-picker. The fix is correct and needs horizontal scrolling to see. Wants a column picker; nobody on this sweep owns that.
- `keepalive` scrolls the body sideways at 390 px (+843 px behind auth, culprit `#ka-sessions-body`). **Identical on dc29f22** — pre-existing.
- `strategies` +183 px and `tenants` `textClip=4` — pre-existing, Admin group, and this branch does not contain #169, so it cannot say whether impl-perf's fix holds.
- The Sessions `†` coverage-mark path is **undrawn by the seed corpus**: no session has both a non-zero baseline cost and an incomplete row (0 of 200), so any audit walking only this corpus reports it clean without rendering it. Verified by `impl-traffic` against a stubbed row instead.
- `searchfold` reads `earning its place` while its dollars are `n/a`. The non-LLM verdict path has always been token-based, not dollar-based; the level-1 note names the gap. Worth a separate decision on whether an economic word may rest on token evidence alone.

## Three filed findings that were wrong in detail

Corrected rather than quietly worked around:

1. **`bob_cost` exists nowhere in the repo at dc29f22.** `grep -rn 'bob_cost'` returns zero hits and all four harness scripts write `agent_cost`. The defect class is real and is fixed; the cited artifact is not. Proven with a synthetic rows file instead.
2. **The two-population ratio is unobservable on seed v2.** Every one of the 16,444 rows reports provider usage, so both populations are identical and the ratio is 0.958 either way. The filed `0.6×` vs `2.77×` is not reproducible here. The code defect is real; no screenshot can show a number change.
3. **`norm_cost == agent_cost` on every seeded row**, so `−11.8%` vs `−13.17%` cannot be demonstrated, and `docs/RESULTS.md` is a **50-task** study while the seeded run is 60 tasks — "reproduces RESULTS.md to the penny" is not checkable on this data.

## Verification

```
CGO_ENABLED=1 go build ./...   OK
go vet ./...                   OK
CGO_ENABLED=1 go test ./dash/  ok  github.com/rossoctl/context-guru/dash  81.597s
```

5 commits. `dash/ui/app.js`, `dash/ui/index.html`, `dash/ui/style.css`, `dash/overview.go`, `dash/bench.go`, `dash/api.go`.
