### PR TITLE
fix(store): give rewind payloads their own reserve, and refuse a removal whose original cannot be stored

### DIFF
--- a/cmd/context-guru-proxy/main.go
+++ b/cmd/context-guru-proxy/main.go
@@ -916,10 +916,11 @@ func effectiveConfig(cfg *config.Config, addr, openai, anthropic, bob, dbPath st
 		"inject_expand":        envOr("INJECT_EXPAND", "auto"),
 		"cheap_model":          os.Getenv("CHEAP_MODEL"),
 		"cheap_model_provider": envOr("CHEAP_MODEL_PROVIDER", "anthropic"),
-		"store":                map[string]any{"ttl_seconds": cfg.Store.TTLSeconds, "max_entries": cfg.Store.MaxEntries},
-		"dashboard":            map[string]any{"db_path": dbPath, "capture_content": content, "trusted_cidrs": cidrs},
-		"build_version":        buildinfo.Version,
-		"build_commit":         buildinfo.Commit,
+		"store": map[string]any{"ttl_seconds": cfg.Store.TTLSeconds,
+			"max_entries": cfg.Store.MaxEntries, "stash_max_bytes": cfg.Store.StashMaxBytes},
+		"dashboard":     map[string]any{"db_path": dbPath, "capture_content": content, "trusted_cidrs": cidrs},
+		"build_version": buildinfo.Version,
+		"build_commit":  buildinfo.Commit,
 	}
 }
 

--- a/components/offload/agentdiet.go
+++ b/components/offload/agentdiet.go
@@ -496,6 +496,12 @@ func (d *AgentDiet) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 		}
 	}
 	if effectiveMode(c, d.mode) == markerFull && !store.StashRoom(c.Store, smallest) {
+		// Counted, not just gated. stash_refused is documented — in config.md, in routes.md and on
+		// the counter itself — as THE signal to raise a budget, and deliberately upstream of
+		// expand_unresolved_missing. A component whose refusals are invisible to it undercuts that:
+		// a deployment starving agentdiet would decline a whole step's removals every turn while
+		// /stats read 0. One increment per declined step, which is what was declined.
+		stashRefusals.Add(1)
 		rep.Gate("stash_reserve_exhausted")
 		if changed == 0 {
 			rep.Skipped = true

--- a/components/offload/agentdiet.go
+++ b/components/offload/agentdiet.go
@@ -558,7 +558,9 @@ func (d *AgentDiet) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 		if !ok {
 			continue
 		}
-		commitMark(c, rep, eff, key, p.content)
+		if !commitMark(c, rep, eff, key, p.content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(&req.Input[p.i], newText)
 		freeze(c, d.Name(), p.content, newText)
 		changed++

--- a/components/offload/agentdiet.go
+++ b/components/offload/agentdiet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
 )
 
 func init() { components.Register("agentdiet", newAgentDiet) }
@@ -473,6 +474,29 @@ func (d *AgentDiet) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 		model = c.Model.For(d.modelSource)
 	}
 	if model == nil { // no model configured: replay-only, never an error
+		if changed == 0 {
+			rep.Skipped = true
+		}
+		return keys, nil
+	}
+
+	// The reserve, before the model call — the same ordering summarize needs and for the same
+	// reason, one step weaker because this component acts per message.
+	//
+	// Every plan this reflection produces will want a payload of its own, so if the reserve
+	// cannot take even the smallest of them the call is paid and every plan is then declined at
+	// commitMark: a model call for a step that is guaranteed to be left verbatim. Probing with
+	// the smallest candidate is deliberately the WEAKEST useful test — it skips only when
+	// nothing at all can be admitted, and never declines a step whose plans might still fit.
+	// A partial fit stays the per-message decision it already is.
+	smallest := 0
+	for _, it := range items {
+		if n := len(it.content); smallest == 0 || n < smallest {
+			smallest = n
+		}
+	}
+	if effectiveMode(c, d.mode) == markerFull && !store.StashRoom(c.Store, smallest) {
+		rep.Gate("stash_reserve_exhausted")
 		if changed == 0 {
 			rep.Skipped = true
 		}

--- a/components/offload/cmdfilter.go
+++ b/components/offload/cmdfilter.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rossoctl/context-guru/components/dsl"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
-	"github.com/rossoctl/context-guru/store"
 )
 
 func init() { components.Register("cmdfilter", newCmdfilter) }
@@ -177,50 +176,46 @@ func (f *Cmdfilter) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			rep.Gate("filter_matched_no_change")
 			continue
 		}
-		// Build the token that goes where the restoration marker would (per
-		// marker_mode) WITHOUT stashing yet, so the never-worse check below can
-		// still bail. Compare the FULL rewritten text (token included) against the
-		// original — the marker costs tokens too, so filtering that barely wins can
-		// still make the message larger (rtk never_worse, at the message level).
-		stashKey := hashKey(content)
-		// degrade full→off when the store can't persist (no unresolvable marker).
-		mode := effectiveMode(c, f.mode)
-		var token string
-		switch mode {
-		case markerFull:
-			token = expand.Marker(stashKey) + recoveryHint(loss, len(strings.Split(out, "\n")))
-		case markerSummary:
-			token = expand.SummaryMarker
-		} // off: no token
-		newText := out
-		if token != "" {
-			newText += "\n" + token
-		}
-		before, after := schema.TextTokens(content), schema.TextTokens(newText)
-		if after >= before {
+		// Through tryMark/commitMark, like every other offloader.
+		//
+		// This block used to build its marker token, run its own never-worse check and call
+		// store.PutStash itself — a hand-rolled copy of the shared pair, differing only in the
+		// recovery hint it appends. The copy is why #188's reserve gate had to be applied here
+		// separately, and it is what let the mutation that stamps an unbacked marker survive a
+		// whole review round in this file alone. The hint is the only thing that was ever
+		// component-specific, and tryMark already takes it as a parameter, so there is nothing
+		// left for a copy to be for. Now the gate cannot be missed here without being missed
+		// everywhere, which is a failure a single test catches.
+		//
+		// Note the hint is computed from the FILTERED text (its line count), so it must be
+		// built before tryMark rather than inside the assemble closure — assemble receives the
+		// finished token.
+		hint := recoveryHint(loss, len(strings.Split(out, "\n")))
+		newText, key, eff, ok := tryMark(c, f.mode, content, hint,
+			func(tok string) string {
+				if tok == "" {
+					return out
+				}
+				return out + "\n" + tok
+			})
+		if !ok {
 			rep.Gate("marker_no_win")
 			continue
 		}
-		if mode == markerFull {
-			// Same contract as commitMark's: the marker is a promise, and a payload the
-			// store's rewind reserve will not take cannot back it. Refuse the filter for
-			// this message rather than emitting a marker nothing resolves (#187). This
-			// path builds its own token instead of calling commitMark, which is exactly
-			// how it would have been missed.
-			if !store.PutStash(c.Store, stashKey, []byte(content)) {
-				stashRefusals.Add(1)
-				rep.Gate("stash_reserve_exhausted")
-				continue
-			}
-			recordOwner(c, stashKey) // scope GET /expand retrieval to this session
-			keys = append(keys, stashKey)
-		} else {
-			rep.Irreversible = true
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
+		before, after := schema.TextTokens(content), schema.TextTokens(newText)
+		if key != "" {
+			keys = append(keys, key)
 		}
 		schema.SetMessageText(m, newText)
 		freeze(c, f.Name(), content, newText) // memoize: later turns replay these bytes
 		if fs := c.Stats(); fs != nil {
-			fs.FilterAct(filt.Family(), filt.Name, stashKey, before-after)
+			// hashKey(content), not tryMark's key: the ledger identifies the message the
+			// filter acted on, and it must keep doing so in the degraded marker modes where
+			// nothing is stashed and there is no store key at all.
+			fs.FilterAct(filt.Family(), filt.Name, hashKey(content), before-after)
 		}
 		changed++
 	}

--- a/components/offload/cmdfilter.go
+++ b/components/offload/cmdfilter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rossoctl/context-guru/components/dsl"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
 )
 
 func init() { components.Register("cmdfilter", newCmdfilter) }
@@ -201,7 +202,16 @@ func (f *Cmdfilter) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			continue
 		}
 		if mode == markerFull {
-			c.Store.Put(stashKey, []byte(content))
+			// Same contract as commitMark's: the marker is a promise, and a payload the
+			// store's rewind reserve will not take cannot back it. Refuse the filter for
+			// this message rather than emitting a marker nothing resolves (#187). This
+			// path builds its own token instead of calling commitMark, which is exactly
+			// how it would have been missed.
+			if !store.PutStash(c.Store, stashKey, []byte(content)) {
+				stashRefusals.Add(1)
+				rep.Gate("stash_reserve_exhausted")
+				continue
+			}
 			recordOwner(c, stashKey) // scope GET /expand retrieval to this session
 			keys = append(keys, stashKey)
 		} else {

--- a/components/offload/collapse.go
+++ b/components/offload/collapse.go
@@ -146,7 +146,9 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			rep.Gate("marker_no_win") // head/tail window+marker wouldn't shrink this output
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(m, newText)
 		freeze(c, cl.Name(), content, newText) // freeze so later turns replay it (no churn)
 		if byChars {

--- a/components/offload/commitgate_extract_test.go
+++ b/components/offload/commitgate_extract_test.go
@@ -1,0 +1,369 @@
+package offload
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/internal/extract"
+	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// metricsExtractByComponent reads one component's extraction figures out of the process-global
+// snapshot. Pricing is held at zero across a test's before/after pair, so the DELTA is what the
+// component recorded and not what the host would charge for it.
+func metricsExtractByComponent(name string) *metrics.ExtractStats {
+	return metrics.ExtractSnapshot(0, 0, 0, 0).ByComponent[name]
+}
+
+// The two extract_llm sites the #188 review found, and the shape of the harm.
+//
+// putResult / putResultGlobal ran BEFORE apply. Once apply could refuse for want of a reserve
+// slot, a declined removal left a pinned cg:res: record asserting "this session sent these
+// compacted bytes" for a message that went upstream unchanged. That record is not inert: the
+// same-session replay path reads it and deliberately bypasses the cache-tail gate — its comment
+// reasons that the bytes were already sent, so splicing is safe at any depth — so on the first
+// later turn with a free slot, the compaction lands inside the provider's cached prefix and the
+// whole suffix is re-written at ~11.5x the read price.
+func TestExtractLLMFreezesNoDecisionForASpliceThatDidNotHappen(t *testing.T) {
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model) // min_tokens: 1, strategy: code, gate off
+	original := strings.Repeat("2026-08-31T10:00:00Z INFO  worker: processed batch\n", 400)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("Summarize the worker log and tell me if any batch failed."),
+		toolResultMsg(original),
+	}}
+	spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	c := &components.Ctx{Session: "gate-test", Store: spy, Ctx: context.Background(),
+		Model: components.ModelSpec{Static: model, Incoming: model}}
+	rep := &components.Report{Component: "extract_llm"}
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload: %v", err)
+	}
+	// Preconditions. Without the call there is no decision to freeze, and without a candidate
+	// reaching phase 3 the assertion below is vacuous — the failure mode this repo keeps hitting.
+	if model.calls == 0 {
+		t.Fatal("the extraction model was never called, so phase 3 was never reached and this " +
+			"test proves nothing")
+	}
+	if got := schema.MessageText(req.Input[1]); got != original {
+		t.Fatalf("the tool output was rewritten although its original could not be stored:\n%q", got)
+	}
+	// The invariant.
+	if got := spy.decisionWrites(); len(got) != 0 {
+		t.Errorf("extract_llm froze %d decision(s) for a splice that did not happen: %v.\n"+
+			"The same-session replay path bypasses the cache-tail gate on the strength of such "+
+			"a record, so the compaction would be spliced into the provider's cached prefix on "+
+			"a later turn — a full-suffix cache write at ~11.5x the read price, which is "+
+			"exactly what TestGlobalCacheHitIsNotSplicedAtDepth exists to prevent",
+			len(got), got)
+	}
+	if _, hit := getResult(c, extract.ContentKey(original)); hit {
+		t.Error("a cg:res: decision is readable for a removal that was refused; the next turn " +
+			"will replay it at any depth")
+	}
+}
+
+// The metrics half of the same finding: nothing may book a saving for a splice that did not
+// happen.
+//
+// RecordExtractionValue, dbgReapply and rep.Replay all ran unconditionally around apply. The
+// case that survives #188's design is the MARKER-INCLUSIVE decline: apply refuses when
+// projection+marker is not smaller than the original, while the savings figure was computed from
+// the projection ALONE — so a message left verbatim still booked the tokens the projection would
+// have saved, and rep.Replay claimed a replay that never went out.
+//
+// The fixture sits deliberately in that gap: the projection is smaller than the content, and the
+// marker plus its recovery hint takes the rewrite back over.
+func TestExtractLLMReportsNoSavingsForASpliceItDeclined(t *testing.T) {
+	// ~5 tokens of head, so the projection wins a little and the marker (a 16-hex id plus
+	// " [full output: call context_guru_expand]") loses more.
+	original := "alpha beta gamma delta epsilon zeta eta theta\n"
+	projected := "alpha beta gamma delta\n"
+	if schema.TextTokens(projected) >= schema.TextTokens(original) {
+		t.Fatal("the fixture's projection is not smaller than its content, so apply would " +
+			"decline for the wrong reason")
+	}
+	withMarker := projected + "\n" + expand.Marker(hashKey(original)) +
+		" [full output: call " + expand.ToolName + "]"
+	if schema.TextTokens(withMarker) < schema.TextTokens(original) {
+		t.Fatal("the fixture's projection still wins WITH the marker, so apply will splice and " +
+			"this test cannot observe a declined splice")
+	}
+
+	st := store.NewMemory(store.Options{MaxEntries: 400}) // healthy: the reserve is not the gate
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model)
+	c := &components.Ctx{Session: "replay-test", Store: st, Ctx: context.Background(),
+		Model: components.ModelSpec{Static: model, Incoming: model}}
+	id := extract.ContentKey(original)
+	putResult(c, id, projected, "")
+	if _, hit := getResult(c, id); !hit {
+		t.Fatal("the fixture's frozen decision is not readable, so the replay path will not be " +
+			"taken and this test would pass vacuously")
+	}
+
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("Summarize the worker log."), toolResultMsg(original),
+	}}
+	rep := &components.Report{Component: "extract_llm"}
+	// The savings counter is process-global and read through a priced snapshot, so the honest
+	// reading is the DELTA over this one call, with pricing held constant.
+	valueUSD := func() float64 {
+		if s := metricsExtractByComponent("extract_llm"); s != nil {
+			return s.GrossValueUSD
+		}
+		return 0
+	}
+	before := valueUSD()
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload: %v", err)
+	}
+	if got := schema.MessageText(req.Input[1]); got != original {
+		t.Fatalf("the fixture was spliced after all (%q), so there is no declined splice to "+
+			"assert about", got)
+	}
+	if rep.Replays != 0 {
+		t.Errorf("rep.Replay fired %d time(s) for a splice that was declined: the message went "+
+			"upstream verbatim, so no replay reached the model", rep.Replays)
+	}
+	if after := valueUSD(); after > before {
+		t.Errorf("extraction gross value rose from %v to %v for a splice that did not happen; "+
+			"the savings figure now includes tokens that were never saved", before, after)
+	}
+}
+
+// The replay path must NOT refuse when the payload has gone — it must replay and report.
+//
+// This is the deliberate asymmetry in #188 after the review, and it is easy to get backwards.
+// A NEW removal declines when the reserve cannot back it, because nothing has been promised yet.
+// A REPLAY of a decision already stamped and already sent cannot decline: the provider's cached
+// prefix holds the compacted bytes, so sending the original back in full is itself the
+// cache-destructive move, and it cannot un-send a marker that went out turns ago. So the splice
+// proceeds, and the dangling promise is counted (stash_missing) rather than obeyed.
+func TestExtractLLMReplaysADanglingDecisionRatherThanFlippingCachedBytes(t *testing.T) {
+	original := strings.Repeat("2026-08-31T10:00:00Z INFO  worker: processed batch\n", 400)
+	// A store holding the frozen decision but refusing every payload: exactly the state a
+	// saturated reserve leaves behind for a decision made on an earlier turn.
+	spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model)
+	c := &components.Ctx{Session: "dangling-test", Store: spy, Ctx: context.Background(),
+		Model: components.ModelSpec{Static: model, Incoming: model}}
+	putResult(c, extract.ContentKey(original), "one line kept", "")
+	if _, hit := getResult(c, extract.ContentKey(original)); !hit {
+		t.Fatal("the fixture's frozen decision is not readable, so the replay path will not be taken")
+	}
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("Summarize the worker log."), toolResultMsg(original),
+	}}
+	rep := &components.Report{Component: "extract_llm"}
+	refusedBefore, missingBefore := StashRefusals(), StashMissing()
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload: %v", err)
+	}
+	if got := schema.MessageText(req.Input[1]); got == original {
+		t.Error("the replay was declined and the original was sent in full: the provider's " +
+			"cached prefix holds the COMPACTED form, so this flips already-cached content and " +
+			"re-writes the whole suffix at ~11.5x the read price — to protect a reversibility " +
+			"promise that a refusal here cannot restore anyway")
+	}
+	if got := StashMissing() - missingBefore; got == 0 {
+		t.Error("StashMissing() did not move: a marker was replayed with no payload behind it " +
+			"and nothing reported the dangling promise")
+	}
+	if got := StashRefusals() - refusedBefore; got != 0 {
+		t.Errorf("StashRefusals() moved by %d on a replay path, want 0: that counter promises "+
+			"the operator that nothing became irreversible", got)
+	}
+}
+
+// A DANGLING replay is the opposite outcome from a declined removal, and the two must not share
+// a counter.
+//
+// Every operator-facing description of stash_refused promises that "the content was left
+// verbatim and nothing became irreversible" — true of a declined removal, and false of a replay
+// whose payload has gone, which is the only case that actually breaks the guarantee #187 was
+// about. Counting them together meant the number an operator watches to confirm nothing broke
+// was incremented by things breaking.
+func TestADanglingReplayIsCountedApartFromADeclinedRemoval(t *testing.T) {
+	// A store that accepts nothing, so the refresh of an already-stamped marker fails: the
+	// payload is not there and cannot be put back.
+	st := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	c := &components.Ctx{Session: "s", Store: st, Ctx: context.Background()}
+	refusedBefore, missingBefore := StashRefusals(), StashMissing()
+
+	// The refresh path: a decision this session already stamped and sent.
+	original := strings.Repeat("a line of output\n", 50)
+	replacement := "[older tool output masked] " + expand.Marker(hashKey(original))
+	st.Memory.Put(frozenKey("s", "mask", contentKey(original)), []byte(replacement))
+	m := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleTool}
+	schema.SetMessageText(&m, original)
+	keys, _, ok := reapplyFrozen(c, "mask", &m)
+	if !ok || len(keys) == 0 {
+		t.Fatal("the frozen decision was not replayed, so no marker was re-sent and this test " +
+			"proves nothing about a dangling one")
+	}
+	// The replay MUST still have happened — declining would flip an already-cached message.
+	if got := schema.MessageText(m); got != replacement {
+		t.Errorf("the replay was declined: got %q, want the frozen replacement %q.\nRefusing "+
+			"here sends the original where the provider's cached prefix holds the masked form, "+
+			"which is the cache-destructive direction and cannot un-send the marker anyway",
+			got, replacement)
+	}
+	if got := StashMissing() - missingBefore; got != 1 {
+		t.Errorf("StashMissing() moved by %d, want 1: a marker went out with no payload behind "+
+			"it and nothing counted the dangling promise", got)
+	}
+	if got := StashRefusals() - refusedBefore; got != 0 {
+		t.Errorf("StashRefusals() moved by %d for a DANGLING replay, want 0. That counter tells "+
+			"the operator 'nothing became irreversible'; a dangling marker is precisely the "+
+			"case where something did", got)
+	}
+}
+
+// The THIRD pre-gate site, which the review did not name and the twelve-caller audit found: a
+// CROSS-SESSION cache hit froze a decision into this session before the splice.
+//
+// The comment on that branch is explicit that it is a NEW decision for this session — "THIS
+// session never sent these compacted bytes, so the provider's cached prefix holds the ORIGINAL"
+// — which is precisely why it is tail-gated. So its payload write can refuse like any other new
+// removal, and freezing ahead of it produced the same dangling record: the same-session replay
+// path then splices at any depth on a later turn, inside the cached prefix that the tail gate
+// two blocks above exists to protect.
+//
+// THE STATE THIS NEEDS, and it took a wrong fixture to see it: a payload is keyed by its CONTENT
+// hash, so a second session compacting the same output finds the first session's payload already
+// there and its write is a refresh that cannot refuse. The refusal is reachable only when the
+// payload is GONE while the global decision naming it survives — which is the ordinary outcome
+// of the two having different durabilities: cg:xres: is PINNED (exempt from LRU eviction) and the
+// payload is not, which is #187 itself.
+//
+// Session A runs against a healthy store; its cg:xres: entry is then carried over to a store that
+// holds no payload and accepts none. The global key is read out of the recorded writes rather than
+// recomputed, because it is built from the component's own extCfg and a fixture that rebuilt it
+// would pass while the real key drifted.
+func TestExtractLLMFreezesNoDecisionForACrossSessionHitItDidNotSplice(t *testing.T) {
+	original := strings.Repeat("2026-08-31T10:00:00Z INFO  worker: processed batch\n", 400)
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model)
+	newReq := func() *bschemas.BifrostChatRequest {
+		return &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+			userMsg("Summarize the worker log."), toolResultMsg(original),
+		}}
+	}
+
+	// --- Session A, healthy store: publishes the result to the GLOBAL namespace.
+	stA := &gatedStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	a := &components.Ctx{Session: "sessA", Store: stA, Ctx: context.Background(),
+		Model: components.ModelSpec{Static: model, Incoming: model}}
+	reqA := newReq()
+	if _, err := e.Offload(reqA, &components.Report{Component: "extract_llm"}, a); err != nil {
+		t.Fatal(err)
+	}
+	if schema.MessageText(reqA.Input[1]) == original {
+		t.Fatal("session A did not compact, so nothing was published globally and session B " +
+			"cannot take the cross-session branch")
+	}
+	var gkey string
+	for _, k := range stA.puts {
+		if strings.HasPrefix(k, store.XResultPrefix) {
+			gkey = k
+			break
+		}
+	}
+	if gkey == "" {
+		t.Fatal("session A published no cg:xres: entry, so the cross-session hit under test " +
+			"cannot occur")
+	}
+	gval, ok := stA.Memory.Get(gkey)
+	if !ok {
+		t.Fatalf("the global entry %q is not readable back", gkey)
+	}
+
+	// --- Session B: the global decision survives, its payload does not, and no payload can be
+	// stored. Exactly the durability gap #187 is about.
+	stB := &refusingStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	stB.Memory.Put(gkey, gval)
+	if _, ok := expand.Resolve(stB, hashKey(original)); ok {
+		t.Fatal("the fixture's store already holds the payload, so session B's write would be a " +
+			"refresh and could not refuse")
+	}
+	stB.puts = nil
+	b := &components.Ctx{Session: "sessB", Store: stB, Ctx: context.Background(),
+		Model: components.ModelSpec{Static: model, Incoming: model}}
+	reqB := newReq()
+	repB := &components.Report{Component: "extract_llm"}
+	callsBefore := model.calls
+	hitsBefore := extractCacheHits("extract_llm")
+	if _, err := e.Offload(reqB, repB, b); err != nil {
+		t.Fatal(err)
+	}
+	// PRECONDITION: the cross-session branch really was taken. Evidenced by the CACHE HIT it
+	// records on entry — not by rep.Replay, which now (correctly) fires only after the splice and
+	// so is absent in exactly the case under test. A fresh model call instead of a hit would mean
+	// the global lookup missed and every assertion below is about the wrong path.
+	if extractCacheHits("extract_llm")-hitsBefore == 0 {
+		t.Fatalf("session B recorded no result-cache hit (calls %d->%d, gates %v, events %v); "+
+			"the cross-session branch was not entered", callsBefore, model.calls,
+			repB.Gates, repB.Events)
+	}
+	if model.calls != callsBefore {
+		t.Fatalf("session B made a fresh model call, so it did not take the cross-session branch")
+	}
+	if repB.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("session B's payload write was not refused, so there is no declined splice to "+
+			"assert about (gates: %v)", repB.Gates)
+	}
+	if got := schema.MessageText(reqB.Input[1]); got != original {
+		t.Errorf("session B's output was rewritten although its original could not be stored")
+	}
+	if got := stB.decisionWrites(); len(got) != 0 {
+		t.Errorf("session B froze %d decision(s) for a cross-session hit it did not splice: %v.\n"+
+			"Its own replay path reads that record on a later turn and bypasses the tail gate, "+
+			"splicing into the cached prefix the gate above it exists to protect", len(got), got)
+	}
+}
+
+// extractCacheHits reads one component's result-cache HIT count out of the process-global
+// snapshot. It is what proves a replay branch was entered even when the branch then declines.
+func extractCacheHits(name string) int64 {
+	if s := metricsExtractByComponent(name); s != nil {
+		return s.CallsAvoided
+	}
+	return 0
+}
+
+// refusingStore holds whatever is Put into it but accepts NO rewind payload, and records the
+// writes. Distinct from gatedStore, whose closed mode still honours a refresh of a payload that
+// is present: here the payload is absent by construction and must stay unstorable.
+type refusingStore struct {
+	*store.Memory
+	puts []string
+}
+
+func (r *refusingStore) Put(key string, payload []byte) {
+	r.puts = append(r.puts, key)
+	r.Memory.Put(key, payload)
+}
+
+func (r *refusingStore) PutStash(string, []byte) bool { return false }
+func (r *refusingStore) StashRoom(int) bool           { return false }
+
+func (r *refusingStore) decisionWrites() []string {
+	var out []string
+	for _, k := range r.puts {
+		for _, p := range decisionPrefixes {
+			if strings.HasPrefix(k, p) {
+				out = append(out, k)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/components/offload/commitgate_extract_test.go
+++ b/components/offload/commitgate_extract_test.go
@@ -100,7 +100,15 @@ func TestExtractLLMReportsNoSavingsForASpliceItDeclined(t *testing.T) {
 	model := &shrinkingModel{}
 	e := newTimeoutTestComponent(t, model)
 	c := &components.Ctx{Session: "replay-test", Store: st, Ctx: context.Background(),
-		Model: components.ModelSpec{Static: model, Incoming: model}}
+		Model: components.ModelSpec{Static: model, Incoming: model},
+		// PRICED HIGH, and without this the savings half of this test does not bind at all.
+		// GrossValueUSD is round4, i.e. 1e-4 granularity, and this fixture saves ~4 tokens; at the
+		// agentFreshPerMTok fallback that is ~1.2e-5 USD, two orders of magnitude below the
+		// rounding step, so `after > before` stays false even with the gate removed. It is the same
+		// trap the sweep counterpart documents — recorded here too because it was missed a second
+		// time in the same change, which is what makes it a trap rather than an oversight.
+		SelfRates:  components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50},
+		CacheAware: true, MaxCachedIdx: -1}
 	id := extract.ContentKey(original)
 	putResult(c, id, projected, "")
 	if _, hit := getResult(c, id); !hit {
@@ -204,7 +212,8 @@ func TestADanglingReplayIsCountedApartFromADeclinedRemoval(t *testing.T) {
 	st.Memory.Put(frozenKey("s", "mask", contentKey(original)), []byte(replacement))
 	m := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleTool}
 	schema.SetMessageText(&m, original)
-	keys, _, ok := reapplyFrozen(c, "mask", &m)
+	var rep components.Report
+	keys, _, ok := reapplyFrozen(c, &rep, "mask", &m)
 	if !ok || len(keys) == 0 {
 		t.Fatal("the frozen decision was not replayed, so no marker was re-sent and this test " +
 			"proves nothing about a dangling one")

--- a/components/offload/commitgate_freshpath_test.go
+++ b/components/offload/commitgate_freshpath_test.go
@@ -1,0 +1,196 @@
+package offload
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// pricedCtx is a context whose saved-token rates are large enough for the savings counters to be
+// OBSERVABLE. GrossValueUSD is round4 — 1e-4 granularity — and a fixture's saving is a few hundred
+// tokens, so at real rates (~3e-7 USD/token) the recorded value rounds to 0.0000 and an assertion
+// on it cannot see the defect. Two tests in this package were written without it and did not bind.
+func pricedCtx(session string, st store.Store, model components.Model) *components.Ctx {
+	return &components.Ctx{
+		Session: session, Store: st, Ctx: context.Background(),
+		Model:      components.ModelSpec{Static: model, Incoming: model},
+		SelfRates:  components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50},
+		CacheAware: true, MaxCachedIdx: -1,
+	}
+}
+
+// THE FRESH PATH must not book a saving, an accepted call or a ratio observation for a splice that
+// did not happen.
+//
+// This was the half the first round missed. The metrics moved on the REPLAY path, while
+// `runCall` — which computes them in a goroutine, before `wg.Wait()` and therefore before phase 3
+// exists — still recorded `RecordExtractionSaving`, `RecordExtractionValue`, `e.ratios.observe`,
+// `calls[k].Accepted` and `calls[k].SavedTokens` off the model reply alone. On a saturated reserve
+// every phase-3 candidate is declined and the run reported the full saving anyway.
+//
+// The ratio feed is the most consequential of the five: it prices FUTURE calls, so a saving that
+// never happened propagates into decisions about work not yet done.
+func TestExtractLLMBooksNothingForAFreshSpliceItCouldNotStash(t *testing.T) {
+	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 400)
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model)
+	// A store that holds anything except a rewind payload: the model call succeeds, the reserve
+	// refuses, phase 3 declines.
+	spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	c := pricedCtx("fresh-gate", spy, model)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("summarize the worker log"), toolResultMsg(body),
+	}}
+	rep := &components.Report{Component: "extract_llm"}
+	valueBefore, savedBefore := extractGrossValue("extract_llm"), extractGrossSaved("extract_llm")
+	ratioBefore := e.ratios.ratio()
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatal(err)
+	}
+	// PRECONDITIONS: the model ran (so there was an outcome to book) and the splice was declined
+	// (so booking it would be wrong). Without both, everything below passes vacuously.
+	if model.calls == 0 {
+		t.Fatal("the extraction model was never called, so nothing could have been booked")
+	}
+	if got := schema.MessageText(req.Input[1]); got != body {
+		t.Fatalf("the candidate was spliced after all, so there is no declined splice to assert "+
+			"about: %.80q", got)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("the payload write was not refused (gates: %v)", rep.Gates)
+	}
+
+	if got := extractGrossSaved("extract_llm") - savedBefore; got != 0 {
+		t.Errorf("RecordExtractionSaving booked %d tokens for a candidate that went upstream "+
+			"verbatim", got)
+	}
+	if got := extractGrossValue("extract_llm"); got > valueBefore {
+		t.Errorf("gross value rose from %v to %v for a splice that did not happen", valueBefore, got)
+	}
+	if got := e.ratios.ratio(); got != ratioBefore {
+		t.Errorf("the ratio tracker moved %v -> %v on a declined splice. That ratio prices FUTURE "+
+			"calls, so a saving that never happened now argues for making more calls whose output "+
+			"will be refused the same way", ratioBefore, got)
+	}
+	for _, call := range rep.Calls {
+		if call.Accepted {
+			t.Error("the ledger row says accepted=true while the request kept its original — the " +
+				"claim its own doc comment makes is that accepted is the never-worse outcome")
+		}
+		if call.SavedTokens != 0 {
+			t.Errorf("the ledger row claims %d saved tokens for a candidate left verbatim",
+				call.SavedTokens)
+		}
+	}
+}
+
+// The sweep's fresh path, same property.
+//
+// `adjudicate` recorded the saving while building its drop list, and the local
+// `sweep_drop_would_not_shrink` pre-check does not cover phase 3's refusals: it is descriptor-only
+// rather than marker-inclusive, and it cannot see the reserve at all.
+func TestSweepBooksNothingForADropItCouldNotStash(t *testing.T) {
+	asker := &labelAsker{verdict: "drop", needed: "none"}
+	asker.cacheRead = 19595
+	e := newSweepSmall(t, "")
+	req := sweepReqStocked()
+	originals := make([]string, len(req.Input))
+	for i := range req.Input {
+		originals[i] = schema.MessageText(req.Input[i])
+	}
+	spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	c := preExpiryCtx("s", asker, spy)
+	c.SelfRates = components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50}
+	rep := &components.Report{Component: "extract_llm_sweep"}
+	valueBefore := extractGrossValue("extract_llm_sweep")
+	savedBefore := extractGrossSaved("extract_llm_sweep")
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload must fail open: %v", err)
+	}
+	if n := atomic.LoadInt64(&asker.calls); n != 1 {
+		t.Fatalf("expected ONE prefix ask, got %d (gates: %v)", n, rep.Gates)
+	}
+	if rep.Events["sweep_dropped"] == 0 {
+		t.Fatalf("the adjudicator dropped nothing, so no saving could have been booked "+
+			"(gates: %v)", rep.Gates)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("no drop was refused for want of a reserve slot (gates: %v)", rep.Gates)
+	}
+	for i := range req.Input {
+		if schema.MessageText(req.Input[i]) != originals[i] {
+			t.Fatalf("message %d was rewritten although its original could not be stored", i)
+		}
+	}
+	if got := extractGrossSaved("extract_llm_sweep") - savedBefore; got != 0 {
+		t.Errorf("the sweep booked %d saved tokens for drops that did not happen", got)
+	}
+	if got := extractGrossValue("extract_llm_sweep"); got > valueBefore {
+		t.Errorf("sweep gross value rose from %v to %v for drops that did not happen",
+			valueBefore, got)
+	}
+	for _, call := range rep.Calls {
+		if call.Accepted {
+			t.Error("the sweep's ledger row says accepted=true while every output went upstream " +
+				"verbatim")
+		}
+		if call.SavedTokens != 0 {
+			t.Errorf("the sweep's ledger row claims %d saved tokens for drops that were refused",
+				call.SavedTokens)
+		}
+	}
+}
+
+// Every component that declines a removal for want of a reserve slot must COUNT it, or the counter
+// the docs name as the signal to raise a budget is not a count of refusals.
+func TestAgentDietRefusalsReachTheRefusalCounter(t *testing.T) {
+	model := &silentModel{}
+	c, err := newAgentDiet([]byte("delay_steps: 0\ncontext_steps: 1\nmin_step_tokens: 10\n" +
+		"min_saved_tokens: 1\nmax_keep_ratio: 1.0\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := c.(*AgentDiet)
+	d.modelClient = model
+	d.mode = markerFull
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("run the tests"),
+		callMsg("t1"), toolResultMsgWithID("t1", strings.Repeat("pytest output line\n", 200)),
+		callMsg("t2"), toolResultMsgWithID("t2", strings.Repeat("more output here\n", 200)),
+	}}
+	rep := &components.Report{Component: "agentdiet"}
+	before := StashRefusals()
+	if _, err := d.Offload(req, rep, ctxFor(store.NewMemory(store.Options{MaxEntries: 1}))); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("agentdiet did not decline for want of a reserve slot, so there is no refusal to "+
+			"count (gates: %v)", rep.Gates)
+	}
+	if got := StashRefusals() - before; got == 0 {
+		t.Error("agentdiet declined a whole step's removals and StashRefusals() did not move. " +
+			"docs/reference/config.md tells operators that stash_refused is THE signal to raise a " +
+			"budget, and that it is deliberately upstream of expand_unresolved_missing — so a " +
+			"deployment starving this component would read 0 while it declined every turn")
+	}
+}
+
+func extractGrossValue(name string) float64 {
+	if s := metricsExtractByComponent(name); s != nil {
+		return s.GrossValueUSD
+	}
+	return 0
+}
+
+func extractGrossSaved(name string) int64 {
+	if s := metricsExtractByComponent(name); s != nil {
+		return s.GrossSavedTokens
+	}
+	return 0
+}

--- a/components/offload/commitgate_freshpath_test.go
+++ b/components/offload/commitgate_freshpath_test.go
@@ -194,3 +194,47 @@ func extractGrossSaved(name string) int64 {
 	}
 	return 0
 }
+
+// THE POSITIVE COUNTERPART: a successful splice must book its outcome even from a fixture whose
+// Report carries no Component.
+//
+// Every "books nothing when declined" test in this package can be satisfied by a component that
+// books nothing ever, so the guard on the booking block needs a test from the other side. This one
+// exists because of the specific way that guard was wrong: it was briefly keyed on
+// `calls[k].Component != ""`, which is just `rep.Component`. components/pipeline.go always sets it
+// in production, so the coupling was invisible there — but most of this package's tests drive
+// Offload with a bare &components.Report{}, and from those fixtures the whole booking block was
+// skipped. A regression inside it could not have been caught from them.
+//
+// So the fixture here deliberately uses a bare Report, and asserts on the RATIO TRACKER rather than
+// on rep.Calls: the ledger append is legitimately filtered on Component, so with an unnamed
+// component there is no row to inspect — which is exactly why the accounting must not depend on the
+// same field.
+func TestExtractLLMBooksItsOutcomeEvenWithAnUnnamedReport(t *testing.T) {
+	model := &shrinkingModel{}
+	e := newTimeoutTestComponent(t, model)
+	st := store.NewMemory(store.Options{MaxEntries: 400}) // healthy: the splice will succeed
+	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 400)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("summarize the worker log"), toolResultMsg(body),
+	}}
+	c := pricedCtx("unnamed-report", st, model)
+	rep := &components.Report{} // NO Component, as most fixtures in this package do
+	ratioBefore := e.ratios.ratio()
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatal(err)
+	}
+	// PRECONDITIONS: the call happened and the splice happened, so there IS an outcome to book.
+	if model.calls == 0 {
+		t.Fatal("the extraction model was never called, so nothing could be booked")
+	}
+	if got := schema.MessageText(req.Input[1]); got == body {
+		t.Fatalf("the candidate was not spliced, so this asserts nothing about booking a splice")
+	}
+	if e.ratios.ratio() == ratioBefore {
+		t.Error("the ratio tracker did not move after a successful splice from a Report with no " +
+			"Component. The accounting is keyed on something only production sets, so every " +
+			"in-package fixture using a bare &components.Report{} silently skips the booking " +
+			"block — and a regression inside it cannot be caught from those tests")
+	}
+}

--- a/components/offload/commitgate_irreversible_test.go
+++ b/components/offload/commitgate_irreversible_test.go
@@ -25,6 +25,12 @@ import (
 //
 // Asserted on rep rather than through the pipeline because rep is what the pipeline reads; the
 // revert itself is pipeline.go's behaviour and already covered there.
+// NO COMPLETENESS CHECK, unlike TestNoStateIsRecordedBeforeTheCommitGate's gateExempt: the three
+// subtests below are hand-maintained, and nothing fails if a sixth commitRefresh caller is added
+// that passes a computed eff and is not listed here. The coverage is complete today — only the two
+// sites passing a computed eff can reach the eff != markerFull branch; state.go and summarize.go's
+// two sites pass markerFull and handle the degraded case themselves — but that rests on reading
+// five call sites rather than on anything mechanical. #198 carries the mechanism.
 func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 200)
 
@@ -89,6 +95,10 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 	})
 
 	t.Run("mask via reapplyFrozen", func(t *testing.T) {
+		// Overlaps TestASummaryModeReplayIsNotRevertedFromTurnTwoOnward deliberately, and neither
+		// replaces the other: that test's subject is reapplyFrozen's behaviour, this entry's is
+		// that reapplyFrozen is held to the SAME assertion as the other three replay branches,
+		// through the same helper. See that test's doc for how the two fail differently.
 		// Pre-existing rather than a regression, and the same omission: every turn AFTER the one
 		// that took the decision replays through reapplyFrozen, which never set Irreversible.
 		st := store.NewMemory(store.Options{MaxEntries: 400})

--- a/components/offload/commitgate_irreversible_test.go
+++ b/components/offload/commitgate_irreversible_test.go
@@ -56,6 +56,40 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 		assertReplayIsExemptFromRevert(t, &rep, req, body)
 	})
 
+	t.Run("extract_sweep_drop", func(t *testing.T) {
+		// The fourth replay branch, and the one nothing pinned: the other three are covered by the
+		// subtests here and by the table test, so this branch could have regressed silently.
+		asker := &labelAsker{verdict: "drop", needed: "none"}
+		asker.cacheRead = 19595
+		e := newSweepSmall(t, "marker_mode: summary\n")
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		c := preExpiryCtx("s-sweep", asker, st)
+		req := sweepReqStocked()
+		originals := make([]string, len(req.Input))
+		for i := range req.Input {
+			originals[i] = schema.MessageText(req.Input[i])
+		}
+		// Turn 1 takes the decisions and freezes them.
+		var r1 components.Report
+		if _, err := e.Offload(req, &r1, c); err != nil {
+			t.Fatal(err)
+		}
+		if r1.Events["sweep_dropped"] == 0 {
+			t.Fatal("turn 1 dropped nothing, so turn 2 has no frozen decision to replay")
+		}
+		// Turn 2 replays them through applySweepDropReplay.
+		req2 := sweepReqStocked()
+		var r2 components.Report
+		if _, err := e.Offload(req2, &r2, c); err != nil {
+			t.Fatal(err)
+		}
+		if r2.Replays == 0 {
+			t.Fatalf("turn 2 replayed nothing, so the branch under test never ran "+
+				"(gates: %v, events: %v)", r2.Gates, r2.Events)
+		}
+		assertReplayIsExemptFromRevert(t, &r2, req2, originals[1])
+	})
+
 	t.Run("mask via reapplyFrozen", func(t *testing.T) {
 		// Pre-existing rather than a regression, and the same omission: every turn AFTER the one
 		// that took the decision replays through reapplyFrozen, which never set Irreversible.

--- a/components/offload/commitgate_irreversible_test.go
+++ b/components/offload/commitgate_irreversible_test.go
@@ -1,0 +1,118 @@
+package offload
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/internal/extract"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// A REPLAY UNDER marker_mode summary/off MUST STILL DECLARE ITSELF IRREVERSIBLE.
+//
+// components/pipeline.go reverts an Offload that shrank the request, returned no cache keys, and
+// set neither Skipped nor Irreversible — "offload dropped content without stashing a cache_key".
+// A deliberate lossy drop is exempt because it sets Irreversible, and commitMark's non-full branch
+// is what sets it.
+//
+// So a replay path that stops calling commitMark stops setting it, and the component is reverted
+// on every replay turn: the transcript goes upstream verbatim, which is a full-suffix cache write
+// per turn — the precise harm the reserve work exists to prevent, produced by the reserve work.
+//
+// Asserted on rep rather than through the pipeline because rep is what the pipeline reads; the
+// revert itself is pipeline.go's behaviour and already covered there.
+func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
+	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 200)
+
+	t.Run("extract_llm", func(t *testing.T) {
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		model := &shrinkingModel{}
+		c, err := newExtractLLM([]byte("min_tokens: 1\nstrategy: code\neconomic_gate: false\n" +
+			"marker_mode: summary\n"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		e := c.(*ExtractLLM)
+		e.modelClient = model
+		ctx := &components.Ctx{Session: "s", Store: st, Ctx: context.Background(),
+			Model: components.ModelSpec{Static: model, Incoming: model}}
+		// A frozen decision, as an earlier turn leaves one — putResult is not gated on markerFull,
+		// which is what makes a summary-mode replay reachable at all.
+		putResult(ctx, extract.ContentKey(body), "one line kept", "")
+		if _, hit := getResult(ctx, extract.ContentKey(body)); !hit {
+			t.Fatal("the fixture's frozen decision is not readable, so the replay path is not taken")
+		}
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+			userMsg("summarize the log"), toolResultMsg(body),
+		}}
+		var rep components.Report
+		if _, err := e.Offload(req, &rep, ctx); err != nil {
+			t.Fatal(err)
+		}
+		assertReplayIsExemptFromRevert(t, &rep, req, body)
+	})
+
+	t.Run("mask via reapplyFrozen", func(t *testing.T) {
+		// Pre-existing rather than a regression, and the same omission: every turn AFTER the one
+		// that took the decision replays through reapplyFrozen, which never set Irreversible.
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		c, err := newMask([]byte("keep_recent: 0\nmin_tokens: 20\nmarker_mode: summary\n"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := &components.Ctx{Ctx: context.Background(), Session: "s", Store: st, MaxCachedIdx: -1}
+		mk := func() *bschemas.BifrostChatRequest {
+			m := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleTool}
+			schema.SetMessageText(&m, body)
+			return &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{m}}
+		}
+		// Turn 1 takes the decision and freezes it. commitMark sets Irreversible here, and that
+		// turn was never the broken one.
+		var r1 components.Report
+		if _, err := c.(components.Offload).Offload(mk(), &r1, ctx); err != nil {
+			t.Fatal(err)
+		}
+		if !r1.Irreversible {
+			t.Fatal("turn 1 did not set Irreversible, so the fixture is not in summary mode and " +
+				"turn 2 below is not the case under test")
+		}
+		// Turn 2 replays it.
+		req2 := mk()
+		var r2 components.Report
+		if _, err := c.(components.Offload).Offload(req2, &r2, ctx); err != nil {
+			t.Fatal(err)
+		}
+		assertReplayIsExemptFromRevert(t, &r2, req2, body)
+	})
+}
+
+// assertReplayIsExemptFromRevert checks the exact conjunction components/pipeline.go tests: the
+// component shrank the request and returned no keys, so it must have said the loss was chosen.
+func assertReplayIsExemptFromRevert(t *testing.T, rep *components.Report, req *bschemas.BifrostChatRequest, original string) {
+	t.Helper()
+	shrank := false
+	for i := range req.Input {
+		if schema.MessageText(req.Input[i]) != original && schema.MessageText(req.Input[i]) != "" {
+			shrank = true
+		}
+	}
+	if !shrank || rep.Skipped {
+		t.Fatalf("the replay did not rewrite anything (skipped=%v), so the revert condition is "+
+			"not reachable and this assertion would pass vacuously", rep.Skipped)
+	}
+	if len(rep.CacheKeys) != 0 {
+		t.Fatalf("the fixture returned cache keys (%v), so it is not in a degraded marker mode",
+			rep.CacheKeys)
+	}
+	if !rep.Irreversible {
+		t.Error("a replay rewrote the message, returned NO cache key, and did not set " +
+			"rep.Irreversible — the exact conjunction components/pipeline.go reverts as " +
+			"\"offload dropped content without stashing a cache_key\". The whole component is " +
+			"reverted and the transcript goes upstream verbatim on every replay turn: a " +
+			"full-suffix cache write per turn, which is the harm this change exists to prevent")
+	}
+}

--- a/components/offload/commitgate_irreversible_test.go
+++ b/components/offload/commitgate_irreversible_test.go
@@ -49,11 +49,12 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
 			userMsg("summarize the log"), toolResultMsg(body),
 		}}
+		originals := capturedText(req)
 		var rep components.Report
 		if _, err := e.Offload(req, &rep, ctx); err != nil {
 			t.Fatal(err)
 		}
-		assertReplayIsExemptFromRevert(t, &rep, req, body)
+		assertReplayIsExemptFromRevert(t, &rep, req, originals)
 	})
 
 	t.Run("extract_sweep_drop", func(t *testing.T) {
@@ -65,10 +66,6 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 		st := store.NewMemory(store.Options{MaxEntries: 400})
 		c := preExpiryCtx("s-sweep", asker, st)
 		req := sweepReqStocked()
-		originals := make([]string, len(req.Input))
-		for i := range req.Input {
-			originals[i] = schema.MessageText(req.Input[i])
-		}
 		// Turn 1 takes the decisions and freezes them.
 		var r1 components.Report
 		if _, err := e.Offload(req, &r1, c); err != nil {
@@ -79,6 +76,7 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 		}
 		// Turn 2 replays them through applySweepDropReplay.
 		req2 := sweepReqStocked()
+		originals := capturedText(req2)
 		var r2 components.Report
 		if _, err := e.Offload(req2, &r2, c); err != nil {
 			t.Fatal(err)
@@ -87,7 +85,7 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 			t.Fatalf("turn 2 replayed nothing, so the branch under test never ran "+
 				"(gates: %v, events: %v)", r2.Gates, r2.Events)
 		}
-		assertReplayIsExemptFromRevert(t, &r2, req2, originals[1])
+		assertReplayIsExemptFromRevert(t, &r2, req2, originals)
 	})
 
 	t.Run("mask via reapplyFrozen", func(t *testing.T) {
@@ -116,21 +114,37 @@ func TestADegradedModeReplayDeclaresItselfIrreversible(t *testing.T) {
 		}
 		// Turn 2 replays it.
 		req2 := mk()
+		originals := capturedText(req2)
 		var r2 components.Report
 		if _, err := c.(components.Offload).Offload(req2, &r2, ctx); err != nil {
 			t.Fatal(err)
 		}
-		assertReplayIsExemptFromRevert(t, &r2, req2, body)
+		assertReplayIsExemptFromRevert(t, &r2, req2, originals)
 	})
 }
 
 // assertReplayIsExemptFromRevert checks the exact conjunction components/pipeline.go tests: the
 // component shrank the request and returned no keys, so it must have said the loss was chosen.
-func assertReplayIsExemptFromRevert(t *testing.T, rep *components.Report, req *bschemas.BifrostChatRequest, original string) {
+//
+// `originals` is the request's text BEFORE the replay, message by message. It used to be a single
+// string — the candidate's original — and every message was compared against it, which made the
+// vacuity guard below vacuous: every fixture carries a userMsg ("summarize the log", …) that
+// differs from the candidate's text by construction, so `shrank` was unconditionally true and the
+// guard could never detect the case its own fatal message describes. The extract_llm subtest had
+// no other protection, so it would have passed vacuously if that replay ever declined — and that
+// replay branch is the one whose regression started this thread.
+func assertReplayIsExemptFromRevert(t *testing.T, rep *components.Report, req *bschemas.BifrostChatRequest, originals []string) {
 	t.Helper()
+	if len(originals) != len(req.Input) {
+		// A replay must not add or drop messages, so a length change means the fixture is not
+		// what this helper assumes and the comparison below would be meaningless.
+		t.Fatalf("the request has %d messages, captured %d before the replay",
+			len(req.Input), len(originals))
+	}
 	shrank := false
 	for i := range req.Input {
-		if schema.MessageText(req.Input[i]) != original && schema.MessageText(req.Input[i]) != "" {
+		got := schema.MessageText(req.Input[i])
+		if got != originals[i] && schema.TextTokens(got) < schema.TextTokens(originals[i]) {
 			shrank = true
 		}
 	}
@@ -149,4 +163,14 @@ func assertReplayIsExemptFromRevert(t *testing.T, rep *components.Report, req *b
 			"reverted and the transcript goes upstream verbatim on every replay turn: a " +
 			"full-suffix cache write per turn, which is the harm this change exists to prevent")
 	}
+}
+
+// capturedText snapshots every message's text, so an assertion can compare each one against its
+// OWN before-state rather than against one shared string.
+func capturedText(req *bschemas.BifrostChatRequest) []string {
+	out := make([]string, len(req.Input))
+	for i := range req.Input {
+		out[i] = schema.MessageText(req.Input[i])
+	}
+	return out
 }

--- a/components/offload/commitgate_summarize_test.go
+++ b/components/offload/commitgate_summarize_test.go
@@ -1,0 +1,218 @@
+package offload
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// gatedStore is a real store whose rewind reserve can be closed part-way through a test, so a
+// SECOND turn can meet a saturated reserve while the first turn's checkpoint is still readable.
+// That two-turn shape is the whole point: the defect only exists once a checkpoint has been
+// emitted, because only then is there cached content for a refusal to flip.
+type gatedStore struct {
+	*store.Memory
+	closed atomic.Bool
+	puts   []string
+}
+
+func (g *gatedStore) Put(key string, payload []byte) {
+	g.puts = append(g.puts, key)
+	g.Memory.Put(key, payload)
+}
+
+// decisionWrites reports the writes that assert a removal HAPPENED — see decisionPrefixes.
+func (g *gatedStore) decisionWrites() []string {
+	var out []string
+	for _, k := range g.puts {
+		for _, p := range decisionPrefixes {
+			if strings.HasPrefix(k, p) {
+				out = append(out, k)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func (g *gatedStore) PutStash(key string, payload []byte) bool {
+	if g.closed.Load() {
+		// A refresh of a payload that is PRESENT still succeeds, exactly as the real reserve
+		// behaves — otherwise this fake would test a state the store cannot produce.
+		if _, ok := g.Memory.Get(key); ok {
+			return g.Memory.PutStash(key, payload)
+		}
+		return false
+	}
+	return g.Memory.PutStash(key, payload)
+}
+
+func (g *gatedStore) StashRoom(size int) bool {
+	if g.closed.Load() {
+		return false
+	}
+	return g.Memory.StashRoom(size)
+}
+
+// countingModel records how many summaries were asked for.
+type countingModel struct {
+	out   string
+	calls int64
+}
+
+func (m *countingModel) Complete(context.Context, string) (string, error) {
+	atomic.AddInt64(&m.calls, 1)
+	return m.out, nil
+}
+
+// summarize must not pay for a summary it cannot checkpoint.
+//
+// The reserve check sat AFTER s.summarize, so a saturated reserve paid the model call — measured
+// at ~57k prompt tokens — and threw the result away. And it did so on EVERY turn, because a
+// refusal saves no checkpoint and therefore changes nothing about the next turn's inputs: the
+// same span arrives, the same call is made, the same refusal follows. The span is all the marker
+// key depends on (key = hashKey(spanJSON)), so nothing about the stash needs the summary to
+// exist and the question can be asked first.
+func TestSummarizeDoesNotPayForACheckpointItCannotStash(t *testing.T) {
+	model := &countingModel{out: "SUMMARY: explored the handler, 3 tests fail."}
+	s := newSummarizeKeepLast(t, 1)
+	s.modelClient = model
+	msgs := []bschemas.ChatMessage{
+		{Role: bschemas.ChatMessageRoleUser},
+		callMsg("t1"), bulkResult("t1"),
+		callMsg("t2"), bulkResult("t2"),
+		callMsg("t3"), bulkResult("t3"),
+	}
+	schema.SetMessageText(&msgs[0], "fix the failing tests")
+
+	// PRECONDITION: with a healthy store this fixture DOES summarize, so a zero call count
+	// below means the reserve check skipped it and not that the fixture never fires.
+	healthy := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), msgs...)}
+	var rep components.Report
+	if _, err := s.Offload(healthy, &rep, ctxFor(store.NewMemory(store.Options{MaxEntries: 400}))); err != nil {
+		t.Fatal(err)
+	}
+	if atomic.LoadInt64(&model.calls) != 1 {
+		t.Fatalf("the fixture made %d model calls against a healthy store, want 1: it does not "+
+			"reach the summarize path, so the assertion below would pass vacuously",
+			atomic.LoadInt64(&model.calls))
+	}
+
+	// The property: a reserve with no room at all, and no call is paid.
+	atomic.StoreInt64(&model.calls, 0)
+	req := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), msgs...)}
+	rep = components.Report{}
+	if _, err := s.Offload(req, &rep, ctxFor(store.NewMemory(store.Options{MaxEntries: 1}))); err != nil {
+		t.Fatal(err)
+	}
+	if n := atomic.LoadInt64(&model.calls); n != 0 {
+		t.Errorf("summarize paid %d model call(s) although the span could not be stashed. Under "+
+			"a saturated reserve it re-pays that call on EVERY turn and refuses again each "+
+			"time, because a refusal saves no checkpoint and so nothing about the next turn "+
+			"changes", n)
+	}
+	if len(req.Input) != len(msgs) {
+		t.Errorf("the transcript was restructured (%d messages, was %d) although the span it "+
+			"replaced could not be stashed", len(req.Input), len(msgs))
+	}
+}
+
+// A refusal must not flip content the provider has already cached.
+//
+// This is #188's own new refusal path producing the harm #188 exists to prevent. Once a
+// checkpoint has been emitted, earlier turns sent [msg0, summary, tail]. When the tail later
+// grows past resummarize_tokens, tryReuse declines and the fresh path runs — and a bare
+// `return nil, nil` there sends the transcript FULL. The provider re-writes the whole suffix at
+// ~11.5x the read price, for a request that saves nothing.
+//
+// The covered prefix is byte-unchanged (tryReuse verified its hash before the size test declined
+// it), so the old checkpoint is still a faithful summary of it: re-emitting is byte-correct, and
+// rolling it forward was merely an improvement that is now unavailable.
+func TestSummarizeReplaysItsCheckpointRatherThanFlippingCachedContent(t *testing.T) {
+	model := &countingModel{out: "SUMMARY: explored the handler, 3 tests fail."}
+	c, err := newSummarize([]byte("keep_last: 1\nmin_tokens: 10\nresummarize_tokens: 200\n" +
+		"trigger:\n  min_messages: 2\n  min_request_tokens: 10\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := c.(*Summarize)
+	s.modelClient = model
+	st := &gatedStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	ctx := ctxFor(st)
+
+	// --- Turn 1: a checkpoint is made and the compacted shape goes upstream.
+	msgs := []bschemas.ChatMessage{{Role: bschemas.ChatMessageRoleUser}}
+	schema.SetMessageText(&msgs[0], "fix the failing tests")
+	for i := 1; i <= 3; i++ {
+		id := "t" + strconv.Itoa(i)
+		msgs = append(msgs, callMsg(id), bulkResult(id))
+	}
+	turn1 := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), msgs...)}
+	var rep components.Report
+	if _, err := s.Offload(turn1, &rep, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(turn1.Input) >= len(msgs) {
+		t.Fatalf("turn 1 did not summarize (%d messages, was %d), so there is no checkpoint and "+
+			"no cached shape for a refusal to flip", len(turn1.Input), len(msgs))
+	}
+	summaryShape := len(turn1.Input)
+	if _, ok := loadCheckpoint(ctx); !ok {
+		t.Fatal("turn 1 saved no checkpoint, so the fallback under test has nothing to fall back to")
+	}
+
+	// --- Turn 2: the tail has grown past resummarize_tokens, so the checkpoint is STALE but
+	// still valid — and the reserve is now closed, so no new checkpoint can be made.
+	grown := append([]bschemas.ChatMessage(nil), msgs...)
+	for i := 4; i <= 9; i++ {
+		id := "t" + strconv.Itoa(i)
+		grown = append(grown, callMsg(id), bulkResult(id))
+	}
+	st.closed.Store(true)
+	turn2 := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), grown...)}
+	rep = components.Report{}
+	if _, err := s.Offload(turn2, &rep, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("turn 2 did not refuse for want of a reserve slot, so the path under test never "+
+			"ran (gates: %v, events: %v)", rep.Gates, rep.Events)
+	}
+	// The property. Sending the full transcript is the flip; re-emitting the checkpoint is not.
+	if len(turn2.Input) == len(grown) {
+		t.Errorf("the refusal sent the transcript FULL (%d messages): earlier turns sent the "+
+			"summarized shape (%d messages), so this flips already-cached content and forces a "+
+			"full-suffix cache write at ~11.5x the read price — #188's own refusal path causing "+
+			"the harm #188 exists to prevent", len(turn2.Input), summaryShape)
+	}
+	// And it must be the SAME summary bytes, or the replay is itself a flip.
+	if got := schema.MessageText(turn2.Input[1]); got != schema.MessageText(turn1.Input[1]) {
+		t.Errorf("the replayed summary differs from the one earlier turns sent:\n got %q\nwant %q",
+			got, schema.MessageText(turn1.Input[1]))
+	}
+	if n := atomic.LoadInt64(&model.calls); n != 1 {
+		t.Errorf("the model was called %d time(s) in total, want 1: turn 2 must fall back to the "+
+			"existing checkpoint, not pay for a summary it cannot store", n)
+	}
+	// A checkpoint that is absent or genuinely diverged has nothing to fall back to, and there
+	// the full transcript is correct — nothing was ever cached in the summarized shape. Asserted
+	// so the fallback cannot quietly become unconditional.
+	fresh := ctxFor(&gatedStore{Memory: store.NewMemory(store.Options{MaxEntries: 1})})
+	only := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), grown...)}
+	rep = components.Report{}
+	if _, err := s.Offload(only, &rep, fresh); err != nil {
+		t.Fatal(err)
+	}
+	if len(only.Input) != len(grown) {
+		t.Errorf("a session with NO checkpoint was rewritten to %d messages: there is no prior "+
+			"shape to preserve, so the full transcript is the correct output and this fallback "+
+			"has become unconditional", len(only.Input))
+	}
+}

--- a/components/offload/commitgate_sweep_test.go
+++ b/components/offload/commitgate_sweep_test.go
@@ -78,6 +78,39 @@ func TestSweepTellsAReserveRefusalApartFromNothingSpent(t *testing.T) {
 		}
 		assertSweepRejection(t, rep, "adjudicated: nothing was spent")
 	})
+	t.Run("spent but no descriptor was smaller", func(t *testing.T) {
+		// The third path into an empty `drop`, and the one that used to be reported as the
+		// adjudicator finding nothing: it judged outputs spent and the descriptor-only never-worse
+		// pre-check removed every one of them. Reachable on outputs barely above the floor, where a
+		// shape descriptor can be larger than the output it describes.
+		asker := &labelAsker{verdict: "drop", needed: "none"}
+		asker.cacheRead = 19595
+		// Built directly rather than through newSweep, which prepends its own min_tokens: 2000 —
+		// this case needs a floor BELOW the descriptor's size, which is the whole point of it.
+		built, err := newExtractSweep([]byte("min_tokens: 5\nmin_inventory: 1\n"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		e := built.(*ExtractSweep)
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+			userMsg("do the thing"),
+			toolResultMsgWithID("t1", "six little words right here now\n"),
+			toolResultMsgWithID("t2", "seven other little words right here\n"),
+		}}
+		rep := &components.Report{Component: "extract_llm_sweep"}
+		if _, err := e.Offload(req, rep, preExpiryCtx("s", asker, st)); err != nil {
+			t.Fatal(err)
+		}
+		if rep.Gates["sweep_drop_would_not_shrink"] == 0 {
+			t.Fatalf("the never-worse pre-check never fired, so this is not the case under test "+
+				"(gates: %v, events: %v)", rep.Gates, rep.Events)
+		}
+		if rep.Events["sweep_dropped"] != 0 {
+			t.Fatalf("a drop got through, so `drop` was not empty for the reason under test")
+		}
+		assertSweepRejection(t, rep, "adjudicated spent, but no descriptor was smaller than its output")
+	})
 	t.Run("spent but no drop could be applied", func(t *testing.T) {
 		asker := &labelAsker{verdict: "drop", needed: "none"}
 		asker.cacheRead = 19595
@@ -319,5 +352,61 @@ func TestSweepReportsItsOwnEconomicsAndTheWiresSeparately(t *testing.T) {
 		t.Errorf("the ledger claims %d saved tokens; the messages actually sent shrank by %d.\n"+
 			"A descriptor-only subtraction ignores the marker and recovery hint that go out with "+
 			"every drop, so the figure overstates by that much per candidate", ledger, wantWire)
+	}
+}
+
+// A REPLAY must be valued the same way the turn that made the decision was.
+//
+// The fresh path was corrected to measure against the spliced message; the replay path was left
+// measuring against the stored descriptor. That made the component contradict ITSELF — the same
+// drop worth more on every replay turn than on the turn it was made — and replays are the steady
+// state, so most of the reported value came from the overstated side.
+func TestSweepReplayBooksWhatTheReplayedMessageActuallySaved(t *testing.T) {
+	asker := &labelAsker{verdict: "drop", needed: "none"}
+	asker.cacheRead = 19595
+	e := newSweepSmall(t, "")
+	st := store.NewMemory(store.Options{MaxEntries: 400})
+	c := preExpiryCtx("s", asker, st)
+	// CacheRead 1 USD/token, so the recorded value equals the token count and clears round4's
+	// 1e-4 step. repeatPerToken is the read rate on a warm cache-aware turn, which is what the
+	// replay path credits at.
+	c.SelfRates = components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50}
+
+	// Turn 1 takes the decisions.
+	var r1 components.Report
+	r1.Component = "extract_llm_sweep"
+	if _, err := e.Offload(sweepReqStocked(), &r1, c); err != nil {
+		t.Fatal(err)
+	}
+	if r1.Events["sweep_dropped"] == 0 {
+		t.Fatal("turn 1 dropped nothing, so turn 2 has no decision to replay")
+	}
+
+	// Turn 2 replays them, and only turn 2's booking is measured.
+	req2 := sweepReqStocked()
+	before := capturedText(req2)
+	valueBefore := extractGrossValue("extract_llm_sweep")
+	r2 := components.Report{Component: "extract_llm_sweep"}
+	if _, err := e.Offload(req2, &r2, c); err != nil {
+		t.Fatal(err)
+	}
+	if r2.Replays == 0 {
+		t.Fatalf("turn 2 replayed nothing (gates: %v, events: %v)", r2.Gates, r2.Events)
+	}
+	wire := 0
+	for i := range req2.Input {
+		if got := schema.MessageText(req2.Input[i]); got != before[i] {
+			wire += schema.TextTokens(before[i]) - schema.TextTokens(got)
+		}
+	}
+	if wire <= 0 {
+		t.Fatal("no message shrank on the replay turn, so there is no wire figure to compare")
+	}
+	booked := extractGrossValue("extract_llm_sweep") - valueBefore
+	if int(booked+0.5) != wire {
+		t.Errorf("the replay booked %v tokens of value; the messages it sent shrank by %d.\n"+
+			"Measuring the replay against the stored descriptor instead of the replayed message "+
+			"makes the same drop worth more on every replay turn than on the turn it was made — "+
+			"and replays are the steady state", booked, wire)
 	}
 }

--- a/components/offload/commitgate_sweep_test.go
+++ b/components/offload/commitgate_sweep_test.go
@@ -55,6 +55,69 @@ func TestSweepFreezesNoDecisionForADropThatDidNotHappen(t *testing.T) {
 	}
 }
 
+// The two rejection reasons must be TELLABLE APART, and one of them was unreachable.
+//
+// `adjudicate` names what it judged spent; phase 3 decides what actually got dropped. When the
+// adjudicator found nothing, the row says "nothing was spent". When it found plenty and the reserve
+// refused every one, the row has to say something else — otherwise the reserve-exhausted case reads
+// as a plain rejection, which is the whole reason the second reason exists.
+//
+// It was dead code on arrival: moving the metrics out of the verdict loop deleted `removed`'s only
+// assignment, so `removed == 0` was always true, every adjudication stamped "nothing was spent",
+// and the `Rejection == ""` guard on the second reason never opened. Nothing caught it because the
+// variable was still read, so it compiled and the suite stayed green.
+func TestSweepTellsAReserveRefusalApartFromNothingSpent(t *testing.T) {
+	t.Run("nothing was spent", func(t *testing.T) {
+		asker := &labelAsker{verdict: "keep", needed: "none"}
+		asker.cacheRead = 19595
+		e := newSweepSmall(t, "")
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		rep := &components.Report{Component: "extract_llm_sweep"}
+		if _, err := e.Offload(sweepReqStocked(), rep, preExpiryCtx("s", asker, st)); err != nil {
+			t.Fatal(err)
+		}
+		assertSweepRejection(t, rep, "adjudicated: nothing was spent")
+	})
+	t.Run("spent but no drop could be applied", func(t *testing.T) {
+		asker := &labelAsker{verdict: "drop", needed: "none"}
+		asker.cacheRead = 19595
+		e := newSweepSmall(t, "")
+		// A store that refuses every payload: the adjudicator judges outputs spent and phase 3
+		// declines all of them.
+		spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+		rep := &components.Report{Component: "extract_llm_sweep"}
+		if _, err := e.Offload(sweepReqStocked(), rep, preExpiryCtx("s", asker, spy)); err != nil {
+			t.Fatal(err)
+		}
+		if rep.Events["sweep_dropped"] == 0 {
+			t.Fatal("the adjudicator judged nothing spent, so this is the OTHER case and the " +
+				"assertion below would pass for the wrong reason")
+		}
+		if rep.Gates["stash_reserve_exhausted"] == 0 {
+			t.Fatalf("no drop was refused for want of a reserve slot (gates: %v)", rep.Gates)
+		}
+		assertSweepRejection(t, rep, "adjudicated spent, but no drop could be applied")
+	})
+}
+
+func assertSweepRejection(t *testing.T, rep *components.Report, want string) {
+	t.Helper()
+	if len(rep.Calls) == 0 {
+		t.Fatal("no ModelCall row was reported, so there is no rejection reason to assert on")
+	}
+	for _, call := range rep.Calls {
+		if call.Rejection != want {
+			t.Errorf("rejection = %q, want %q.\nAn operator reading the ledger cannot tell a "+
+				"turn where nothing was worth dropping from a turn where everything was and the "+
+				"store had no room — and those want opposite responses", call.Rejection, want)
+		}
+		if call.Accepted {
+			t.Error("the row says accepted=true alongside a rejection reason: the same " +
+				"self-contradictory row this change set out to remove")
+		}
+	}
+}
+
 // The metrics half on the sweep path: a refused drop must not book its token savings.
 //
 // RecordExtractionValue sat ABOVE the ok check on applySweepDrop's return, so a drop the reserve
@@ -187,5 +250,74 @@ func TestAgentDietDoesNotPayForAReflectionItCannotStash(t *testing.T) {
 	if rep.Gates["stash_reserve_exhausted"] == 0 {
 		t.Errorf("the skip was not recorded as stash_reserve_exhausted, so a run that stopped "+
 			"reducing looks like a run with nothing to reduce (gates: %v)", rep.Gates)
+	}
+}
+
+// The sweep's debug row must carry its OWN economics, and the ledger must carry the WIRE's.
+//
+// Two separate numbers that a single variable used to serve, which is how one of them was lost:
+//
+//   - `removed_tokens` on cg.sweep.ask is what the ADJUDICATOR judged it was freeing. Moving the
+//     metrics out of the verdict loop deleted that variable's only assignment, so the field went
+//     permanently 0 and the sweep's economics vanished from the debug log while everything still
+//     compiled and passed.
+//   - the ledger's SavedTokens is what actually reached the wire. Measured against the spliced
+//     message rather than the descriptor, because in markerFull the text written is
+//     descriptor + marker + recovery hint — a descriptor-only subtraction overstates every
+//     candidate by the marker's tokens, and the comment on that line claims it is the wire figure.
+func TestSweepReportsItsOwnEconomicsAndTheWiresSeparately(t *testing.T) {
+	asker := &labelAsker{verdict: "drop", needed: "none"}
+	asker.cacheRead = 19595
+	e := newSweepSmall(t, "")
+	st := store.NewMemory(store.Options{MaxEntries: 400})
+	req := sweepReqStocked()
+	originals := make([]string, len(req.Input))
+	for i := range req.Input {
+		originals[i] = schema.MessageText(req.Input[i])
+	}
+	ctx, buf := debugCtx(t)
+	c := preExpiryCtx("s", asker, st)
+	c.Ctx = ctx
+	rep := &components.Report{Component: "extract_llm_sweep"}
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Events["sweep_dropped"] == 0 {
+		t.Fatal("nothing was dropped, so neither figure has anything to report")
+	}
+
+	// --- The adjudicator's own figure reaches the debug row.
+	rows := records(t, buf, "cg.sweep.ask")
+	if len(rows) != 1 {
+		t.Fatalf("expected one cg.sweep.ask record, got %d", len(rows))
+	}
+	removedTokens, ok := rows[0]["removed_tokens"].(float64)
+	if !ok {
+		t.Fatalf("cg.sweep.ask has no numeric removed_tokens field: %v", rows[0])
+	}
+	if removedTokens == 0 {
+		t.Error("cg.sweep.ask reports removed_tokens=0 on a turn that dropped content: the " +
+			"adjudicator's own economics are no longer in the debug log, which is the only place " +
+			"a run's sweep decisions can be reconstructed from")
+	}
+
+	// --- The ledger's figure is the wire's, to the token.
+	wantWire := 0
+	for i := range req.Input {
+		if got := schema.MessageText(req.Input[i]); got != originals[i] {
+			wantWire += schema.TextTokens(originals[i]) - schema.TextTokens(got)
+		}
+	}
+	if wantWire <= 0 {
+		t.Fatal("no message shrank, so there is no wire figure to compare against")
+	}
+	var ledger int
+	for _, call := range rep.Calls {
+		ledger += call.SavedTokens
+	}
+	if ledger != wantWire {
+		t.Errorf("the ledger claims %d saved tokens; the messages actually sent shrank by %d.\n"+
+			"A descriptor-only subtraction ignores the marker and recovery hint that go out with "+
+			"every drop, so the figure overstates by that much per candidate", ledger, wantWire)
 	}
 }

--- a/components/offload/commitgate_sweep_test.go
+++ b/components/offload/commitgate_sweep_test.go
@@ -109,7 +109,48 @@ func TestSweepTellsAReserveRefusalApartFromNothingSpent(t *testing.T) {
 		if rep.Events["sweep_dropped"] != 0 {
 			t.Fatalf("a drop got through, so `drop` was not empty for the reason under test")
 		}
-		assertSweepRejection(t, rep, "adjudicated spent, but no descriptor was smaller than its output")
+		// The reason no longer names the skip — the GATES do, and they cannot fall out of date when
+		// a skip path is added. What the reason owes the operator is that the model judged output
+		// spent, which is the distinction "nothing was spent" destroyed.
+		assertSweepRejection(t, rep, "adjudicated 2 spent, but none became a drop (see gates)")
+		if rep.Gates["sweep_drop_would_not_shrink"] == 0 {
+			t.Error("the reason defers to the gates for WHICH skip it was, so the gate has to be there")
+		}
+	})
+	t.Run("spent but every verdict refused its own obligation", func(t *testing.T) {
+		// The path the enumerating version reported as "nothing was spent": the model answers drop
+		// while naming something that still needs the output, so extract.Judge sets
+		// RefusedObligation and every candidate is skipped. Included because deriving the reason
+		// from the verdict is only worth anything if it covers a skip the enumeration missed.
+		asker := &labelAsker{verdict: "drop", needed: "the pytest run in step 4"}
+		asker.cacheRead = 19595
+		e := newSweepSmall(t, "")
+		st := store.NewMemory(store.Options{MaxEntries: 400})
+		rep := &components.Report{Component: "extract_llm_sweep"}
+		if _, err := e.Offload(sweepReqStocked(), rep, preExpiryCtx("s", asker, st)); err != nil {
+			t.Fatal(err)
+		}
+		if rep.Gates["sweep_drop_refused_obligation"] == 0 {
+			t.Fatalf("no verdict refused its obligation, so this is not the case under test "+
+				"(gates: %v, events: %v)", rep.Gates, rep.Events)
+		}
+		if rep.Events["sweep_dropped"] != 0 {
+			t.Fatal("a drop got through, so `drop` was not empty for the reason under test")
+		}
+		if len(rep.Calls) == 0 {
+			t.Fatal("no ModelCall row was reported")
+		}
+		for _, call := range rep.Calls {
+			if call.Rejection == "adjudicated: nothing was spent" {
+				t.Error("the ledger says the adjudicator found nothing spent, when it judged " +
+					"EVERY output spent and we declined each one for self-contradiction. That is " +
+					"the conflation these reasons exist to prevent, and the enumerating version " +
+					"reported exactly this")
+			}
+			if !strings.Contains(call.Rejection, "spent, but none became a drop") {
+				t.Errorf("rejection = %q, want the spent-but-not-dropped reason", call.Rejection)
+			}
+		}
 	})
 	t.Run("spent but no drop could be applied", func(t *testing.T) {
 		asker := &labelAsker{verdict: "drop", needed: "none"}
@@ -151,12 +192,26 @@ func assertSweepRejection(t *testing.T, rep *components.Report, want string) {
 	}
 }
 
-// The metrics half on the sweep path: a refused drop must not book its token savings.
+// A declined replay must record nothing — and the honest statement of what this test still pins is
+// narrower than what it was written for.
 //
-// RecordExtractionValue sat ABOVE the ok check on applySweepDrop's return, so a drop the reserve
-// declined still credited the tokens it would have saved. rep.Replay on that path was already
-// guarded correctly, which is what made the unguarded metric next to it easy to miss.
-func TestSweepReportsNoSavingsForARefusedReplay(t *testing.T) {
+// It was written when the saving was computed from the stored DESCRIPTOR, so a declined replay could
+// book a non-zero figure and moving the recorder above the ok gate was observable. Measuring the
+// spliced message instead — the right fix, and one the review asked for — made `saved == 0` TRUE BY
+// CONSTRUCTION on a decline, because sweepDrop only calls SetMessageText on success. So the savings
+// half of this test cannot fail any more, whatever the recorder's position.
+//
+// That is worth stating rather than quietly leaving a test that looks like a guard:
+//
+//   - What still BINDS here is rep.Replay, which sits inside the ok branch and would fire for a
+//     message that was never rewritten. The mutation below is what proves it.
+//   - What guards the SAVING is now TestSweepReplayBooksWhatTheReplayedMessageActuallySaved: revert
+//     the basis to descriptor-only and it fails, which also restores this test's original premise.
+//
+// The general lesson, and the reason for this comment: a measurement change can void a test that
+// never mentioned the measurement. Nothing in this function referred to the basis, and correcting
+// the basis silently removed its only signal.
+func TestSweepRecordsNoReplayForADropItDeclined(t *testing.T) {
 	// The fixture has to sit in a NARROW gap, and getting it wrong makes this test vacuous: the
 	// saving is computed from the descriptor ALONE, so the descriptor must be smaller than the
 	// content (or no saving would be booked either way and the mutation escapes), while
@@ -202,11 +257,14 @@ func TestSweepReportsNoSavingsForARefusedReplay(t *testing.T) {
 			"assert about", got)
 	}
 	if rep.Replays != 0 {
-		t.Errorf("rep.Replay fired %d time(s) for a replay that did not splice", rep.Replays)
+		t.Errorf("rep.Replay fired %d time(s) for a replay that did not splice: the message went "+
+			"upstream verbatim, so no replay reached the model", rep.Replays)
 	}
+	// Kept, but no longer load-bearing: with the wire basis a declined replay cannot book a saving,
+	// so this asserts a structural property rather than guarding a reachable defect. See the doc
+	// above for which test guards the basis itself.
 	if after := sweepValueUSD(); after > before {
-		t.Errorf("sweep gross value rose from %v to %v for a drop that did not happen; the "+
-			"savings figure now includes tokens that were never saved", before, after)
+		t.Errorf("sweep gross value rose from %v to %v for a drop that did not happen", before, after)
 	}
 }
 

--- a/components/offload/commitgate_sweep_test.go
+++ b/components/offload/commitgate_sweep_test.go
@@ -1,0 +1,191 @@
+package offload
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/internal/extract"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// The sweep's phase 3 had the same defect as extract_llm's, one file over.
+//
+// putResult ran BEFORE applySweepDrop, so a drop refused for want of a reserve slot left a frozen
+// cg:res: record for a removal that never happened. The same-session replay path above reads that
+// record and bypasses the depth gate on the reasoning that the bytes were already sent — so on a
+// later turn with a free slot, the output is removed from inside the provider's cached prefix.
+func TestSweepFreezesNoDecisionForADropThatDidNotHappen(t *testing.T) {
+	asker := &labelAsker{verdict: "drop", needed: "none"}
+	asker.cacheRead = 19595
+	e := newSweepSmall(t, "")
+	req := sweepReqStocked()
+	originals := make([]string, len(req.Input))
+	for i := range req.Input {
+		originals[i] = schema.MessageText(req.Input[i])
+	}
+	spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	rep := &components.Report{}
+	if _, err := e.Offload(req, rep, preExpiryCtx("s", asker, spy)); err != nil {
+		t.Fatalf("Offload must fail open: %v", err)
+	}
+	// PRECONDITIONS. The adjudicator must have been asked and must have said "drop", or phase 3
+	// was never reached and every assertion below passes on a transcript nothing touched.
+	if n := atomic.LoadInt64(&asker.calls); n != 1 {
+		t.Fatalf("expected ONE prefix ask, got %d (gates: %v)", n, rep.Gates)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Fatalf("no drop was refused for want of a reserve slot, so the defect's precondition "+
+			"never held (gates: %v, events: %v)", rep.Gates, rep.Events)
+	}
+	// The invariant.
+	if got := spy.decisionWrites(); len(got) != 0 {
+		t.Errorf("the sweep froze %d decision(s) for a drop that did not happen: %v.\nA later "+
+			"turn replays such a record at any depth, removing the output from inside the "+
+			"provider's cached prefix", len(got), got)
+	}
+	for i := range req.Input {
+		if got := schema.MessageText(req.Input[i]); got != originals[i] {
+			t.Errorf("message %d was rewritten although its original could not be stored", i)
+		}
+	}
+}
+
+// The metrics half on the sweep path: a refused drop must not book its token savings.
+//
+// RecordExtractionValue sat ABOVE the ok check on applySweepDrop's return, so a drop the reserve
+// declined still credited the tokens it would have saved. rep.Replay on that path was already
+// guarded correctly, which is what made the unguarded metric next to it easy to miss.
+func TestSweepReportsNoSavingsForARefusedReplay(t *testing.T) {
+	// The fixture has to sit in a NARROW gap, and getting it wrong makes this test vacuous: the
+	// saving is computed from the descriptor ALONE, so the descriptor must be smaller than the
+	// content (or no saving would be booked either way and the mutation escapes), while
+	// descriptor+marker must NOT be (or the splice succeeds and there is no declined replay).
+	// Searched rather than hard-coded, because both sides depend on the tokenizer.
+	content := sweepDeclineFixture(t)
+	e := newSweepSmall(t, "")
+	asker := &labelAsker{verdict: "keep", needed: "none"}
+	asker.cacheRead = 19595
+	st := store.NewMemory(store.Options{MaxEntries: 400})
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("do the thing"), toolResultMsg(content),
+	}}
+	c := preExpiryCtx("s", asker, st)
+	// PRICED HIGH, deliberately. The saving under test is a few tokens, and at real cache-read
+	// rates (~3e-7 USD/token) that is ~1e-6 USD — which round4 reports as 0.0000, so a saving
+	// wrongly booked would be indistinguishable from none and this test would pass against the
+	// very defect it exists to catch. A rate of 1 USD/token makes the counter observable without
+	// changing which BRANCH runs: savedTokenValue reads SelfRates.CacheRead on a warm cache-aware
+	// turn, which is what preExpiryCtx sets up.
+	c.SelfRates = components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50}
+	// Freeze a decision whose descriptor is LONGER than the content once the marker is added, so
+	// the replay path is entered and then declines.
+	putResult(c, extract.ContentKey(content), sweepDescriptor(content), "")
+	if _, hit := getResult(c, extract.ContentKey(content)); !hit {
+		t.Fatal("the fixture's frozen decision is not readable, so the replay path is not taken")
+	}
+	rep := &components.Report{Component: "extract_llm_sweep"}
+	before, hitsBefore := sweepValueUSD(), sweepCacheHits()
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload: %v", err)
+	}
+	// PRECONDITION, and this test was vacuous without it: an unchanged message is ALSO what a
+	// component that never ran leaves behind, so "the message is verbatim and no saving was
+	// booked" proves nothing until the replay branch is known to have been entered. The cache
+	// lookup is recorded on entry to that branch, before any of the checks that can decline.
+	if got := sweepCacheHits() - hitsBefore; got == 0 {
+		t.Fatalf("the sweep recorded no result-cache HIT, so the replay path was not entered and "+
+			"the assertions below would pass on a transcript nothing touched (gates: %v)", rep.Gates)
+	}
+	if got := schema.MessageText(req.Input[1]); got != content {
+		t.Fatalf("the fixture was spliced after all (%q), so there is no declined replay to "+
+			"assert about", got)
+	}
+	if rep.Replays != 0 {
+		t.Errorf("rep.Replay fired %d time(s) for a replay that did not splice", rep.Replays)
+	}
+	if after := sweepValueUSD(); after > before {
+		t.Errorf("sweep gross value rose from %v to %v for a drop that did not happen; the "+
+			"savings figure now includes tokens that were never saved", before, after)
+	}
+}
+
+// sweepDeclineFixture finds a tool output for which the sweep's shape descriptor is a real
+// reduction and the descriptor PLUS the marker is not. Fails loudly rather than returning a
+// best effort: a fixture that misses the gap would make the caller pass against the bug.
+func sweepDeclineFixture(t *testing.T) string {
+	t.Helper()
+	for n := 1; n <= 400; n++ {
+		content := strings.Repeat("record of the audit log\n", n)
+		desc := sweepDescriptor(content)
+		withMarker := desc + "\n" + expand.Marker(hashKey(content)) +
+			" [full output: call " + expand.ToolName + "]"
+		if schema.TextTokens(desc) < schema.TextTokens(content) &&
+			schema.TextTokens(withMarker) >= schema.TextTokens(content) {
+			return content
+		}
+	}
+	t.Fatal("no content size makes the descriptor a win while the descriptor+marker is not; the " +
+		"never-worse decline this test needs is unreachable, so it would pass vacuously")
+	return ""
+}
+
+func sweepValueUSD() float64 {
+	if s := metricsExtractByComponent("extract_llm_sweep"); s != nil {
+		return s.GrossValueUSD
+	}
+	return 0
+}
+
+// sweepCacheHits counts result-cache HITS, not lookups. CacheLookups counts misses too, so a
+// precondition built on it was satisfied by the MISS recorded further down the loop — it "proved"
+// the replay branch had been entered when it had not.
+func sweepCacheHits() int64 {
+	if s := metricsExtractByComponent("extract_llm_sweep"); s != nil {
+		return s.CallsAvoided
+	}
+	return 0
+}
+
+// agentdiet pays a reflection model call over a whole step, and every plan it produces wants a
+// payload. If the reserve cannot take even the smallest of them, the call is paid and every plan
+// is then declined at commitMark — a model call for a step guaranteed to be left verbatim.
+//
+// Weaker than summarize's check on purpose: it probes with the SMALLEST candidate, so it skips
+// only when nothing at all can be admitted and never declines a step whose plans might still fit.
+func TestAgentDietDoesNotPayForAReflectionItCannotStash(t *testing.T) {
+	model := &silentModel{}
+	c, err := newAgentDiet([]byte("delay_steps: 0\ncontext_steps: 1\nmin_step_tokens: 10\n" +
+		"min_saved_tokens: 1\nmax_keep_ratio: 1.0\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := c.(*AgentDiet)
+	d.modelClient = model
+	d.mode = markerFull
+
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("run the tests"),
+		callMsg("t1"), toolResultMsgWithID("t1", strings.Repeat("pytest output line\n", 200)),
+		callMsg("t2"), toolResultMsgWithID("t2", strings.Repeat("more output here\n", 200)),
+	}}
+	// A reserve with no room at all.
+	st := store.NewMemory(store.Options{MaxEntries: 1})
+	rep := &components.Report{Component: "agentdiet"}
+	if _, err := d.Offload(req, rep, ctxFor(st)); err != nil {
+		t.Fatalf("Offload: %v", err)
+	}
+	if n := atomic.LoadInt64(&model.calls); n != 0 {
+		t.Errorf("the reflection model was called %d time(s) although the reserve could not "+
+			"hold ANY payload: every plan it produced would be declined at commitMark, so the "+
+			"call is paid for a step that is guaranteed to be left verbatim", n)
+	}
+	if rep.Gates["stash_reserve_exhausted"] == 0 {
+		t.Errorf("the skip was not recorded as stash_reserve_exhausted, so a run that stopped "+
+			"reducing looks like a run with nothing to reduce (gates: %v)", rep.Gates)
+	}
+}

--- a/components/offload/commitgate_test.go
+++ b/components/offload/commitgate_test.go
@@ -1,0 +1,316 @@
+package offload
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// THE INVARIANT THIS FILE EXISTS FOR
+//
+// commitMark is the only thing that knows whether a removal is happening, because #188 gave it
+// the power to refuse. So NOTHING DERIVED FROM THE REMOVAL MAY BE RECORDED BEFORE IT RETURNS
+// TRUE — not the splice, not a frozen decision, not a metric, not rep.Replay.
+//
+// It is an invariant rather than three bugs because the failure it produces is worse than the
+// lost saving. A frozen decision with no splice behind it is a broken promise one layer up: on
+// a later turn the same-session replay path reads that record and DELIBERATELY BYPASSES the
+// cache-tail gate — its reasoning is that these bytes were already sent — so once a reserve
+// slot frees, the compaction is spliced into a message that is by then inside the provider's
+// cached prefix, forcing a full-suffix cache write at ~11.5x the read price. #188's
+// reversibility fix would have introduced a reversibility-adjacent bug.
+//
+// Three call sites had it (extract_llm's phase 3, its cross-session hit, the sweep's phase 3),
+// which is why this is a table over components rather than three tests: the next caller to get
+// it wrong is the one nobody has written yet. gateExempt below is what makes that a hard
+// failure instead of a silent gap.
+
+// decisionPrefixes are the namespaces whose contents assert that a removal HAPPENED. A write to
+// any of them for a removal that was refused is the defect above.
+var decisionPrefixes = []string{
+	store.ResultPrefix,  // cg:res:  extract_llm / sweep replayed decision
+	store.XResultPrefix, // cg:xres: the cross-session copy
+	store.FrozenPrefix,  // cg:frz:  mask / collapse / skeleton / ... freeze
+	"cg:own:",           // stash ownership — asserts a payload of ours is in the store
+	"cg:sum:",           // summarize's checkpoint
+}
+
+// spyStore refuses every rewind payload and records every other write, so a test can ask "what
+// did this component claim after being told it could not store the original?".
+//
+// It embeds *store.Memory rather than reimplementing the Store surface: the component behavior
+// under test depends on Get/Sticky/etc. working normally, and a hand-written fake that quietly
+// returned nothing would make every component skip for the wrong reason.
+type spyStore struct {
+	*store.Memory
+	puts []string
+}
+
+func (s *spyStore) Put(key string, payload []byte) {
+	s.puts = append(s.puts, key)
+	s.Memory.Put(key, payload)
+}
+
+// PutStash refuses everything — a reserve with no room at all — and records nothing, because a
+// refused payload is not a write.
+func (s *spyStore) PutStash(string, []byte) bool { return false }
+
+// StashRoom matches PutStash, or a component that probes first would be told to proceed and
+// then refused, testing a path this fixture is not aiming at.
+func (s *spyStore) StashRoom(int) bool { return false }
+
+func (s *spyStore) decisionWrites() []string {
+	var out []string
+	for _, k := range s.puts {
+		for _, p := range decisionPrefixes {
+			if strings.HasPrefix(k, p) {
+				out = append(out, k)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// wireMarkerRe matches a marker in MARSHALLED bytes, in both spellings. encoding/json
+// HTML-escapes "<", and every marker follows a newline, so on the wire a marker usually exists
+// only as \u003c\u003ccg:HASH\u003e\u003e — a scan for the plain form alone reports zero
+// markers on a body full of them.
+var wireMarkerRe = regexp.MustCompile(`(?:<|(?i:\\u003c)){2}cg:([A-Za-z0-9_-]{1,64})(?:>|(?i:\\u003e)){2}`)
+
+func markersOnWire(t *testing.T, msgs []bschemas.ChatMessage) []string {
+	t.Helper()
+	b, err := json.Marshal(msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, m := range wireMarkerRe.FindAllStringSubmatch(string(b), -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// gateCase is one component driven to the commit gate. build returns the component and the
+// request; the same pair is built twice, once against a healthy store and once against a
+// saturated one, so the two runs cannot share mutated state.
+type gateCase struct {
+	name  string
+	build func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx)
+}
+
+// gateExempt lists registered Offload components this table does NOT drive, with the reason.
+// Adding a component without adding a case here or above fails
+// TestEveryOffloadComponentIsHeldToTheCommitGate — which is the point: the invariant's whole
+// weakness is the caller nobody thought about.
+var gateExempt = map[string]string{
+	"failed_run": "needs a superseded failed RUN (a later successful invocation of the same " +
+		"command) to have anything to collapse; the shape is covered by mask, which shares " +
+		"its commit path verbatim — tryMark, commitMark, SetMessageText, freeze",
+	"readlifecycle": "needs a read/edit event pair across messages to classify a body as " +
+		"stale; same commit path as mask",
+	"skeleton": "acts only on a line-numbered source dump or a fenced block whose grammar " +
+		"tree-sitter recognises, so a fixture depends on the cg_skeleton build tag",
+	"smartcrush": "acts only on a JSON array of records above its floor; same commit path " +
+		"as dedup",
+	"agentdiet": "reached only through a reflection model call over a multi-STEP trajectory; " +
+		"its reserve behavior is pinned by TestAgentDietDoesNotPayForAReflectionItCannotStash",
+	"extract_llm_sweep": "the adjudicator needs a model verdict naming candidates; its two " +
+		"pre-gate sites are pinned by TestSweepFreezesNoDecisionForADropThatDidNotHappen",
+	"summarize": "replaces a span rather than one message, so 'left verbatim' means a whole " +
+		"skipped checkpoint; pinned by TestSummarizeSkipsTheCheckpointWhenTheSpanCannotBeStashed " +
+		"and TestSummarizeReplaysItsCheckpointRatherThanFlippingCachedContent",
+	"extract_llm": "needs an extraction model; its three pre-gate sites are pinned by " +
+		"TestExtractLLMFreezesNoDecisionForASpliceThatDidNotHappen and " +
+		"TestExtractLLMReportsNoSavingsForARefusedReplay",
+}
+
+func ctxFor(st store.Store) *components.Ctx {
+	return &components.Ctx{Ctx: context.Background(), Session: "s", Store: st, MaxCachedIdx: -1}
+}
+
+func toolMsgs(texts ...string) *bschemas.BifrostChatRequest {
+	req := &bschemas.BifrostChatRequest{Provider: bschemas.Anthropic}
+	for _, txt := range texts {
+		m := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleTool}
+		schema.SetMessageText(&m, txt)
+		req.Input = append(req.Input, m)
+	}
+	return req
+}
+
+// noisyLines is content collapseObviousNoise provably reduces: the SAME line repeated
+// consecutively, as a retry loop dumps a traceback. Distinct lines are not noise to it — every
+// unique informative line is kept verbatim, which is the whole point of that reducer — so a
+// fixture of "Downloading package-N" would reach the component and be declined before the gate,
+// and the invariant test's precondition catches exactly that.
+func noisyLines(tag string) string {
+	head := "Traceback (most recent call last):\n  File \"" + tag + ".py\", line 3\nValueError: bad\n"
+	return head + strings.Repeat(head, 200)
+}
+
+func gateCases() []gateCase {
+	return []gateCase{
+		{"mask", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newMask([]byte("keep_recent: 0\nmin_tokens: 20\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload), toolMsgs(wideOutput("m1"), wideOutput("m2")), ctxFor(st)
+		}},
+		{"linecap", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newLinecap([]byte("max_line_chars: 40\nmin_size: 10\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload), toolMsgs(wideOutput("l1"), wideOutput("l2")), ctxFor(st)
+		}},
+		{"collapse", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newCollapse([]byte("max_tokens: 20\nhead_lines: 2\ntail_lines: 2\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := strings.Repeat("a line of log output that goes on for a while\n", 80)
+			return c.(components.Offload), toolMsgs(body, body+"tail\n"), ctxFor(st)
+		}},
+		{"dedup", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newDedup([]byte("min_tokens: 20\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := wideOutput("dup")
+			return c.(components.Offload), toolMsgs(body, body), ctxFor(st)
+		}},
+		{"extract", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newExtract([]byte("min_tokens: 20\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload), toolMsgs(noisyLines("a"), noisyLines("b")), ctxFor(st)
+		}},
+		{"cmdfilter", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			c, err := newCmdfilter([]byte("min_size: 1\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			const pipNag = "WARNING: Running pip as the 'root' user can result in broken permissions and " +
+				"conflicting behaviour with the system package manager, possibly rendering your system " +
+				"unusable. It is recommended to use a virtual environment instead: " +
+				"https://pip.pypa.io/warnings/venv\n" +
+				"WARNING: You are using pip version 21.0.1; however, version 23.0.1 is available.\n" +
+				"You should consider upgrading via the '/usr/bin/python3 -m pip install --upgrade pip' command.\n"
+			req := &bschemas.BifrostChatRequest{Provider: bschemas.Anthropic,
+				Input: []bschemas.ChatMessage{cmdToolMsg(pipNag)}}
+			return c.(components.Offload), req, ctxFor(st)
+		}},
+	}
+}
+
+// TestNoStateIsRecordedBeforeTheCommitGate is the invariant.
+//
+// Each case runs twice. The HEALTHY run is a precondition, not decoration: it proves the
+// fixture actually reaches the gate and produces a marker and a decision. Without it a
+// component that silently stopped acting — a changed default, a floor raised — would make the
+// saturated run pass by doing nothing at all, and a vacuous pass is indistinguishable from a
+// real one in the output.
+func TestNoStateIsRecordedBeforeTheCommitGate(t *testing.T) {
+	for _, tc := range gateCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			// --- Precondition: with a store that CAN hold payloads, this fixture removes
+			// something, stamps a resolvable marker, and records a decision.
+			healthy := store.NewMemory(store.Options{MaxEntries: 400})
+			comp, req, c := tc.build(t, healthy)
+			var rep components.Report
+			if _, err := comp.Offload(req, &rep, c); err != nil {
+				t.Fatalf("healthy run: %v", err)
+			}
+			healthyMarkers := markersOnWire(t, req.Input)
+			if len(healthyMarkers) == 0 {
+				t.Fatalf("the fixture stamped NO marker against a healthy store, so it never "+
+					"reached the commit gate and the saturated run below would pass vacuously "+
+					"(component %s: check its config and the candidate size)", tc.name)
+			}
+			for _, id := range healthyMarkers {
+				if _, ok := expand.Resolve(healthy, id); !ok {
+					t.Fatalf("healthy run: marker <<cg:%s>> does not resolve; the fixture is "+
+						"broken before the invariant is even tested", id)
+				}
+			}
+
+			// --- The invariant: told it cannot store originals, the component must record
+			// nothing about a removal it did not make.
+			spy := &spyStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+			comp, req, c = tc.build(t, spy)
+			before := make([]string, len(req.Input))
+			for i := range req.Input {
+				before[i] = schema.MessageText(req.Input[i])
+			}
+			rep = components.Report{}
+			if _, err := comp.Offload(req, &rep, c); err != nil {
+				t.Fatalf("saturated run: %v", err)
+			}
+			if got := markersOnWire(t, req.Input); len(got) != 0 {
+				t.Errorf("%d marker(s) reached the wire with no payload behind them: %v. A "+
+					"refused removal must leave the message VERBATIM", len(got), got)
+			}
+			if got := spy.decisionWrites(); len(got) != 0 {
+				t.Errorf("the component recorded %d decision(s) for a removal that did not "+
+					"happen: %v.\nOn a later turn the same-session replay path reads such a "+
+					"record and bypasses the cache-tail gate, splicing into a message that is "+
+					"by then inside the provider's cached prefix — a full-suffix cache write "+
+					"at ~11.5x the read price", len(got), got)
+			}
+			for i := range req.Input {
+				if got := schema.MessageText(req.Input[i]); got != before[i] {
+					t.Errorf("message %d was rewritten although its original could not be "+
+						"stored:\n got %q\nwant %q", i, got, before[i])
+				}
+			}
+		})
+	}
+}
+
+// TestEveryOffloadComponentIsHeldToTheCommitGate is the completeness half, and it is the part
+// that survives the next contributor.
+//
+// The invariant above is only as good as its table, and a table is exactly the thing a new
+// component is not added to. So every registered Offload must be either driven above or listed
+// in gateExempt with a reason — the same mechanism proxy/promexport_coverage_test.go uses to
+// stop a new /stats field from quietly never reaching Prometheus.
+func TestEveryOffloadComponentIsHeldToTheCommitGate(t *testing.T) {
+	covered := map[string]bool{}
+	for _, tc := range gateCases() {
+		covered[tc.name] = true
+	}
+	for _, name := range components.Names() {
+		c, err := components.New(name, nil)
+		if err != nil {
+			continue // not constructible with an empty config; not an Offload question
+		}
+		if _, ok := c.(components.Offload); !ok {
+			continue
+		}
+		if covered[name] {
+			if why, dup := gateExempt[name]; dup {
+				t.Errorf("%s is both driven by gateCases and listed in gateExempt (%q); one of "+
+					"the two is stale", name, why)
+			}
+			continue
+		}
+		if why := gateExempt[name]; strings.TrimSpace(why) == "" {
+			t.Errorf("Offload %q is neither driven by TestNoStateIsRecordedBeforeTheCommitGate "+
+				"nor listed in gateExempt with a reason.\nEvery offloader calls commitMark, and "+
+				"commitMark can REFUSE — so this component may be recording a frozen decision, "+
+				"a metric or a splice for a removal that never happened. Add a gateCase, or add "+
+				"an entry to gateExempt naming the test that pins it instead.", name)
+		}
+	}
+}

--- a/components/offload/commitgate_test.go
+++ b/components/offload/commitgate_test.go
@@ -121,16 +121,13 @@ var gateExempt = map[string]string{
 		"tree-sitter recognises, so a fixture depends on the cg_skeleton build tag",
 	"smartcrush": "acts only on a JSON array of records above its floor; same commit path " +
 		"as dedup",
-	"agentdiet": "reached only through a reflection model call over a multi-STEP trajectory; " +
-		"its reserve behavior is pinned by TestAgentDietDoesNotPayForAReflectionItCannotStash",
-	"extract_llm_sweep": "the adjudicator needs a model verdict naming candidates; its two " +
-		"pre-gate sites are pinned by TestSweepFreezesNoDecisionForADropThatDidNotHappen",
+	"agentdiet": "reached only through a reflection model call over a multi-STEP trajectory, so " +
+		"its candidates are steps rather than messages; pinned by " +
+		"TestAgentDietDoesNotPayForAReflectionItCannotStash and " +
+		"TestAgentDietRefusalsReachTheRefusalCounter",
 	"summarize": "replaces a span rather than one message, so 'left verbatim' means a whole " +
 		"skipped checkpoint; pinned by TestSummarizeSkipsTheCheckpointWhenTheSpanCannotBeStashed " +
 		"and TestSummarizeReplaysItsCheckpointRatherThanFlippingCachedContent",
-	"extract_llm": "needs an extraction model; its three pre-gate sites are pinned by " +
-		"TestExtractLLMFreezesNoDecisionForASpliceThatDidNotHappen and " +
-		"TestExtractLLMReportsNoSavingsForARefusedReplay",
 }
 
 func ctxFor(st store.Store) *components.Ctx {
@@ -196,6 +193,27 @@ func gateCases() []gateCase {
 			}
 			return c.(components.Offload), toolMsgs(noisyLines("a"), noisyLines("b")), ctxFor(st)
 		}},
+		{"extract_llm", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			// In the table rather than exempt, because the metric assertions below are the whole
+			// point for this one: its savings, its ratio feed and its ledger row are all computed
+			// in a goroutine before phase 3 exists, and the first fix round moved only the replay
+			// path's. A model is the only reason it was ever exempt.
+			model := &shrinkingModel{}
+			e := newTimeoutTestComponent(t, model)
+			body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 400)
+			req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+				userMsg("summarize the worker log"), toolResultMsg(body),
+			}}
+			return e, req, pricedCtx("gate-table", st, model)
+		}},
+		{"extract_llm_sweep", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
+			asker := &labelAsker{verdict: "drop", needed: "none"}
+			asker.cacheRead = 19595
+			e := newSweepSmall(t, "")
+			c := preExpiryCtx("gate-table-sweep", asker, st)
+			c.SelfRates = components.TokenRates{Input: 10, CacheRead: 1, CacheWrite: 12.5, Output: 50}
+			return e, sweepReqStocked(), c
+		}},
 		{"cmdfilter", func(t *testing.T, st store.Store) (components.Offload, *bschemas.BifrostChatRequest, *components.Ctx) {
 			c, err := newCmdfilter([]byte("min_size: 1\n"))
 			if err != nil {
@@ -228,7 +246,7 @@ func TestNoStateIsRecordedBeforeTheCommitGate(t *testing.T) {
 			// something, stamps a resolvable marker, and records a decision.
 			healthy := store.NewMemory(store.Options{MaxEntries: 400})
 			comp, req, c := tc.build(t, healthy)
-			var rep components.Report
+			rep := components.Report{Component: tc.name}
 			if _, err := comp.Offload(req, &rep, c); err != nil {
 				t.Fatalf("healthy run: %v", err)
 			}
@@ -253,13 +271,38 @@ func TestNoStateIsRecordedBeforeTheCommitGate(t *testing.T) {
 			for i := range req.Input {
 				before[i] = schema.MessageText(req.Input[i])
 			}
-			rep = components.Report{}
+			rep = components.Report{Component: tc.name}
+			valueBefore, savedBefore := extractGrossValue(tc.name), extractGrossSaved(tc.name)
 			if _, err := comp.Offload(req, &rep, c); err != nil {
 				t.Fatalf("saturated run: %v", err)
 			}
 			if got := markersOnWire(t, req.Input); len(got) != 0 {
 				t.Errorf("%d marker(s) reached the wire with no payload behind them: %v. A "+
 					"refused removal must leave the message VERBATIM", len(got), got)
+			}
+			// METRICS, not only store writes. A saving booked for a removal that did not happen
+			// is the same invariant one layer over: /stats reports value the run never delivered,
+			// and for extract_llm the ratio tracker it also feeds prices FUTURE calls, so the
+			// mis-recording outlives the turn that caused it. Asserted for every case in the
+			// table rather than per component, because "which components record savings" is
+			// exactly the kind of fact that changes without the test being revisited.
+			if got := extractGrossSaved(tc.name) - savedBefore; got != 0 {
+				t.Errorf("%d saved tokens were booked for removals that did not happen: the run "+
+					"reports a saving it did not deliver", got)
+			}
+			if got := extractGrossValue(tc.name); got > valueBefore {
+				t.Errorf("gross value rose from %v to %v for removals that did not happen",
+					valueBefore, got)
+			}
+			for _, call := range rep.Calls {
+				if call.Accepted {
+					t.Error("a ledger row says accepted=true while every candidate went upstream " +
+						"verbatim")
+				}
+				if call.SavedTokens != 0 {
+					t.Errorf("a ledger row claims %d saved tokens for candidates left verbatim",
+						call.SavedTokens)
+				}
 			}
 			if got := spy.decisionWrites(); len(got) != 0 {
 				t.Errorf("the component recorded %d decision(s) for a removal that did not "+

--- a/components/offload/dedup.go
+++ b/components/offload/dedup.go
@@ -67,7 +67,9 @@ func (d *Dedup) Offload(req *schemas.BifrostChatRequest, rep *components.Report,
 			rep.Gate("marker_no_win") // pointer+marker wouldn't shrink this duplicate
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(m, newText)
 		changed++
 		if key != "" {

--- a/components/offload/extract.go
+++ b/components/offload/extract.go
@@ -79,7 +79,9 @@ func (e *Extract) Offload(req *bschemas.BifrostChatRequest, rep *components.Repo
 			rep.Gate("marker_no_win") // projection+marker wouldn't shrink this message
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(msg, newText)
 		changed++
 		if key != "" {

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1452,19 +1452,36 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// is documented as "the never-worse outcome — the same condition that spliced the
 			// result above, so the log cannot say accepted while the request kept the original",
 			// and that claim is only true if it is set here.
-			calls[k].Accepted = true
-			calls[k].SavedTokens = out[k].saved
 			// Feed the observed ratio so the gate prices future calls on what this workload
 			// actually achieves. Only a splice is evidence of that: a result the reserve refused
 			// tells us the model CAN shrink this content and that we could not use it, and a
 			// future call will be refused the same way — so crediting the ratio would keep the
 			// gate authorising calls whose output is discarded. A model that produced nothing is
 			// separate evidence and is still observed as ratio 0, in runCall.
-			e.ratios.observe(out[k].saved, out[k].before)
-			metrics.RecordExtractionSaving(rep.Component, out[k].saved)
-			// What the removal was WORTH, at this turn's regime. On a cold sweep that is the
-			// cache-write rate; the replays above are credited at the read rate.
-			metrics.RecordExtractionValue(rep.Component, float64(out[k].saved)*val.perToken)
+			//
+			// THE COST OF NOT OBSERVING, stated because the choice is a trade and not a free win:
+			// under a persistently saturated reserve nothing advances r.total, so ratio() stays
+			// pinned to its prior and exploring() keeps granting maxExploreCalls per session
+			// instead of self-terminating once the sample is large enough. That is a small
+			// permanent spend on exactly the deployments this change is for. It is bounded per
+			// session and it buys a tracker that is not lying, which is the better side of the
+			// trade — but the previous behaviour did terminate exploration, and pretending
+			// otherwise would misread the diff.
+			//
+			// Only for a slot that actually made a call. A single-flight FOLLOWER returns before
+			// filling its slot, so before is 0 there and the three lines below would book zeros —
+			// and set Accepted on a row whose Component is "" — for a splice that did happen. The
+			// follower's saving goes unbooked either way (its leader books the shared result once);
+			// what this guard removes is the pretence of measuring it.
+			if out[k].before > 0 {
+				calls[k].Accepted = true
+				calls[k].SavedTokens = out[k].saved
+				e.ratios.observe(out[k].saved, out[k].before)
+				metrics.RecordExtractionSaving(rep.Component, out[k].saved)
+				// What the removal was WORTH, at this turn's regime. On a cold sweep that is the
+				// cache-write rate; the replays above are credited at the read rate.
+				metrics.RecordExtractionValue(rep.Component, float64(out[k].saved)*val.perToken)
+			}
 			putResult(c, cands[k].id, out[k].projected, out[k].summary)
 			if !e.rewrite || effectiveMode(c, e.mode) == markerFull {
 				putResultGlobal(c, extract.ResultKey(cands[k].id, e.modelName, extCfg),

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1189,6 +1189,19 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		type outT struct {
 			projected, summary string
 			saved, before      int
+			// called marks a slot that actually issued a model call. A single-flight FOLLOWER
+			// returns before filling its slot, so the accounting in phase 3 must skip it.
+			//
+			// An explicit flag rather than a proxy. `before > 0` was indirect — `before` is in
+			// scope in the follower branch, so filling it there would silently re-enable the
+			// booking — and `calls[k].Component != ""` traded that for a worse coupling: it is
+			// just rep.Component, which components/pipeline.go always sets in production but which
+			// most of this package's tests leave empty on a bare &components.Report{}. That made
+			// the whole booking block unreachable from those fixtures, so a future regression
+			// inside it could not be caught from them. Given how much of this change's value came
+			// from tests that catch exactly that class, coupling accounting to a labelling field
+			// was the wrong trade.
+			called bool
 		}
 		out := make([]outT, len(cands))
 		// One deferred debug record per call, invoked after phase 3 so `accepted` describes the
@@ -1269,6 +1282,7 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			metrics.RecordExtractionCall(rep.Component, latency)
 			_, inTok, outTok := callSink.Totals()
 			cw, cr := callSink.CacheTotals()
+			out[k].called = true
 			calls[k] = components.ModelCall{
 				Component: rep.Component, Model: callModel,
 				Strategy: strategy, Aggressiveness: string(e.aggro),
@@ -1321,7 +1335,11 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 				}
 			}
 			if res != "" && res != cands[k].content {
-				out[k] = outT{projected: res, summary: sum}
+				// FIELD ASSIGNMENT, not a fresh struct: `called` was set above and a struct literal
+				// here silently reset it, so phase 3 skipped the booking for every real call. The
+				// follower path above may use a literal because it has no `called` to preserve —
+				// which is exactly what made this easy to miss.
+				out[k].projected, out[k].summary = res, sum
 				calls[k].Summary, calls[k].After = sum, res
 				// THE OUTCOME IS CARRIED, NOT BOOKED. A model result is not a removal: phase 3
 				// still has to splice it, and after #188 that can decline — the reserve refuses
@@ -1487,26 +1505,21 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// do while the reserve is saturated) and wants the re-run's numbers, so it is on that
 			// issue's candidate list rather than guessed at in this diff.
 			//
-			// Only for a slot that actually MADE A CALL — a single-flight FOLLOWER returns before
-			// filling its slot, and Component is what says so (it is also what the ledger append
-			// below filters on, so the two agree by construction).
+			// Only for a slot that actually MADE A CALL — see outT.called for why the condition is
+			// an explicit flag rather than a proxy.
 			//
 			// A DEFENCE, NOT A FIX: nothing was escaping before it. ratioTracker.observe returns
 			// early on totalTok <= 0, both recorders are no-ops at 0, out[k].saved is already 0 in
-			// a follower slot, and a follower's row was dropped by the same Component filter. So
-			// this prevents no live defect, and saying otherwise would leave a future reader
-			// reasoning from a false premise. What it does buy is that the booking no longer
-			// depends on three unrelated zero-guards staying zero-guards, and that the condition is
-			// stated where the booking happens.
+			// a follower slot, and a follower's row is dropped by the Component filter on the
+			// append below. So this prevents no live defect, and saying otherwise would leave a
+			// future reader reasoning from a false premise. What it buys is that the booking no
+			// longer depends on three unrelated zero-guards staying zero-guards, and that the
+			// condition is stated where the booking happens.
 			//
-			// Keyed on Component rather than on `before` deliberately: `before` is in scope in the
-			// follower branch, so anyone who later fills it there would silently re-enable this
-			// booking. Component cannot be set by a slot that made no call.
-			//
-			// The follower's saving stays UNBOOKED either way — its leader books the shared result
-			// once, and attributing it twice would over-count. Booking per spliced message rather
-			// than per call is the real fix and is larger than this change.
-			if calls[k].Component != "" {
+			// The follower's saving stays UNBOOKED — its leader books the shared result once, and
+			// attributing it twice would over-count. Booking per spliced message rather than per
+			// call is the real fix and is larger than this change.
+			if out[k].called {
 				calls[k].Accepted = true
 				calls[k].SavedTokens = out[k].saved
 				e.ratios.observe(out[k].saved, out[k].before)

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -780,9 +780,21 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 
 	// apply splices a compacted projection + marker into message i (serial: store writes
 	// and message mutation are not concurrency-safe).
-	apply := func(i int, content, projected, summary string) {
+	//
+	// IT REPORTS WHETHER THE SPLICE HAPPENED, and every caller must gate on that. It can
+	// decline for three reasons now — the projection does not shrink, the marker-inclusive
+	// never-worse check fails, or the store's rewind reserve refuses the payload — and after
+	// #188 the last of those makes it a silent no-op on a path whose callers used to assume it
+	// always acted. What they recorded ahead of it (a frozen cg:res: decision, a token-savings
+	// metric, a replay event) then described a splice that did not occur. See commitMark.
+	//
+	// replay=true marks a decision this session already stamped and sent on an earlier turn.
+	// Then the payload write is a REFRESH, which must never refuse: declining would send the
+	// message verbatim where the provider's cached prefix holds the compacted bytes, which is
+	// the cache-destructive direction and cannot un-send the marker anyway. See commitRefresh.
+	apply := func(i int, content, projected, summary string, replay bool) bool {
 		if projected == "" || schema.TextTokens(projected) >= schema.TextTokens(content) {
-			return
+			return false
 		}
 		hint := " [full output: call " + expand.ToolName + "]"
 		newText, key, eff, ok := tryMark(c, e.mode, content, hint, func(tok string) string {
@@ -792,16 +804,22 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			return projected + "\n" + tok
 		})
 		if !ok {
-			return
+			return false
 		}
-		if !commitMark(c, rep, eff, key, content) {
-			return // the store cannot back the marker; leave this output verbatim
+		if replay {
+			// Never refuses; a false answer means the payload is gone and the marker being
+			// replayed is dangling. Counted there, and the replay proceeds regardless.
+			commitRefresh(c, key, content)
+			recordOwner(c, key)
+		} else if !commitMark(c, rep, eff, key, content) {
+			return false // the store cannot back the marker; leave this output verbatim
 		}
 		schema.SetMessageText(&req.Input[i], newText)
 		changed++
 		if key != "" {
 			keys = append(keys, key)
 		}
+		return true
 	}
 
 	// Phase 1 (serial, cheap): reapply frozen compactions on every turn (keeps the
@@ -874,12 +892,18 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// cache-read rate. This is the other half of the honest net figure: the first
 			// application alone under-reports the value, and pricing the replays at the first
 			// application's rate over-reports it by 12.5x.
-			if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
-				metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
+			// Every one of these three describes a splice, so all three wait for it. Before
+			// #188 apply always acted, so recording ahead of it was merely untidy; now it can
+			// decline, and a run with an exhausted reserve reported replays and token savings
+			// that never happened — over-reporting the exact figure the iteration-024 re-run
+			// will be judged on.
+			if apply(i, content, cached.Projected, cached.Summary, true) {
+				if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
+					metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
+				}
+				dbgReapply++
+				rep.Replay("reapplied_same_session")
 			}
-			apply(i, content, cached.Projected, cached.Summary)
-			dbgReapply++
-			rep.Replay("reapplied_same_session")
 			continue
 		}
 		// A NEW compaction, on the UNCACHED region only (cache-safe): when cache-aware that
@@ -945,10 +969,19 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		if !e.rewrite || effectiveMode(c, e.mode) == markerFull {
 			if cached, hit := getResultGlobal(c, extract.ResultKey(id, e.modelName, extCfg)); hit {
 				metrics.RecordExtractionCacheLookup(rep.Component, true)
+				// A cross-session hit is a NEW decision for THIS session — the comment above
+				// is explicit that this session never sent these compacted bytes — so the
+				// payload write is a commitMark that may refuse, and the splice comes before
+				// the freeze for the same reason it does in phase 3. Freezing a decision this
+				// session never spliced is what lets the same-session replay path above splice
+				// it at depth on a later turn, inside the cached prefix, which is the harm the
+				// tail gate two blocks up exists to prevent.
+				if !apply(i, content, cached.Projected, cached.Summary, false) {
+					continue
+				}
 				// Freeze into this session so later turns replay it byte-for-byte from the
 				// same-session path above, at any depth.
 				putResult(c, id, cached.Projected, cached.Summary)
-				apply(i, content, cached.Projected, cached.Summary)
 				dbgReapply++
 				rep.Replay("reapplied_cross_session")
 				continue
@@ -1382,12 +1415,24 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// result also qualified for cross-session sharing. Then publish globally only when
 			// recoverable. One key per decision (#40) — projected text and summary travel
 			// together, so a replay can never emit half a decision.
+			// THE SPLICE FIRST, then the decision. The order was the other way, and the
+			// reserve's new ability to refuse made that a defect: a declined removal left a
+			// pinned cg:res: record claiming "this session sent these compacted bytes" for a
+			// message that went upstream unchanged. On a later turn the same-session replay
+			// path above reads that record and deliberately bypasses the cache-tail gate —
+			// its reasoning is that the bytes were already sent — so once a reserve slot
+			// freed, the compaction was spliced into a message by then inside the provider's
+			// cached prefix, forcing a full-suffix cache write at ~11.5x the read price. That
+			// is exactly what TestGlobalCacheHitIsNotSplicedAtDepth exists to prevent, arrived
+			// at from the other side.
+			if !apply(cands[k].i, cands[k].content, out[k].projected, out[k].summary, false) {
+				continue
+			}
 			putResult(c, cands[k].id, out[k].projected, out[k].summary)
 			if !e.rewrite || effectiveMode(c, e.mode) == markerFull {
 				putResultGlobal(c, extract.ResultKey(cands[k].id, e.modelName, extCfg),
 					out[k].projected, out[k].summary)
 			}
-			apply(cands[k].i, cands[k].content, out[k].projected, out[k].summary)
 		}
 	}
 

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -808,8 +808,10 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		}
 		if replay {
 			// Never refuses; a false answer means the payload is gone and the marker being
-			// replayed is dangling. Counted there, and the replay proceeds regardless.
-			commitRefresh(c, key, content)
+			// replayed is dangling. Counted there, and the replay proceeds regardless. It also
+			// owns rep.Irreversible for the degraded marker modes, which commitMark used to set
+			// on this path — see commitRefresh.
+			commitRefresh(c, rep, eff, key, content)
 			recordOwner(c, key)
 		} else if !commitMark(c, rep, eff, key, content) {
 			return false // the store cannot back the marker; leave this output verbatim
@@ -1182,8 +1184,17 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		// overwhelming: a turn whose entire transcript re-bills at 1.25x fresh. On this warm
 		// per-output path the extra second buys a fraction of a cent, so it stays fully concurrent
 		// and the flag above is best-effort.
-		type outT struct{ projected, summary string }
+		// saved/before carry the CALL's arithmetic to phase 3 rather than letting the goroutine
+		// that computed it book the outcome — see the accept branch in runCall.
+		type outT struct {
+			projected, summary string
+			saved, before      int
+		}
 		out := make([]outT, len(cands))
+		// One deferred debug record per call, invoked after phase 3 so `accepted` describes the
+		// splice rather than the model reply. nil for a call that never ran (a single-flight
+		// follower) or when DEBUG is off.
+		logRows := make([]func(), len(cands))
 		// One record per call, written to its own slot so the goroutines need no lock (a
 		// Report is copied by value across this codebase and cannot carry one).
 		calls := make([]components.ModelCall, len(cands))
@@ -1310,17 +1321,21 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 				}
 			}
 			if res != "" && res != cands[k].content {
-				out[k] = outT{res, sum}
-				calls[k].Accepted = true
-				calls[k].SavedTokens = before - schema.TextTokens(res)
+				out[k] = outT{projected: res, summary: sum}
 				calls[k].Summary, calls[k].After = sum, res
-				// Feed the observed ratio so the gate prices future calls on what this
-				// workload actually achieves, not on an assumption.
-				e.ratios.observe(before-schema.TextTokens(res), before)
-				metrics.RecordExtractionSaving(rep.Component, before-schema.TextTokens(res))
-				// What the removal was WORTH, at this turn's regime. On a cold sweep that is
-				// the cache-write rate; the replays below are credited at the read rate.
-				metrics.RecordExtractionValue(rep.Component, float64(before-schema.TextTokens(res))*val.perToken)
+				// THE OUTCOME IS CARRIED, NOT BOOKED. A model result is not a removal: phase 3
+				// still has to splice it, and after #188 that can decline — the reserve refuses
+				// the payload, or the never-worse check fails with the marker included. Recording
+				// here meant a saturated reserve reported the full saving, credited the gross
+				// value, logged `accepted=true` for a request that kept its original, and fed the
+				// ratio tracker a saving that never happened. That last one is the worst of them:
+				// the ratio prices FUTURE calls, so the mis-recording propagated into decisions
+				// about work not yet done.
+				//
+				// Recorded in phase 3 instead, per candidate, once the splice is a fact. This
+				// runs in a goroutine, so the value simply rides in the slot phase 3 already reads.
+				out[k].saved = before - schema.TextTokens(res)
+				out[k].before = before
 			} else if !timedOut {
 				e.ratios.observe(0, before) // a miss is real evidence: ratio 0
 			}
@@ -1367,15 +1382,23 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// is guarded. `content_key` rather than the content — the key is what the result
 			// cache, the freeze and the cross-session lookup are all keyed on, so it is the
 			// identity that joins this record to every other one about the same candidate.
+			// DEFERRED TO AFTER PHASE 3, not emitted here, and the comment above is why: `accepted`
+			// is only the never-worse outcome if it is read after the splice has been attempted.
+			// Phase 3 now fills Accepted/SavedTokens, so a record emitted in this goroutine would
+			// report accepted=false on every call — the mirror image of the overclaim it used to
+			// make. A closure rather than a struct because each goroutine's locals (latency, the
+			// token tiers, timedOut) are exactly what the record needs, and they are already here.
 			if dbg {
-				logging.From(c.Ctx).Debug("cg.extract_llm.call",
-					"session", c.Session, "content_key", cands[k].id,
-					"candidate_tokens", before, "model", callModel,
-					"latency_ms", latency, "input_tokens", inTok, "output_tokens", outTok,
-					"cache_read", cr, "cache_write", cw, "cost_usd", calls[k].CostUSD,
-					"accepted", calls[k].Accepted, "saved_tokens", calls[k].SavedTokens,
-					"rejection", calls[k].Rejection, "gate", cands[k].gate,
-					"strategy", strategy, "timed_out", timedOut)
+				logRows[k] = func() {
+					logging.From(c.Ctx).Debug("cg.extract_llm.call",
+						"session", c.Session, "content_key", cands[k].id,
+						"candidate_tokens", before, "model", callModel,
+						"latency_ms", latency, "input_tokens", inTok, "output_tokens", outTok,
+						"cache_read", cr, "cache_write", cw, "cost_usd", calls[k].CostUSD,
+						"accepted", calls[k].Accepted, "saved_tokens", calls[k].SavedTokens,
+						"rejection", calls[k].Rejection, "gate", cands[k].gate,
+						"strategy", strategy, "timed_out", timedOut)
+				}
 			}
 		}
 		for k := 0; k < len(cands); k++ {
@@ -1397,9 +1420,6 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// filling its ModelCall slot, and its gate is precisely the one that says so.
 			for _, g := range gateNames[k] {
 				rep.Gate(g)
-			}
-			if calls[k].Component != "" {
-				rep.Calls = append(rep.Calls, calls[k])
 			}
 		}
 		for k := range cands { // Phase 3 (serial): freeze + splice.
@@ -1428,10 +1448,38 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if !apply(cands[k].i, cands[k].content, out[k].projected, out[k].summary, false) {
 				continue
 			}
+			// The splice is a fact, so the outcome may now be booked. `accepted` in the ledger row
+			// is documented as "the never-worse outcome — the same condition that spliced the
+			// result above, so the log cannot say accepted while the request kept the original",
+			// and that claim is only true if it is set here.
+			calls[k].Accepted = true
+			calls[k].SavedTokens = out[k].saved
+			// Feed the observed ratio so the gate prices future calls on what this workload
+			// actually achieves. Only a splice is evidence of that: a result the reserve refused
+			// tells us the model CAN shrink this content and that we could not use it, and a
+			// future call will be refused the same way — so crediting the ratio would keep the
+			// gate authorising calls whose output is discarded. A model that produced nothing is
+			// separate evidence and is still observed as ratio 0, in runCall.
+			e.ratios.observe(out[k].saved, out[k].before)
+			metrics.RecordExtractionSaving(rep.Component, out[k].saved)
+			// What the removal was WORTH, at this turn's regime. On a cold sweep that is the
+			// cache-write rate; the replays above are credited at the read rate.
+			metrics.RecordExtractionValue(rep.Component, float64(out[k].saved)*val.perToken)
 			putResult(c, cands[k].id, out[k].projected, out[k].summary)
 			if !e.rewrite || effectiveMode(c, e.mode) == markerFull {
 				putResultGlobal(c, extract.ResultKey(cands[k].id, e.modelName, extCfg),
 					out[k].projected, out[k].summary)
+			}
+		}
+		// AFTER phase 3, because rep.Calls takes a COPY of each row and phase 3 is what sets
+		// Accepted/SavedTokens now. Appending before it exported a ledger of rows that all read
+		// accepted=false, which is the mirror image of the bug being fixed.
+		for k := range calls {
+			if calls[k].Component != "" {
+				rep.Calls = append(rep.Calls, calls[k])
+			}
+			if logRows[k] != nil {
+				logRows[k]()
 			}
 		}
 	}

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1461,12 +1461,31 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			//
 			// THE COST OF NOT OBSERVING, stated because the choice is a trade and not a free win:
 			// under a persistently saturated reserve nothing advances r.total, so ratio() stays
-			// pinned to its prior and exploring() keeps granting maxExploreCalls per session
-			// instead of self-terminating once the sample is large enough. That is a small
-			// permanent spend on exactly the deployments this change is for. It is bounded per
-			// session and it buys a tracker that is not lying, which is the better side of the
-			// trade — but the previous behaviour did terminate exploration, and pretending
-			// otherwise would misread the diff.
+			// pinned to its prior and exploring() keeps granting maxExploreCalls instead of
+			// self-terminating once the sample is large enough.
+			//
+			// AND THE COST IS NOT PER-SESSION-BOUNDED, which is the easy thing to assume and the
+			// wrong thing to write down. The store is ONE process-wide instance, so saturation is
+			// CORRELATED rather than independent: when the reserve is full it is full for every
+			// session at once. The spend is therefore maxExploreCalls x every concurrent session,
+			// repeating for as long as the episode lasts — and with a sliding 10,000 s TTL an
+			// episode can run for hours. The deployments that pay it are the under-provisioned
+			// ones (see #190), which are the least able to absorb it.
+			//
+			// Still small beside the cache writes this gate's honesty prevents, so the trade stands:
+			// observing the achieved ratio would authorise calls whose output is discarded, and
+			// observing 0 would assert the workload is incompressible, which is false and would
+			// also suppress calls that WOULD land once the reserve frees. Observing nothing is the
+			// only one of the three that does not lie. But the previous behaviour did terminate
+			// exploration, and a reader reasoning from a "bounded per session" claim would
+			// under-count this by the number of concurrent sessions.
+			//
+			// The option that gets both properties is to gate exploring() on RESERVE HEALTH rather
+			// than on r.total — stash_refused already distinguishes "cannot learn because we are
+			// refusing" from "no evidence yet", which is the distinction r.total cannot express.
+			// Deliberately not done here: it is the same question as #190 (what a component should
+			// do while the reserve is saturated) and wants the re-run's numbers, so it is on that
+			// issue's candidate list rather than guessed at in this diff.
 			//
 			// Only for a slot that actually made a call. A single-flight FOLLOWER returns before
 			// filling its slot, so before is 0 there and the three lines below would book zeros —

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1487,12 +1487,26 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// do while the reserve is saturated) and wants the re-run's numbers, so it is on that
 			// issue's candidate list rather than guessed at in this diff.
 			//
-			// Only for a slot that actually made a call. A single-flight FOLLOWER returns before
-			// filling its slot, so before is 0 there and the three lines below would book zeros —
-			// and set Accepted on a row whose Component is "" — for a splice that did happen. The
-			// follower's saving goes unbooked either way (its leader books the shared result once);
-			// what this guard removes is the pretence of measuring it.
-			if out[k].before > 0 {
+			// Only for a slot that actually MADE A CALL — a single-flight FOLLOWER returns before
+			// filling its slot, and Component is what says so (it is also what the ledger append
+			// below filters on, so the two agree by construction).
+			//
+			// A DEFENCE, NOT A FIX: nothing was escaping before it. ratioTracker.observe returns
+			// early on totalTok <= 0, both recorders are no-ops at 0, out[k].saved is already 0 in
+			// a follower slot, and a follower's row was dropped by the same Component filter. So
+			// this prevents no live defect, and saying otherwise would leave a future reader
+			// reasoning from a false premise. What it does buy is that the booking no longer
+			// depends on three unrelated zero-guards staying zero-guards, and that the condition is
+			// stated where the booking happens.
+			//
+			// Keyed on Component rather than on `before` deliberately: `before` is in scope in the
+			// follower branch, so anyone who later fills it there would silently re-enable this
+			// booking. Component cannot be set by a slot that made no call.
+			//
+			// The follower's saving stays UNBOOKED either way — its leader books the shared result
+			// once, and attributing it twice would over-count. Booking per spliced message rather
+			// than per call is the real fix and is larger than this change.
+			if calls[k].Component != "" {
 				calls[k].Accepted = true
 				calls[k].SavedTokens = out[k].saved
 				e.ratios.observe(out[k].saved, out[k].before)

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -794,7 +794,9 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		if !ok {
 			return
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			return // the store cannot back the marker; leave this output verbatim
+		}
 		schema.SetMessageText(&req.Input[i], newText)
 		changed++
 		if key != "" {

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -306,10 +306,15 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		// can never emit different bytes than the turn that decided it.
 		if cached, hit := getResult(c, id); hit {
 			metrics.RecordExtractionCacheLookup(rep.Component, true)
-			if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
-				metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
-			}
-			if k, ok := applySweepDrop(c, rep, e.mode, msg, content); ok {
+			// Inside the ok branch, with rep.Replay. It used to sit above the call, so a drop
+			// applySweepDrop declined still booked its token savings — and after #188 that
+			// call can decline for a new reason (the reserve), on precisely the runs where the
+			// savings figure is being measured. rep.Replay on this path was already guarded
+			// correctly; this is the metric matching it.
+			if k, ok := applySweepDropReplay(c, rep, e.mode, msg, content); ok {
+				if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
+					metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
+				}
 				changed++
 				if k != "" {
 					keys = append(keys, k)
@@ -475,17 +480,24 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		}
 		// Phase 3 (serial): freeze + splice.
 		for _, k := range drop {
-			desc := sweepDescriptor(cands[k].content)
+			// THE DROP FIRST, then the decision. putResult ran ahead of applySweepDrop, and
+			// once the reserve could refuse that left a frozen cg:res: record for a drop that
+			// never happened — the same dangling-decision-then-late-splice shape as
+			// extract_llm's phase 3: the same-session replay path above reads the record,
+			// bypasses the depth gate because the bytes were "already sent", and removes the
+			// output from inside the provider's cached prefix on some later turn.
+			key, ok := applySweepDrop(c, rep, e.mode, &req.Input[cands[k].i], cands[k].content)
+			if !ok {
+				continue
+			}
 			// Freeze the decision so every later turn replays it byte-for-byte from the same-session
 			// path above, at any depth. Session-scoped only: unlike a compaction, a drop is a
 			// judgement about THIS transcript's obligations, so it must never be served to another
 			// session whose agent may still need the output.
-			putResult(c, cands[k].id, desc, "")
-			if key, ok := applySweepDrop(c, rep, e.mode, &req.Input[cands[k].i], cands[k].content); ok {
-				changed++
-				if key != "" {
-					keys = append(keys, key)
-				}
+			putResult(c, cands[k].id, sweepDescriptor(cands[k].content), "")
+			changed++
+			if key != "" {
+				keys = append(keys, key)
 			}
 		}
 	}

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -305,8 +305,23 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		// came from a model, but the REPLACEMENT is a pure function of (content, config), so a replay
 		// can never emit different bytes than the turn that decided it.
 		// The cached VALUE is no longer read: the saving is measured against the message as
-		// replayed, not against the stored descriptor. Only the HIT matters here — it is what says
-		// this session already sent these bytes and may replay them at any depth.
+		// replayed, not against the stored descriptor. Only the HIT is consulted.
+		//
+		// WHAT THE HIT ACTUALLY PROVES, stated precisely because the depth bypass below rests on it
+		// and the key cannot carry the stronger claim. resultKey is cg:res:<session>:<id> — session
+		// and content hash, no component tag (state.go) — and extract_llm keys the same namespace
+		// off the same extract.ContentKey. The shipped `housellm` preset runs extract_llm
+		// immediately before this component in one pipeline (config/config.go), so a record written
+		// by extract_llm for content M is indistinguishable from one written here.
+		//
+		// So a hit proves "SOME component in this session recorded a decision for these bytes",
+		// not "this component already sent this descriptor". The bypass is still sound in practice —
+		// the replacement is a pure function of (content, config), so a replay emits the same bytes
+		// whichever component decided — but the sequence that would exercise the difference (M
+		// verbatim, at cached depth, with a live cg:res: from extract_llm and no marker on it) has
+		// not been constructed, and unreachability has not been established either. Filed rather
+		// than asserted here (#197); namespacing the record or storing a component tag would make
+		// the stronger claim true by construction.
 		if _, hit := getResult(c, id); hit {
 			metrics.RecordExtractionCacheLookup(rep.Component, true)
 			// Inside the ok branch, with rep.Replay. It used to sit above the call, so a drop
@@ -924,6 +939,9 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 	// judgedTokens is the adjudicator's OWN arithmetic, for the debug row only: what it believed
 	// it was freeing, descriptor-only and before phase 3 has had a chance to refuse any of it.
 	// Deliberately not the ledger's figure — see the rejection test below.
+	// spentJudged counts verdicts that said "drop", whether or not we then acted on them. See its
+	// increment for why the ledger's reason is derived from this rather than from the skip gates.
+	var spentJudged int
 	var judgedTokens int
 	for _, v := range verdicts {
 		if v.Label < 0 || v.Label >= len(cands) {
@@ -960,6 +978,18 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 		// but "the model judged this still needed" and "the model tried to remove something it had
 		// just said was needed" are different events, and folding the second into the keep total is
 		// what would make the alertable one invisible in the ratio an operator actually looks at.
+		// WHAT THE MODEL ANSWERED, not what validation concluded — and the difference is the whole
+		// point. extract.Judge returns early on a self-contradictory drop WITHOUT setting a.Drop
+		// (adjudicate.go: `RefusedObligation = true; return a`), so counting a.Drop alone misses
+		// precisely the path that made this reason wrong: a model answering "drop" with a needed_by
+		// for every candidate produced a ledger row saying the adjudicator found nothing spent.
+		//
+		// Counted before the skips below, because each of those is OUR decision not to act on a
+		// judgement the model did make. VerdictUnusable is deliberately NOT counted: there the model
+		// answered something other than drop or keep, so it did not judge the output spent.
+		if a.Drop || a.RefusedObligation {
+			spentJudged++
+		}
 		if a.RefusedObligation {
 			r.gate("sweep_drop_refused_obligation")
 			continue
@@ -1007,16 +1037,28 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 	// self-contradictory shape this change set out to remove, arrived at from the other side. The
 	// compiler cannot see it because `removed` is still read.
 	if len(drop) == 0 {
-		// THREE reasons, not two. `drop` being empty means the adjudicator judged nothing spent —
-		// UNLESS the never-worse pre-check above removed everything it did judge spent, which is
-		// reachable on a transcript of just-above-floor outputs whose shape descriptors are close
-		// to their own size. Reporting that as "nothing was spent" tells the operator the model
-		// found nothing worth removing when it found plenty and the descriptors were not smaller:
-		// the same conflation the two reasons exist to prevent, one path further back.
-		if r.raised("sweep_drop_would_not_shrink") {
-			r.rec.Rejection = "adjudicated spent, but no descriptor was smaller than its output"
-		} else {
+		// TWO QUESTIONS, and only the first is the adjudicator's: did the model judge anything
+		// spent, and if it did, why did none of it become a drop?
+		//
+		// Enumerating the second was the mistake. An earlier version tested only the never-worse
+		// pre-check and reported every other skip — refused obligation, unusable verdict, unknown
+		// or duplicate label — as "the adjudicator found nothing spent", which tells an operator
+		// the model saw nothing worth removing when it judged EVERY output spent and we declined
+		// each one. Concretely: a model that answers drop with a needed_by for every candidate
+		// trips RefusedObligation throughout and produced exactly that row.
+		//
+		// So the reason is derived from spentJudged, which cannot miss a skip path, and the GATES
+		// carry which skip it was — they are already raised, already exported, and unlike a
+		// hand-written reason string they stay correct when a skip is added.
+		// A verdict we could not key to an output (unknown or duplicate label) is skipped above
+		// before Judge runs, so its answer is unknown and it cannot be counted either way. It raises
+		// its own gate, which is the honest record: the reason below speaks only for verdicts that
+		// were actually read.
+		if spentJudged == 0 {
 			r.rec.Rejection = "adjudicated: nothing was spent"
+		} else {
+			r.rec.Rejection = fmt.Sprintf(
+				"adjudicated %d spent, but none became a drop (see gates)", spentJudged)
 		}
 	}
 	if debugExtractLLM(c) {

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -475,10 +475,8 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		for _, ev := range call.events {
 			rep.Event(ev)
 		}
-		if call.rec.Component != "" {
-			rep.Calls = append(rep.Calls, call.rec)
-		}
 		// Phase 3 (serial): freeze + splice.
+		applied := 0
 		for _, k := range drop {
 			// THE DROP FIRST, then the decision. putResult ran ahead of applySweepDrop, and
 			// once the reserve could refuse that left a frozen cg:res: record for a drop that
@@ -495,10 +493,34 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 			// judgement about THIS transcript's obligations, so it must never be served to another
 			// session whose agent may still need the output.
 			putResult(c, cands[k].id, sweepDescriptor(cands[k].content), "")
+			// Booked here, where the drop is a fact. rep.Replay on the replay path above was
+			// already guarded this way; the fresh path was not.
+			saved := schema.TextTokens(cands[k].content) -
+				schema.TextTokens(sweepDescriptor(cands[k].content))
+			if saved > 0 {
+				applied += saved
+				metrics.RecordExtractionSaving(rep.Component, saved)
+				metrics.RecordExtractionValue(rep.Component, float64(saved)*val.perToken)
+			}
 			changed++
 			if key != "" {
 				keys = append(keys, key)
 			}
+		}
+		// AFTER phase 3: rep.Calls takes a COPY of the row, and Accepted/SavedTokens are only
+		// knowable once the drops have been applied. `applied` is what reached the wire, which is
+		// the figure the ledger's own doc claims it carries.
+		if applied > 0 {
+			call.rec.Accepted = true
+			call.rec.SavedTokens = applied
+		} else if call.rec.Rejection == "" {
+			// The adjudicator named spent outputs and NONE of them could be dropped. Distinct
+			// from "nothing was spent", and it is the reserve-exhausted shape: without its own
+			// reason the row read as a plain rejection.
+			call.rec.Rejection = "adjudicated spent, but no drop could be applied"
+		}
+		if call.rec.Component != "" {
+			rep.Calls = append(rep.Calls, call.rec)
 		}
 	}
 
@@ -927,9 +949,12 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 		}
 		r.event("sweep_dropped")
 		drop = append(drop, v.Label)
-		removed += sz - after
-		metrics.RecordExtractionSaving(rep.Component, sz-after)
-		metrics.RecordExtractionValue(rep.Component, float64(sz-after)*savedTokenValue(c).perToken)
+		// NOT BOOKED HERE. A verdict is a decision, not a removal: phase 3 still has to apply it,
+		// and that can decline — the reserve refuses the payload, or the marker-inclusive
+		// never-worse check fails. The descriptor-only pre-check above catches neither (it is not
+		// marker-inclusive, and it cannot see the reserve at all), so a saturated reserve booked
+		// the full saving for outputs that went upstream untouched. Recorded in phase 3 instead,
+		// per candidate, once the drop is a fact.
 	}
 	// An output named in the inventory that no verdict mentioned is UNJUDGED, and it must not look
 	// like a keep: 4ca1f13 found a live arm where the model silently omitted labels and the missing
@@ -940,10 +965,11 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 			r.gate("sweep_verdict_missing")
 		}
 	}
-	if removed > 0 {
-		r.rec.Accepted = true
-		r.rec.SavedTokens = removed
-	} else {
+	// `removed` is what the ADJUDICATOR judged spent, which is why Accepted/SavedTokens are filled
+	// by the caller after phase 3 rather than here: they describe drops that actually happened, and
+	// the two numbers diverge exactly when the reserve is refusing. The rejection reason is still
+	// this function's to state — it is about the verdict, not about the splice.
+	if removed == 0 {
 		r.rec.Rejection = "adjudicated: nothing was spent"
 	}
 	if debugExtractLLM(c) {

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -495,8 +495,14 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 			putResult(c, cands[k].id, sweepDescriptor(cands[k].content), "")
 			// Booked here, where the drop is a fact. rep.Replay on the replay path above was
 			// already guarded this way; the fresh path was not.
+			//
+			// Measured against the message AS SPLICED, not against the descriptor. In markerFull
+			// the text written is descriptor + marker + recovery hint, so a descriptor-only
+			// subtraction overstates every candidate by the marker's tokens — and the comment
+			// below claims this figure is what reached the wire, which is the one thing a
+			// descriptor-only number is not.
 			saved := schema.TextTokens(cands[k].content) -
-				schema.TextTokens(sweepDescriptor(cands[k].content))
+				schema.TextTokens(schema.MessageText(req.Input[cands[k].i]))
 			if saved > 0 {
 				applied += saved
 				metrics.RecordExtractionSaving(rep.Component, saved)
@@ -895,7 +901,10 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 
 	var drop []int
 	seen := map[int]bool{}
-	var removed int
+	// judgedTokens is the adjudicator's OWN arithmetic, for the debug row only: what it believed
+	// it was freeing, descriptor-only and before phase 3 has had a chance to refuse any of it.
+	// Deliberately not the ledger's figure — see the rejection test below.
+	var judgedTokens int
 	for _, v := range verdicts {
 		if v.Label < 0 || v.Label >= len(cands) {
 			// A verdict for something we did not offer. NEVER acted on: the label is how a decision is
@@ -949,6 +958,7 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 		}
 		r.event("sweep_dropped")
 		drop = append(drop, v.Label)
+		judgedTokens += sz - after
 		// NOT BOOKED HERE. A verdict is a decision, not a removal: phase 3 still has to apply it,
 		// and that can decline — the reserve refuses the payload, or the marker-inclusive
 		// never-worse check fails. The descriptor-only pre-check above catches neither (it is not
@@ -965,17 +975,24 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 			r.gate("sweep_verdict_missing")
 		}
 	}
-	// `removed` is what the ADJUDICATOR judged spent, which is why Accepted/SavedTokens are filled
-	// by the caller after phase 3 rather than here: they describe drops that actually happened, and
-	// the two numbers diverge exactly when the reserve is refusing. The rejection reason is still
-	// this function's to state — it is about the verdict, not about the splice.
-	if removed == 0 {
+	// THE VERDICT SET, not a token total. Accepted/SavedTokens are filled by the caller after
+	// phase 3, because they describe drops that actually HAPPENED and the two diverge exactly when
+	// the reserve is refusing. What is this function's to state is whether the adjudicator judged
+	// anything spent at all — and `drop` IS that set, so it is what the test reads.
+	//
+	// It used to read `removed == 0`, and moving the metrics out of this loop deleted `removed`'s
+	// only assignment while leaving the read: Go then guarantees it stays 0, so EVERY adjudication
+	// stamped "nothing was spent", including ones that dropped content. A row could carry
+	// accepted=true, a large saved_tokens, and "nothing was spent" at once — the same
+	// self-contradictory shape this change set out to remove, arrived at from the other side. The
+	// compiler cannot see it because `removed` is still read.
+	if len(drop) == 0 {
 		r.rec.Rejection = "adjudicated: nothing was spent"
 	}
 	if debugExtractLLM(c) {
 		logging.From(c.Ctx).Debug("cg.sweep.ask", "offered", len(items),
 			"verdicts", len(verdicts), "dropped", len(drop), "candidate_tokens", before,
-			"removed_tokens", removed, "cache_read", usage.CacheRead, "fresh", usage.Fresh)
+			"removed_tokens", judgedTokens, "cache_read", usage.CacheRead, "fresh", usage.Fresh)
 	}
 	return drop, r
 }

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -304,7 +304,10 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		// That is what makes the replay safe in the sense TailOnlyCold's doc requires: the DECISION
 		// came from a model, but the REPLACEMENT is a pure function of (content, config), so a replay
 		// can never emit different bytes than the turn that decided it.
-		if cached, hit := getResult(c, id); hit {
+		// The cached VALUE is no longer read: the saving is measured against the message as
+		// replayed, not against the stored descriptor. Only the HIT matters here — it is what says
+		// this session already sent these bytes and may replay them at any depth.
+		if _, hit := getResult(c, id); hit {
 			metrics.RecordExtractionCacheLookup(rep.Component, true)
 			// Inside the ok branch, with rep.Replay. It used to sit above the call, so a drop
 			// applySweepDrop declined still booked its token savings — and after #188 that
@@ -312,7 +315,12 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 			// savings figure is being measured. rep.Replay on this path was already guarded
 			// correctly; this is the metric matching it.
 			if k, ok := applySweepDropReplay(c, rep, e.mode, msg, content); ok {
-				if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
+				// Measured against the message AS REPLAYED, for the same reason the fresh path is:
+				// the text written is descriptor + marker + hint. Correcting only the fresh path
+				// left this component contradicting ITSELF — the same drop valued higher on every
+				// replay turn than on the turn it was made, and replays are the steady state, so
+				// most of the reported value came from the overstated side.
+				if saved := schema.TextTokens(content) - schema.TextTokens(schema.MessageText(*msg)); saved > 0 {
 					metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
 				}
 				changed++
@@ -575,6 +583,18 @@ type sweepResult struct {
 
 func (r *sweepResult) gate(name string)  { r.gates = append(r.gates, name) }
 func (r *sweepResult) event(name string) { r.events = append(r.events, name) }
+
+// raised reports whether a gate was recorded. The gates are carried as a SLICE because the raise
+// happens on the serial path, so this is a scan rather than a map lookup — the list is one entry
+// per declined candidate, which is bounded by the inventory.
+func (r *sweepResult) raised(name string) bool {
+	for _, g := range r.gates {
+		if g == name {
+			return true
+		}
+	}
+	return false
+}
 
 // adjudicate makes ONE prefix ask about every candidate and returns the labels it authorised
 // dropping.
@@ -987,7 +1007,17 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 	// self-contradictory shape this change set out to remove, arrived at from the other side. The
 	// compiler cannot see it because `removed` is still read.
 	if len(drop) == 0 {
-		r.rec.Rejection = "adjudicated: nothing was spent"
+		// THREE reasons, not two. `drop` being empty means the adjudicator judged nothing spent —
+		// UNLESS the never-worse pre-check above removed everything it did judge spent, which is
+		// reachable on a transcript of just-above-floor outputs whose shape descriptors are close
+		// to their own size. Reporting that as "nothing was spent" tells the operator the model
+		// found nothing worth removing when it found plenty and the descriptors were not smaller:
+		// the same conflation the two reasons exist to prevent, one path further back.
+		if r.raised("sweep_drop_would_not_shrink") {
+			r.rec.Rejection = "adjudicated spent, but no descriptor was smaller than its output"
+		} else {
+			r.rec.Rejection = "adjudicated: nothing was spent"
+		}
 	}
 	if debugExtractLLM(c) {
 		logging.From(c.Ctx).Debug("cg.sweep.ask", "offered", len(items),

--- a/components/offload/extract_sweep_drop.go
+++ b/components/offload/extract_sweep_drop.go
@@ -85,6 +85,25 @@ func recordCount(content string) (int, bool) {
 // without this a drop just above the floor could grow the message it was meant to shrink.
 func applySweepDrop(c *components.Ctx, rep *components.Report, mode markerMode,
 	msg *bschemas.ChatMessage, content string) (key string, ok bool) {
+	return sweepDrop(c, rep, mode, msg, content, false)
+}
+
+// applySweepDropReplay is applySweepDrop for a drop THIS SESSION ALREADY MADE on an earlier
+// turn, replayed to keep the request prefix byte-stable.
+//
+// It exists because the two cases must answer a refused payload differently, and sharing one
+// function made them answer it the same way. A NEW drop declines — nothing has been promised
+// yet, so leaving the output verbatim costs only tokens. A REPLAY cannot decline: the provider's
+// cached prefix already holds the removed form, so sending the output back in full is itself the
+// cache-destructive move, and it cannot un-send the marker that went out turns ago. So the
+// replay proceeds and a missing payload is diagnosed rather than obeyed (see commitRefresh).
+func applySweepDropReplay(c *components.Ctx, rep *components.Report, mode markerMode,
+	msg *bschemas.ChatMessage, content string) (key string, ok bool) {
+	return sweepDrop(c, rep, mode, msg, content, true)
+}
+
+func sweepDrop(c *components.Ctx, rep *components.Report, mode markerMode,
+	msg *bschemas.ChatMessage, content string, replay bool) (key string, ok bool) {
 	desc := sweepDescriptor(content)
 	hint := " [full output: call " + expand.ToolName + "]"
 	newText, key, eff, ok := tryMark(c, mode, content, hint, func(tok string) string {
@@ -96,7 +115,10 @@ func applySweepDrop(c *components.Ctx, rep *components.Report, mode markerMode,
 	if !ok {
 		return "", false
 	}
-	if !commitMark(c, rep, eff, key, content) {
+	if replay {
+		commitRefresh(c, key, content) // never refuses; a false answer is counted as dangling
+		recordOwner(c, key)
+	} else if !commitMark(c, rep, eff, key, content) {
 		return "", false // the store cannot back the marker; the drop does not happen
 	}
 	schema.SetMessageText(msg, newText)

--- a/components/offload/extract_sweep_drop.go
+++ b/components/offload/extract_sweep_drop.go
@@ -96,7 +96,9 @@ func applySweepDrop(c *components.Ctx, rep *components.Report, mode markerMode,
 	if !ok {
 		return "", false
 	}
-	commitMark(c, rep, eff, key, content)
+	if !commitMark(c, rep, eff, key, content) {
+		return "", false // the store cannot back the marker; the drop does not happen
+	}
 	schema.SetMessageText(msg, newText)
 	return key, true
 }

--- a/components/offload/extract_sweep_drop.go
+++ b/components/offload/extract_sweep_drop.go
@@ -116,7 +116,9 @@ func sweepDrop(c *components.Ctx, rep *components.Report, mode markerMode,
 		return "", false
 	}
 	if replay {
-		commitRefresh(c, key, content) // never refuses; a false answer is counted as dangling
+		// Never refuses; a false answer is counted as dangling. Also sets rep.Irreversible in the
+		// degraded marker modes, which commitMark used to do on this path.
+		commitRefresh(c, rep, eff, key, content)
 		recordOwner(c, key)
 	} else if !commitMark(c, rep, eff, key, content) {
 		return "", false // the store cannot back the marker; the drop does not happen

--- a/components/offload/extract_sweep_test.go
+++ b/components/offload/extract_sweep_test.go
@@ -70,6 +70,15 @@ func (m *labelAsker) Ask(ctx context.Context, session, ask string) (string, comp
 // newSweep builds the component through its registered constructor, so the config surface under test
 // is the real one. The floor is above the filler outputs in sweepReq, so exactly the intended
 // candidates reach the inventory.
+//
+// IT PREPENDS ITS OWN min_tokens, so passing one in extraYAML does not override it — YAML rejects
+// the duplicate key and newExtractSweep fails with
+//
+//	yaml: unmarshal errors: line 3: mapping key "min_tokens" already defined at line 1
+//
+// which reads as a broken component rather than as a fixture mistake. A test that needs a different
+// floor — e.g. one BELOW the shape descriptor's own size, to reach the never-worse pre-check —
+// should call newExtractSweep directly rather than routing through here.
 func newSweep(t *testing.T, extraYAML string) *ExtractSweep {
 	t.Helper()
 	c, err := newExtractSweep([]byte("min_tokens: 2000\n" + extraYAML))

--- a/components/offload/failed_run.go
+++ b/components/offload/failed_run.go
@@ -169,7 +169,9 @@ func (fr *FailedRun) Offload(req *schemas.BifrostChatRequest, rep *components.Re
 			rep.Gate("marker_no_win") // collapse+marker wouldn't shrink this run
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(m, newText)
 		freeze(c, fr.Name(), content, newText) // freeze so later turns replay it (no churn)
 		changed++

--- a/components/offload/linecap.go
+++ b/components/offload/linecap.go
@@ -143,7 +143,9 @@ func (lc *Linecap) Offload(req *schemas.BifrostChatRequest, rep *components.Repo
 			rep.Gate("marker_no_win")
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(m, newText)
 		if key != "" {
 			keys = append(keys, key)

--- a/components/offload/marker.go
+++ b/components/offload/marker.go
@@ -152,9 +152,20 @@ func commitMark(c *components.Ctx, rep *components.Report, eff markerMode, key, 
 // left the store (the TTL reclaimed it) and the marker on the wire is dangling. That is the
 // genuinely broken promise, and it is counted apart from stashRefusals — see stashMissing for
 // why conflating them made the one dangerous outcome invisible.
-func commitRefresh(c *components.Ctx, key, original string) bool {
-	if key == "" {
-		return true // summary/off: no payload was ever promised
+func commitRefresh(c *components.Ctx, rep *components.Report, eff markerMode, key, original string) bool {
+	if eff != markerFull {
+		// THE DEGRADED MODES STILL NEED rep.Irreversible, and this is the whole reason the
+		// parameters are here. commitMark's non-full branch sets it, so when the replay branches
+		// stopped calling commitMark they stopped setting it — and a replay-only turn under
+		// marker_mode summary/off then spliced with no keys, rep.Skipped false and
+		// rep.Irreversible false, which is exactly the shape components/pipeline.go reverts as
+		// "offload dropped content without stashing a cache_key". The transcript went upstream
+		// verbatim on EVERY turn: a full-suffix cache write, the harm this change exists to stop.
+		//
+		// Owned here rather than at each call site because there are four of them and the last
+		// two got it wrong.
+		rep.Irreversible = true
+		return true
 	}
 	if !store.PutStash(c.Store, key, []byte(original)) {
 		stashMissing.Add(1)

--- a/components/offload/marker.go
+++ b/components/offload/marker.go
@@ -104,6 +104,21 @@ func tryMark(c *components.Ctx, mode markerMode, original, hint string, assemble
 // it with a marker", which is the bug. Leaving it verbatim costs tokens the pipeline wanted to
 // save and keeps the invariant CLAUDE.md states as a hard boundary — every lossy Offload is
 // reversible — true regardless of load.
+//
+// THE CALLER'S HALF OF THE CONTRACT, and it is an invariant rather than a courtesy: NOTHING
+// DERIVED FROM THE REMOVAL MAY BE RECORDED BEFORE THIS RETURNS TRUE. Not the splice, not a
+// frozen decision (putResult / putResultGlobal / freeze), not a metric, not a debug counter,
+// not rep.Replay, not a saved token figure. This function is now the only place that knows
+// whether the removal is happening at all, so anything written ahead of it describes work that
+// may not occur — and a frozen decision with no splice behind it is the SAME broken promise
+// one layer up: a later turn's replay path reads it, deliberately bypasses the cache-tail gate
+// on the reasoning that these bytes were already sent, and splices into a message that is by
+// then inside the provider's cached prefix, forcing a full-suffix cache write at ~11.5x the
+// read price. TestNoStateIsRecordedBeforeTheCommitGate holds every registered Offload to this.
+//
+// Replaying a decision ALREADY stamped and already sent is the other case, and it is not this
+// function — see commitRefresh, which never refuses because refusing there is itself the
+// cache-destructive move.
 func commitMark(c *components.Ctx, rep *components.Report, eff markerMode, key, original string) bool {
 	if eff == markerFull {
 		if !store.PutStash(c.Store, key, []byte(original)) {
@@ -115,6 +130,36 @@ func commitMark(c *components.Ctx, rep *components.Report, eff markerMode, key, 
 		return true
 	}
 	rep.Irreversible = true
+	return true
+}
+
+// commitRefresh refreshes the payload behind a marker THIS SESSION HAS ALREADY STAMPED AND
+// SENT, and reports whether the payload is actually there.
+//
+// It never refuses, and that is the point of it being a different function from commitMark.
+// The two look alike — both write a payload for a marker — but they sit on opposite sides of
+// the decision:
+//
+//   - commitMark is asked "may I make this promise?", and a no costs only the tokens the
+//     removal would have saved.
+//   - commitRefresh is telling the store about a promise ALREADY OUTSTANDING. The marker is in
+//     the provider's cached prefix. Declining here would mean sending the message verbatim
+//     instead — flipping already-cached content and re-writing the whole suffix — to protect a
+//     reversibility guarantee that a refusal cannot restore anyway, because the marker went out
+//     turns ago. So the replay always proceeds.
+//
+// The return value is therefore not a permission but a DIAGNOSIS: false means the payload has
+// left the store (the TTL reclaimed it) and the marker on the wire is dangling. That is the
+// genuinely broken promise, and it is counted apart from stashRefusals — see stashMissing for
+// why conflating them made the one dangerous outcome invisible.
+func commitRefresh(c *components.Ctx, key, original string) bool {
+	if key == "" {
+		return true // summary/off: no payload was ever promised
+	}
+	if !store.PutStash(c.Store, key, []byte(original)) {
+		stashMissing.Add(1)
+		return false
+	}
 	return true
 }
 
@@ -134,6 +179,29 @@ var stashRefusals atomic.Int64
 // was full. Non-zero means max_entries is too small for what this configuration removes;
 // the removals did not happen, so nothing became irreversible.
 func StashRefusals() int64 { return stashRefusals.Load() }
+
+// stashMissing counts REPLAYS of a marker whose payload has left the store — a dangling marker
+// that just went out on the wire.
+//
+// It is separate from stashRefusals because the two are opposite outcomes, and one shared
+// counter made the dangerous one unreadable. Every operator-facing description of a refusal —
+// /stats, cg_stash_refused_total, docs/reference/routes.md — promises that "the content was
+// left verbatim and nothing became irreversible". That is true of a declined removal and FALSE
+// of a dangling replay, which is the only case that actually breaks the guarantee #187 was
+// about. Counting them together meant the number an operator watches to confirm nothing broke
+// was incremented by things breaking.
+//
+// They also have different shapes over time. A refusal is one event per declined removal. A
+// missing payload cannot be restored — the replayed bytes must stay byte-identical to the turn
+// that created them — so it re-reports on every turn for every affected message: this counter
+// grows with TURN COUNT, not with distinct broken markers. Read it as "dangling replays are
+// happening", not as "N markers are dangling", and raise ttl_seconds rather than max_entries.
+var stashMissing atomic.Int64
+
+// StashMissing returns how many marker replays found no payload behind them. Non-zero means
+// markers ARE on the wire that the store cannot resolve — unlike StashRefusals, this is a
+// broken promise, and the leading indicator for expand_unresolved_missing.
+func StashMissing() int64 { return stashMissing.Load() }
 
 // markerModeField is the marker_mode descriptor, shared by every Offload that honors the
 // key. Declared once because the accepted values are parseMarkerMode's, above.

--- a/components/offload/marker.go
+++ b/components/offload/marker.go
@@ -1,9 +1,12 @@
 package offload
 
 import (
+	"sync/atomic"
+
 	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
 )
 
 // markerMode selects what an Offload component leaves behind in place of the
@@ -87,14 +90,50 @@ func tryMark(c *components.Ctx, mode markerMode, original, hint string, assemble
 // stash the original under key (full mode) or record the deliberate lossy drop
 // (summary/off set rep.Irreversible so the pipeline's "dropped without stashing"
 // guard doesn't revert them). Call only when tryMark returned ok.
-func commitMark(c *components.Ctx, rep *components.Report, eff markerMode, key, original string) {
+//
+// It reports whether the removal MAY PROCEED, and a caller that ignores the answer
+// reintroduces #187. In full mode the marker about to be written is a promise that the
+// original can be produced on request, so the stash write is the point at which that promise
+// is either backed or not: when the store's rewind reserve cannot take the payload
+// (store.PutStash false) there is nothing to serve, and stamping the marker anyway is how a
+// reversible removal silently became an irreversible one — 209 times in iteration 024's arm B,
+// where the agent asked for content back and got a placeholder.
+//
+// false therefore means REFUSE the removal: leave the content verbatim. Not "drop it without a
+// marker" (marker_mode: off), which is a lossy drop the operator did not ask for, and not "drop
+// it with a marker", which is the bug. Leaving it verbatim costs tokens the pipeline wanted to
+// save and keeps the invariant CLAUDE.md states as a hard boundary — every lossy Offload is
+// reversible — true regardless of load.
+func commitMark(c *components.Ctx, rep *components.Report, eff markerMode, key, original string) bool {
 	if eff == markerFull {
-		c.Store.Put(key, []byte(original))
+		if !store.PutStash(c.Store, key, []byte(original)) {
+			stashRefusals.Add(1)
+			rep.Gate("stash_reserve_exhausted")
+			return false
+		}
 		recordOwner(c, key) // scope GET /expand retrieval to this session
-		return
+		return true
 	}
 	rep.Irreversible = true
+	return true
 }
+
+// stashRefusals counts removals declined because the store could not hold the original.
+//
+// Process-wide, like frozenHits, and reported separately from the store's own
+// StashStats: the store counts refusals its reserve issued, this counts removals a
+// COMPONENT abandoned because of one, and the two differ whenever a caller consults the
+// answer and does something other than skip. It is the leading indicator for
+// expand_unresolved_missing — which cannot move until the agent happens to ask for
+// something — so a run that has quietly stopped being able to promise reversibility is
+// visible here at the moment the budget binds rather than whenever the model next calls
+// expand.
+var stashRefusals atomic.Int64
+
+// StashRefusals returns how many removals were declined because the store's rewind reserve
+// was full. Non-zero means max_entries is too small for what this configuration removes;
+// the removals did not happen, so nothing became irreversible.
+func StashRefusals() int64 { return stashRefusals.Load() }
 
 // markerModeField is the marker_mode descriptor, shared by every Offload that honors the
 // key. Declared once because the accepted values are parseMarkerMode's, above.

--- a/components/offload/mask.go
+++ b/components/offload/mask.go
@@ -116,7 +116,9 @@ func (m *Mask) Offload(req *bschemas.BifrostChatRequest, rep *components.Report,
 			rep.Gate("marker_no_win") // rewrite+marker wouldn't shrink this message
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(msg, newText)
 		freeze(c, m.Name(), content, newText) // freeze so later turns replay it (no churn)
 		changed++

--- a/components/offload/readlifecycle.go
+++ b/components/offload/readlifecycle.go
@@ -194,7 +194,9 @@ func (rl *ReadLifecycle) Offload(req *bschemas.BifrostChatRequest, rep *componen
 			rep.Gate("marker_no_win")
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(msg, newText)
 		freeze(c, rl.Name(), content, newText)
 		changed++

--- a/components/offload/skeleton.go
+++ b/components/offload/skeleton.go
@@ -178,7 +178,9 @@ func (s *Skeleton) Offload(req *schemas.BifrostChatRequest, rep *components.Repo
 			rep.Gate("marker_no_win") // skeleton+marker wouldn't shrink this message; leave it verbatim
 			continue
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(m, newText)
 		freeze(c, s.Name(), content, newText)
 		emitted++

--- a/components/offload/smartcrush.go
+++ b/components/offload/smartcrush.go
@@ -85,7 +85,9 @@ func (s *SmartCrush) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		if !ok {
 			continue // crushed array+marker wouldn't shrink this message; leave it verbatim
 		}
-		commitMark(c, rep, eff, key, content)
+		if !commitMark(c, rep, eff, key, content) {
+			continue // the store cannot back the marker; leave this message verbatim
+		}
 		schema.SetMessageText(msg, newText)
 		changed++
 		if key != "" {

--- a/components/offload/stashreserve_test.go
+++ b/components/offload/stashreserve_test.go
@@ -1,0 +1,181 @@
+package offload
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// wideOutput is a tool output linecap will certainly rewrite: one very long line.
+func wideOutput(tag string) string {
+	return "line " + tag + ": " + strings.Repeat(tag+"x", 900)
+}
+
+// Every marker in the REQUEST AS MARSHALLED must resolve.
+//
+// This is the invariant #187 broke, and it is asserted on the rendered bytes rather than on
+// the component's return value on purpose: a component can compute a key, hand it back to the
+// pipeline, and still have written a marker into the message — so a test that reads only the
+// returned keys would pass while the wire carried a marker nothing can serve. The store here
+// holds a 2-slot reserve against three large outputs, so the third removal MUST be refused,
+// and the message it would have cut MUST arrive verbatim.
+func TestNoMarkerReachesTheWireWithoutItsPayload(t *testing.T) {
+	st := store.NewMemory(store.Options{MaxEntries: 4}) // reserve = 2
+	comp, err := newLinecap([]byte("max_line_chars: 40\nmin_size: 10\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &bschemas.BifrostChatRequest{}
+	for _, tag := range []string{"a", "b", "c", "d", "e"} {
+		m := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleTool}
+		schema.SetMessageText(&m, wideOutput(tag))
+		req.Input = append(req.Input, m)
+	}
+	original := make([]string, len(req.Input))
+	for i := range req.Input {
+		original[i] = schema.MessageText(req.Input[i])
+	}
+	before := StashRefusals()
+	var rep components.Report
+	c := &components.Ctx{Ctx: context.Background(), Session: "s", Store: st, MaxCachedIdx: -1}
+	if _, err := comp.(*Linecap).Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+
+	// The rendered request, which is what the model actually reads. Scanned with the ESCAPED
+	// spelling as well as the plain one, because encoding/json HTML-escapes "<" by default and
+	// every marker is appended after a newline — so a marker the model reads as <<cg:HASH>>
+	// usually exists in the bytes on the wire only as \u003c\u003ccg:HASH\u003e\u003e. A test
+	// that scanned for the plain form alone would report zero markers on a body full of them
+	// and pass while the wire carried unbacked ones (expand.rawMarkerRe exists for the same
+	// reason, on the proxy's side of the same problem).
+	wire, err := json.Marshal(req.Input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wireMarkerRe := regexp.MustCompile(`(?:<|(?i:\\u003c)){2}cg:([A-Za-z0-9_-]{1,64})(?:>|(?i:\\u003e)){2}`)
+	var markers []string
+	for _, m := range wireMarkerRe.FindAllStringSubmatch(string(wire), -1) {
+		markers = append(markers, m[1])
+	}
+	if len(markers) == 0 {
+		t.Fatal("the fixture produced no markers at all, so it cannot show whether an " +
+			"unbacked one reaches the wire — check the linecap config")
+	}
+	for _, id := range markers {
+		if _, ok := expand.Resolve(st, id); !ok {
+			t.Errorf("marker <<cg:%s>> is in the marshalled request and resolves to NOTHING: "+
+				"the model is being told it can retrieve content this proxy cannot produce. "+
+				"That is expand_unresolved_missing, from the inside (#187)", id)
+		}
+	}
+	if len(markers) > 2 {
+		t.Errorf("%d markers reached the wire against a 2-payload reserve; a refused removal "+
+			"must leave the message VERBATIM, not stamp a marker anyway", len(markers))
+	}
+	// And the refusal is counted, so an operator sees the budget bind at the moment it binds
+	// rather than whenever the model next happens to call expand.
+	if got := StashRefusals() - before; got == 0 {
+		t.Error("StashRefusals() did not move while removals were being declined; nothing " +
+			"upstream of expand_unresolved_missing reports an exhausted reserve")
+	}
+	// Whatever was left verbatim must still be its original text — refusing is "leave it
+	// alone", not "cut it and say nothing".
+	verbatim := 0
+	for i := range req.Input {
+		txt := schema.MessageText(req.Input[i])
+		if expand.HasPlaceholder(txt) {
+			continue
+		}
+		verbatim++
+		if txt != original[i] {
+			t.Errorf("message %d carries no marker and is not its original text either: a "+
+				"refused removal turned into a silent lossy drop, which is the other way to "+
+				"break the invariant", i)
+		}
+	}
+	if verbatim == 0 {
+		t.Error("every message was rewritten, so no removal was refused; the reserve did not bind")
+	}
+}
+
+// cmdfilter builds its marker token inline instead of calling commitMark, so the reserve
+// contract has to be honored a second time in that file — which is exactly the kind of
+// second copy a fix forgets. One filtered output, a reserve with no room at all, and the
+// message must arrive unchanged rather than carrying a marker nothing can serve.
+func TestCmdfilterRefusesRatherThanStampingAnUnbackedMarker(t *testing.T) {
+	// The pip advisory pair: a real captured output the shipped filters match.
+	const pipNag = "WARNING: Running pip as the 'root' user can result in broken permissions and " +
+		"conflicting behaviour with the system package manager, possibly rendering your system " +
+		"unusable. It is recommended to use a virtual environment instead: " +
+		"https://pip.pypa.io/warnings/venv\n" +
+		"WARNING: You are using pip version 21.0.1; however, version 23.0.1 is available.\n" +
+		"You should consider upgrading via the '/usr/bin/python3 -m pip install --upgrade pip' command.\n"
+	comp, err := newCmdfilter([]byte("min_size: 1\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A reserve of zero slots: max_entries 1 => stashCap 0, so no payload can ever be held.
+	st := store.NewMemory(store.Options{MaxEntries: 1})
+	req := &bschemas.BifrostChatRequest{Provider: bschemas.Anthropic,
+		Input: []bschemas.ChatMessage{cmdToolMsg(pipNag)}}
+	c := &components.Ctx{Ctx: context.Background(), Session: "s", Store: st, MaxCachedIdx: -1}
+	var rep components.Report
+	if _, err := comp.(components.Offload).Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.MessageText(req.Input[0])
+	if expand.HasPlaceholder(got) {
+		for _, id := range expand.ParseMarkers(got) {
+			if _, ok := expand.Resolve(st, id); !ok {
+				t.Errorf("cmdfilter stamped <<cg:%s>> with a reserve of zero slots; the payload "+
+					"is nowhere and the filter was not reversible", id)
+			}
+		}
+	}
+	if got != pipNag {
+		t.Errorf("cmdfilter rewrote the output although its original could not be stored:\n%q", got)
+	}
+}
+
+// summarize REPLACES the span it covers, so it cannot leave "this message" verbatim the way
+// the per-message offloaders can — refusing means skipping the checkpoint entirely. The
+// failure it must not have is emitting the summary anyway, since the marker inside it is then
+// the only route back to a span that is no longer in the transcript at all.
+func TestSummarizeSkipsTheCheckpointWhenTheSpanCannotBeStashed(t *testing.T) {
+	s := newSummarizeKeepLast(t, 1)
+	st := store.NewMemory(store.Options{MaxEntries: 1}) // reserve = 0 slots
+	msgs := []bschemas.ChatMessage{
+		{Role: bschemas.ChatMessageRoleUser},
+		callMsg("t1"), bulkResult("t1"),
+		callMsg("t2"), bulkResult("t2"),
+		callMsg("t3"), bulkResult("t3"),
+	}
+	schema.SetMessageText(&msgs[0], "fix the failing tests")
+	req := &bschemas.BifrostChatRequest{Input: append([]bschemas.ChatMessage(nil), msgs...)}
+	c := &components.Ctx{Ctx: context.Background(), Session: "s", Store: st, MaxCachedIdx: -1}
+	var rep components.Report
+	if _, err := s.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	if len(req.Input) != len(msgs) {
+		t.Errorf("summarize restructured the transcript (%d messages, was %d) although the span "+
+			"it replaced could not be stashed: the summary's marker is the only route back to a "+
+			"span that is now gone", len(req.Input), len(msgs))
+	}
+	for i := range req.Input {
+		for _, id := range expand.ParseMarkers(schema.MessageText(req.Input[i])) {
+			if _, ok := expand.Resolve(st, id); !ok {
+				t.Errorf("message %d carries <<cg:%s>> and the store cannot produce it", i, id)
+			}
+		}
+	}
+}

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -245,7 +245,7 @@ func reapplyFrozen(c *components.Ctx, rep *components.Report, comp string, m *bs
 		// cannot un-send the marker — and commitRefresh counts it as stash_missing, which is
 		// the counter for a broken promise. It used to increment stashRefusals, the counter
 		// whose whole operator-facing meaning is "nothing became irreversible".
-		commitRefresh(c, k, content)
+		commitRefresh(c, rep, markerFull, k, content)
 	}
 	schema.SetMessageText(m, rs)
 	return keys, saved, true

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -238,7 +238,14 @@ func reapplyFrozen(c *components.Ctx, rep *components.Report, comp string, m *bs
 		rep.Irreversible = true
 	}
 	for _, k := range keys {
-		c.Store.Put(k, []byte(content)) // refresh the stashed original for expand
+		// Refresh the stashed original for expand. A key already present is always
+		// retained (see store.Stasher), so a refusal means this replayed decision's
+		// payload had already left the store — the replacement bytes must still be
+		// replayed verbatim (declining would flip an already-cached message), so the
+		// marker stays and the refusal is counted instead of hidden.
+		if !store.PutStash(c.Store, k, []byte(content)) {
+			stashRefusals.Add(1)
+		}
 	}
 	schema.SetMessageText(m, rs)
 	return keys, saved, true

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -238,14 +238,14 @@ func reapplyFrozen(c *components.Ctx, rep *components.Report, comp string, m *bs
 		rep.Irreversible = true
 	}
 	for _, k := range keys {
-		// Refresh the stashed original for expand. A key already present is always
-		// retained (see store.Stasher), so a refusal means this replayed decision's
-		// payload had already left the store — the replacement bytes must still be
-		// replayed verbatim (declining would flip an already-cached message), so the
-		// marker stays and the refusal is counted instead of hidden.
-		if !store.PutStash(c.Store, k, []byte(content)) {
-			stashRefusals.Add(1)
-		}
+		// Refresh the stashed original for expand. A key already present is always retained
+		// (see store.Stasher), so a false answer means this replayed decision's payload had
+		// already left the store: the marker about to go out is DANGLING. The replacement
+		// bytes are replayed anyway — declining would flip an already-cached message and
+		// cannot un-send the marker — and commitRefresh counts it as stash_missing, which is
+		// the counter for a broken promise. It used to increment stashRefusals, the counter
+		// whose whole operator-facing meaning is "nothing became irreversible".
+		commitRefresh(c, k, content)
 	}
 	schema.SetMessageText(m, rs)
 	return keys, saved, true

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -171,18 +171,47 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// that checkpoint is still small — no LLM call, and the summary message stays
 	// byte-identical (KV-cache stable). Roll the checkpoint forward only once the
 	// tail grows past resummarize_tokens.
-	if out, keys, ok := s.tryReuse(c, msgs, headCount, start, end); ok {
-		if len(keys) == 0 {
+	reusedMsgs, reusedKeys, reused, stale := s.tryReuse(c, msgs, headCount, start, end)
+	if reused {
+		if len(reusedKeys) == 0 {
 			rep.Irreversible = true // reused a non-full checkpoint (nothing stashed)
 		}
-		req.Input = out
-		return keys, nil
+		req.Input = reusedMsgs
+		return reusedKeys, nil
 	}
 
 	span := msgs[start:end]
 	if schema.MessagesTokens(&bschemas.BifrostChatRequest{Input: span}) < s.minTokens {
 		rep.Skipped = true
 		return nil, nil
+	}
+
+	// THE RESERVE IS CONSULTED BEFORE THE MODEL CALL, not after it.
+	//
+	// The span is all the marker key depends on (key = hashKey(spanJSON)), and the payload is
+	// the span itself — so nothing about the stash needs the summary to exist. The check used
+	// to sit after s.summarize, which meant a saturated reserve paid the call (measured at ~57k
+	// prompt tokens) and threw the result away, then did it again on the NEXT turn, and every
+	// turn after, because a refusal saves no checkpoint and so changes nothing about the next
+	// turn's inputs. Asking first turns an unbounded stream of wasted calls into a skip.
+	//
+	// A probe, not a claim: StashRoom reserves nothing, so the real PutStash below can still
+	// refuse if another session took the slot in between. That is a rare race rather than the
+	// steady state, and it lands on the same refusal path. Claiming the slot up here instead
+	// would leak one payload's worth of reserve every time the model call then failed — the
+	// resource this whole change exists to protect.
+	mode := effectiveMode(c, s.mode)
+	var spanJSON []byte
+	var key string
+	if mode == markerFull {
+		var err error
+		if spanJSON, err = json.Marshal(span); err != nil {
+			return nil, err
+		}
+		key = hashKey(string(spanJSON))
+		if !store.StashRoom(c.Store, len(spanJSON)) {
+			return s.refuse(c, rep, req, msgs, headCount, start, stale)
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(c.Ctx, summarizeCallTimeout)
@@ -209,23 +238,17 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// pipeline's dropped-without-stash guard permits it.
 	// full is reversible only if the store persists the stash; otherwise degrade
 	// to an irreversible off-style drop (no unresolvable marker).
-	mode := effectiveMode(c, s.mode)
-	var key string
 	if mode == markerFull {
-		spanJSON, err := json.Marshal(span)
-		if err != nil {
-			return nil, err
-		}
-		key = hashKey(string(spanJSON))
 		// A summary REPLACES the span it covers, so the marker in the summary text is the
 		// only route back to it. If the store's rewind reserve cannot hold the span, this
 		// component must not summarize at all: unlike the per-message offloaders it cannot
 		// leave "this message" verbatim, so refusing means skipping the whole checkpoint.
+		//
+		// Reachable despite the StashRoom probe above (the probe claims nothing and another
+		// session can take the slot in between), which is why the refusal path still exists
+		// here — the probe removes the steady-state waste, not the race.
 		if !store.PutStash(c.Store, key, spanJSON) {
-			stashRefusals.Add(1)
-			rep.Gate("stash_reserve_exhausted")
-			rep.Skipped = true
-			return nil, nil
+			return s.refuse(c, rep, req, msgs, headCount, start, stale)
 		}
 	} else {
 		rep.Irreversible = true
@@ -276,49 +299,75 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	return nil, nil
 }
 
-// tryReuse re-emits the previous summary if (1) a checkpoint exists, (2) the
-// covered prefix (msgs[1:1+CoveredCount]) is byte-unchanged, and (3) the tail
-// since that boundary is below resummarize_tokens. It returns the rebuilt
-// [msg0, priorSummary, msgs[boundary:]] and the (refreshed) stash key. No LLM
-// call. ok=false means "re-summarize fresh".
-func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, headCount, start, end int) ([]bschemas.ChatMessage, []string, bool) {
-	if s.resummarizeTokens <= 0 {
-		return nil, nil, false
+// refuse is what summarize does when the rewind reserve will not hold the span: no new
+// checkpoint is made, and the transcript is left in the most cache-stable shape available.
+//
+// That last part is the whole reason this is a function rather than `return nil, nil`. Plain
+// `nil, nil` sends the transcript FULL, and when this session had already emitted a checkpoint
+// on earlier turns — [msg0, summary, tail] — that is a flip of already-cached content in the
+// exact direction #188 exists to avoid, triggered by #188's own new refusal path. The provider
+// re-writes the whole suffix at ~11.5x the read price, for a request that saves nothing.
+//
+// So when a checkpoint is STALE-BUT-VALID (tryReuse confirmed the covered prefix is
+// byte-unchanged and declined only because the tail grew past resummarize_tokens), re-emit it.
+// Rolling it forward was an improvement that is now unavailable; the old checkpoint's bytes are
+// still the ones the provider has cached. A checkpoint that is absent or genuinely diverged has
+// nothing to fall back to, and there the full transcript is correct: nothing was cached in the
+// summarized shape.
+func (s *Summarize) refuse(c *components.Ctx, rep *components.Report, req *bschemas.BifrostChatRequest,
+	msgs []bschemas.ChatMessage, headCount, start int, stale bool) ([]string, error) {
+	stashRefusals.Add(1)
+	rep.Gate("stash_reserve_exhausted")
+	if !stale {
+		rep.Skipped = true
+		return nil, nil
 	}
 	cp, ok := loadCheckpoint(c)
 	if !ok || cp.CoveredCount <= 0 {
-		return nil, nil, false
+		rep.Skipped = true
+		return nil, nil // nothing to fall back to
 	}
 	boundary := start + cp.CoveredCount
-	if boundary > end { // covered prefix would overlap the kept tail — can't reuse
-		return nil, nil, false
+	if boundary > len(msgs) {
+		rep.Skipped = true
+		return nil, nil
 	}
-	covered := msgs[start:boundary]
-	if spanHash(covered) != cp.CoveredHash {
-		return nil, nil, false // prefix diverged (different session / edited) → fresh
-	}
-	// The un-summarized middle since the checkpoint (excludes the kept last-K).
-	if schema.MessagesTokens(&bschemas.BifrostChatRequest{Input: msgs[boundary:end]}) >= s.resummarizeTokens {
-		return nil, nil, false // grown enough — roll the checkpoint forward
-	}
-	// Refresh the stashed original span so expand keeps resolving it (full-mode
-	// checkpoints only — summary/off never stashed, so Key is empty).
+	// The stash refresh, and the reason it is a refresh rather than a new claim: this payload
+	// was accepted on the turn the checkpoint was made, so a key already present is retained
+	// whatever the reserve says (see store.Stasher) and this cannot be the thing that refuses.
+	// A false answer means the payload has since expired and the replayed marker is dangling —
+	// counted as stash_missing, and the replay proceeds because the summary text must stay
+	// byte-identical to the turn that created it.
 	if cp.Key != "" {
-		if b, err := json.Marshal(covered); err == nil {
-			// A refresh of a key already present always succeeds (see store.Stasher), so a
-			// refusal here means the payload had ALREADY left the store — the marker in the
-			// replayed summary is dangling and cannot be un-dangled, because the summary
-			// text must stay byte-identical to the turn that created it. Count it; the
-			// alternative (re-summarizing to avoid the marker) is the cache-write this
-			// checkpoint exists to prevent.
-			if !store.PutStash(c.Store, cp.Key, b) {
-				stashRefusals.Add(1)
-			}
+		if b, err := json.Marshal(msgs[start:boundary]); err == nil {
+			commitRefresh(c, cp.Key, string(b))
 		}
 	}
-	// USER for the same reason as the fresh-summary path above: a system role at index 1
-	// is rejected by the provider. The replayed checkpoint must match that shape exactly,
-	// or a replayed turn would emit different bytes from the turn that created it.
+	out, keys := s.emitCheckpoint(cp, msgs, headCount, boundary)
+	if len(keys) == 0 {
+		rep.Irreversible = true
+	}
+	rep.Event("reserve_exhausted_replayed_checkpoint")
+	// The component DID act — it rewrote the transcript — so it is not Skipped. Saying
+	// otherwise would report a turn that emitted a summary as a turn that did nothing.
+	replaced := len(msgs) - len(out)
+	if replaced <= 0 {
+		rep.Skipped = true
+		return nil, nil
+	}
+	req.Input = out
+	return keys, nil
+}
+
+// emitCheckpoint builds [head, priorSummary, msgs[boundary:]] from a checkpoint, with the
+// boundary walked past any leading tool messages and orphaned tool_results dropped. Shared by
+// tryReuse and the refusal fallback so a replayed checkpoint is byte-identical whichever path
+// emits it — a difference between them would itself be a cache flip.
+func (s *Summarize) emitCheckpoint(cp sumCheckpoint, msgs []bschemas.ChatMessage,
+	headCount, boundary int) ([]bschemas.ChatMessage, []string) {
+	// USER for the same reason as the fresh-summary path: a system role at index 1 is rejected
+	// by the provider. The replayed checkpoint must match that shape exactly, or a replayed
+	// turn would emit different bytes from the turn that created it.
 	summaryMsg := bschemas.ChatMessage{Role: bschemas.ChatMessageRoleUser}
 	schema.SetMessageText(&summaryMsg, cp.SummaryMsg)
 	// The replayed boundary must respect exchange atomicity exactly as the fresh path does,
@@ -336,9 +385,61 @@ func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, hea
 		out = repaired
 	}
 	if cp.Key != "" {
-		return out, []string{cp.Key}, true
+		return out, []string{cp.Key}
 	}
-	return out, nil, true
+	return out, nil
+}
+
+// tryReuse re-emits the previous summary if (1) a checkpoint exists, (2) the
+// covered prefix (msgs[1:1+CoveredCount]) is byte-unchanged, and (3) the tail
+// since that boundary is below resummarize_tokens. It returns the rebuilt
+// [msg0, priorSummary, msgs[boundary:]] and the (refreshed) stash key. No LLM
+// call. ok=false means "re-summarize fresh".
+//
+// stale reports WHICH kind of ok=false this was: true means the checkpoint is still VALID and
+// only the size test declined it (the tail grew past resummarize_tokens), so re-emitting it is
+// still byte-correct. The fresh path needs that distinction, because if it cannot produce a new
+// checkpoint its only cache-safe fallback is the old one — see the refusal path in Offload.
+func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, headCount, start, end int) (out []bschemas.ChatMessage, keys []string, ok, stale bool) {
+	if s.resummarizeTokens <= 0 {
+		return nil, nil, false, false
+	}
+	cp, ok := loadCheckpoint(c)
+	if !ok || cp.CoveredCount <= 0 {
+		return nil, nil, false, false
+	}
+	boundary := start + cp.CoveredCount
+	if boundary > end { // covered prefix would overlap the kept tail — can't reuse
+		return nil, nil, false, false
+	}
+	covered := msgs[start:boundary]
+	if spanHash(covered) != cp.CoveredHash {
+		return nil, nil, false, false // prefix diverged (different session / edited) → fresh
+	}
+	// The un-summarized middle since the checkpoint (excludes the kept last-K).
+	if schema.MessagesTokens(&bschemas.BifrostChatRequest{Input: msgs[boundary:end]}) >= s.resummarizeTokens {
+		// STALE, not invalid: the prefix hash matched just above, so this checkpoint is still a
+		// faithful summary of msgs[start:boundary] and re-emitting it produces the same bytes
+		// earlier turns sent. Rolling it forward is merely BETTER, so a fresh attempt that
+		// cannot complete may fall back to it instead of sending the transcript full.
+		return nil, nil, false, true
+	}
+	// Refresh the stashed original span so expand keeps resolving it (full-mode
+	// checkpoints only — summary/off never stashed, so Key is empty).
+	if cp.Key != "" {
+		if b, err := json.Marshal(covered); err == nil {
+			// A refresh of a key already present always succeeds (see store.Stasher), so a
+			// false answer here means the payload had ALREADY left the store — the marker in
+			// the replayed summary is dangling and cannot be un-dangled, because the summary
+			// text must stay byte-identical to the turn that created it. Counted as
+			// stash_missing (a broken promise) rather than stash_refused (a removal declined);
+			// the alternative, re-summarizing to avoid the marker, is the cache-write this
+			// checkpoint exists to prevent.
+			commitRefresh(c, cp.Key, string(b))
+		}
+	}
+	emitted, ks := s.emitCheckpoint(cp, msgs, headCount, boundary)
+	return emitted, ks, true, false
 }
 
 // summarize builds the trajectory string and asks the model once (bounded retry).

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
 )
 
 func init() { components.Register("summarize", newSummarize) }
@@ -216,7 +217,16 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 			return nil, err
 		}
 		key = hashKey(string(spanJSON))
-		c.Store.Put(key, spanJSON)
+		// A summary REPLACES the span it covers, so the marker in the summary text is the
+		// only route back to it. If the store's rewind reserve cannot hold the span, this
+		// component must not summarize at all: unlike the per-message offloaders it cannot
+		// leave "this message" verbatim, so refusing means skipping the whole checkpoint.
+		if !store.PutStash(c.Store, key, spanJSON) {
+			stashRefusals.Add(1)
+			rep.Gate("stash_reserve_exhausted")
+			rep.Skipped = true
+			return nil, nil
+		}
 	} else {
 		rep.Irreversible = true
 	}
@@ -295,7 +305,15 @@ func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, hea
 	// checkpoints only — summary/off never stashed, so Key is empty).
 	if cp.Key != "" {
 		if b, err := json.Marshal(covered); err == nil {
-			c.Store.Put(cp.Key, b)
+			// A refresh of a key already present always succeeds (see store.Stasher), so a
+			// refusal here means the payload had ALREADY left the store — the marker in the
+			// replayed summary is dangling and cannot be un-dangled, because the summary
+			// text must stay byte-identical to the turn that created it. Count it; the
+			// alternative (re-summarizing to avoid the marker) is the cache-write this
+			// checkpoint exists to prevent.
+			if !store.PutStash(c.Store, cp.Key, b) {
+				stashRefusals.Add(1)
+			}
 		}
 	}
 	// USER for the same reason as the fresh-summary path above: a system role at index 1

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -171,7 +171,7 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// that checkpoint is still small — no LLM call, and the summary message stays
 	// byte-identical (KV-cache stable). Roll the checkpoint forward only once the
 	// tail grows past resummarize_tokens.
-	reusedMsgs, reusedKeys, reused, stale := s.tryReuse(c, msgs, headCount, start, end)
+	reusedMsgs, reusedKeys, reused, stale := s.tryReuse(c, rep, msgs, headCount, start, end)
 	if reused {
 		if len(reusedKeys) == 0 {
 			rep.Irreversible = true // reused a non-full checkpoint (nothing stashed)
@@ -340,7 +340,7 @@ func (s *Summarize) refuse(c *components.Ctx, rep *components.Report, req *bsche
 	// byte-identical to the turn that created it.
 	if cp.Key != "" {
 		if b, err := json.Marshal(msgs[start:boundary]); err == nil {
-			commitRefresh(c, cp.Key, string(b))
+			commitRefresh(c, rep, markerFull, cp.Key, string(b))
 		}
 	}
 	out, keys := s.emitCheckpoint(cp, msgs, headCount, boundary)
@@ -400,7 +400,8 @@ func (s *Summarize) emitCheckpoint(cp sumCheckpoint, msgs []bschemas.ChatMessage
 // only the size test declined it (the tail grew past resummarize_tokens), so re-emitting it is
 // still byte-correct. The fresh path needs that distinction, because if it cannot produce a new
 // checkpoint its only cache-safe fallback is the old one — see the refusal path in Offload.
-func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, headCount, start, end int) (out []bschemas.ChatMessage, keys []string, ok, stale bool) {
+func (s *Summarize) tryReuse(c *components.Ctx, rep *components.Report, msgs []bschemas.ChatMessage,
+	headCount, start, end int) (out []bschemas.ChatMessage, keys []string, ok, stale bool) {
 	if s.resummarizeTokens <= 0 {
 		return nil, nil, false, false
 	}
@@ -435,7 +436,7 @@ func (s *Summarize) tryReuse(c *components.Ctx, msgs []bschemas.ChatMessage, hea
 			// stash_missing (a broken promise) rather than stash_refused (a removal declined);
 			// the alternative, re-summarizing to avoid the marker, is the cache-write this
 			// checkpoint exists to prevent.
-			commitRefresh(c, cp.Key, string(b))
+			commitRefresh(c, rep, markerFull, cp.Key, string(b))
 		}
 	}
 	emitted, ks := s.emitCheckpoint(cp, msgs, headCount, boundary)

--- a/components/offload/summarymodereplay_test.go
+++ b/components/offload/summarymodereplay_test.go
@@ -31,6 +31,17 @@ import (
 // working: it acts, it computes a replacement, and the pipeline throws it away afterwards.
 //
 // Found while auditing replay paths for a related review; the defect is independent of that work.
+//
+// NOT A SUBSTITUTE for the `mask via reapplyFrozen` subtest of
+// TestADegradedModeReplayDeclaresItselfIrreversible, and do not delete that one as redundant to
+// this. The two have different SUBJECTS that happen to share an assertion: this asserts a property
+// of reapplyFrozen, while the subtest asserts that all four replay branches are held to the same
+// assertion through the same helper — uniformity, not the property.
+//
+// They fail differently, which is the test of whether both are needed. Special-case the helper so it
+// suits extract_llm and extract_sweep_drop but not reapplyFrozen and the table catches it while this
+// test stays green; break reapplyFrozen itself and both fire. Dropping the subtest loses the first
+// case entirely, and that is the case that matters for a helper three other branches depend on.
 func TestASummaryModeReplayIsNotRevertedFromTurnTwoOnward(t *testing.T) {
 	body := strings.Repeat("a line of log output that goes on for a while\n", 60)
 	st := store.NewMemory(store.Options{})

--- a/dash/redact.go
+++ b/dash/redact.go
@@ -79,7 +79,8 @@ var configAllowlist = map[string]bool{
 	"preset": true, "pipeline": true, "mode": true, "cache_mode": true,
 	"inject_expand": true, "store": true, "components": true,
 	"store_enabled": true, "store_ttl_seconds": true, "store_max_entries": true,
-	"listen_addr": true, "openai_upstream": true, "anthropic_upstream": true,
+	"store_stash_max_bytes": true,
+	"listen_addr":           true, "openai_upstream": true, "anthropic_upstream": true,
 	"bob_upstream": true, "force_model": true, "cheap_model": true,
 	"cheap_model_provider": true, "cheap_model_base": true,
 	"dashboard": true, "db_path": true, "retention": true, "capture_content": true,
@@ -88,7 +89,7 @@ var configAllowlist = map[string]bool{
 	"strategy": true, "source": true, "model": true, "trigger": true,
 	"min_request_tokens": true, "llm_every_n_requests": true, "llm_max_per_request": true,
 	"marker_mode": true, "min_items": true, "keep_first": true, "keep_last": true,
-	"enabled": true, "ttl_seconds": true, "max_entries": true,
+	"enabled": true, "ttl_seconds": true, "max_entries": true, "stash_max_bytes": true,
 }
 
 // openKeys name subtrees whose immediate child keys are USER-CHOSEN and therefore

--- a/docs/design.md
+++ b/docs/design.md
@@ -201,9 +201,11 @@ lossy — the known TTL edge, much narrower now the TTL slides on every read (se
 ## State: the Store
 
 One `Store` interface, in-memory TTL+LRU default (both hosts share it). Defaults: **10000s sliding
-TTL, 1000 entries, 100 sticky sessions**. It carries, keyed per session:
+TTL, 5000 entries, a 256 MiB rewind reserve, 100 sticky sessions**. It carries, keyed per session:
 
-- **Rewind** — `cache_key → original bytes` (what the expand loop resolves).
+- **Rewind** — `cache_key → original bytes` (what the expand loop resolves). Held in a reserve
+  that **refuses** rather than evicting a live payload, because the marker naming it has already
+  been sent: see the [config reference](reference/config.md#store).
 - **Sticky** — the set of content ids already reduced on prior turns (for byte-stable output
   across turns; scaffolding for cache stability).
 
@@ -625,7 +627,7 @@ pipeline: [format, dedup, failed_run, cmdfilter, cachesplit]   # order + enable
 components:
   collapse:   { max_tokens: 2000, head_lines: 20, tail_lines: 20 }
   smartcrush: { min_items: 5, keep_first: 3, keep_last: 2 }
-store: { ttl_seconds: 10000, max_entries: 1000 }
+store: { ttl_seconds: 10000, max_entries: 5000 }
 ```
 
 A component registers its constructor + config type via `init()`; adding one makes it

--- a/docs/how-to/recover-context.md
+++ b/docs/how-to/recover-context.md
@@ -52,17 +52,21 @@ sequenceDiagram
 ## Recovery needs the store
 
 The store *is* the reversibility mechanism. It defaults to in-memory TTL+LRU — 10000s
-sliding TTL (refreshed on every read), 1000 entries, 100 sticky sessions — and holds, per
-session:
+sliding TTL (refreshed on every read), 5000 entries, a 256 MiB rewind reserve, 100 sticky
+sessions — and holds, per session:
 
-- **Rewind** — `cache_key → original bytes`, what the expand loop resolves.
+- **Rewind** — `cache_key → original bytes`, what the expand loop resolves. These live in a
+  **reserve** that is never evicted to admit a new payload: once a marker has been sent the
+  promise is outstanding, so a full reserve makes the pipeline **decline the next removal**
+  (counted as `stash_refused`) instead of quietly breaking an older one.
 - **Sticky** — content ids already reduced on earlier turns, so output stays byte-stable
   across turns.
 - **Frozen decisions** — the exact replacement bytes an offloader replays so an
   already-cached message stays byte-identical. These are pinned against eviction: losing one
   flips a message inside the provider's cached prefix and rewrites the whole suffix at
-  ~11.5× the read price. The pin is capped at half `max_entries` so one session cannot
-  starve the rewind stashes.
+  ~11.5× the read price. The pin is capped at half `max_entries`, and pins plus rewind
+  payloads together leave a quarter of `max_entries` always evictable, so neither exemption
+  can starve the other or the plain cache.
 
 Set `store.enabled: false` and offloads become **one-way** — nothing is stashed and nothing
 can be recovered. The [llm-d compaction service](../examples/llm-d-service.md) does this
@@ -73,8 +77,11 @@ deliberately (with `marker_mode: off`) so `/compact` returns a clean, marker-fre
 
 **The model called expand and got a placeholder back.** The original expired or was evicted
 from the store. The provider requires one `tool_result` per `tool_call_id`, so an explicit
-placeholder is sent rather than nothing — which turns that offload lossy. Raise
-`store.ttl` / `store.max_entries` if you see it often.
+placeholder is sent rather than nothing — which turns that offload lossy. Check `stash_missing`
+and `stash_expired` at [`/stats`](../reference/routes.md#get-stats): both mean a payload left the
+store, so raise `store.ttl_seconds`. `stash_refused` is the *other* case and needs
+`store.max_entries` or `store.stash_max_bytes` — there nothing became irreversible, because the
+removals were declined.
 
 The turn still **completes**: the placeholder continuation is sent even when *nothing*
 resolved, so the model reads "no longer available" and finishes with text. It used to replay

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -24,8 +24,36 @@ The document has six top-level fields (from the `Config` struct in
 |---|---|---|
 | `enabled` | `true` | Toggles the state store. `false` wires a `store.Nop`: nothing is stashed, so offloads become **one-way** and must run `marker_mode: off`. |
 | `ttl_seconds` | `10000` | Entry lifetime, and it **slides** — a `Get` refreshes the deadline, so an entry replayed every turn never ages out. Raised from 1800 because Terminal-Bench tasks average ~1975 s of wall clock and run to 4 h, so the old default expired live frozen decisions mid-task. |
-| `max_entries` | `1000` | LRU cap. Frozen-decision keys (`cg:frz:`, `cg:res:`, `cg:len:`) are **pinned** — exempt from LRU eviction, because losing one is cache-destructive rather than merely a miss. The pin is capped at half `max_entries`, and eviction reclaims **expired** entries first (pinned included). |
+| `max_entries` | `5000` | LRU cap. Two groups of keys are **exempt** from LRU eviction, and they behave differently when full — see below. Eviction reclaims **expired** entries first, exempt ones included. Raised from 1,000: one process-wide store serves every concurrent session, and a single reversible removal writes five entries (the payload, `cg:own:`, `cg:xseen:`, and the two pinned decision records), so 1,000 was an order of magnitude under the observed volume. |
+| `stash_max_bytes` | `268435456` (256 MiB) | What the **rewind reserve** may cost in memory. Entries are a poor proxy for it in this one namespace: every other exempt entry is a marker line or an integer, a rewind payload is a whole tool output. Whichever of `max_entries` and this binds first, binds. |
 | `max_sessions` | `100` | Cap on per-session sticky-id sets. |
+
+#### The two exemptions, and the floor under them
+
+**Pinned decisions** (`cg:frz:`, `cg:res:`, `cg:xres:`, `cg:len:`, `cg:ttl:`, `cg:seen:`) are
+exempt because losing one is cache-destructive rather than merely a miss: the replacement bytes
+for an already-cached message stop being reproducible, so the message flips and the provider
+re-writes the whole suffix at ~11.5x the read price. Over its cap a pin simply becomes an
+ordinary evictable entry.
+
+**The rewind reserve** holds the payloads behind `<<cg:HASH>>` markers. It cannot be a pin
+prefix — a payload key *is* the marker id, a bare content hash the model reads out of the
+request — so it is claimed explicitly and, unlike a pin, a payload that cannot be admitted is
+**refused**: the component declines the removal and leaves the content verbatim rather than
+stamping a marker nothing can resolve. Only the TTL releases a slot.
+
+Each exemption is capped at half `max_entries`, and **a quarter of `max_entries` is held back
+from both** so something is always evictable. Without that floor the two could occupy the whole
+cap, and a cache with nothing evictable does not fail loudly: the next write to an unpinned
+namespace is evicted by its own insert, silently turning `cg:keep:` (the flag that stops the
+expand loop), `cg:sum:` (summarize checkpoints) and `cg:own:` (which gates `GET /expand`) into
+no-ops.
+
+**When `stash_refused` rises**, raise `max_entries` or `stash_max_bytes` — read `stash_live`
+against `stash_capacity` and `stash_bytes` against `stash_max_bytes` at
+[`/stats`](routes.md#get-stats) to see which budget bound. Nothing became irreversible: the
+removals did not happen. `stash_missing` is the different, worse number — a marker replayed with
+no payload behind it — and its fix is `ttl_seconds`.
 
 The pinned prefixes are a code-level property of the key layout, supplied by their owners via
 `store.Options.PinPrefixes` — not a YAML knob.
@@ -64,7 +92,7 @@ components:
   collapse:   { max_tokens: 2000, head_lines: 20, tail_lines: 20 }
   smartcrush: { min_items: 5, keep_first: 3, keep_last: 2 }
   cmdfilter:  { min_size: 400 }   # the default; measured, see components/cmdfilter.md
-store: { ttl_seconds: 10000, max_entries: 1000 }
+store: { ttl_seconds: 10000, max_entries: 5000 }
 mode: sync                          # sync | observe
 ```
 

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -195,6 +195,23 @@ A healthy long-horizon run shows `frozen_hits` climbing with turn count and `fro
 0; a rising `frozen_dropped` means decisions are dying mid-session (TTL too short for the task,
 or the entry cap too small for the session's working set).
 
+### Rewind reserve (reversibility health)
+
+The store holds the **originals** behind `<<cg:HASH>>` markers in a reserve of its own — half the
+entry cap — that LRU pressure cannot evict. Before #187 those payloads shared the cache's evictable
+half with per-removal bookkeeping while the *decisions* naming them were pinned, so the more a
+configuration removed the more of its own reversibility it destroyed, silently.
+
+| Field | Meaning |
+|---|---|
+| `stash_live` / `stash_capacity` | Payloads held now, and the reserve's size (`max_entries / 2`). `live` approaching `capacity` is the warning. |
+| `stash_refused` | Removals **declined** because the reserve was full. The content was left verbatim and nothing became irreversible — raise `max_entries`. |
+| `stash_expired` | Payloads reclaimed by the TTL. The one remaining way an outstanding marker stops resolving — raise `ttl_seconds`. |
+
+`stash_refused` is the **leading** indicator for `expand_unresolved_missing`: that counter cannot
+move until the agent happens to call `expand`, so a proxy that had stopped being able to promise
+reversibility read as perfectly healthy until one did. This one moves when the budget binds.
+
 ### cmdfilter attribution
 
 | Field | Meaning |

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -197,20 +197,32 @@ or the entry cap too small for the session's working set).
 
 ### Rewind reserve (reversibility health)
 
-The store holds the **originals** behind `<<cg:HASH>>` markers in a reserve of its own — half the
-entry cap — that LRU pressure cannot evict. Before #187 those payloads shared the cache's evictable
-half with per-removal bookkeeping while the *decisions* naming them were pinned, so the more a
-configuration removed the more of its own reversibility it destroyed, silently.
+The store holds the **originals** behind `<<cg:HASH>>` markers in a reserve of its own that LRU
+pressure cannot evict, bounded by two budgets: half the entry cap, and `stash_max_bytes`. Before
+#187 those payloads shared the cache's evictable half with per-removal bookkeeping while the
+*decisions* naming them were pinned, so the more a configuration removed the more of its own
+reversibility it destroyed, silently.
 
 | Field | Meaning |
 |---|---|
-| `stash_live` / `stash_capacity` | Payloads held now, and the reserve's size (`max_entries / 2`). `live` approaching `capacity` is the warning. |
-| `stash_refused` | Removals **declined** because the reserve was full. The content was left verbatim and nothing became irreversible — raise `max_entries`. |
-| `stash_expired` | Payloads reclaimed by the TTL. The one remaining way an outstanding marker stops resolving — raise `ttl_seconds`. |
+| `stash_live` / `stash_capacity` | Payloads held now, and the reserve's entry cap (`max_entries / 2`). `live` approaching `capacity` is the warning. |
+| `stash_bytes` / `stash_max_bytes` | What those payloads cost, and the byte budget (`stash_max_bytes`). Entries are a poor proxy for memory here — a payload is a whole tool output, every other exempt entry is a marker line — so read both pairs to see **which** budget bound. |
+| `stash_refused` | Removals **declined** because the reserve was full. The content was left verbatim and nothing became irreversible — raise `max_entries` or `stash_max_bytes`. |
+| `stash_missing` | Marker replays that found **no payload** behind them: a dangling `<<cg:HASH>>` went upstream. This one *is* a broken promise — raise `ttl_seconds`. |
+| `stash_expired` | Payloads reclaimed by the TTL. With `stash_missing`, the remaining way an outstanding marker stops resolving — raise `ttl_seconds`. |
 
 `stash_refused` is the **leading** indicator for `expand_unresolved_missing`: that counter cannot
 move until the agent happens to call `expand`, so a proxy that had stopped being able to promise
 reversibility read as perfectly healthy until one did. This one moves when the budget binds.
+
+**Do not read `stash_refused` and `stash_missing` as the same thing.** They are opposite outcomes,
+and they were one counter until the #188 review pointed out that made the safe case
+indistinguishable from the dangerous one. A refusal means a removal did **not** happen — the
+content went upstream verbatim, and the cost is tokens. A missing payload means a marker went out
+with nothing behind it, which is the failure #187 was about. Alert on `stash_missing`; watch
+`stash_refused`. `stash_missing` also grows with **turn count** rather than with distinct dangling
+markers: a payload that has gone cannot be restored (the replayed bytes must stay byte-identical to
+the turn that created them), so every later turn re-reports it for every affected message.
 
 ### cmdfilter attribution
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -758,15 +758,29 @@ type Snapshot struct {
 	// the arm where the sweep was inert).
 	//
 	// StashRefused counts removals DECLINED because the reserve was full: content left
-	// verbatim, nothing became irreversible, and the fix is a larger max_entries.
+	// verbatim, nothing became irreversible, and the fix is a larger max_entries (or
+	// stash_max_bytes — read Bytes against MaxBytes to see which budget bound).
+	//
+	// StashMissing is the OPPOSITE outcome and must not be read as a refusal: a marker was
+	// replayed with no payload behind it, so a dangling marker went out on the wire. It is the
+	// one case here that genuinely breaks reversibility. The two shared a counter until the
+	// #188 review, which meant the number an operator watches to confirm nothing broke was
+	// being incremented by things breaking. It also grows with TURN COUNT rather than with
+	// distinct broken markers — a missing payload cannot be restored, so every later turn
+	// re-reports it for every affected message.
+	//
 	// StashExpired counts payloads the TTL reclaimed, which is the one remaining way an
 	// outstanding marker stops resolving; the fix for that is a larger ttl_seconds. Live
-	// against Capacity says how close the reserve is to binding before either fires.
+	// against Capacity, and Bytes against MaxBytes, say how close each budget is to binding
+	// before any of them fires.
 	// Filled by the host at serve time (offload + store live below metrics).
 	StashRefused  int64 `json:"stash_refused"`
+	StashMissing  int64 `json:"stash_missing"`
 	StashExpired  int64 `json:"stash_expired"`
 	StashLive     int   `json:"stash_live"`
 	StashCapacity int   `json:"stash_capacity"`
+	StashBytes    int64 `json:"stash_bytes"`
+	StashMaxBytes int64 `json:"stash_max_bytes"`
 	// CompactionResets counts turns whose cached-prefix boundary restarted because the
 	// AGENT compacted its own transcript (it shrank under a stable session id). The
 	// session id deliberately survives that compaction so one conversation is one

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -751,6 +751,22 @@ type Snapshot struct {
 	FrozenDropped  int64 `json:"frozen_dropped"`
 	FrozenRepaired int64 `json:"frozen_repaired"`
 	FrozenFlips    int64 `json:"frozen_flips"`
+	// Rewind-reserve health — the REVERSIBILITY cost line, and the leading indicator for
+	// expand_unresolved_missing. That counter can only move when the agent happens to ask
+	// for removed content, so a run whose store could no longer hold payloads read as
+	// perfectly healthy until it did (#187: 209 failed expands in one benchmark arm, 0 in
+	// the arm where the sweep was inert).
+	//
+	// StashRefused counts removals DECLINED because the reserve was full: content left
+	// verbatim, nothing became irreversible, and the fix is a larger max_entries.
+	// StashExpired counts payloads the TTL reclaimed, which is the one remaining way an
+	// outstanding marker stops resolving; the fix for that is a larger ttl_seconds. Live
+	// against Capacity says how close the reserve is to binding before either fires.
+	// Filled by the host at serve time (offload + store live below metrics).
+	StashRefused  int64 `json:"stash_refused"`
+	StashExpired  int64 `json:"stash_expired"`
+	StashLive     int   `json:"stash_live"`
+	StashCapacity int   `json:"stash_capacity"`
 	// CompactionResets counts turns whose cached-prefix boundary restarted because the
 	// AGENT compacted its own transcript (it shrank under a stable session id). The
 	// session id deliberately survives that compaction so one conversation is one

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -502,22 +502,38 @@ func (h *Handler) renderMetrics() string {
 			dropped, repaired := fl.FrozenLossStats()
 			promLine(&b, "cg_frozen_decisions_total", `outcome="dropped"`, float64(dropped))
 			promLine(&b, "cg_frozen_decisions_total", `outcome="repaired"`, float64(repaired))
-			live, capacity, _, expired := fl.StashStats()
+			st := fl.StashStats()
 			promHeaderProc(&b, "cg_stash_reserve_entries",
 				"Rewind payloads (the originals behind <<cg:HASH>> markers) held now, and the reserve's size. live approaching capacity is the warning; reaching it turns into declined removals, not broken markers.", "gauge")
-			promLine(&b, "cg_stash_reserve_entries", `state="live"`, float64(live))
-			promLine(&b, "cg_stash_reserve_entries", `state="capacity"`, float64(capacity))
+			promLine(&b, "cg_stash_reserve_entries", `state="live"`, float64(st.Live))
+			promLine(&b, "cg_stash_reserve_entries", `state="capacity"`, float64(st.Capacity))
+			// The reserve's OTHER budget, and the one that binds first for large payloads: a
+			// payload is a whole tool output while every other exempt entry is a marker line, so
+			// an entry count alone names a memory figure anywhere across two orders of
+			// magnitude. Paired with the entry gauge so an operator can see WHICH budget bound
+			// and therefore which knob to turn.
+			promHeaderProc(&b, "cg_stash_reserve_bytes",
+				"What the held rewind payloads cost, and the reserve's byte budget (stash_max_bytes). Read against cg_stash_reserve_entries: entries near capacity means raise max_entries, bytes near the budget means raise stash_max_bytes.", "gauge")
+			promLine(&b, "cg_stash_reserve_bytes", `state="live"`, float64(st.Bytes))
+			promLine(&b, "cg_stash_reserve_bytes", `state="capacity"`, float64(st.MaxBytes))
 			promHeaderProc(&b, "cg_stash_expired_total",
 				"Rewind payloads reclaimed by the TTL. The one remaining way an outstanding marker stops resolving; raise ttl_seconds.", "counter")
-			promLine(&b, "cg_stash_expired_total", "", float64(expired))
+			promLine(&b, "cg_stash_expired_total", "", float64(st.Expired))
 		}
 		// Process-wide, so outside the cast for the same reason hit/miss are: a component
 		// declines the removal, whichever store instance refused the payload. This is the
 		// LEADING indicator for cg_expand_unresolved_total{cause="missing"}, which cannot move
 		// until the agent happens to call expand.
 		promHeaderProc(&b, "cg_stash_refused_total",
-			"Removals declined because the store's rewind reserve was full. The content was left verbatim and nothing became irreversible; raise max_entries.", "counter")
+			"Removals declined because the store's rewind reserve was full. The content was left verbatim and nothing became irreversible; raise max_entries or stash_max_bytes.", "counter")
 		promLine(&b, "cg_stash_refused_total", "", float64(offload.StashRefusals()))
+		// The counter that means the promise DID break, kept apart from the one above because
+		// the help text above makes a guarantee this case violates. Alert on this one; watch
+		// that one. It grows with turn count rather than with distinct dangling markers,
+		// because a payload that has gone cannot be restored and every later turn replays it.
+		promHeaderProc(&b, "cg_stash_missing_total",
+			"Marker replays that found NO payload behind them: a dangling <<cg:HASH>> went upstream, so this is a broken reversibility promise rather than a declined removal. Raise ttl_seconds. Grows per turn per affected message, not per distinct marker.", "counter")
+		promLine(&b, "cg_stash_missing_total", "", float64(offload.StashMissing()))
 
 		// Same rule as the two families above, and this counter would have had the same bug:
 		// Snapshot.AdjudicateStray is filled only by the /stats handler (proxy.go), so a promLine

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -502,7 +502,22 @@ func (h *Handler) renderMetrics() string {
 			dropped, repaired := fl.FrozenLossStats()
 			promLine(&b, "cg_frozen_decisions_total", `outcome="dropped"`, float64(dropped))
 			promLine(&b, "cg_frozen_decisions_total", `outcome="repaired"`, float64(repaired))
+			live, capacity, _, expired := fl.StashStats()
+			promHeaderProc(&b, "cg_stash_reserve_entries",
+				"Rewind payloads (the originals behind <<cg:HASH>> markers) held now, and the reserve's size. live approaching capacity is the warning; reaching it turns into declined removals, not broken markers.", "gauge")
+			promLine(&b, "cg_stash_reserve_entries", `state="live"`, float64(live))
+			promLine(&b, "cg_stash_reserve_entries", `state="capacity"`, float64(capacity))
+			promHeaderProc(&b, "cg_stash_expired_total",
+				"Rewind payloads reclaimed by the TTL. The one remaining way an outstanding marker stops resolving; raise ttl_seconds.", "counter")
+			promLine(&b, "cg_stash_expired_total", "", float64(expired))
 		}
+		// Process-wide, so outside the cast for the same reason hit/miss are: a component
+		// declines the removal, whichever store instance refused the payload. This is the
+		// LEADING indicator for cg_expand_unresolved_total{cause="missing"}, which cannot move
+		// until the agent happens to call expand.
+		promHeaderProc(&b, "cg_stash_refused_total",
+			"Removals declined because the store's rewind reserve was full. The content was left verbatim and nothing became irreversible; raise max_entries.", "counter")
+		promLine(&b, "cg_stash_refused_total", "", float64(offload.StashRefusals()))
 
 		// Same rule as the two families above, and this counter would have had the same bug:
 		// Snapshot.AdjudicateStray is filled only by the /stats handler (proxy.go), so a promLine

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rossoctl/context-guru/components/offload"
 	"github.com/rossoctl/context-guru/expand"
 	"github.com/rossoctl/context-guru/internal/adjudicate"
 	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/store"
 )
 
 // TestEverySnapshotFieldIsExportedOrExempt.
@@ -92,9 +94,12 @@ var notExportedWhy = map[string]string{
 	"FrozenDropped":             `cg_frozen_decisions_total{outcome="dropped"}, from store.Memory.FrozenLossStats()`,
 	"FrozenRepaired":            `cg_frozen_decisions_total{outcome="repaired"}, from store.Memory.FrozenLossStats()`,
 	"StashRefused":              "cg_stash_refused_total, from offload.StashRefusals()",
+	"StashMissing":              "cg_stash_missing_total, from offload.StashMissing()",
 	"StashExpired":              "cg_stash_expired_total, from store.Memory.StashStats()",
 	"StashLive":                 `cg_stash_reserve_entries{state="live"}, from store.Memory.StashStats()`,
 	"StashCapacity":             `cg_stash_reserve_entries{state="capacity"}, from store.Memory.StashStats()`,
+	"StashBytes":                `cg_stash_reserve_bytes{state="live"}, from store.Memory.StashStats()`,
+	"StashMaxBytes":             `cg_stash_reserve_bytes{state="capacity"}, from store.Memory.StashStats()`,
 	"Extract":                   "the cg_extract_* family, from metrics.ExtractSnapshot()",
 
 	// Not numbers. Prometheus has no string sample, and a list of names would have to
@@ -242,4 +247,57 @@ func containsLine(body, line string) bool {
 		}
 	}
 	return false
+}
+
+// TestStashReserveSeriesRender applies the same guard as TestExpandUnresolvedSeriesRender and
+// TestAdjudicateStraySeriesRender to the two series #188's review added, and for the same reason
+// those two exist: TestEverySnapshotFieldIsExportedOrExempt cannot catch a dropped series. By its
+// own documented design it checks that the exporter READS a field, and both of these are read
+// live from their owner (store.Memory.StashStats, offload.StashMissing) rather than off `s`, so
+// they are listed in notExportedWhy and the reflection check never looks at them at all.
+//
+// Two properties, and the second is the one a coverage map cannot express:
+//
+//  1. The lines RENDER, so an operator can build a dashboard panel before anything has gone wrong.
+//  2. cg_stash_missing_total MOVES with the counter behind it. A dangling marker is the one
+//     reserve outcome that genuinely breaks reversibility, so a series that renders a hard-wired
+//     zero would be worse than no series: it is the panel that says "nothing broke".
+func TestStashReserveSeriesRender(t *testing.T) {
+	h := New(nil, nil, metrics.NewAggregator(), Options{})
+	// A real store, so the reserve gauges have something to report. Without one the whole block
+	// is skipped (the handler casts to *store.Memory) and the byte gauge would be absent for a
+	// reason unrelated to the exporter.
+	h.store = store.NewMemory(store.Options{MaxEntries: 100, StashMaxBytes: 4096})
+	body := h.renderMetrics()
+	for _, want := range []string{
+		`cg_stash_reserve_bytes{state="live"} 0`,
+		`cg_stash_reserve_bytes{state="capacity"} 4096`,
+		`cg_stash_reserve_entries{state="capacity"} 50`,
+	} {
+		if !containsLine(body, want) {
+			t.Errorf("/metrics is missing the line %q: an operator told to raise a budget "+
+				"cannot see which budget bound", want)
+		}
+	}
+	// The byte gauge must read the STORE, not a snapshot field the aggregator never fills.
+	st := h.store.(*store.Memory)
+	if !st.PutStash("aaaaaaaaaaaaaaa1", make([]byte, 512)) {
+		t.Fatal("the fixture's payload was refused, so the gauge has nothing to move")
+	}
+	if containsLine(h.renderMetrics(), `cg_stash_reserve_bytes{state="live"} 0`) {
+		t.Error(`cg_stash_reserve_bytes{state="live"} still reads 0 after a payload was stored: ` +
+			`the series is not reading the store's own accounting`)
+	}
+
+	// cg_stash_missing_total: renders, and moves. Baseline-relative because StashMissing is a
+	// process-wide counter shared with every other test in this binary.
+	before := offload.StashMissing()
+	if !containsLine(h.renderMetrics(), fmt.Sprintf("cg_stash_missing_total %d", before)) {
+		t.Errorf("/metrics does not render cg_stash_missing_total at %d; the one reserve outcome "+
+			"that breaks a promise has no series", before)
+	}
+	if help := helpLine(h.renderMetrics(), "cg_stash_missing_total"); !strings.Contains(help, "dangling") {
+		t.Errorf("HELP does not distinguish a dangling marker from a declined removal, which is "+
+			"the whole reason this counter is separate from cg_stash_refused_total:\n  %s", help)
+	}
 }

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -91,6 +91,10 @@ var notExportedWhy = map[string]string{
 	"FrozenMisses":              `cg_frozen_decisions_total{outcome="miss"}, from offload.FrozenStats()`,
 	"FrozenDropped":             `cg_frozen_decisions_total{outcome="dropped"}, from store.Memory.FrozenLossStats()`,
 	"FrozenRepaired":            `cg_frozen_decisions_total{outcome="repaired"}, from store.Memory.FrozenLossStats()`,
+	"StashRefused":              "cg_stash_refused_total, from offload.StashRefusals()",
+	"StashExpired":              "cg_stash_expired_total, from store.Memory.StashStats()",
+	"StashLive":                 `cg_stash_reserve_entries{state="live"}, from store.Memory.StashStats()`,
+	"StashCapacity":             `cg_stash_reserve_entries{state="capacity"}, from store.Memory.StashStats()`,
 	"Extract":                   "the cg_extract_* family, from metrics.ExtractSnapshot()",
 
 	// Not numbers. Prometheus has no string sample, and a list of names would have to

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1906,10 +1906,16 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 	// Process-wide, like FrozenHits, and so filled outside the cast below: a removal declined
 	// for want of a stash slot is counted by the COMPONENT, whatever store instance refused it.
 	snap.StashRefused = offload.StashRefusals()
+	// The dangling-marker counter, process-wide for the same reason: it is a COMPONENT that
+	// replayed a marker whose payload had gone, whichever store instance lost it. Reported
+	// separately from StashRefused because they are opposite outcomes — see metrics.Snapshot.
+	snap.StashMissing = offload.StashMissing()
 	if fl, ok := h.store.(*store.Memory); ok { // process store; hosted per-tenant stores report via the dashboard
 		snap.FrozenDropped, snap.FrozenRepaired = fl.FrozenLossStats()
 		snap.FrozenFlips = snap.FrozenDropped - snap.FrozenRepaired
-		snap.StashLive, snap.StashCapacity, _, snap.StashExpired = fl.StashStats()
+		st := fl.StashStats()
+		snap.StashLive, snap.StashCapacity, snap.StashExpired = st.Live, st.Capacity, st.Expired
+		snap.StashBytes, snap.StashMaxBytes = st.Bytes, st.MaxBytes
 	}
 	// Cached-prefix restarts after an agent compaction. Same layering as the pool counters
 	// below: the counter lives in `modes`, so the host merges it here.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1903,9 +1903,13 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 	// the description stopped working — which nothing else in this snapshot can reveal.
 	snap.AdjudicateStray = adjudicate.StrayAnswered()
 	snap.FrozenHits, snap.FrozenMisses = offload.FrozenStats()
+	// Process-wide, like FrozenHits, and so filled outside the cast below: a removal declined
+	// for want of a stash slot is counted by the COMPONENT, whatever store instance refused it.
+	snap.StashRefused = offload.StashRefusals()
 	if fl, ok := h.store.(*store.Memory); ok { // process store; hosted per-tenant stores report via the dashboard
 		snap.FrozenDropped, snap.FrozenRepaired = fl.FrozenLossStats()
 		snap.FrozenFlips = snap.FrozenDropped - snap.FrozenRepaired
+		snap.StashLive, snap.StashCapacity, _, snap.StashExpired = fl.StashStats()
 	}
 	// Cached-prefix restarts after an agent compaction. Same layering as the pool counters
 	// below: the counter lives in `modes`, so the host merges it here.

--- a/proxy/stashreserve_test.go
+++ b/proxy/stashreserve_test.go
@@ -1,0 +1,130 @@
+package proxy_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rossoctl/context-guru/config"
+	"github.com/rossoctl/context-guru/metrics"
+	"github.com/rossoctl/context-guru/proxy"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// The rewind reserve, end to end through the handler (#187).
+//
+// Two things are asserted on RENDERED output rather than on any in-process value, because both
+// have a handler between the value and the reader and that is where this class of bug lives:
+//
+//   - the body that reaches the UPSTREAM must not carry a <<cg:HASH>> marker whose payload the
+//     store cannot serve. The model reads that body; a component's return value is not what the
+//     model reads, and #187 was precisely a marker on the wire with nothing behind it.
+//   - /stats must actually publish the exhaustion. `stash_refused` is filled by the /stats
+//     handler after the aggregator snapshot is taken, so a correctly-counted refusal can be
+//     dropped on the way out — the same shape as the frozen_* family, which exported a
+//     permanent 0 for exactly that reason.
+func TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself(t *testing.T) {
+	var sent atomic.Value // the last body the upstream received
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent.Store(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer upstream.Close()
+
+	// max_entries 4 => a 2-payload reserve, against five large tool outputs. Every component
+	// in the pipeline is an Offload whose marker_mode defaults to full, so the sixth removal
+	// onwards has nowhere to put its original.
+	cfg, err := config.LoadBytes([]byte("pipeline: [linecap]\ncomponents:\n  linecap: {max_line_chars: 40, min_size: 10}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg := metrics.NewAggregator()
+	pipe, err := cfg.Build(agg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.NewMemory(store.Options{MaxEntries: 4})
+	h := proxy.New(pipe, st, agg, proxy.Options{OpenAIUpstream: upstream.URL, AnthropicUpstream: upstream.URL})
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	msgs := []map[string]any{{"role": "user", "content": "go"}}
+	for _, tag := range []string{"a", "b", "c", "d", "e"} {
+		msgs = append(msgs, map[string]any{
+			"role": "tool", "tool_call_id": tag,
+			"content": "line " + tag + ": " + strings.Repeat(tag+"q", 900),
+		})
+	}
+	body, err := json.Marshal(map[string]any{"model": "gpt-x", "messages": msgs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(srv.URL+"/openai/v1/chat/completions", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	wire, _ := sent.Load().(string)
+	if wire == "" {
+		t.Fatal("the upstream received nothing, so there is no rendered request to assert on")
+	}
+	// Both spellings: encoding/json HTML-escapes "<", and every marker is written after a
+	// newline, so on the wire a marker usually exists only as \u003c\u003ccg:HASH\u003e\u003e.
+	markerRe := regexp.MustCompile(`(?:<|(?i:\\u003c)){2}cg:([A-Za-z0-9_-]{1,64})(?:>|(?i:\\u003e)){2}`)
+	found := markerRe.FindAllStringSubmatch(wire, -1)
+	if len(found) == 0 {
+		t.Fatal("the request that reached the upstream carries no markers at all, so it cannot " +
+			"show whether an unbacked one got through — the fixture is not offloading")
+	}
+	for _, m := range found {
+		if _, ok := st.Get(m[1]); !ok {
+			t.Errorf("the body sent UPSTREAM offers the model <<cg:%s>> and the store cannot "+
+				"produce it: a removal advertised as reversible is not. That is #187 on the wire", m[1])
+		}
+	}
+	if len(found) > 2 {
+		t.Errorf("%d markers reached the upstream against a 2-payload reserve: a removal whose "+
+			"payload cannot be stored must be refused, not stamped anyway", len(found))
+	}
+
+	sresp, err := http.Get(srv.URL + "/stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sbody, _ := io.ReadAll(sresp.Body)
+	sresp.Body.Close()
+	var snap struct {
+		StashRefused  int64 `json:"stash_refused"`
+		StashLive     int   `json:"stash_live"`
+		StashCapacity int   `json:"stash_capacity"`
+	}
+	if err := json.Unmarshal(sbody, &snap); err != nil {
+		t.Fatalf("/stats did not parse: %v\n%s", err, sbody)
+	}
+	if snap.StashCapacity != 2 {
+		t.Errorf("/stats stash_capacity = %d, want 2 (max_entries 4): the handler is not "+
+			"publishing the store's reserve, so nobody can see how close it is to binding",
+			snap.StashCapacity)
+	}
+	if snap.StashLive != 2 {
+		t.Errorf("/stats stash_live = %d, want 2", snap.StashLive)
+	}
+	if snap.StashRefused == 0 {
+		t.Error("/stats stash_refused = 0 while removals were being declined for want of a " +
+			"payload slot. This is the LEADING indicator for expand_unresolved_missing, which " +
+			"cannot move until the agent happens to call expand — so with this at 0 an " +
+			"exhausted reserve is invisible until an agent is already confused")
+	}
+	if !strings.Contains(string(sbody), `"stash_refused"`) {
+		t.Error(`/stats does not render a "stash_refused" key at all`)
+	}
+}

--- a/proxy/stashreserve_test.go
+++ b/proxy/stashreserve_test.go
@@ -10,11 +10,16 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/rossoctl/context-guru/components/offload"
 	"github.com/rossoctl/context-guru/config"
 	"github.com/rossoctl/context-guru/metrics"
 	"github.com/rossoctl/context-guru/proxy"
 	"github.com/rossoctl/context-guru/store"
 )
+
+// offloadStashMissing reads the process-wide dangling-replay counter. Wrapped so the assertions
+// below name the thing rather than the package path.
+func offloadStashMissing() int64 { return offload.StashMissing() }
 
 // The rewind reserve, end to end through the handler (#187).
 //
@@ -104,8 +109,11 @@ func TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself(t *t
 	sresp.Body.Close()
 	var snap struct {
 		StashRefused  int64 `json:"stash_refused"`
+		StashMissing  int64 `json:"stash_missing"`
 		StashLive     int   `json:"stash_live"`
 		StashCapacity int   `json:"stash_capacity"`
+		StashBytes    int64 `json:"stash_bytes"`
+		StashMaxBytes int64 `json:"stash_max_bytes"`
 	}
 	if err := json.Unmarshal(sbody, &snap); err != nil {
 		t.Fatalf("/stats did not parse: %v\n%s", err, sbody)
@@ -126,5 +134,155 @@ func TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself(t *t
 	}
 	if !strings.Contains(string(sbody), `"stash_refused"`) {
 		t.Error(`/stats does not render a "stash_refused" key at all`)
+	}
+	// The reserve's OTHER budget. Without both an operator told to "raise max_entries" cannot
+	// tell whether entries were the binding constraint at all — a payload is a whole tool output
+	// while every other exempt entry is a marker line, so the two budgets bind at very different
+	// workloads.
+	if snap.StashMaxBytes == 0 {
+		t.Error("/stats stash_max_bytes = 0: the byte budget is not published, so an operator " +
+			"reading stash_refused cannot tell which of the two budgets bound")
+	}
+	if snap.StashBytes == 0 {
+		t.Error("/stats stash_bytes = 0 although payloads are held: the reserve's real cost is " +
+			"invisible")
+	}
+	if snap.StashBytes > snap.StashMaxBytes {
+		t.Errorf("/stats reports %d bytes held against a %d-byte budget", snap.StashBytes, snap.StashMaxBytes)
+	}
+	// stash_missing is the opposite outcome from stash_refused and must be its own key: a
+	// refusal promises that nothing became irreversible, and a dangling marker is exactly the
+	// case where something did. Nothing dangled in this fixture, so the assertion is on the
+	// key's PRESENCE — a field that renders only when non-zero cannot be alerted on.
+	if !strings.Contains(string(sbody), `"stash_missing"`) {
+		t.Error(`/stats does not render a "stash_missing" key, so the one reserve outcome that ` +
+			`genuinely breaks reversibility is indistinguishable from the safe one`)
+	}
+	if snap.StashMissing != 0 {
+		t.Errorf("/stats stash_missing = %d in a fixture where every refusal left the content "+
+			"verbatim; a declined removal is being counted as a dangling marker", snap.StashMissing)
+	}
+}
+
+// lostPayloadStore is a real store in which ONE rewind payload has gone while the PINNED frozen
+// decision naming it survives. That combination is not contrived: cg:frz: is exempt from LRU
+// eviction and the payload is not — which is #187 — and the TTL reaches an idle payload before an
+// actively replayed decision. It is built as a wrapper because store.Memory has no delete.
+type lostPayloadStore struct {
+	*store.Memory
+	lost atomic.Value // string: the marker key whose payload is gone
+}
+
+func (s *lostPayloadStore) hidden(key string) bool {
+	k, _ := s.lost.Load().(string)
+	return k != "" && k == key
+}
+
+func (s *lostPayloadStore) Get(key string) ([]byte, bool) {
+	if s.hidden(key) {
+		return nil, false
+	}
+	return s.Memory.Get(key)
+}
+
+// PutStash refuses the lost key specifically. A refresh of a payload that is PRESENT still
+// succeeds, exactly as the real reserve behaves — the point is a payload that is absent and
+// cannot be put back, which is what makes the replayed marker dangling rather than merely tight.
+func (s *lostPayloadStore) PutStash(key string, payload []byte) bool {
+	if s.hidden(key) {
+		return false
+	}
+	return s.Memory.PutStash(key, payload)
+}
+
+// /stats must publish stash_missing from the live counter, and the VALUE has to move.
+//
+// The key alone is not enough, and a test asserting only its presence passed with the wiring
+// deleted: metrics.Snapshot renders the field at 0 either way. Snapshot.StashMissing is filled by
+// the /stats handler AFTER the aggregator snapshot is taken — the same shape that made the
+// frozen_* family export a permanent 0 — so a dropped assignment here leaves the one counter that
+// reports a BROKEN reversibility promise reading zero forever, on the page an operator checks to
+// confirm nothing broke.
+func TestStatsPublishesDanglingReplaysFromTheLiveCounter(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer upstream.Close()
+
+	// mask, because it FREEZES its decision and replays it on every later turn — the replay is
+	// the path on which a payload can be found missing.
+	cfg, err := config.LoadBytes([]byte(
+		"pipeline: [mask]\ncomponents:\n  mask: {keep_recent: 0, min_tokens: 20}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg := metrics.NewAggregator()
+	pipe, err := cfg.Build(agg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := &lostPayloadStore{Memory: store.NewMemory(store.Options{MaxEntries: 400})}
+	h := proxy.New(pipe, st, agg, proxy.Options{OpenAIUpstream: upstream.URL, AnthropicUpstream: upstream.URL})
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	body, err := json.Marshal(map[string]any{"model": "gpt-x", "messages": []map[string]any{
+		{"role": "user", "content": "go"},
+		{"role": "tool", "tool_call_id": "a",
+			"content": "line a: " + strings.Repeat("aq", 900)},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	post := func() {
+		resp, err := http.Post(srv.URL+"/openai/v1/chat/completions",
+			"application/json", strings.NewReader(string(body)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Turn 1: mask offloads, freezes the decision and stashes the original.
+	post()
+	var stashed string
+	for _, k := range st.Memory.StashedKeysForTest() {
+		stashed = k
+	}
+	if stashed == "" {
+		t.Fatal("turn 1 stashed no payload, so there is no marker whose payload can go missing")
+	}
+
+	// The payload is now gone; the pinned frozen decision naming it is not.
+	st.lost.Store(stashed)
+	before := offloadStashMissing()
+	post() // turn 2 replays the frozen decision and finds nothing behind its marker
+	live := offloadStashMissing()
+	if live == before {
+		t.Fatalf("no dangling replay was recorded (still %d), so this test cannot show whether "+
+			"/stats publishes them", live)
+	}
+
+	sresp, err := http.Get(srv.URL + "/stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sbody, _ := io.ReadAll(sresp.Body)
+	sresp.Body.Close()
+	var snap struct {
+		StashMissing int64 `json:"stash_missing"`
+		StashRefused int64 `json:"stash_refused"`
+	}
+	if err := json.Unmarshal(sbody, &snap); err != nil {
+		t.Fatalf("/stats did not parse: %v\n%s", err, sbody)
+	}
+	if snap.StashMissing != live {
+		t.Errorf("/stats stash_missing = %d while offload.StashMissing() = %d: the handler is "+
+			"not publishing the live counter, so the ONE reserve outcome that breaks a "+
+			"reversibility promise reads zero on the page an operator checks",
+			snap.StashMissing, live)
 	}
 }

--- a/proxy/stats_golden_test.go
+++ b/proxy/stats_golden_test.go
@@ -78,6 +78,14 @@ var statsGoldenTopLevel = []string{
 	"requests",
 	"saved_tokens",
 	"savings_pct",
+	// The rewind reserve (#187). stash_refused is the LEADING indicator for
+	// expand_unresolved_missing, which cannot move until the agent happens to call expand —
+	// so a run that had stopped being able to promise reversibility read as healthy. Added to
+	// the reviewed contract rather than loosening the assertion, per the rule above.
+	"stash_capacity",
+	"stash_expired",
+	"stash_live",
+	"stash_refused",
 	"savings_pct_attempted",
 	"savings_pct_new_input",
 	"sse_buffered",

--- a/proxy/stats_golden_test.go
+++ b/proxy/stats_golden_test.go
@@ -78,14 +78,6 @@ var statsGoldenTopLevel = []string{
 	"requests",
 	"saved_tokens",
 	"savings_pct",
-	// The rewind reserve (#187). stash_refused is the LEADING indicator for
-	// expand_unresolved_missing, which cannot move until the agent happens to call expand —
-	// so a run that had stopped being able to promise reversibility read as healthy. Added to
-	// the reviewed contract rather than loosening the assertion, per the rule above.
-	"stash_capacity",
-	"stash_expired",
-	"stash_live",
-	"stash_refused",
 	"savings_pct_attempted",
 	"savings_pct_new_input",
 	"sse_buffered",
@@ -94,6 +86,25 @@ var statsGoldenTopLevel = []string{
 	"sse_streamed",
 	"sse_ttfb_ms_avg",
 	"sse_ttfb_ms_avg_buffered",
+	// The rewind reserve (#187, #188). stash_refused is the LEADING indicator for
+	// expand_unresolved_missing, which cannot move until the agent happens to call expand — so
+	// a run that had stopped being able to promise reversibility read as healthy. stash_missing
+	// is its OPPOSITE and is listed separately on purpose: a refusal means nothing became
+	// irreversible, while a missing payload means a dangling marker went out. The two shared one
+	// key until the #188 review pointed out that made the safe case indistinguishable from the
+	// dangerous one. stash_bytes/stash_max_bytes are the reserve's other budget — entries are a
+	// poor proxy for memory in this namespace. Added to the reviewed contract rather than
+	// loosening the assertion, per the rule above.
+	//
+	// In alphabetical order like the rest: the first four landed appended in #188 and broke the
+	// ordering, which the test does not catch (it compares sets) and a reader does.
+	"stash_bytes",
+	"stash_capacity",
+	"stash_expired",
+	"stash_live",
+	"stash_max_bytes",
+	"stash_missing",
+	"stash_refused",
 	// summarize_* are the same three figures for `summarize`, which owns a SEPARATE
 	// budget: its call covers the whole middle of the transcript (~57k prompt tokens
 	// measured) rather than one tool output, so the two components cannot share a

--- a/store/stash_test.go
+++ b/store/stash_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The key mix ONE reversible removal actually writes, in the proportion the pipeline writes
+// it. This is the arithmetic #187 turned on, so the regression tests below drive it rather
+// than a bare loop of stashes: the payload is one entry of five, and two of the other four
+// are PINNED (cg:res:, cg:xres:), so under the old plain-Put behavior the cache kept "that
+// output was dropped" and evicted "here is what it was".
+//
+// Measured before the fix, 600 removals against the shipped defaults of the day (1,000
+// entries): 100 of 600 payloads survived against 350 of 600 of each pinned decision — the
+// payload was 3.5x less durable than the record naming it.
+func writeRemoval(t *testing.T, m *Memory, n int, payload []byte) (stashKey string, retained bool) {
+	t.Helper()
+	id := strconv.Itoa(n)
+	stashKey = "aaaaaaaaaaaaaaaa" + id // a bare marker id, as expand.Marker embeds it
+	retained = PutStash(m, stashKey, payload)
+	m.Put("cg:own:sess:"+id, []byte{1})     // GET /expand ownership record
+	m.Put("cg:xseen:"+id, []byte{1})        // recurrence flag
+	m.Put(ResultPrefix+"sess:"+id, payload) // the session decision   (PINNED)
+	m.Put(XResultPrefix+id, payload)        // the cross-session copy  (PINNED)
+	return stashKey, retained
+}
+
+// A payload PutStash accepted must still be there after the cache has churned many times
+// over — the #187 regression. What made this a defect rather than a tuning artifact is that
+// the marker was already stamped: the request told the model it could have the content back.
+func TestAnAcceptedStashSurvivesThePressureThatEvictsThePlainCache(t *testing.T) {
+	m := NewMemory(Options{MaxEntries: 100}) // reserve = 50
+	payload := make([]byte, 512)
+	var accepted []string
+	for i := 0; i < 40; i++ { // under the reserve, so every one is accepted
+		k, ok := writeRemoval(t, m, i, payload)
+		if !ok {
+			t.Fatalf("removal %d refused with the reserve not yet full", i)
+		}
+		accepted = append(accepted, k)
+	}
+	// Churn the unpinned, un-stashed namespaces hard enough to turn the whole cache over.
+	for i := 0; i < 5000; i++ {
+		m.Put("cg:xseen:churn"+strconv.Itoa(i), []byte{1})
+	}
+	for _, k := range accepted {
+		if _, ok := m.Get(k); !ok {
+			t.Fatalf("stash %s was evicted after being accepted: a marker was stamped for "+
+				"content this store can no longer produce, which is exactly #187", k)
+		}
+	}
+}
+
+// The reserve refuses rather than evicting a live payload, and it says so.
+//
+// The alternative — evict the oldest stash to admit the new one — keeps the mechanism
+// removing at full rate and breaks an OLD promise per new one. That is the property #187
+// called out: the guarantee degrading as the mechanism succeeds. Refusing moves the cost
+// onto removals not yet made.
+func TestAFullReserveRefusesInsteadOfEvictingALivePayload(t *testing.T) {
+	m := NewMemory(Options{MaxEntries: 20}) // reserve = 10
+	payload := make([]byte, 64)
+	first, ok := writeRemoval(t, m, 0, payload)
+	if !ok {
+		t.Fatal("the first removal of an empty store was refused")
+	}
+	for i := 1; i < 10; i++ {
+		if _, ok := writeRemoval(t, m, i, payload); !ok {
+			t.Fatalf("removal %d refused below the reserve size", i)
+		}
+	}
+	if _, ok := writeRemoval(t, m, 10, payload); ok {
+		t.Fatal("the 11th removal into a 10-slot reserve was accepted; a refusal is what lets " +
+			"the component decline the removal instead of stamping an unresolvable marker")
+	}
+	if _, ok := m.Get(first); !ok {
+		t.Fatal("the OLDEST payload was evicted to admit a new one: an outstanding marker just " +
+			"stopped resolving, which is the failure this reserve exists to prevent")
+	}
+	live, capacity, refused, _ := m.StashStats()
+	if live != 10 || capacity != 10 || refused != 1 {
+		t.Fatalf("StashStats() = (live %d, capacity %d, refused %d), want (10, 10, 1)", live, capacity, refused)
+	}
+}
+
+// Refreshing a payload that is already present is never refused, however full the reserve.
+//
+// Components re-stash on every replay turn (offload.reapplyFrozen, extract_llm's apply) to
+// keep an already-emitted marker resolvable. If a refresh could be refused, a component would
+// decline to replay a decision it had already stamped, and the message would flip
+// representation inside the provider's cached prefix — the cache-destructive direction, for
+// content that is sitting right there.
+func TestRefreshingALivePayloadIsNeverRefused(t *testing.T) {
+	m := NewMemory(Options{MaxEntries: 4}) // reserve = 2
+	if !m.PutStash("aaaaaaaaaaaaaaa1", []byte("one")) {
+		t.Fatal("first stash refused")
+	}
+	if !m.PutStash("aaaaaaaaaaaaaaa2", []byte("two")) {
+		t.Fatal("second stash refused")
+	}
+	if m.PutStash("aaaaaaaaaaaaaaa3", []byte("three")) {
+		t.Fatal("a third stash was accepted into a 2-slot reserve")
+	}
+	if !m.PutStash("aaaaaaaaaaaaaaa1", []byte("one again")) {
+		t.Fatal("a REFRESH of a payload already in the reserve was refused; a component would " +
+			"decline to replay a marker it has already stamped and flip a cached message")
+	}
+	if b, ok := m.Get("aaaaaaaaaaaaaaa1"); !ok || string(b) != "one again" {
+		t.Fatalf("refreshed payload = (%q, %v), want (\"one again\", true)", b, ok)
+	}
+	// The same contract for an entry that is PRESENT but holds no reserve slot — what a
+	// plain Put under a marker key leaves behind (a store shared with a caller that does not
+	// use the capability, or a key written before the reserve filled). "Retained" is a
+	// question about the payload, not about the slot: the bytes are right there, and answering
+	// false would make a component decline to replay a marker it has already stamped.
+	m.Put("aaaaaaaaaaaaaaa4", []byte("four"))
+	if !m.PutStash("aaaaaaaaaaaaaaa4", []byte("four again")) {
+		t.Fatal("PutStash refused a payload that is IN THE STORE, because the reserve was full")
+	}
+	if b, ok := m.Get("aaaaaaaaaaaaaaa4"); !ok || string(b) != "four again" {
+		t.Fatalf("payload after a refused-slot refresh = (%q, %v), want (\"four again\", true)", b, ok)
+	}
+}
+
+// The TTL is the only thing that releases a reserve slot now that pressure cannot, so it has
+// to actually release one — otherwise a long-lived proxy refuses every removal forever on the
+// strength of payloads that expired hours ago.
+func TestTheTTLReleasesReserveSlots(t *testing.T) {
+	m := NewMemory(Options{MaxEntries: 4, TTLSeconds: 10}) // reserve = 2
+	now := time.Now()
+	m.SetClock(func() time.Time { return now })
+	if !m.PutStash("aaaaaaaaaaaaaaa1", []byte("one")) || !m.PutStash("aaaaaaaaaaaaaaa2", []byte("two")) {
+		t.Fatal("filling an empty reserve was refused")
+	}
+	if m.PutStash("aaaaaaaaaaaaaaa3", []byte("three")) {
+		t.Fatal("a third stash was accepted into a full reserve")
+	}
+	now = now.Add(11 * time.Second) // both payloads are now past their TTL
+	if !m.PutStash("aaaaaaaaaaaaaaa3", []byte("three")) {
+		t.Fatal("the reserve stayed full after its payloads expired: it never recovers")
+	}
+	if _, _, _, expired := m.StashStats(); expired == 0 {
+		t.Fatal("StashStats() reports 0 expired payloads after two were reclaimed by the TTL; " +
+			"an operator reading expand_unresolved_missing cannot tell 'raise ttl_seconds' " +
+			"from 'raise max_entries'")
+	}
+}
+
+// The property #187 asks for by name: the guarantee must not degrade as the mechanism
+// succeeds.
+//
+// Before the fix, every extra removal both consumed a slot and added a pinned decision, so
+// BROKEN promises grew with the amount of work done. Here the number of broken promises is
+// zero at every load — what grows instead is the count of removals declined, which is a
+// refusal to promise rather than a promise broken.
+func TestBrokenPromisesDoNotGrowWithLoad(t *testing.T) {
+	payload := make([]byte, 512)
+	prevRefused := int64(-1)
+	for _, removals := range []int{40, 200, 1000} {
+		m := NewMemory(Options{MaxEntries: 100}) // reserve = 50
+		var accepted []string
+		for i := 0; i < removals; i++ {
+			if k, ok := writeRemoval(t, m, i, payload); ok {
+				accepted = append(accepted, k)
+			}
+		}
+		broken := 0
+		for _, k := range accepted {
+			if _, ok := m.Get(k); !ok {
+				broken++
+			}
+		}
+		_, _, refused, _ := m.StashStats()
+		if broken != 0 {
+			t.Errorf("%d removals: %d of %d advertised-reversible removals cannot be reversed; "+
+				"reversibility is still load-dependent", removals, broken, len(accepted))
+		}
+		if refused <= prevRefused {
+			t.Errorf("%d removals: refused = %d, not above the previous load's %d — the cost of "+
+				"a full reserve must land on removals NOT MADE, and be counted",
+				removals, refused, prevRefused)
+		}
+		prevRefused = refused
+	}
+}

--- a/store/stash_test.go
+++ b/store/stash_test.go
@@ -339,3 +339,33 @@ func TestStashRoomAnswersBeforeThePayloadIsBuilt(t *testing.T) {
 			"staler than PutStash's, so summarize skips checkpoints the store would accept")
 	}
 }
+
+// The floor has to be a floor at EVERY max_entries, not only where max/4 rounds up.
+//
+// max/4 is 0 for max_entries of 2 or 3, and each exemption is capped at max/2 — so the two could
+// reach the whole cap and the "unconditional" guarantee that something is always evictable, which
+// both store.go and docs/reference/config.md state as unconditional, had a hole at the bottom of
+// the range. Only absurd configs reach it; the documented claim is still either true or it is not.
+func TestTheEvictableFloorHoldsAtEveryEntryCap(t *testing.T) {
+	for _, max := range []int{2, 3, 4, 8, 100} {
+		m := NewMemory(Options{MaxEntries: max})
+		// Saturate both exemptions as hard as this cap allows.
+		payload := []byte("x")
+		for i := 0; i < max*2; i++ {
+			id := strconv.Itoa(i)
+			m.PutStash("aaaaaaaaaaaaaaaa"+id, payload)
+			m.Put(ResultPrefix+"sess:"+id, payload)
+			m.Put(FrozenPrefix+"sess:"+id, payload)
+		}
+		// The property: a write to an unpinned namespace survives its own Put.
+		m.Put("cg:keep:probe", []byte{1})
+		if _, ok := m.Get("cg:keep:probe"); !ok {
+			t.Errorf("max_entries %d: a cg:keep: write did not survive its own Put, so the "+
+				"exemptions have taken the whole cap and writes to the unpinned namespaces are "+
+				"silent no-ops", max)
+		}
+		if got := m.evictableEntriesForTest(); got < 1 {
+			t.Errorf("max_entries %d: %d entries are evictable, want at least 1", max, got)
+		}
+	}
+}

--- a/store/stash_test.go
+++ b/store/stash_test.go
@@ -31,10 +31,15 @@ func writeRemoval(t *testing.T, m *Memory, n int, payload []byte) (stashKey stri
 // over — the #187 regression. What made this a defect rather than a tuning artifact is that
 // the marker was already stamped: the request told the model it could have the content back.
 func TestAnAcceptedStashSurvivesThePressureThatEvictsThePlainCache(t *testing.T) {
-	m := NewMemory(Options{MaxEntries: 100}) // reserve = 50
+	// 400 entries, not 100. One removal writes THREE exempt entries (the payload plus the two
+	// pinned decisions), and the exemptions are jointly bounded at max−max/4 so that a quarter
+	// of the cache always stays evictable — so the real key mix saturates the joint budget at
+	// max/4 removals, well before the reserve's own max/2 cap. 400 leaves room for 100
+	// removals; this test takes 40 of them.
+	m := NewMemory(Options{MaxEntries: 400})
 	payload := make([]byte, 512)
 	var accepted []string
-	for i := 0; i < 40; i++ { // under the reserve, so every one is accepted
+	for i := 0; i < 40; i++ { // under both budgets, so every one is accepted
 		k, ok := writeRemoval(t, m, i, payload)
 		if !ok {
 			t.Fatalf("removal %d refused with the reserve not yet full", i)
@@ -62,26 +67,32 @@ func TestAnAcceptedStashSurvivesThePressureThatEvictsThePlainCache(t *testing.T)
 func TestAFullReserveRefusesInsteadOfEvictingALivePayload(t *testing.T) {
 	m := NewMemory(Options{MaxEntries: 20}) // reserve = 10
 	payload := make([]byte, 64)
-	first, ok := writeRemoval(t, m, 0, payload)
-	if !ok {
-		t.Fatal("the first removal of an empty store was refused")
+	// Bare PutStash rather than the full writeRemoval mix, so the bound under test is the
+	// RESERVE's own entry cap and nothing else. With the real mix the joint exempt budget binds
+	// first (three exempt entries per removal against max−max/4), which is a different property
+	// and has its own test below — sharing one fixture would leave neither bound pinned.
+	stashed := func(n int) string { return "aaaaaaaaaaaaaaaa" + strconv.Itoa(n) }
+	first := stashed(0)
+	if !m.PutStash(first, payload) {
+		t.Fatal("the first payload into an empty reserve was refused")
 	}
 	for i := 1; i < 10; i++ {
-		if _, ok := writeRemoval(t, m, i, payload); !ok {
-			t.Fatalf("removal %d refused below the reserve size", i)
+		if !m.PutStash(stashed(i), payload) {
+			t.Fatalf("payload %d refused below the reserve size", i)
 		}
 	}
-	if _, ok := writeRemoval(t, m, 10, payload); ok {
-		t.Fatal("the 11th removal into a 10-slot reserve was accepted; a refusal is what lets " +
+	if m.PutStash(stashed(10), payload) {
+		t.Fatal("the 11th payload into a 10-slot reserve was accepted; a refusal is what lets " +
 			"the component decline the removal instead of stamping an unresolvable marker")
 	}
 	if _, ok := m.Get(first); !ok {
 		t.Fatal("the OLDEST payload was evicted to admit a new one: an outstanding marker just " +
 			"stopped resolving, which is the failure this reserve exists to prevent")
 	}
-	live, capacity, refused, _ := m.StashStats()
-	if live != 10 || capacity != 10 || refused != 1 {
-		t.Fatalf("StashStats() = (live %d, capacity %d, refused %d), want (10, 10, 1)", live, capacity, refused)
+	st := m.StashStats()
+	if st.Live != 10 || st.Capacity != 10 || st.Refused != 1 {
+		t.Fatalf("StashStats() = (live %d, capacity %d, refused %d), want (10, 10, 1)",
+			st.Live, st.Capacity, st.Refused)
 	}
 }
 
@@ -141,7 +152,7 @@ func TestTheTTLReleasesReserveSlots(t *testing.T) {
 	if !m.PutStash("aaaaaaaaaaaaaaa3", []byte("three")) {
 		t.Fatal("the reserve stayed full after its payloads expired: it never recovers")
 	}
-	if _, _, _, expired := m.StashStats(); expired == 0 {
+	if st := m.StashStats(); st.Expired == 0 {
 		t.Fatal("StashStats() reports 0 expired payloads after two were reclaimed by the TTL; " +
 			"an operator reading expand_unresolved_missing cannot tell 'raise ttl_seconds' " +
 			"from 'raise max_entries'")
@@ -172,7 +183,7 @@ func TestBrokenPromisesDoNotGrowWithLoad(t *testing.T) {
 				broken++
 			}
 		}
-		_, _, refused, _ := m.StashStats()
+		refused := m.StashStats().Refused
 		if broken != 0 {
 			t.Errorf("%d removals: %d of %d advertised-reversible removals cannot be reversed; "+
 				"reversibility is still load-dependent", removals, broken, len(accepted))
@@ -183,5 +194,148 @@ func TestBrokenPromisesDoNotGrowWithLoad(t *testing.T) {
 				removals, refused, prevRefused)
 		}
 		prevRefused = refused
+	}
+}
+
+// The two exemptions must never occupy the whole entry cap, because a cache with nothing
+// evictable does not fail loudly — it silently discards writes.
+//
+// pinCap and stashCap are each max/2, so before the evictable floor they could sum to max. At
+// that point evictOldest walks the list, finds every entry exempt and returns false, and the
+// next plain Put pushes its entry to the front where the eviction loop immediately takes it
+// back as the only non-exempt entry in the cache. The write "succeeds" and the key is gone.
+//
+// Each of the unpinned namespaces that happens to is load-bearing: cg:keep: is what stops the
+// expand loop (content the agent just expanded gets re-compacted without it), cg:sum: is
+// summarize's checkpoint, cg:own: gates GET /expand, cg:xseen: prices recurrence. And the
+// state is reached by exactly the workload the reserve was built for — a reversible removal
+// writes two pinned decisions and one stash, so both exemptions saturate together.
+func TestTheExemptionsLeaveAGuaranteedEvictableFloor(t *testing.T) {
+	const max = 200
+	m := NewMemory(Options{MaxEntries: max})
+	payload := make([]byte, 64)
+	// Drive the real key mix until the store refuses, which is the joint budget binding: three
+	// exempt entries per removal against max−max/4.
+	removals, refused := 0, 0
+	for i := 0; i < max; i++ {
+		if _, ok := writeRemoval(t, m, i, payload); ok {
+			removals++
+		} else {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatal("the fixture never saturated the exemptions, so it cannot show whether a floor " +
+			"is held back — raise the removal count")
+	}
+	// The precondition that makes the assertion below meaningful: the exemptions are as full as
+	// this store will let them get.
+	st := m.StashStats()
+	if st.Live == 0 {
+		t.Fatal("no payload was retained at all; the fixture is not exercising the reserve")
+	}
+	// The property. A write to an UNPINNED namespace must still be readable afterwards — under
+	// max/2 + max/2 it was evicted by the very Put that inserted it.
+	m.Put("cg:keep:justexpanded", []byte{1})
+	if _, ok := m.Get("cg:keep:justexpanded"); !ok {
+		t.Error("a cg:keep: write did not survive its own Put: the exemptions have consumed the " +
+			"whole entry cap, so isKeptVerbatim is permanently false and content the agent just " +
+			"expanded will be re-compacted — the expand loop that flag exists to stop")
+	}
+	m.Put("cg:sum:sess", []byte(`{"c":1}`))
+	if _, ok := m.Get("cg:sum:sess"); !ok {
+		t.Error("a cg:sum: checkpoint did not survive its own Put: summarize can never " +
+			"checkpoint, so it re-pays its model call on every turn")
+	}
+	// And the floor is a real quantity, not just "one write got through".
+	if got := m.evictableEntriesForTest(); got < max/4 {
+		t.Errorf("only %d of %d entries are evictable, want at least the max/4 = %d floor",
+			got, max, max/4)
+	}
+}
+
+// The reserve is bounded in BYTES as well as entries, and the byte budget is the one that
+// binds first for large payloads.
+//
+// Entries are a poor proxy for memory in this namespace and only in this namespace: every
+// other exempt entry is a marker line, a compacted projection or an integer, while a payload
+// is a whole tool output. So "2,500 entries" named a memory figure anywhere across two orders
+// of magnitude depending on nothing the operator had chosen.
+func TestTheReserveIsBoundedInBytesNotOnlyEntries(t *testing.T) {
+	// Entries are deliberately not the constraint: a 1,000-entry cap is a 500-slot reserve,
+	// and 6 payloads is nowhere near it. 5 KiB of budget against 2 KiB payloads is.
+	m := NewMemory(Options{MaxEntries: 1000, StashMaxBytes: 5 << 10})
+	payload := make([]byte, 2<<10)
+	accepted := 0
+	for i := 0; i < 6; i++ {
+		if m.PutStash("aaaaaaaaaaaaaaaa"+strconv.Itoa(i), payload) {
+			accepted++
+		}
+	}
+	if accepted != 2 {
+		t.Errorf("%d payloads of 2 KiB were accepted into a 5 KiB reserve, want 2: the byte "+
+			"budget is not bounding the reserve, so max_entries is still the only limit and it "+
+			"does not describe memory", accepted)
+	}
+	st := m.StashStats()
+	if st.Bytes != int64(accepted)*int64(len(payload)) || st.MaxBytes != 5<<10 {
+		t.Errorf("StashStats() = (bytes %d, max %d), want (%d, %d): an operator cannot tell "+
+			"WHICH budget bound, and so cannot tell whether to raise max_entries or "+
+			"stash_max_bytes", st.Bytes, st.MaxBytes, accepted*len(payload), 5<<10)
+	}
+	if st.Live >= st.Capacity {
+		t.Errorf("live %d reached capacity %d, so this test proved nothing about bytes",
+			st.Live, st.Capacity)
+	}
+	// A refusal on bytes is still a refusal, counted the same way: it means removals were
+	// declined, not made irreversibly.
+	if st.Refused != 4 {
+		t.Errorf("StashStats().Refused = %d, want 4; a byte-budget refusal must be reported "+
+			"exactly like an entry-budget one", st.Refused)
+	}
+	// And the bytes are RELEASED with the slot, or the budget ratchets shut permanently.
+	m.SetClock(func() time.Time { return time.Now().Add(2 * DefaultTTL) })
+	if !m.PutStash("bbbbbbbbbbbbbbbb", payload) {
+		t.Error("the reserve stayed byte-full after its payloads expired: stashBytes is never " +
+			"credited back, so one busy period disables marker mode for the life of the process")
+	}
+}
+
+// StashRoom answers the capacity question BEFORE the caller pays to produce the content whose
+// marker the payload would back.
+//
+// It exists for one caller shape: summarize's model call was measured at ~57k prompt tokens,
+// and it used to be paid and then thrown away when the reserve refused — every turn, because a
+// refusal saves no checkpoint and so changes nothing about the next turn's inputs.
+func TestStashRoomAnswersBeforeThePayloadIsBuilt(t *testing.T) {
+	// A reserve of exactly ONE slot, so that a probe which claimed a slot would make the very
+	// next probe answer differently. Sized at 2 for that reason: with room for two payloads a
+	// claiming probe still reports room on the second call, and the assertion below would pass
+	// against the bug it exists to catch.
+	m := NewMemory(Options{MaxEntries: 2}) // reserve = 1
+	payload := make([]byte, 64)
+	if !m.StashRoom(len(payload)) {
+		t.Fatal("StashRoom said an empty reserve was full")
+	}
+	// A probe must claim nothing, or two probes in a row would disagree for no reason.
+	if !m.StashRoom(len(payload)) {
+		t.Error("a second StashRoom probe said full: the probe consumed a slot, so a caller " +
+			"that asks twice is told to skip work the store would have taken")
+	}
+	m.PutStash("aaaaaaaaaaaaaaa1", payload)
+	if m.StashRoom(len(payload)) {
+		t.Error("StashRoom said a full reserve had room; the model call it guards is paid and " +
+			"discarded")
+	}
+	if m.StashStats().Refused != 0 {
+		t.Error("a probe incremented the refusal counter: stash_refused must count removals " +
+			"DECLINED, and a probe declines nothing")
+	}
+	// The probe must reclaim what the TTL has released, exactly as PutStash does — otherwise a
+	// long-lived proxy skips work forever on the strength of payloads that expired hours ago.
+	m.SetClock(func() time.Time { return time.Now().Add(2 * DefaultTTL) })
+	if !m.StashRoom(len(payload)) {
+		t.Error("StashRoom reported full after its payloads had expired: the probe's answer is " +
+			"staler than PutStash's, so summarize skips checkpoints the store would accept")
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -410,9 +410,19 @@ func (m *Memory) DisableSlidingTTLForTest() {
 // own existing over-cap behavior: a pin degrades to an ordinary evictable entry (it is still
 // readable, and its loss is reported where losses happen), a stash is REFUSED (so the caller
 // declines the removal rather than promising what it cannot deliver). No new failure shape.
-func (m *Memory) pinCap() int         { return m.max / 2 }
-func (m *Memory) stashCap() int       { return m.max / 2 }
-func (m *Memory) evictableFloor() int { return m.max / 4 }
+func (m *Memory) pinCap() int   { return m.max / 2 }
+func (m *Memory) stashCap() int { return m.max / 2 }
+
+// evictableFloor is at least ONE entry. max/4 alone is 0 for max_entries of 2 or 3, and the
+// exemptions (max/2 each) could then reach the whole cap — so the guarantee this comment and
+// docs/reference/config.md both describe as unconditional had a hole at the bottom of the range.
+// Only absurd configs reach it, but "unconditional" is either true or it is not.
+func (m *Memory) evictableFloor() int {
+	if f := m.max / 4; f > 0 {
+		return f
+	}
+	return 1
+}
 
 // exemptRoom reports whether one more exempt entry can be admitted without eating into the
 // evictable floor. Consulted by both exemptions, which is what makes the floor a floor.

--- a/store/store.go
+++ b/store/store.go
@@ -60,6 +60,14 @@ type Stasher interface {
 	// Refreshing a payload already present always succeeds — a live entry must never be
 	// refused, or a replay of an already-stamped marker would flip that message's bytes.
 	PutStash(key string, payload []byte) bool
+	// StashRoom reports whether a NEW payload of size bytes would be admitted right now.
+	// It is a probe, not a reservation: it claims nothing, and a PutStash after it can
+	// still refuse (another goroutine took the slot). It exists for the one caller shape
+	// that cannot recover from a refusal cheaply — a component that must PAY A MODEL CALL
+	// to produce the text whose marker the payload backs. summarize's call was measured at
+	// ~57k prompt tokens, and under a saturated reserve it was paid and thrown away on
+	// every turn. Asking first turns that into a skip.
+	StashRoom(size int) bool
 }
 
 // PutStash writes a rewind payload through the Stasher capability when the store has it,
@@ -70,6 +78,16 @@ func PutStash(s Store, key string, payload []byte) bool {
 		return st.PutStash(key, payload)
 	}
 	s.Put(key, payload)
+	return true
+}
+
+// StashRoom reports whether a new payload of size bytes would be admitted. A store without
+// the Stasher capability has no reserve to exhaust, so it always has room — the same
+// direction PutStash degrades in.
+func StashRoom(s Store, size int) bool {
+	if st, ok := s.(Stasher); ok {
+		return st.StashRoom(size)
+	}
 	return true
 }
 
@@ -165,8 +183,24 @@ type Memory struct {
 	maxStick    int
 	pinPrefixes []string
 	now         func() time.Time // injectable for tests
-	pinnedN     int              // live pinned (frozen) entries, capped at max/2
+	pinnedN     int              // live pinned (frozen) entries, capped at pinCap()
 	stashN      int              // live rewind payloads, capped at stashCap()
+	// stashBytes is the reserve's REAL cost, and stashMaxBytes is what bounds it. Entries
+	// are the wrong unit for this one namespace: every other exempt entry is a marker line,
+	// a compacted projection or an integer, while a payload is a whole tool output — so
+	// "5,000 entries" names a memory figure anywhere between a few megabytes and a few
+	// gigabytes depending on nothing the operator chose. The entry caps below still apply
+	// (list and map slots cost something, and the evictable floor is an entry property);
+	// this is the budget that binds first when payloads are large.
+	stashBytes    int64
+	stashMaxBytes int64
+	// nextExpiry is a LOWER BOUND on the earliest expires among live entries, so a sweep
+	// can be skipped outright when nothing can possibly have expired. Without it every
+	// refused PutStash walked the whole list under this mutex looking for reclaimable
+	// entries — O(max) per refusal, on precisely the saturated path where refusals are
+	// continuous. A lower bound is enough: too low costs one wasted sweep, and it can never
+	// be too high because every write sets its entry's expiry to now+ttl, the latest of any.
+	nextExpiry time.Time
 	// stashRefusedN counts payloads PutStash DECLINED because the reserve was full — i.e.
 	// removals that were not made, rather than removals made irreversibly. stashExpiredN
 	// counts payloads the TTL reclaimed, which is the only way a stash leaves now that LRU
@@ -197,7 +231,10 @@ type Options struct {
 	// not something an operator should be tuning.
 	PinPrefixes []string `yaml:"-"`
 	MaxEntries  int      `yaml:"max_entries"`
-	MaxSessions int      `yaml:"max_sessions"`
+	// StashMaxBytes caps the rewind reserve in BYTES. Zero => DefaultStashMaxBytes. See
+	// Memory.stashBytes for why this namespace is budgeted in bytes and the rest in entries.
+	StashMaxBytes int64 `yaml:"stash_max_bytes"`
+	MaxSessions   int   `yaml:"max_sessions"`
 }
 
 // Nop is a Store that persists nothing: Put discards, Get/Sticky always miss.
@@ -211,6 +248,10 @@ func (Nop) Put(string, []byte) {}
 // skips effectiveMode (which already degrades a full marker to off when !Persists()), and
 // the answer is the same either way: do not advertise reversibility.
 func (Nop) PutStash(string, []byte) bool { return false }
+
+// StashRoom is false for the same reason PutStash is: there is nowhere to put a payload, so
+// a caller about to pay a model call for content this store would have to back should not.
+func (Nop) StashRoom(int) bool { return false }
 
 func (Nop) Get(string) ([]byte, bool)         { return nil, false }
 func (Nop) Sticky(string) map[string]struct{} { return nil }
@@ -235,10 +276,28 @@ const DefaultTTL = 10000 * time.Second
 // is what makes overrunning it visible rather than silent, so this number does not have to be
 // right, only sane.
 //
-// Entry count is a PROXY for memory, and a poor one for this namespace: pinned decisions and
-// the bookkeeping flags are tiny, a stashed payload is a whole tool output. An operator
-// running large payloads should set max_entries against bytes they can afford, not entries.
+// Entry count is a PROXY for memory, and a poor one for the payloads: pinned decisions and
+// the bookkeeping flags are tiny, a stashed payload is a whole tool output. That is why the
+// reserve carries its own BYTE budget (DefaultStashMaxBytes) rather than leaving max_entries
+// to mean two unrelated things — this constant now bounds only how many entries the cache
+// tracks, and stash_max_bytes bounds what they cost.
 const DefaultMaxEntries = 5000
+
+// DefaultStashMaxBytes bounds the rewind reserve's memory: 256 MiB.
+//
+// The arithmetic it comes from, so an operator can redo it with their own numbers: the reserve
+// holds at most stashCap() = max_entries/2 = 2,500 payloads, and a payload is one tool output.
+// Real agent traffic in this repo's own corpus runs tens of kilobytes per output (the measured
+// examples in extract_llm's comments are a 26k-token access log and a ~7k-token file read), so
+// 2,500 × ~100 KB ≈ 250 MB is the entry cap's worth at the large end of ordinary. 256 MiB is
+// therefore the point where the two budgets bind at roughly the same time for ordinary
+// payloads — and the byte budget binds FIRST, as it should, for a workload whose outputs are
+// bigger than that.
+//
+// It is sane rather than measured, exactly like max_entries, and for the same reason: what
+// makes a wrong value safe is that overrunning it REFUSES removals and says so
+// (stash_refused), instead of quietly making them irreversible.
+const DefaultStashMaxBytes = 256 << 20
 
 // NewMemory builds an in-memory store. Zero/negative option fields fall back to
 // defaults (DefaultTTL, DefaultMaxEntries, 100 sessions of sticky sets).
@@ -251,6 +310,10 @@ func NewMemory(o Options) *Memory {
 	if max <= 0 {
 		max = DefaultMaxEntries
 	}
+	stashMax := o.StashMaxBytes
+	if stashMax <= 0 {
+		stashMax = DefaultStashMaxBytes
+	}
 	stick := o.MaxSessions
 	if stick <= 0 {
 		stick = 100
@@ -261,7 +324,8 @@ func NewMemory(o Options) *Memory {
 	}
 	return &Memory{
 		ttl: ttl, max: max, maxStick: stick, pinPrefixes: pins,
-		ll: list.New(), items: map[string]*list.Element{},
+		stashMaxBytes: stashMax,
+		ll:            list.New(), items: map[string]*list.Element{},
 		sticky:     map[string]map[string]struct{}{},
 		lostFrozen: map[string]struct{}{},
 		now:        time.Now,
@@ -269,6 +333,36 @@ func NewMemory(o Options) *Memory {
 }
 
 func (*Memory) Persists() bool { return true }
+
+// evictableEntriesForTest counts entries the LRU may take. For TESTS only: the evictable floor
+// is a property of the whole cache rather than of any one write, so asserting it needs the
+// count, and a test that inferred it from "one Put survived" would pass with a floor of one.
+func (m *Memory) evictableEntriesForTest() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for el := m.ll.Back(); el != nil; el = el.Prev() {
+		if e := el.Value.(*entry); !e.pinned && !e.stash {
+			n++
+		}
+	}
+	return n
+}
+
+// StashedKeysForTest lists the keys the reserve currently holds. For TESTS only: a test that
+// needs to act on a specific payload cannot recompute its key without duplicating the component's
+// hashing, and a duplicate would pass while the real key drifted.
+func (m *Memory) StashedKeysForTest() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []string
+	for el := m.ll.Back(); el != nil; el = el.Prev() {
+		if e := el.Value.(*entry); e.stash {
+			out = append(out, e.key)
+		}
+	}
+	return out
+}
 
 // SetClock replaces the store's time source. For TESTS only — TTL behavior over a
 // multi-hour agent session is not testable in real time, and the freeze lifetime is
@@ -287,10 +381,67 @@ func (m *Memory) DisableSlidingTTLForTest() {
 	m.noSlide = true
 }
 
-// stashCap bounds the rewind reserve at half the entry cap, the same share the pins get.
-// Half and not more because the two halves are the two things reversibility needs at once:
-// the payload to serve, and the decision that keeps the message it came out of byte-stable.
-func (m *Memory) stashCap() int { return m.max / 2 }
+// The three entry budgets, and why there are three.
+//
+// pinCap and stashCap are each half the entry cap: those are the two things reversibility
+// needs at once — the payload to serve, and the decision that keeps the message it came out
+// of byte-stable — so neither may starve the other.
+//
+// evictableFloor is what stops them from adding up. Each cap alone is half, so together they
+// could reach the WHOLE entry cap, and then evictOldest walks the list, finds every entry
+// exempt, and returns false. A cache with nothing evictable does not fail loudly: the next
+// plain Put pushes its entry to the front, the eviction loop finds that same just-inserted
+// entry as the only non-exempt one and removes it, so writes to the UNPINNED namespaces
+// become silent no-ops — and each of those namespaces is load-bearing:
+//
+//   - cg:keep: (offload.MarkKeptVerbatim) — isKeptVerbatim goes permanently false, so content
+//     the agent just expanded is re-compacted, which is the expand loop the flag exists to stop.
+//   - cg:sum:  (offload.saveCheckpoint) — summarize can never checkpoint, so it re-pays its
+//     model call every turn and never reuses.
+//   - cg:own:  (offload.recordOwner) — GET /expand refuses a key the session really does own.
+//   - cg:xseen: — the economic gate misprices recurrence.
+//
+// Worse, that state is reached by exactly the workload this reserve was built for: a
+// reversible removal writes two pinned decisions and one stash, so pin pressure and reserve
+// pressure saturate together. So a quarter of the entry cap is held back from BOTH exemptions
+// and stays evictable, unconditionally.
+//
+// Which exemption loses when the joint budget binds is whoever asks last, and each keeps its
+// own existing over-cap behavior: a pin degrades to an ordinary evictable entry (it is still
+// readable, and its loss is reported where losses happen), a stash is REFUSED (so the caller
+// declines the removal rather than promising what it cannot deliver). No new failure shape.
+func (m *Memory) pinCap() int         { return m.max / 2 }
+func (m *Memory) stashCap() int       { return m.max / 2 }
+func (m *Memory) evictableFloor() int { return m.max / 4 }
+
+// exemptRoom reports whether one more exempt entry can be admitted without eating into the
+// evictable floor. Consulted by both exemptions, which is what makes the floor a floor.
+func (m *Memory) exemptRoom() bool {
+	return m.pinnedN+m.stashN < m.max-m.evictableFloor()
+}
+
+// StashRoom reports whether a NEW payload of size bytes would be admitted right now: a free
+// entry slot under both the reserve cap and the shared exempt budget, and enough of the byte
+// budget left. It reclaims what the TTL has released first, exactly as PutStash does, so the
+// answer is not stale — a probe that said "full" on the strength of payloads that expired
+// hours ago would skip work the store would in fact have taken.
+//
+// It claims nothing. See Stasher.StashRoom for why a probe exists at all.
+func (m *Memory) StashRoom(size int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stashN >= m.stashCap() || !m.exemptRoom() || !m.byteRoom(size) {
+		m.sweepExpired()
+	}
+	return m.stashN < m.stashCap() && m.exemptRoom() && m.byteRoom(size)
+}
+
+// byteRoom reports whether size more bytes fit in the reserve's byte budget. A payload larger
+// than the whole budget is refused rather than admitted-and-over: the budget is the promise
+// the operator sized, and one outsized output must not be the thing that breaks it.
+func (m *Memory) byteRoom(size int) bool {
+	return m.stashBytes+int64(size) <= m.stashMaxBytes
+}
 
 // PutStash stores a rewind payload under its marker key and reports whether it is retained.
 // See Stasher for why the store cannot recognise these keys on its own, and why the boolean
@@ -309,31 +460,45 @@ func (m *Memory) PutStash(key string, payload []byte) bool {
 	defer m.mu.Unlock()
 	if el, ok := m.items[key]; ok {
 		e := el.Value.(*entry)
+		// Byte accounting follows the payload, not the write: a refresh replaces the bytes,
+		// so the reserve must be charged the difference. In practice it is zero — a stash key
+		// IS the hash of its payload, so a refresh under the same key carries the same bytes —
+		// but the accounting must not depend on that being true of every caller.
+		if e.stash {
+			m.stashBytes += int64(len(payload)) - int64(len(e.payload))
+		}
 		e.payload = payload
 		e.expires = m.now().Add(m.ttl)
 		// Claim a reserve slot if one has freed, exactly as Put re-claims a pin slot. An
 		// entry already present is retained whatever the reserve says: refusing a REFRESH
 		// would make a component decline to replay a marker it has already stamped, which
 		// flips the message inside the provider's cached prefix — the cache-destructive
-		// direction, and for content that is sitting right there.
-		if !e.stash && m.stashN < m.stashCap() {
+		// direction, and for content that is sitting right there. That is also why the byte
+		// budget is not consulted here: a refresh is never refused, so an over-budget refresh
+		// is charged honestly and the refusals it causes land on the NEXT new payload.
+		if !e.stash && m.stashN < m.stashCap() && m.exemptRoom() {
 			e.stash = true
 			m.stashN++
+			m.stashBytes += int64(len(payload))
 		}
 		m.ll.MoveToFront(el)
 		return true
 	}
 	// The TTL is the only thing that releases a reserve slot now, so collect what it has
 	// released before declaring the reserve full — otherwise a long-lived process refuses
-	// forever on the strength of payloads that expired hours ago.
-	for m.stashN >= m.stashCap() && m.reclaimExpired() {
+	// forever on the strength of payloads that expired hours ago. One sweep, not one per
+	// reclaimed entry: this is the saturated path, so it runs on every refusal.
+	if m.stashN >= m.stashCap() || !m.exemptRoom() || !m.byteRoom(len(payload)) {
+		m.sweepExpired()
 	}
-	if m.stashN >= m.stashCap() {
+	if m.stashN >= m.stashCap() || !m.exemptRoom() || !m.byteRoom(len(payload)) {
 		m.stashRefusedN++
 		return false
 	}
 	e := &entry{key: key, payload: payload, expires: m.now().Add(m.ttl), stash: true}
 	m.stashN++
+	m.stashBytes += int64(len(payload))
+	m.noteExpiry(e.expires)
 	m.items[key] = m.ll.PushFront(e)
 	for m.ll.Len() > m.max {
 		if !m.evictOldest() {
@@ -343,18 +508,38 @@ func (m *Memory) PutStash(key string, payload []byte) bool {
 	return true
 }
 
-// StashStats reports the rewind reserve: payloads live now, the reserve's size, how many
-// payloads PutStash REFUSED (removals declined, not removals made irreversibly), and how many
-// the TTL reclaimed.
+// StashStat is the rewind reserve's state, reported as a struct because the reserve now has
+// two budgets and returning six positional values invites the caller to mix them up.
+type StashStat struct {
+	Live     int   // payloads held right now
+	Capacity int   // the reserve's entry cap (stashCap)
+	Bytes    int64 // what those payloads cost
+	MaxBytes int64 // the reserve's byte budget
+	// Refused counts payloads PutStash DECLINED — removals not made, rather than removals
+	// made irreversibly. Expired counts payloads the TTL reclaimed, which is the only way a
+	// stash leaves now that LRU pressure cannot evict one.
+	Refused int64
+	Expired int64
+}
+
+// StashStats reports the rewind reserve against both of its budgets.
 //
-// refused is the operator-facing number, and it is deliberately upstream of
+// Refused is the operator-facing number, and it is deliberately upstream of
 // expand_unresolved_missing: that counter only moves when the AGENT asks for content and is
 // told it is gone, so a run could exhaust the reserve for an hour and read as healthy until
 // something happened to request an expand. This one moves at the moment the budget binds.
-func (m *Memory) StashStats() (live, capacity int, refused, expired int64) {
+//
+// Reading Live/Capacity against Bytes/MaxBytes is what tells an operator WHICH budget bound,
+// and so which knob to turn: entries near capacity with bytes far from the budget means raise
+// max_entries; the reverse means raise stash_max_bytes (or reduce what the pipeline removes).
+func (m *Memory) StashStats() StashStat {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.stashN, m.stashCap(), m.stashRefusedN, m.stashExpiredN
+	return StashStat{
+		Live: m.stashN, Capacity: m.stashCap(),
+		Bytes: m.stashBytes, MaxBytes: m.stashMaxBytes,
+		Refused: m.stashRefusedN, Expired: m.stashExpiredN,
+	}
 }
 
 func (m *Memory) Put(key string, payload []byte) {
@@ -382,7 +567,7 @@ func (m *Memory) Put(key string, payload []byte) {
 		// Claim a pin slot if one has since freed (an earlier session's decisions expired):
 		// the cap is a live-entry budget, not a lifetime quota, so re-freezing every turn
 		// eventually protects this decision instead of leaving it permanently second-class.
-		if !e.pinned && m.isPinPrefix(key) && !m.noSlide && m.pinnedN < m.max/2 {
+		if !e.pinned && m.isPinPrefix(key) && !m.noSlide && m.pinnedN < m.pinCap() && m.exemptRoom() {
 			e.pinned = true
 			m.pinnedN++
 		}
@@ -396,10 +581,11 @@ func (m *Memory) Put(key string, payload []byte) {
 	// readable right now, and calling it "dropped" at write time both inflates the drop
 	// count with live entries and makes the very next re-freeze look like a repair. Its
 	// loss, if it comes, is recorded where losses actually happen (remove).
-	if m.isPinPrefix(key) && !m.noSlide && m.pinnedN < m.max/2 {
+	if m.isPinPrefix(key) && !m.noSlide && m.pinnedN < m.pinCap() && m.exemptRoom() {
 		e.pinned = true
 		m.pinnedN++
 	}
+	m.noteExpiry(e.expires)
 	m.items[key] = m.ll.PushFront(e)
 	for m.ll.Len() > m.max {
 		if !m.evictOldest() {
@@ -507,28 +693,54 @@ func (m *Memory) MarkSticky(session, id string) {
 	s[id] = struct{}{}
 }
 
-// reclaimExpired removes one already-EXPIRED entry, pinned or stashed included, and reports
-// whether it found one. Without it an exempt entry is immortal — the TTL is otherwise only
+// noteExpiry keeps nextExpiry a valid LOWER BOUND on the earliest expires in the store. Every
+// write sets its entry's expiry to now+ttl — the latest of any live entry — so the bound only
+// ever needs seeding, never raising: the first write after a sweep supplies it, and a sweep
+// recomputes it exactly.
+func (m *Memory) noteExpiry(t time.Time) {
+	if m.nextExpiry.IsZero() || t.Before(m.nextExpiry) {
+		m.nextExpiry = t
+	}
+}
+
+// sweepExpired removes EVERY already-expired entry, pinned and stashed included, and reports
+// how many it took. Without it an exempt entry is immortal — the TTL is otherwise only
 // enforced in Get, and a dead session is never read again — so pinnedN/stashN would ratchet
 // to their caps and stay there, leaking the reserve and silently disabling the exemption for
 // every later session.
-func (m *Memory) reclaimExpired() bool {
+//
+// One pass over the list, and skipped outright when nextExpiry proves nothing can have
+// expired. The predecessor reclaimed a single entry per call, so a saturated reserve walked
+// the whole list under the global mutex on every refused PutStash, and again per entry when
+// several had expired.
+func (m *Memory) sweepExpired() int {
 	now := m.now()
+	if !m.nextExpiry.IsZero() && !now.After(m.nextExpiry) {
+		return 0 // the earliest expiry is still in the future; nothing to find
+	}
+	n := 0
+	var soonest time.Time
 	for el := m.ll.Back(); el != nil; {
 		prev := el.Prev()
-		if e := el.Value.(*entry); now.After(e.expires) {
+		e := el.Value.(*entry)
+		if now.After(e.expires) {
 			m.remove(el)
-			return true
+			n++
+		} else if soonest.IsZero() || e.expires.Before(soonest) {
+			soonest = e.expires
 		}
 		el = prev
 	}
-	return false
+	// Recomputed from what survived, so the bound is exact here and only decays (safely,
+	// downward) as later writes seed it.
+	m.nextExpiry = soonest
+	return n
 }
 
 // evictOldest drops the least-recently-used entry that is neither pinned nor stashed,
 // walking back over the exempt ones. Reports false when nothing is evictable.
 func (m *Memory) evictOldest() bool {
-	if m.reclaimExpired() {
+	if m.sweepExpired() > 0 {
 		return true
 	}
 	// Nothing expired, so take the LRU entry that is not exempt. Stashes are exempt for a
@@ -552,7 +764,8 @@ func (m *Memory) remove(el *list.Element) {
 	}
 	if e.stash {
 		m.stashN--
-		// A stash only reaches here via reclaimExpired (LRU pressure cannot take one), so
+		m.stashBytes -= int64(len(e.payload))
+		// A stash only reaches here via sweepExpired (LRU pressure cannot take one), so
 		// this counts TTL reclamation. Counted rather than silent because it is the one
 		// remaining way an outstanding marker can stop resolving, and an operator seeing
 		// expand_unresolved_missing needs to know whether the answer is "raise max_entries"

--- a/store/store.go
+++ b/store/store.go
@@ -35,6 +35,44 @@ type Store interface {
 	Persists() bool
 }
 
+// Stasher is an OPTIONAL Store capability: writing a REWIND PAYLOAD — the original bytes
+// behind a <<cg:HASH>> marker — under its own reserved budget, and reporting whether the
+// payload was actually retained.
+//
+// It exists because a rewind payload cannot be recognised from its key. The pin namespaces
+// below all carry a "cg:" prefix, but a stash key IS the marker id: a bare lowercase-hex
+// content hash the model reads out of the request and hands back to the expand tool (see
+// expand.Marker). Prefixing it would rewrite every marker's bytes, and marker bytes sit
+// inside the provider's cached prefix — so the only way for the store to tell a payload from
+// any other entry is for the writer to say so. That is this method.
+//
+// The RETURN VALUE is the load-bearing half. Before it, a payload was written with Put and
+// then evicted as the least-recently-used entry of a cache whose pinned half held the
+// DECISIONS referring to it, so a removal advertised as reversible (a marker was stamped)
+// became irreversible with nothing reported — issue #187. false now means "this payload is
+// NOT stored", and the caller's contract is to not advertise reversibility: refuse the
+// removal and leave the content verbatim. See components/offload.commitMark.
+//
+// Stores that do not implement it degrade to the legacy behavior (Put, always "retained"),
+// which is why writers go through the PutStash helper rather than asserting at each site.
+type Stasher interface {
+	// PutStash stores a rewind payload under key and reports whether it is now retained.
+	// Refreshing a payload already present always succeeds — a live entry must never be
+	// refused, or a replay of an already-stamped marker would flip that message's bytes.
+	PutStash(key string, payload []byte) bool
+}
+
+// PutStash writes a rewind payload through the Stasher capability when the store has it,
+// and reports whether the payload is retained. A store without the capability keeps the
+// legacy behavior: an ordinary Put, reported as retained.
+func PutStash(s Store, key string, payload []byte) bool {
+	if st, ok := s.(Stasher); ok {
+		return st.PutStash(key, payload)
+	}
+	s.Put(key, payload)
+	return true
+}
+
 // FrozenLoser is an OPTIONAL Store capability: reporting that a frozen decision
 // under key was dropped (TTL expiry / pin cap) rather than never taken. A bare Get
 // miss cannot tell those apart, and they call for opposite behavior — "never frozen"
@@ -56,11 +94,16 @@ type FrozenLoser interface {
 // inside the provider's cached prefix and the whole suffix is re-written at 11.5x the
 // read price. They are small (a marker line, a compacted projection, an integer), still
 // honor the sliding TTL, and the exemption is capped at half the entry cap so a
-// pathological session can never pin the whole cache. The rewind stashes (bare content
-// hashes, the large payloads the expand loop resolves) stay fully evictable.
+// pathological session can never pin the whole cache.
 //
 // The prefixes are declared by their OWNERS (components/offload, apply) and passed in via
 // Options.PinPrefixes — the store must not know what a component names its keys.
+//
+// The rewind stashes are NOT in this list and never can be (their keys are bare marker ids —
+// see Stasher), which used to mean they were "fully evictable". That was the bug in #187:
+// this cache kept "that output was dropped" while evicting "here is what it was", so the
+// reversibility guarantee degraded exactly as the pipeline removed more. They now have their
+// own reserve, claimed through PutStash and bounded by stashCap.
 const (
 	FrozenPrefix = "cg:frz:" // mask / failed_run freeze decisions
 	ResultPrefix = "cg:res:" // extract_llm's replayed result (projection + summary, one key)
@@ -100,6 +143,11 @@ type entry struct {
 	payload []byte
 	expires time.Time
 	pinned  bool // exempt from LRU eviction (frozen decision); TTL still applies
+	// stash marks a REWIND PAYLOAD written through PutStash. Also exempt from LRU
+	// eviction, and — unlike a pin, which silently degrades to an evictable entry once
+	// over its cap — a stash that cannot be admitted is REFUSED, so the caller declines
+	// the removal instead of stamping a marker nothing can resolve. TTL still applies.
+	stash bool
 }
 
 // Memory is an in-memory Store: a TTL+LRU cache for rewind payloads plus a
@@ -118,6 +166,13 @@ type Memory struct {
 	pinPrefixes []string
 	now         func() time.Time // injectable for tests
 	pinnedN     int              // live pinned (frozen) entries, capped at max/2
+	stashN      int              // live rewind payloads, capped at stashCap()
+	// stashRefusedN counts payloads PutStash DECLINED because the reserve was full — i.e.
+	// removals that were not made, rather than removals made irreversibly. stashExpiredN
+	// counts payloads the TTL reclaimed, which is the only way a stash leaves now that LRU
+	// pressure cannot evict one.
+	stashRefusedN int64
+	stashExpiredN int64
 	// lostFrozen remembers keys whose FROZEN entry was dropped anyway (TTL expiry, or
 	// the pin cap). It is the "was frozen, now LOST" signal a caller cannot otherwise
 	// distinguish from "never frozen" — see FrozenLost. Bounded like sticky.
@@ -150,7 +205,13 @@ type Options struct {
 // offloads become irreversible, which is why they must use marker_mode: off.
 type Nop struct{}
 
-func (Nop) Put(string, []byte)                {}
+func (Nop) Put(string, []byte) {}
+
+// PutStash retains nothing, so it reports nothing retained. Reachable only if a caller
+// skips effectiveMode (which already degrades a full marker to off when !Persists()), and
+// the answer is the same either way: do not advertise reversibility.
+func (Nop) PutStash(string, []byte) bool { return false }
+
 func (Nop) Get(string) ([]byte, bool)         { return nil, false }
 func (Nop) Sticky(string) map[string]struct{} { return nil }
 func (Nop) MarkSticky(string, string)         {}
@@ -162,8 +223,25 @@ func (Nop) Persists() bool                    { return false }
 // (test suites, training runs) with the sliding refresh doing the rest.
 const DefaultTTL = 10000 * time.Second
 
+// DefaultMaxEntries is the store's default entry cap.
+//
+// It was 1,000, and that was the quantity #187 was measured against: ONE process-wide store
+// serves every concurrent session (cmd/context-guru-proxy builds it once), and each
+// reversible removal writes FIVE entries — the payload, cg:own:, cg:xseen:, and two pinned
+// decision records (cg:res:, cg:xres:). So a 1,000-entry cache held roughly 1/5 of half its
+// slots' worth of payloads while the decisions naming them were pinned, and iteration 024's
+// arm B — hundreds of removals across eight concurrent workers — overran it by an order of
+// magnitude. 5,000 puts the cap in the same order as the observed volume; PutStash's refusal
+// is what makes overrunning it visible rather than silent, so this number does not have to be
+// right, only sane.
+//
+// Entry count is a PROXY for memory, and a poor one for this namespace: pinned decisions and
+// the bookkeeping flags are tiny, a stashed payload is a whole tool output. An operator
+// running large payloads should set max_entries against bytes they can afford, not entries.
+const DefaultMaxEntries = 5000
+
 // NewMemory builds an in-memory store. Zero/negative option fields fall back to
-// defaults (DefaultTTL, 1000 entries, 100 sessions of sticky sets).
+// defaults (DefaultTTL, DefaultMaxEntries, 100 sessions of sticky sets).
 func NewMemory(o Options) *Memory {
 	ttl := time.Duration(o.TTLSeconds) * time.Second
 	if o.TTLSeconds <= 0 {
@@ -171,7 +249,7 @@ func NewMemory(o Options) *Memory {
 	}
 	max := o.MaxEntries
 	if max <= 0 {
-		max = 1000
+		max = DefaultMaxEntries
 	}
 	stick := o.MaxSessions
 	if stick <= 0 {
@@ -207,6 +285,76 @@ func (m *Memory) DisableSlidingTTLForTest() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.noSlide = true
+}
+
+// stashCap bounds the rewind reserve at half the entry cap, the same share the pins get.
+// Half and not more because the two halves are the two things reversibility needs at once:
+// the payload to serve, and the decision that keeps the message it came out of byte-stable.
+func (m *Memory) stashCap() int { return m.max / 2 }
+
+// PutStash stores a rewind payload under its marker key and reports whether it is retained.
+// See Stasher for why the store cannot recognise these keys on its own, and why the boolean
+// is the point.
+//
+// The policy, and the property it is chosen for: a live stash is NEVER evicted to make room
+// for a new one. Under the old plain-Put behavior the guarantee decayed as the pipeline
+// succeeded — every extra removal both consumed a slot and added a pinned decision, so more
+// compaction meant more BROKEN promises. Refusing instead moves that pressure onto the
+// removals not yet made: promises already outstanding stay good however long the run gets,
+// and the mechanism declines new work rather than doing it irreversibly. Capacity becomes a
+// configured quantity (max_entries) and exhaustion becomes a counter, in exchange for
+// reversibility no longer being load-dependent.
+func (m *Memory) PutStash(key string, payload []byte) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if el, ok := m.items[key]; ok {
+		e := el.Value.(*entry)
+		e.payload = payload
+		e.expires = m.now().Add(m.ttl)
+		// Claim a reserve slot if one has freed, exactly as Put re-claims a pin slot. An
+		// entry already present is retained whatever the reserve says: refusing a REFRESH
+		// would make a component decline to replay a marker it has already stamped, which
+		// flips the message inside the provider's cached prefix — the cache-destructive
+		// direction, and for content that is sitting right there.
+		if !e.stash && m.stashN < m.stashCap() {
+			e.stash = true
+			m.stashN++
+		}
+		m.ll.MoveToFront(el)
+		return true
+	}
+	// The TTL is the only thing that releases a reserve slot now, so collect what it has
+	// released before declaring the reserve full — otherwise a long-lived process refuses
+	// forever on the strength of payloads that expired hours ago.
+	for m.stashN >= m.stashCap() && m.reclaimExpired() {
+	}
+	if m.stashN >= m.stashCap() {
+		m.stashRefusedN++
+		return false
+	}
+	e := &entry{key: key, payload: payload, expires: m.now().Add(m.ttl), stash: true}
+	m.stashN++
+	m.items[key] = m.ll.PushFront(e)
+	for m.ll.Len() > m.max {
+		if !m.evictOldest() {
+			break // everything left is pinned or stashed
+		}
+	}
+	return true
+}
+
+// StashStats reports the rewind reserve: payloads live now, the reserve's size, how many
+// payloads PutStash REFUSED (removals declined, not removals made irreversibly), and how many
+// the TTL reclaimed.
+//
+// refused is the operator-facing number, and it is deliberately upstream of
+// expand_unresolved_missing: that counter only moves when the AGENT asks for content and is
+// told it is gone, so a run could exhaust the reserve for an hour and read as healthy until
+// something happened to request an expand. This one moves at the moment the budget binds.
+func (m *Memory) StashStats() (live, capacity int, refused, expired int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stashN, m.stashCap(), m.stashRefusedN, m.stashExpiredN
 }
 
 func (m *Memory) Put(key string, payload []byte) {
@@ -359,14 +507,13 @@ func (m *Memory) MarkSticky(session, id string) {
 	s[id] = struct{}{}
 }
 
-// evictOldest drops the least-recently-used UNPINNED entry, walking back over pinned
-// (frozen) ones. Reports false when nothing is evictable.
-func (m *Memory) evictOldest() bool {
+// reclaimExpired removes one already-EXPIRED entry, pinned or stashed included, and reports
+// whether it found one. Without it an exempt entry is immortal — the TTL is otherwise only
+// enforced in Get, and a dead session is never read again — so pinnedN/stashN would ratchet
+// to their caps and stay there, leaking the reserve and silently disabling the exemption for
+// every later session.
+func (m *Memory) reclaimExpired() bool {
 	now := m.now()
-	// Pass 1: reclaim anything already EXPIRED, pinned included. Without this a pinned
-	// entry is immortal — the TTL is only enforced in Get, and a dead session is never
-	// read again — so pinnedN would ratchet to max/2 and stay there, leaking half the
-	// cache and silently disabling pinning for every later session.
 	for el := m.ll.Back(); el != nil; {
 		prev := el.Prev()
 		if e := el.Value.(*entry); now.After(e.expires) {
@@ -375,9 +522,22 @@ func (m *Memory) evictOldest() bool {
 		}
 		el = prev
 	}
-	// Pass 2: nothing expired, so take the LRU entry that is not pinned.
+	return false
+}
+
+// evictOldest drops the least-recently-used entry that is neither pinned nor stashed,
+// walking back over the exempt ones. Reports false when nothing is evictable.
+func (m *Memory) evictOldest() bool {
+	if m.reclaimExpired() {
+		return true
+	}
+	// Nothing expired, so take the LRU entry that is not exempt. Stashes are exempt for a
+	// DIFFERENT reason from pins: a pin protects the bytes of an already-cached message, a
+	// stash protects a promise this proxy made to the model in a marker it has already sent.
+	// Evicting one here is what #187 was — the cheap decision record survived, the payload it
+	// pointed at did not, and the removal became irreversible with nothing reported.
 	for el := m.ll.Back(); el != nil; el = el.Prev() {
-		if !el.Value.(*entry).pinned {
+		if e := el.Value.(*entry); !e.pinned && !e.stash {
 			m.remove(el)
 			return true
 		}
@@ -389,6 +549,15 @@ func (m *Memory) remove(el *list.Element) {
 	e := el.Value.(*entry)
 	if e.pinned {
 		m.pinnedN--
+	}
+	if e.stash {
+		m.stashN--
+		// A stash only reaches here via reclaimExpired (LRU pressure cannot take one), so
+		// this counts TTL reclamation. Counted rather than silent because it is the one
+		// remaining way an outstanding marker can stop resolving, and an operator seeing
+		// expand_unresolved_missing needs to know whether the answer is "raise max_entries"
+		// (refused) or "raise ttl_seconds" (expired).
+		m.stashExpiredN++
 	}
 	// Any replay decision disappearing must be detectable — keyed on the NAMESPACE, not on
 	// the pin flag. An entry that missed the pin cap is exactly the one most likely to be


### PR DESCRIPTION
Closes #187.

## The cause, established

**The issue's hypothesis is correct**, and the store's own comment said so before the fix did: *"The rewind stashes (bare content hashes, the large payloads the expand loop resolves) stay fully evictable."*

A stash payload's key **is the marker id** — a bare lowercase-hex content hash the model reads out of the request and hands back to `context_guru_expand` (`expand.Marker`, `offload.hashKey` / `extract.ContentKey`). It therefore carries none of the pinned `cg:*` prefixes, and it cannot be given one: marker bytes sit inside the provider's cached prefix, so prefixing the key would rewrite every marker. Meanwhile the **decision records that reference it** are pinned (`cg:res:`, `cg:xres:`, `cg:frz:`).

The arithmetic that turns that into 209 failed expands:

* **one store per process.** `cmd/context-guru-proxy` builds `cfg.NewStore()` once (`main.go:480`); every concurrent session shares it. The iteration 024 arm configs set no `store:` block, so: 1,000 entries, pin cap 500, `DefaultTTL` 10,000 s.
* **one reversible removal writes five entries** — the payload (unpinned), `cg:own:` (unpinned), `cg:xseen:` (unpinned), `cg:res:` (pinned), `cg:xres:` (pinned). The payload competed for ~1/5 of the evictable half while the two records naming it were exempt.

Measured directly against the shipped defaults of the day (600 removals writing that real key mix):

```
removals=600  stash_live=100  res_live=350  xres_live=350  own_live=100  xseen_live=100  frozen_dropped=500
```

**100 of 600 payloads survived against 350 of 600 of each pinned decision — the payload was 3.5x less durable than the record that pointed at it.** 500 markers had been stamped for content the store could no longer produce.

### The other two candidate causes are refuted

* **The stash expired.** `DefaultTTL` is 10,000 s and *sliding* (refreshed on `Get`, and components re-`Put` on every replay turn); the runs are shorter. The reproduction above evicts payloads with the clock stationary, so expiry is not needed to produce the symptom.
* **The store did not persist.** The process store is `*store.Memory` (`Persists() == true`), and `effectiveMode` already degrades a full marker to `off` when it is not — so a non-persisting store cannot leave a dangling marker. Arm A ran the same store and scored 0.
* **The key was written under a session id nothing reads.** Both resolution paths are session-**independent** bare `Get`s: `proxy.repairExpandErrors` → `expand.Resolve(tn.Store, id)` (`proxy.go:1297`) and the response continuation loop (`proxy.go:1653`). `offload.OwnsKey` — the only session-scoped read — gates the management `GET /expand` endpoint alone.

## What changed

**`store.Stasher` / `store.PutStash` — a reserve for rewind payloads, and a boolean.** An optional Store capability (same pattern as `FrozenLoser`), because the store cannot recognise these keys on its own; stores without it keep the legacy behavior. `Memory` flags such entries, exempts them from LRU eviction, and bounds them at `max_entries / 2` — the same share the pins get.

**The return value is the fix, not the reserve.** A live payload is **never** evicted to admit a new one. When the reserve is full `PutStash` returns false, and the caller declines the removal:

* `offload.commitMark` now returns a bool; all twelve offloaders (`mask`, `failed_run`, `collapse`, `dedup`, `extract`, `extract_llm`, the sweep's drop, `linecap`, `skeleton`, `smartcrush`, `readlifecycle`, `agentdiet`) `continue` — the message is left **verbatim**, not cut, and no marker is stamped.
* `cmdfilter` builds its marker token inline rather than through `commitMark`, so it honors the same contract in its own file.
* `summarize` *replaces* the span it covers, so it cannot leave one message alone: it skips the whole checkpoint.
* The two **refresh** paths (`reapplyFrozen`, summarize's checkpoint replay) count a refusal but still replay — refusing there would flip an already-cached message. A refresh of a payload that is present is never refused, for the same reason.

**Only the TTL releases a slot**, and `PutStash` collects expired ones before declaring the reserve full, so a long-lived proxy recovers.

**Visibility.** `stash_refused`, `stash_live`, `stash_capacity`, `stash_expired` at `/stats` (added to the golden contract) and `cg_stash_refused_total`, `cg_stash_reserve_entries`, `cg_stash_expired_total` at `/metrics`. `stash_refused` is the *leading* indicator: `expand_unresolved_missing` cannot move until an agent happens to call expand, so a proxy that had stopped being able to promise reversibility read as healthy until one did.

**`DefaultMaxEntries` 1,000 → 5,000.** 1,000 was an order of magnitude under the observed volume (hundreds of removals × five entries × eight concurrent workers). The doc comment says plainly that entry count is a poor proxy for memory in this namespace and that an operator with large payloads should size `max_entries` against bytes.

## What happens now when the budget is exhausted

The removal **does not happen**. The tool output is forwarded verbatim, `stash_refused` increments, and the component records a `stash_reserve_exhausted` gate. Nothing that was promised stops being deliverable; the pipeline saves fewer tokens and says so.

That is the property #187 asked for by name. Before, every extra removal both consumed a slot and added a pinned decision, so **broken promises grew with the amount of work done**. Now what grows is the count of removals *declined* — a refusal to promise instead of a promise broken. `TestBrokenPromisesDoNotGrowWithLoad` asserts exactly that at 40 / 200 / 1000 removals against a 50-slot reserve: broken = 0 at every load, refusals strictly rising.

## Mutations run, and what each broke

The bug is still representable (nothing here is a type-level impossibility), so every test was verified by **reverting its subject** in a scratch tree and confirming failure.

| # | Mutation | Caught by |
|---|---|---|
| M1 | `evictOldest` stops exempting stashes (the original #187 mechanism) | `TestAnAcceptedStashSurvivesThePressureThatEvictsThePlainCache` (payload evicted after acceptance), `TestAFullReserveRefusesInsteadOfEvictingALivePayload`, `TestBrokenPromisesDoNotGrowWithLoad` — *30/40, 190/200, 990/1000 advertised-reversible removals cannot be reversed* |
| M2 | `PutStash` evicts the oldest payload and reports success instead of refusing | all four store tests, plus **both rendered-output tests**: 5 markers on the wire against a 2-payload reserve, 3 of them resolving to nothing |
| M3 | `commitMark` ignores the refusal and stamps the marker anyway | `TestNoMarkerReachesTheWireWithoutItsPayload` and the proxy end-to-end test — *the body sent UPSTREAM offers the model `<<cg:…>>` and the store cannot produce it* |
| M4 | `/stats` handler drops `stash_live` / `stash_capacity` | proxy test: rendered `stash_capacity = 0, want 2` |
| M5 | `/stats` handler drops `stash_refused` (computed, then thrown away) | proxy test: rendered `stash_refused = 0` while removals were being declined |
| M6 | `PutStash` never reclaims expired payloads | `TestTheTTLReleasesReserveSlots` — *the reserve stayed full after its payloads expired: it never recovers* |
| M7 | a refresh of a payload that is present but holds no slot is refused | `TestRefreshingALivePayloadIsNeverRefused` |
| M8 | `cmdfilter` stamps its inline marker despite the refusal | `TestCmdfilterRefusesRatherThanStampingAnUnbackedMarker` |
| M9 | `summarize` emits the checkpoint despite the refusal | `TestSummarizeSkipsTheCheckpointWhenTheSpanCannotBeStashed` — *restructured the transcript (2 messages, was 7)… the summary's marker is the only route back to a span that is now gone* |
| M10 | `DefaultMaxEntries` back to 1,000 | **nothing.** Deliberate — see below |

**M7 and M8 initially escaped**, which is why they are here: the first refresh test used a key that already held a slot, and the first cmdfilter mutation removed the only use of an import so it failed to *compile* rather than failing a test. Both were re-cut to compile and to bind, and tests were added for them.

Two of the three new tests assert on **rendered output**, not on return values: `json.Marshal` of the rewritten messages (offload) and the body the fake upstream actually received (proxy), each scanned for markers in **both** spellings — `encoding/json` HTML-escapes `<`, and every marker follows a newline, so on the wire a marker usually exists only as `<<cg:HASH>>`. The first draft of that check scanned only the plain form, reported zero markers on a body full of them, and would have passed while the wire carried unbacked ones.

## What I could not establish

* **That eviction is what produced iteration 024's 209 specifically.** The mechanism is established from the code and reproduced against the exact shipped defaults and the exact key mix; what is *not* available is a store-level counter from that run (`results.md` records no `frozen_dropped` / store figures, and the raw run artifacts are another session's live evidence). The reproduction shows `frozen_dropped = 500` alongside the evicted payloads, so a re-run should show `frozen_dropped > 0` in arm B and 0 in arm A if this is the whole story.
* **`DefaultMaxEntries = 5000` is not test-pinned** (M10 breaks nothing). A test asserting the constant would assert it against itself; its *effect* is covered by the reserve tests, which are parameterised on `MaxEntries`. The number is sane, not measured — the refusal counter is what makes a wrong choice visible.
* **A byte budget.** The reserve counts entries, and a payload is a whole tool output while a pinned decision is a marker line. Sizing the reserve in bytes is the honest follow-up; it is not in this PR.
* **#47 shares this root cause** — one fixed entry budget serving unrelated namespaces with a single `max/2` exemption, which is why the reproduction dropped 500 *pinned* decisions too. **Not fixed here.** The larger default relieves the pin pressure #47 describes (the pin cap goes 500 → 2,500) without addressing its `TailOnly` fail-open.

## Impact on iteration 024's published results

From the issue, so that whoever reads this knows a re-run is needed to separate the two:

* **The reward result is CONSERVATIVE, not threatened.** Arm B won 8 tasks to 0 (clustered p = 0.0078, harm bound 11.2%) *while carrying 209 failed expands*. That was a handicap the winning arm bore.
* **The latency conclusion is CONFOUNDED by this defect and was stated too strongly.** `results.md` reports arm B taking 13% more turns on pairs both arms solved and calls the latency hypothesis "refuted". 209 failed expands over 75 runs is ~2.8 per run against ~33 turns/run, so failed-expand round-trips could account for a meaningful share of that 13%. It should read *"not supported, and partly confounded by this defect."*
* Cost figures are mildly contaminated — a failed expand costs the tokens and the turn and delivers nothing.
* Most generally: **iteration 024 measured "the mechanism plus a reversibility bug", not the mechanism.** Re-running after this fix is the only way to separate them.

## Verification

`gofmt -l .` clean · `CGO_ENABLED=1 go vet ./...` clean · `CGO_ENABLED=1 go test ./...` all packages pass (Go 1.26.4, eval box).


---

## Review round 2 (`3f12b9d`)

The seven inline findings, the doc finding and the ordering note are all addressed. The two themes were fixed as **invariants**, because in both cases the flagged sites were not the whole set.

### Theme 1 — nothing is recorded before the gate

`commitMark` can refuse, so anything written ahead of it may describe work that did not happen — and the dangerous half is not the lost saving. A frozen `cg:res:` decision with no splice behind it is read on a later turn by the same-session replay path, which **deliberately bypasses the cache-tail gate** on the reasoning that these bytes were already sent; once a reserve slot frees, the compaction lands inside the provider's cached prefix and the whole suffix is re-written at ~11.5x the read price. The reversibility fix had introduced a reversibility-adjacent bug.

Audited all twelve `commitMark` callers. Ten were already clean. Four sites recorded state early — the three in the review, plus **the cross-session cache hit** (`extract_llm.go:~975`), which the review did not name: its own comment argues the branch is a NEW decision for this session, which is why it is tail-gated, so its payload write can refuse like any other.

Enforced rather than commented:

* `commitMark`'s doc states the rule and names what it covers (splice, frozen decision, metrics, debug counters, `rep.Replay`).
* `TestNoStateIsRecordedBeforeTheCommitGate` drives registered offloaders against a saturated reserve and asserts **no marker on the wire** and **no decision write**, with a healthy-store precondition so a component that silently stopped acting cannot pass it vacuously.
* `TestEveryOffloadComponentIsHeldToTheCommitGate` requires every registered Offload to be driven or listed in `gateExempt` **with the test that pins it** — so the thirteenth caller has to declare itself. Same mechanism `promexport_coverage_test.go` uses for `/stats` fields.
* `cmdfilter` no longer hand-rolls its own token, never-worse check and `PutStash`. It differed from `tryMark` only in the recovery hint `tryMark` already takes as a parameter, and that duplicate is exactly why M8 escaped a whole review round in that file alone.

**A replay is now a different operation from a new removal.** Gating alone would have made the replay paths worse: refusing there sends the original in full where the cached prefix holds the compacted bytes, which is the cache-destructive direction and cannot un-send a marker that went out turns ago. `commitRefresh` never refuses and reports a missing payload as a diagnosis. #188 already stated that rule for `reapplyFrozen`; extract_llm's and the sweep's same-session replays were missed.

### Theme 2 — the reserve's budgets

* **`stash_max_bytes`, default 256 MiB.** Promoted from follow-up to fix, as the review suggested it might be. Entries are a poor proxy for memory in this one namespace — every other exempt entry is a marker line or an integer, a payload is a whole tool output — so `max_entries` named a memory figure spanning two orders of magnitude depending on nothing the operator chose. `/stats` and `/metrics` publish `stash_bytes` against `stash_max_bytes` beside the entry pair, so **which** budget bound is visible.
* **A guaranteed evictable floor.** `pinCap` and `stashCap` are each `max/2`, so together they could occupy the whole entry cap — and a cache with nothing evictable fails silently, not loudly: the next plain `Put` is evicted by its own insert, turning `cg:keep:` (the flag that stops the expand loop), `cg:sum:`, `cg:own:` and `cg:xseen:` into no-ops, on precisely the workload the reserve was built for. A quarter of `max_entries` is now held back from both exemptions.
* **Refusals are O(1).** `sweepExpired` makes one pass instead of one per reclaimed entry, and `nextExpiry` skips the walk entirely when nothing can have expired. Before, every refused `PutStash` walked the whole list under the global mutex.

**Per-session partitioning was considered and declined.** No session reads another's payload (`OwnsKey` enforces it), so what is shared is the *budget*, not the data; a fair-share cap would need a share number as arbitrary as the one it replaced, plus an ownership rule for a content-hash key two sessions can legitimately both stash. Sizing against the real resource addresses the same failure more honestly.

### Two counters, because they were opposite outcomes

`stash_refused` and `stash_missing` shared a counter. Every operator-facing description of a refusal promises "the content was left verbatim and nothing became irreversible" — true of a declined removal, false of a replay whose payload has gone, which is the *only* case that actually breaks the #187 guarantee. So the number an operator watches to confirm nothing broke was incremented by things breaking.

`stash_missing` also grows with **turn count**, not with distinct dangling markers — a missing payload cannot be restored, because the replayed bytes must stay byte-identical to the turn that created them — and both the counter and `routes.md` say so.

### summarize

* **The reserve is consulted before the model call.** The span is all the marker key depends on. Previously a saturated reserve paid a ~57k-prompt-token call and discarded it, then did it again every turn, because a refusal saves no checkpoint and so nothing about the next turn changes. A **probe**, not an early claim: claiming the slot would leak a payload whenever the call then failed. `agentdiet` gets the same probe, weaker on purpose (smallest candidate, so it skips only when nothing at all fits).
* **A refusal no longer flips cached content.** Once a checkpoint has been emitted, earlier turns sent `[msg0, summary, tail]`; a bare `return nil, nil` sent the transcript **full**. When the checkpoint is stale-but-valid — `tryReuse` verified the prefix hash and declined only on size — it is re-emitted instead, through an `emitCheckpoint` shared with `tryReuse` so the two cannot drift. A session with no checkpoint still sends the full transcript, and that case is asserted so the fallback cannot become unconditional.

### Docs

`docs/reference/config.md` — the page an operator reads when `stash_refused` tells them to raise `max_entries` — documented `max_entries` as `1000` and eviction as pinning-only. Now: 5,000, `stash_max_bytes`, both exemptions, the floor and why its absence is silent, and explicit guidance that `stash_refused` means raise a budget while `stash_missing` means raise `ttl_seconds`. Also corrected in `docs/design.md` (both sites) and `docs/how-to/recover-context.md` (defaults, the rewind bullet, the pin-cap sentence, the troubleshooting note). `routes.md` separates the two counters. The four `statsGoldenTopLevel` keys are back in alphabetical order.

### Verification

`gofmt -l .` clean · `CGO_ENABLED=1 go vet ./...` clean · `CGO_ENABLED=1 go test ./...` all packages pass (Go 1.26.4, eval box).

**23 mutations, each reverting one subject whole in a scratch tree, all caught.** Full table in the commit body. The ones worth reading: M11 (floor removed) reports `0 of 200 entries are evictable` and the `cg:keep:` write vanishing — the reviewer's predicted failure, reproduced; M25 (bare return) sends 19 messages where 2 were cached; M30 (`/stats` wire dropped) reads `stash_missing = 0` while the live counter reads 1.

**Four tests were vacuous or wrong on the first cut**, recorded rather than quietly fixed because the shapes recur here: one asserted an unchanged message, which is also what a component that never ran leaves behind; one was blind because `round4` renders a ~1e-6 USD saving as `0.0000`; one assumed a replay could refuse, which by the new design it cannot; and one cross-session fixture used the same content in both sessions, where the payload is already present and the write is a refresh that cannot refuse. M27 also initially "passed" only by breaking the build, and was re-cut to compile and bind.

### Still open, deliberately

* **The shared-hold window is narrowed, not closed** — filed as #190, with the four candidate fixes and their trade-offs. A busy period can still hold the reserve until the TTL releases it. What changed: the bound is now memory the operator chose, the refusal is O(1) and counted, and a saturated reserve can no longer take the rest of the cache down with it. Which fix is right should be decided by a re-run's `stash_refused` and both budget pairs, not by another guess at a default.
* **`cg_stash_*` has no Grafana panel or alert** — filed as #189. The series exist; `deploy/grafana/dashboards/context-guru.json` does not reference them, and `cg_stash_missing_total` is the alertable one.
* **`#47` is still not fixed**, and `DefaultMaxEntries = 5000` is still sane rather than measured — unchanged from the original description.

---

## Review round 3 (`a67c597`)

Seven more findings, all fixed. Two were mine to answer for: a **regression** this PR introduced, and finding 1 of round 2 having been **half-applied** by me.

### The regression: a degraded-mode replay stopped declaring itself irreversible

`commitMark`'s non-full branch sets `rep.Irreversible`, and that flag is what exempts a deliberate lossy drop from `components/pipeline.go`'s "dropped content without stashing a cache_key" revert. When the replay branches stopped calling `commitMark`, they stopped setting it — so under `marker_mode: summary`/`off`, **every replay turn reverted the whole component and sent the transcript verbatim**: a full-suffix cache write per turn, which is the harm this PR exists to prevent.

Confirmed by execution, two turns of `extract_llm` at `markerSummary`:

```
turn 1 (fresh, via commitMark): keys=0 Irreversible=true  Replays=0
turn 2 (replay branch):         keys=0 Irreversible=false Replays=1
```

`commitRefresh` now takes the `rep`/`eff` pair and owns `rep.Irreversible` symmetrically with `commitMark`, so the two cannot drift and a third caller cannot reintroduce it.

**A third instance predates this PR.** `reapplyFrozen` has never set the flag, and a summary-mode replacement carries no `<<cg:HASH>>` to parse so it returns no keys either — meaning a summary-mode `mask` has been reverted on every turn from turn 2 onward, independently of the reserve work. Fixed here under the same rule, since leaving it would mean the shared helper was correct and its oldest caller was not.

### The fresh paths were still booking before the gate

Round 2 moved the **replay** paths' metrics and left the fresh ones:

* **`extract_llm`** — `RecordExtractionSaving`, `RecordExtractionValue`, `e.ratios.observe`, `calls[k].Accepted` and `calls[k].SavedTokens` all ran inside `runCall`: in a goroutine, before `wg.Wait()`, and therefore before phase 3 exists. On a saturated reserve every candidate is declined and the run reported the full saving anyway. The arithmetic now rides in the `outT` slot phase 3 already reads.
* **The ratio feed is the consequential one** — it prices *future* calls, so the damage outlives the turn. A declined splice now observes **nothing**: crediting the achieved ratio keeps the gate authorising calls whose output is discarded, while crediting 0 would claim the workload is incompressible, which is false. A model that produced nothing is separate evidence and is still observed as ratio 0.
* **`extract_sweep`** — `adjudicate` booked while building its drop list, and the local `sweep_drop_would_not_shrink` pre-check covers neither refusal phase 3 can now raise: it is descriptor-only rather than marker-inclusive, and cannot see the reserve at all. `Accepted`/`SavedTokens` are now filled from what was **applied** rather than from what the adjudicator judged spent — the two diverge exactly when the reserve refuses — with a distinct rejection reason for "adjudicated spent, but no drop could be applied".
* Two knock-ons, both caught by existing tests: the per-call debug record is emitted in the goroutine, so it would have logged `accepted=false` on every call (`TestExtractLLMLogsOneRecordPerCall` failed on it); and both ledger appends had to move after phase 3, because `rep.Calls` takes a copy.

### The invariant test now covers the class

Following the reviewer's suggestion, which is better than the three point fixes it replaces: `TestNoStateIsRecordedBeforeTheCommitGate` asserts **metric deltas** — gross saved tokens, gross value, and every ledger row's `accepted`/`saved_tokens` — alongside store writes, and **`extract_llm` and `extract_llm_sweep` are driven by the table** rather than exempted from it. `gateExempt` is down to `agentdiet` and `summarize`, each naming the test that pins it.

### Also

* **`agentdiet`'s reserve gate now counts.** Gating without incrementing `stashRefusals` made one component's refusals invisible to the counter `docs/reference/config.md` names as *the* signal to raise a budget.
* **`evictableFloor` is at least 1.** `max/4` is 0 for `max_entries` of 2 or 3, so the two exemptions could reach the whole cap and the floor documented here as unconditional had a hole at the bottom of the range.
* **`TestExtractLLMReportsNoSavingsForASpliceItDeclined` was blind** in the half its own name claims — ~4 tokens at the `agentFreshPerMTok` fallback is ~1.2e-5 USD against `round4`'s 1e-4 step. Only the rates fixture was wrong; the assertions are unchanged. It is the second time that trap landed in this change, so the fixture is now factored into a `pricedCtx()` helper carrying the reason.

### Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all packages pass · `./dash` passes standalone (70s).

**30 mutations, every one caught by a TEST failure rather than a build break.** Round 1's 23 were re-run against this commit and **three no longer landed** — M17, M23, M33 — because this commit changed the code they patch; a mutation that does not land proves nothing, so they were re-cut and re-verified. One of them (M17) had been "caught" in round 1 only via a `goto` that failed to compile, so that result was not evidence either. The harness now distinguishes a build break from a test failure.

New this round: M34 (replay drops the flag), M35 (the pre-existing twin in `reapplyFrozen`), M36 (`extract_llm` books early → 6072 tokens booked, ratio moved 0.12 → 0.45, `accepted=true` on a verbatim request), M37 (sweep books early → 86,458 tokens), M38 (`agentdiet` stops counting), M39 (bare `max/4` → 0 evictable at `max_entries: 2`), M40 (metric ungated with `rep.Replay` left guarded — proves the savings half now binds **alone**), M41/M42 (both fresh paths caught by the **table** test alone), M43 (an Offload in neither the table nor `gateExempt`).

---

## Review round 4 (`c7e41ad`)

One HIGH regression from round 3, its MEDIUM consequence, and three LOW findings.

### The regression, same shape as the one round 3 fixed

Moving the metrics out of `adjudicate`'s verdict loop deleted `removed`'s only assignment and left the `if removed == 0` read. Go then guarantees it stays 0, so **every** adjudication stamped `"adjudicated: nothing was spent"` — including ones that dropped content. A ledger row could carry `accepted=true`, a large `saved_tokens`, *and* `"nothing was spent"` simultaneously: exactly the self-contradictory row this work exists to eliminate. The compiler could not catch it because the variable is still **read**, so it built and the suite stayed green.

The rejection now tests `len(drop) == 0` — which is what the comment above it already claimed, since `drop` *is* "what the adjudicator judged spent". The token total gets its own name, `judgedTokens`, for the `cg.sweep.ask` debug row it was really serving; that field had gone permanently 0, taking the sweep's economics out of the only place a run's decisions can be reconstructed from.

**Its consequence:** the reserve-exhausted rejection reason added in round 3 was **dead code**, because `adjudicate` always left a non-empty `Rejection` so the `Rejection == ""` guard never opened — meaning the case that reason exists to distinguish still read as a plain rejection. Fixed by the above, and now asserted by name.

### The ledger carries the wire's figure

`saved` was `content − descriptor`, but in `markerFull` the text spliced is `descriptor + marker + recovery hint`, so every candidate was overstated by the marker's tokens — while the comment beside it claimed the figure was "what reached the wire". Measured against the spliced message instead. **86,458 claimed against 86,201 actually sent** on the stocked fixture, ~23 tokens per drop.

Deliberately *not* applied to `extract_llm`'s projection-only figure: pre-existing, unclaimed, and moving a published savings number for unrelated reasons belongs in its own change.

### Also

* **The ratio comment argued one direction only.** Under a persistently saturated reserve nothing advances `r.total`, so `ratio()` stays pinned to its prior and `exploring()` keeps granting its per-session budget instead of self-terminating — a small permanent spend on exactly the deployments this PR is for. The comment now states it as a trade, not a win.
* **The single-flight follower is guarded rather than fragile.** It returned with `before` still 0 while phase 3 spliced its projection, booking `observe(0,0)` and two zero savings and setting `Accepted` on a row whose `Component` is `""` — harmless only through three independent zero-guards. Now gated on `before > 0`. The follower's saving stays unbooked (its leader books the shared result once); the guard removes the pretence of measuring it, not the under-count.

### Tests for the three things nothing pinned

* `TestSweepTellsAReserveRefusalApartFromNothingSpent` — both rejection strings by name, one subtest each, with preconditions so neither can pass by landing in the other's case.
* `TestADegradedModeReplayDeclaresItselfIrreversible` gains an **`extract_sweep_drop`** subtest — the one replay branch of four with nothing pinning it.
* `TestSweepReportsItsOwnEconomicsAndTheWiresSeparately` — the debug row's `removed_tokens` is non-zero after a turn that dropped, and the ledger total equals the exact token delta of the messages actually sent.

### Split out: #194

The `reapplyFrozen` fix is a **pre-existing `main` defect**, verified independently at the merge base (`51fcd91`), where `reapplyFrozen` takes no `rep` parameter at all. On the reviewer's recommendation it is now **#194** off `main`, closing **#193** — a summary-mode revert bug that is live today should not ship only when this PR does, and this PR still carries the open reserve-lifetime question in #190.

This branch keeps the same three lines for now and will be rebased onto `main` once #194 lands, at which point its `state.go` diff reduces to a single call-site change. Not stripped pre-emptively, because this branch's tests depend on them.

### Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all packages pass, on **both** branches.

5 new mutations, all caught by a test failure. **Three of the five did not bind on the first attempt**, recorded because the reasons recur: M44 as first cut was behaviour-*equivalent* to the fix rather than a revert of the bug; M45 had no assertion to fail because nothing read the debug row (that escape is what produced the debug-row assertion); M48 named a test that did not exist, so `go test` reported "no tests to run" and exited 0. The harness now treats that as not-caught — the third distinct way a mutation has looked like evidence without being any.

---

## Review rounds 5 and 6 (`b01f153`)

### A correct fix voided a test — and the accurate framing matters

Moving the sweep's saving to the wire basis (round 4's request) made `saved == 0` **by construction** on a declined replay, because `sweepDrop` only calls `SetMessageText` on success. So `TestSweepReportsNoSavingsForARefusedReplay` could no longer fail.

**The accurate statement is that the failure mode was eliminated, not that a hole is unguarded.** The reviewer filed it as the latter and then corrected it: a mutation that books above the `ok` gate now books nothing, so it is *behaviour-equivalent* rather than an escaped bug. Both halves of the resolution were then verified independently:

* the test is re-scoped to `rep.Replay`, which sits inside the `ok` branch and still binds;
* `TestSweepReplayBooksWhatTheReplayedMessageActuallySaved` guards the basis — revert the replay measurement to the descriptor and it fails, and nothing else in the package does.

Renamed to `TestSweepRecordsNoReplayForADropItDeclined`, since the old name claimed the half that is now structural.

### The ledger's reason is derived, not enumerated

"Three reasons, not two" was still short by at least two paths: `RefusedObligation` and `VerdictUnusable` both skip without raising the pre-check gate, so a model answering *drop* with a `needed_by` for every candidate produced a row saying the adjudicator found nothing spent — when it judged every output spent and we declined each one for self-contradiction.

The reason now derives from `spentJudged`, counted where the verdict is read, and the **gates** carry which skip it was. Counted as `a.Drop || a.RefusedObligation`, because `extract.Judge` returns early on a self-contradictory drop **without** setting `a.Drop` — so counting `a.Drop` alone missed precisely the path that made the reason wrong. The two label paths are skipped before `Judge` runs, so their answer is unknown and is not counted either way.

### Accounting no longer keys on a labelling field — and the fix for that had a bug

`calls[k].Component != ""` is just `rep.Component`, which `pipeline.go` always sets in production. So the coupling was invisible there and broke the **tests**: most fixtures in this package pass a bare `&components.Report{}`, and from those the whole booking block was skipped, making a future regression inside it uncatchable. Now an explicit `out[k].called`.

That repair introduced its own bug and the test written for it caught it: the accept branch did `out[k] = outT{…}`, a struct literal that silently reset `called`, so phase 3 skipped the booking for **every real call**. Reintroducing the literal fails exactly one test — the positive-direction one that did not exist before this round.

**Because every existing test asserted "books nothing when declined"** — which a component that books nothing *ever* also satisfies. `TestExtractLLMBooksItsOutcomeEvenWithAnUnnamedReport` is the counterpart, and it deliberately uses a bare `Report` because that is the fixture shape the coupling broke.

### A comment that asserted what the key cannot express

A `cg:res:` hit does not prove "this session already sent **these** bytes": `resultKey` is `cg:res:<session>:<id>` with no component tag, `extract_llm` keys the same namespace off the same `ContentKey`, and the shipped `housellm` preset runs both in one pipeline. Corrected to state what a hit actually proves.

The design fix is **#197**, with the reachability analysis — the obvious path through a refused reserve slot turns out not to exist, and unreachability is not established either. **Not fixed here**, on the same argument accepted for #195: a change altering which records a component replays changes savings, inside a PR whose numbers feed the re-run. That leaves an invariant holding by accident of the current pipeline shapes rather than by construction — documented and filed is not as good as fixed, only better than asserted.

### Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all packages pass.

Mutations are now scored through five gates — landed exactly once, compiled, the test ran, it failed, **and the failure output contains the subject's own assertion text** — because "did it fail" scored two earlier mutations as evidence when they were not.

**Eight ways a check on this PR looked like evidence without being any**, in two kinds:

*Failures of evidence* (a harness gate catches these): a non-compiling mutant; `round4` rendering the delta `0.0000`; a precondition a never-ran component also satisfies; `go test -run` on a non-existent name exiting 0; a behaviour-equivalent mutant; a vacuity guard that could not fail.

*Failures of test scope* (no gate catches these): a measurement change voiding a test that never mentioned the measurement; and a whole assertion direction missing, where every test pinned the negative case and none the positive. The habits that do catch them: after changing how a quantity is computed, re-run the mutations for every test asserting on that quantity; and for each invariant, ask whether a component that did nothing at all would also pass.
