### PR TITLE
feat(kvcache): measure the idle keep-alive per ping — cache outcome, gaps and cost

### DIFF
--- a/deploy/harbor/keepalive_ping_stats.py
+++ b/deploy/harbor/keepalive_ping_stats.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Per-ping forensics for the idle keep-alive: did OUR ping hit the provider cache, how
+long after the previous request did it fire, did the request that followed it hit, and
+what did the ping cost.
+
+Two subcommands, and the split is not stylistic: the service database is readable only by the
+account the service runs as, and that account has no site-packages. So the half that reads it
+uses nothing but the standard library, and the half that wants a DataFrame runs afterwards as
+whoever has pandas.
+
+  collect   stdlib only (sqlite3 + csv). Reads the dashboard database READ-ONLY, so it runs as
+            the service account. Writes one CSV row per ping. Also accepts a session export
+            bundle instead, which needs no privileged access at all.
+  stats     pandas. Loads that CSV into a DataFrame and prints the tables.
+
+A ping is identified by requests.keepalive = 1. That is exact in one direction and a lower
+bound in the other, and the difference matters when reading a count off this script:
+
+  No false positives. `KeepAlive: true` is set in exactly ONE non-test place in the service,
+  proxy/keepalive.go:964 (record1), and nothing ever UPDATEs the column afterwards — the
+  strategy backfill writes keepalive_strategy_id only (dash/keepalivestrategybackfill.go:151).
+  No benchmark, simulation or campaign path writes a ping row. Rows older than the mechanism
+  read 0 by the ALTER TABLE default, and correctly so: the column and the emitter shipped in
+  the same commit (50e3966, #86), so there is no window of pings that predates the flag.
+
+  False negatives, all of them OUTSIDE the table. A ping that never got a row: refused by the
+  tenant rate limiter, failed in transport, or answered 4xx — that last one returns before
+  record1 (proxy/keepalive.go:906) so a REFUSED ping is invisible here. The table therefore
+  holds pings that were sent AND answered non-4xx; the process counters in KeepAliveStats
+  (/stats) hold what was attempted. Read "pings" below as recorded pings, not as pings sent.
+  Pings answered 5xx ARE recorded, with status >= 500 and no usage — the status line in the
+  summary is where they show up.
+
+One caveat about the service's OWN attribution columns, which this script carries but does not
+compute: keepalive_pings is an in-process counter consumed by keeper.arrive() during the
+PREPARATION of the next request on the session (proxy/proxy.go:1109), before that request is
+sent upstream and therefore before its status is known. So the first row to arrive takes the
+credit whatever becomes of it, and keepalive_saved_usd is only nonzero on a row that read more
+than it wrote. In the production export checked here, the row that arrived first was a 400 every
+time, so the credit landed on a row that read nothing and $0.00 was attributed — while the real
+resumption a second later read the ping's prefix back token for token. Read
+next_real_keepalive_saved_usd as the service's own attribution, and next_real_cache_hit together
+with next_real_cache_read as what actually happened.
+
+`collect` does not trust the flag alone: it also evaluates an INDEPENDENT structural
+fingerprint of the row shape record1 produces, in both directions, so a mislabelled row shows
+up as a number rather than as a silently wrong average.
+
+No message content is read — request_content is never touched. Tenant ids are
+pseudonymized and session ids hashed unless --raw-ids is passed.
+"""
+import argparse, csv, glob, hashlib, io, os, sqlite3, sys, tempfile, zipfile
+
+DB = "/var/lib/context-guru/cg.db"
+
+# Columns pulled for every row of a ping-bearing session. Enough to compute the four
+# metrics, and enough to audit one suspicious row without going back to the database.
+COLS = [
+    "id", "ts", "tenant_id", "session_id", "keepalive", "model", "agent", "status",
+    "cache_read", "cache_write", "cache_write_1h", "fresh_input", "output_tokens",
+    "cost_usd", "upstream_ms", "cache_miss_reason", "keepalive_pings",
+    "keepalive_saved_usd", "keepalive_strategy_id",
+    # The independent fingerprint. record1 sets max_tokens=1 and leaves every one of the
+    # rest at its zero value, because a ping has no agent request behind it to fill them.
+    "max_tokens", "stream", "messages", "tokens_before", "mode", "cg_latency_ms", "ttfb_ms",
+]
+
+SQL = f"""
+WITH ka(tenant_id, session_id) AS (
+  SELECT DISTINCT tenant_id, session_id FROM requests
+  WHERE keepalive = 1 AND session_id <> '' AND ts >= ?
+)
+SELECT {', '.join('r.' + c for c in COLS)}
+FROM requests r JOIN ka ON r.tenant_id = ka.tenant_id AND r.session_id = ka.session_id
+WHERE r.ts >= ?
+ORDER BY r.tenant_id, r.session_id, r.ts, r.id
+"""
+
+OUT_COLS = [
+    # identity / provenance
+    "ping_id", "tenant", "session", "ping_ts_ms", "ping_seq", "pings_in_span",
+    "model", "agent", "status", "strategy_id",
+    # 1. did the ping hit, and 4. what did it cost
+    "ping_cache_hit", "ping_cache_read", "ping_cache_write", "ping_cache_write_1h",
+    "ping_fresh_input", "ping_output_tokens", "ping_wrote_more_than_read",
+    "ping_cost_usd", "ping_cost_unpriced", "ping_upstream_ms",
+    # 2. how long after the message before it
+    "gap_before_s", "gap_before_raw_s", "prev_id", "prev_is_ping", "prev_ts_ms",
+    "gap_before_prev_real_s", "prev_real_id", "prev_real_cache_read", "prev_real_cache_write",
+    # 3. the message after: did it hit, how long after
+    "gap_after_s", "next_id", "next_is_ping", "next_ts_ms",
+    "gap_after_next_real_s", "next_real_id", "next_real_cache_hit",
+    "next_real_cache_read", "next_real_cache_write", "next_real_cache_miss_reason",
+    "next_real_cost_usd", "next_real_keepalive_pings", "next_real_keepalive_saved_usd",
+    "next_real_credited", "nonok_rows_before", "nonok_rows_after",
+    # data quality
+    "fingerprint_ok", "no_prev_row", "no_next_row",
+]
+
+
+def fingerprint(r):
+    """Is this row shaped like something record1 wrote, judged without the keepalive flag?
+
+    record1 fills the ping's own tokens, cost, status and max_tokens=1 and leaves
+    everything an agent request would carry at zero: no messages, no pre-compaction token
+    count, no operating mode, no cache-miss attribution (a ping is deliberately excluded
+    from it), no in-process latency. A real /v1/messages call cannot have zero messages.
+    """
+    return (r["max_tokens"] == 1 and r["stream"] == 0 and r["messages"] == 0
+            and r["tokens_before"] == 0 and r["mode"] == ""
+            and r["cache_miss_reason"] == "" and r["output_tokens"] <= 1
+            and r["cg_latency_ms"] == 0 and r["ttfb_ms"] == 0)
+
+
+def start_ms(r):
+    """When this request went on the wire, for a row of either kind.
+
+    The two writers stamp ts differently: a real request carries its START
+    (proxy/dashcapture.go, TS: c.start.UnixMilli()) while a ping carries the moment
+    record1 booked it, which is AFTER the round trip. Every gap here is start-to-start,
+    because that is the footing the provider's cache lifetime and the keeper's own Idle
+    are both measured on — "how long a session must be idle before the first ping,
+    measured from the previous request's START" (CachePolicy.Idle). gap_before_raw_s keeps
+    the uncorrected ts-to-ts figure for anyone reproducing this from the raw columns.
+    """
+    return r["ts"] - r["upstream_ms"] if r["keepalive"] else r["ts"]
+
+
+def sessions(rows):
+    """Group the ordered rows into sessions, yielding one list per (tenant, session)."""
+    cur, key = [], None
+    for r in rows:
+        k = (r["tenant_id"], r["session_id"])
+        if k != key and cur:
+            yield cur
+            cur = []
+        key = k
+        cur.append(r)
+    if cur:
+        yield cur
+
+
+def spans(rows):
+    """Positions of each maximal run of consecutive ping rows, as (start, length).
+
+    A run between two real requests IS one idle span: the keeper resets its per-span
+    counter when a real request re-records the session, so a run's length is K-in-practice
+    and a ping's position in the run is its ping number.
+    """
+    out, i = [], 0
+    while i < len(rows):
+        if rows[i]["keepalive"]:
+            j = i
+            while j < len(rows) and rows[j]["keepalive"]:
+                j += 1
+            out.append((i, j - i))
+            i = j
+        else:
+            i += 1
+    return out
+
+
+INT = {"id", "ts", "keepalive", "status", "cache_read", "cache_write", "cache_write_1h",
+       "fresh_input", "output_tokens", "max_tokens", "stream", "messages", "tokens_before",
+       "keepalive_pings"}
+FLT = {"cost_usd", "upstream_ms", "cg_latency_ms", "ttfb_ms", "keepalive_saved_usd"}
+
+
+def collect(db, since_ms, raw_ids):
+    """Rows straight from the service database. Read-only, and must run as `cg`."""
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    rows = [dict(r) for r in con.execute(SQL, (since_ms, since_ms))]
+    # How far back the table itself goes, so a ping count is read against the window that
+    # could have contained pings rather than against "all history".
+    first_ts = con.execute("SELECT MIN(ts) FROM requests").fetchone()[0]
+    con.close()
+    return build(rows, first_ts, raw_ids)
+
+
+def collect_export(path, raw_ids):
+    """Rows from a session export bundle — a zip, or an already-extracted directory.
+
+    The shape expected is one directory per session, each holding a turns.csv that is
+    `SELECT * FROM requests` for that session, so every column this needs is present including
+    keepalive. It is the only source available without the service account's read on the live
+    database, and the numbers come out identical to reading the database directly.
+    """
+    tmp = None
+    if zipfile.is_zipfile(path):
+        tmp = tempfile.mkdtemp(prefix="ping_stats.")
+        with zipfile.ZipFile(path) as z:
+            z.extractall(tmp)
+        path = tmp
+    files = sorted(glob.glob(os.path.join(path, "*", "turns.csv")))
+    if not files:
+        sys.exit(f"no */turns.csv under {path}: not a session export bundle")
+    rows = []
+    for f in files:
+        for r in csv.DictReader(open(f)):
+            if "keepalive" not in r:
+                sys.exit(f"{f} predates the keepalive column; it cannot contain pings")
+            rows.append({c: int(float(r[c] or 0)) if c in INT else
+                            float(r[c] or 0) if c in FLT else (r.get(c) or "")
+                         for c in COLS})
+    rows = [r for r in rows if r["session_id"]]
+    keyed = {(r["tenant_id"], r["session_id"]) for r in rows if r["keepalive"]}
+    first_ts = min((r["ts"] for r in rows), default=None)
+    rows = sorted((r for r in rows if (r["tenant_id"], r["session_id"]) in keyed),
+                  key=lambda r: (r["tenant_id"], r["session_id"], r["ts"], r["id"]))
+    return build(rows, first_ts, raw_ids)
+
+
+def build(rows, table_first_ts, raw_ids):
+    """One output row per ping, from rows of ping-bearing sessions in (session, ts, id) order."""
+    tenants, out = {}, []
+    for sess in sessions(rows):
+        # Pseudonyms, assigned in first-seen order so a rerun over the same window is stable.
+        t = sess[0]["tenant_id"]
+        if t not in tenants:
+            tenants[t] = f"t{len(tenants) + 1:02d}"
+        for start, n in spans(sess):
+            # The last agent request before this span and the first one after it. Either can be
+            # absent: the span may sit against the retention edge of the table.
+            #
+            # "Agent request" means keepalive = 0 AND a 2xx from upstream, and the second half is
+            # not fussiness. In the one production export available to check this against, EVERY
+            # ping was followed within ~1 s by a status-400 row carrying a single message and no
+            # tokens, and the actual resumption came the second after that. Those rows still get
+            # a cache_miss_reason from AttributeCache (four of them read 'ttl_expiry'), so taking
+            # the immediate next row inverts the answer to "did the request after the ping hit":
+            # it reported 0 of 4 hitting where 2 of 4 in fact read back the ping's own prefix,
+            # token for token. A row that never reached the provider has no cache result to read.
+            ok = lambda r: not r["keepalive"] and 200 <= r["status"] < 300
+            prev_real = next((sess[i] for i in range(start - 1, -1, -1) if ok(sess[i])), None)
+            next_real = next((sess[i] for i in range(start + n, len(sess)) if ok(sess[i])), None)
+            # How many non-2xx agent rows were stepped over to find it, so the skip is a number
+            # on the row rather than a silent choice.
+            skipped_before = sum(1 for i in range(start - 1, -1, -1)
+                                 if not sess[i]["keepalive"] and not ok(sess[i])
+                                 and (prev_real is None or sess[i]["ts"] > prev_real["ts"]))
+            skipped_after = sum(1 for i in range(start + n, len(sess))
+                                if not sess[i]["keepalive"] and not ok(sess[i])
+                                and (next_real is None or sess[i]["ts"] < next_real["ts"]))
+            for seq in range(1, n + 1):
+                p = sess[start + seq - 1]
+                prev = sess[start + seq - 2] if start + seq - 2 >= 0 else None
+                nxt = sess[start + seq] if start + seq < len(sess) else None
+                p_start = start_ms(p)
+                gap = lambda a, b: None if a is None or b is None else round((a - b) / 1000.0, 3)
+                out.append({
+                    "ping_id": p["id"],
+                    "tenant": t if raw_ids else tenants[t],
+                    "session": p["session_id"] if raw_ids
+                               else hashlib.sha256(p["session_id"].encode()).hexdigest()[:12],
+                    "ping_ts_ms": p["ts"], "ping_seq": seq, "pings_in_span": n,
+                    "model": p["model"], "agent": p["agent"], "status": p["status"],
+                    "strategy_id": p["keepalive_strategy_id"] or "",
+
+                    "ping_cache_hit": int(p["cache_read"] > 0),
+                    "ping_cache_read": p["cache_read"], "ping_cache_write": p["cache_write"],
+                    "ping_cache_write_1h": p["cache_write_1h"],
+                    "ping_fresh_input": p["fresh_input"],
+                    "ping_output_tokens": p["output_tokens"],
+                    "ping_wrote_more_than_read": int(p["cache_write"] > p["cache_read"]),
+                    "ping_cost_usd": p["cost_usd"],
+                    # Event.Price only prices a row when the model is in the price table AND
+                    # some token counter is nonzero; an unpriced ping reads as $0.00 and would
+                    # drag the mean cost down without saying so.
+                    "ping_cost_unpriced": int(p["cost_usd"] == 0 and bool(
+                        p["cache_read"] or p["cache_write"] or p["output_tokens"])),
+                    "ping_upstream_ms": p["upstream_ms"],
+
+                    "gap_before_s": gap(p_start, start_ms(prev)) if prev else None,
+                    "gap_before_raw_s": gap(p["ts"], prev["ts"]) if prev else None,
+                    "prev_id": prev["id"] if prev else None,
+                    "prev_is_ping": prev["keepalive"] if prev else None,
+                    "prev_ts_ms": prev["ts"] if prev else None,
+                    "gap_before_prev_real_s": gap(p_start, prev_real["ts"]) if prev_real else None,
+                    "prev_real_id": prev_real["id"] if prev_real else None,
+                    "prev_real_cache_read": prev_real["cache_read"] if prev_real else None,
+                    "prev_real_cache_write": prev_real["cache_write"] if prev_real else None,
+                    "nonok_rows_before": skipped_before,
+
+                    "gap_after_s": gap(start_ms(nxt), p_start) if nxt else None,
+                    "next_id": nxt["id"] if nxt else None,
+                    "next_is_ping": nxt["keepalive"] if nxt else None,
+                    "next_ts_ms": nxt["ts"] if nxt else None,
+                    "gap_after_next_real_s": gap(next_real["ts"], p_start) if next_real else None,
+                    "next_real_id": next_real["id"] if next_real else None,
+                    "next_real_cache_hit": int(next_real["cache_read"] > 0) if next_real else None,
+                    "next_real_cache_read": next_real["cache_read"] if next_real else None,
+                    "next_real_cache_write": next_real["cache_write"] if next_real else None,
+                    "next_real_cache_miss_reason": next_real["cache_miss_reason"] if next_real else None,
+                    "next_real_cost_usd": next_real["cost_usd"] if next_real else None,
+                    "next_real_keepalive_pings": next_real["keepalive_pings"] if next_real else None,
+                    "next_real_keepalive_saved_usd": next_real["keepalive_saved_usd"] if next_real else None,
+                    "next_real_credited": int(next_real["keepalive_saved_usd"] > 0) if next_real else None,
+                    "nonok_rows_after": skipped_after,
+
+                    "fingerprint_ok": int(fingerprint(p)),
+                    "no_prev_row": int(prev is None),
+                    "no_next_row": int(nxt is None),
+                })
+
+    # The other half of the identification question: rows that LOOK like a ping but are not
+    # flagged as one. Counted over the same window, and reported rather than folded in.
+    unflagged = sum(1 for r in rows if not r["keepalive"] and fingerprint(r))
+    return out, {"rows_scanned": len(rows), "pings": len(out),
+                 "flagged_not_fingerprinted": sum(1 for r in out if not r["fingerprint_ok"]),
+                 "fingerprinted_not_flagged": unflagged,
+                 "table_first_ts": table_first_ts, "first_ping_ts": min((r["ping_ts_ms"] for r in out), default=None)}
+
+
+def cmd_collect(args):
+    out, audit = (collect_export(args.export, args.raw_ids) if args.export
+                  else collect(args.db, args.since_ms, args.raw_ids))
+    with open(args.out, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=OUT_COLS)
+        w.writeheader()
+        w.writerows(out)
+    os.chmod(args.out, 0o644)
+    print(f"wrote {args.out}: {audit['pings']} pings from {audit['rows_scanned']} rows "
+          f"of ping-bearing sessions", file=sys.stderr)
+    print(f"identification audit: {audit['flagged_not_fingerprinted']} flagged pings whose "
+          f"row shape disagrees, {audit['fingerprinted_not_flagged']} unflagged rows shaped "
+          f"like a ping", file=sys.stderr)
+    d = lambda ms: "-" if ms is None else __import__("datetime").datetime.utcfromtimestamp(
+        ms / 1000).strftime("%Y-%m-%d %H:%M")
+    print(f"window: table starts {d(audit['table_first_ts'])}Z, first recorded ping "
+          f"{d(audit['first_ping_ts'])}Z (UTC)", file=sys.stderr)
+
+
+def cmd_stats(args):
+    import pandas as pd
+    df = pd.read_csv(args.csv)
+    print(summarize(df))
+
+
+def summarize(df):
+    """The two tables asked for: averages, and the cache-miss counts with percentages."""
+    import pandas as pd
+    n = len(df)
+    if not n:
+        return "no pings in this window"
+    L = []
+    span = (pd.to_datetime(df.ping_ts_ms.min(), unit="ms").strftime("%Y-%m-%d"),
+            pd.to_datetime(df.ping_ts_ms.max(), unit="ms").strftime("%Y-%m-%d"))
+    L.append(f"{n} pings | {df.session.nunique()} sessions | {df.tenant.nunique()} tenants "
+             f"| {span[0]} .. {span[1]}")
+    if df.fingerprint_ok.eq(0).any():
+        L.append(f"WARNING: {int(df.fingerprint_ok.eq(0).sum())} pings whose row shape does "
+                 f"not match the keep-alive writer — inspect before trusting these numbers")
+
+    avg = pd.DataFrame({
+        "mean": df[MEASURES].mean(), "median": df[MEASURES].median(),
+        "p95": df[MEASURES].quantile(0.95), "n": df[MEASURES].count(),
+    })
+    L += ["", "AVERAGES  (gaps are start-to-start seconds; *_prev_real / *_next_real skip",
+          "           over intervening pings to the nearest real agent request)",
+          avg.to_string(float_format=lambda v: f"{v:,.4f}")]
+
+    def pct(mask, of=n):
+        return f"{int(mask.sum()):>7d}  {100.0 * mask.sum() / of:>6.2f}%" if of else "      0       -"
+
+    hit, late = df.ping_cache_hit.eq(1), df.ping_wrote_more_than_read.eq(1)
+    L += ["", "WHAT THE PING DID  (four disjoint outcomes)       n     pct       spend"]
+    for lab, m in [("clean read: hit, wrote no more", hit & ~late),
+                   ("partial: read, but wrote MORE than it read", hit & late),
+                   ("wrote a new entry, read nothing", ~hit & late),
+                   ("no usage at all (see status)", ~hit & ~late)]:
+        L.append(f"  {lab:41s} {pct(m)}  ${df.loc[m, 'ping_cost_usd'].sum():>9,.2f}")
+    L += [f"  {'-> cache MISS (cache_read = 0) in total':41s} {pct(~hit)}",
+          f"  {'-> priced at $0 (model not in price table)':41s} {pct(df.ping_cost_unpriced.eq(1))}",
+          f"  {'-> upstream status != 200':41s} {pct(df.status.ne(200))}"]
+
+    have = df.next_real_cache_hit.notna()
+    m = int(have.sum())
+    L += ["", f"THE REQUEST AFTER THE PING ({m} of {n} pings have one in the table)"]
+    if m:
+        L += [f"next real request HIT                          {pct(df.next_real_cache_hit.eq(1), m)}",
+              f"next real request MISS                         {pct(df.next_real_cache_hit.eq(0), m)}",
+              f"credited to the ping (keepalive_saved_usd > 0) {pct(df.next_real_credited.eq(1), m)}",
+              "  (that last line is the SERVICE's attribution, which a non-2xx row arriving "
+              "first can consume", "   before the real resumption — see the module docstring; "
+              "the HIT line above is what happened)"]
+        reasons = df.loc[have, "next_real_cache_miss_reason"].fillna("").value_counts()
+        L.append("  by cache_miss_reason: " +
+                 ", ".join(f"{k or '(blank)'}={v}" for k, v in reasons.items()))
+        if df.nonok_rows_after.gt(0).any():
+            L.append(f"  {int(df.nonok_rows_after.gt(0).sum())} pings had a non-2xx row between "
+                     f"them and that request, stepped over ({int(df.nonok_rows_after.sum())} rows "
+                     f"in total) — counting one as the request after inverts this table")
+
+    by = df.groupby("ping_seq").agg(
+        pings=("ping_id", "size"), hit_pct=("ping_cache_hit", lambda s: 100 * s.mean()),
+        mean_gap_before_s=("gap_before_s", "mean"), mean_cost_usd=("ping_cost_usd", "mean"),
+        total_cost_usd=("ping_cost_usd", "sum"))
+    L += ["", "BY PING POSITION IN THE IDLE SPAN",
+          by.to_string(float_format=lambda v: f"{v:,.4f}")]
+    g = df.gap_before_s.dropna()
+    if len(g) > 1:
+        med = g.median()
+        band = g.between(med - 12, med + 12)
+        neg, dbl = g.lt(0), g.gt(1.75 * med)
+        L += ["", f"timing self-check: {100 * band.mean():.1f}% of gap_before_s sits within "
+                  f"+/-12s of the median {med:,.1f}s — the band a 2s sweep firing one tick after "
+                  f"Idle produces, across however many Idle settings are configured.",
+              f"  {int(neg.sum())} negative ({100 * neg.mean():.2f}%): the ping was still in "
+              f"flight when a request arrived, so ts ordering puts that request first. Money "
+              f"spent on an idle span that had already ended; arrive() can cancel a pending "
+              f"ping, not one on the wire.",
+              f"  {int(dbl.sum())} near 2x the median ({100 * dbl.mean():.2f}%): sweep stamps "
+              f"startedAt and increments the counter BEFORE dispatch, so an attempt that bailed "
+              f"at the rate limiter, in transport, or on a 4xx advanced the timer and wrote no "
+              f"row. These are the visible shadow of pings missing from the table."]
+    L += ["", f"total spent on pings in this window: ${df.ping_cost_usd.sum():,.4f}"]
+    if df.no_prev_row.any() or df.no_next_row.any():
+        L.append(f"note: {int(df.no_prev_row.sum())} pings have no preceding row and "
+                 f"{int(df.no_next_row.sum())} no following row in the table (retention "
+                 f"edge or evicted neighbour) — their gaps are blank, not zero")
+    return "\n".join(L)
+
+
+MEASURES = ["gap_before_s", "gap_before_prev_real_s", "gap_after_s",
+            "gap_after_next_real_s", "ping_cost_usd", "ping_cache_read",
+            "ping_upstream_ms", "next_real_cost_usd", "next_real_keepalive_saved_usd"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("collect", help="read the DB (as cg) or an export bundle into a CSV")
+    c.add_argument("--db", default=DB)
+    c.add_argument("--export", help="a session export zip or extracted directory to read "
+                                   "instead of the live database (no privileged access needed)")
+    c.add_argument("--out", required=True)
+    c.add_argument("--since-ms", type=int, default=0,
+                   help="epoch ms lower bound; 0 scans the whole table (a full scan of a "
+                        "2 GB live database — bound it when you can)")
+    c.add_argument("--raw-ids", action="store_true",
+                   help="keep real tenant and session ids instead of pseudonyms")
+    c.set_defaults(fn=cmd_collect)
+
+    s = sub.add_parser("stats", help="load the CSV into a DataFrame and print the tables")
+    s.add_argument("csv")
+    s.set_defaults(fn=cmd_stats)
+
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/harbor/keepalive_ping_stats.py
+++ b/deploy/harbor/keepalive_ping_stats.py
@@ -25,7 +25,7 @@ bound in the other, and the difference matters when reading a count off this scr
 
   False negatives, all of them OUTSIDE the table. A ping that never got a row: refused by the
   tenant rate limiter, failed in transport, or answered 4xx — that last one returns before
-  record1 (proxy/keepalive.go:906) so a REFUSED ping is invisible here. The table therefore
+  record1 (proxy/keepalive.go:908) so a REFUSED ping is invisible here. The table therefore
   holds pings that were sent AND answered non-4xx; the process counters in KeepAliveStats
   (/stats) hold what was attempted. Read "pings" below as recorded pings, not as pings sent.
   Pings answered 5xx ARE recorded, with status >= 500 and no usage — the status line in the
@@ -33,7 +33,7 @@ bound in the other, and the difference matters when reading a count off this scr
 
 One caveat about the service's OWN attribution columns, which this script carries but does not
 compute: keepalive_pings is an in-process counter consumed by keeper.arrive() during the
-PREPARATION of the next request on the session (proxy/proxy.go:1109), before that request is
+PREPARATION of the next request on the session (proxy/proxy.go:1143), before that request is
 sent upstream and therefore before its status is known. So the first row to arrive takes the
 credit whatever becomes of it, and keepalive_saved_usd is only nonzero on a row that read more
 than it wrote. In the production export checked here, the row that arrived first was a 400 every
@@ -47,9 +47,11 @@ fingerprint of the row shape record1 produces, in both directions, so a mislabel
 up as a number rather than as a silently wrong average.
 
 No message content is read — request_content is never touched. Tenant ids are
-pseudonymized and session ids hashed unless --raw-ids is passed.
+pseudonymized and session ids hashed unless --raw-ids is passed. agent is not covered by
+that flag: it is exported verbatim either way, and the Go side falls back to up to 32
+raw characters of the client's User-Agent string for anything it does not recognize.
 """
-import argparse, csv, glob, hashlib, io, os, sqlite3, sys, tempfile, zipfile
+import argparse, csv, glob, hashlib, os, sqlite3, sys, tempfile, zipfile
 
 DB = "/var/lib/context-guru/cg.db"
 
@@ -315,11 +317,16 @@ def build(rows, table_first_ts, raw_ids):
 def cmd_collect(args):
     out, audit = (collect_export(args.export, args.raw_ids) if args.export
                   else collect(args.db, args.since_ms, args.raw_ids))
-    with open(args.out, "w", newline="") as f:
+    # 0600, and created that way rather than chmod'd afterwards: the row carries TENANT ID
+    # plus per-row dollar figures (ping_cost_usd, next_real_cost_usd) even pseudonymized,
+    # and unconditionally under --raw-ids, so a world-readable default (0644 minus umask)
+    # hands per-customer spend to every local user. O_CREAT|O_TRUNC with the mode set at
+    # creation leaves no window where the file exists with wider permissions.
+    fd = os.open(args.out, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=OUT_COLS)
         w.writeheader()
         w.writerows(out)
-    os.chmod(args.out, 0o644)
     print(f"wrote {args.out}: {audit['pings']} pings from {audit['rows_scanned']} rows "
           f"of ping-bearing sessions", file=sys.stderr)
     print(f"identification audit: {audit['flagged_not_fingerprinted']} flagged pings whose "

--- a/deploy/harbor/test_keepalive_ping_stats.py
+++ b/deploy/harbor/test_keepalive_ping_stats.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Exercises the collector against a synthetic requests table. No production access.
+
+Run it directly -- `python3 deploy/harbor/test_keepalive_ping_stats.py` -- or under pytest.
+Only the summarize tests need pandas; the collector tests are stdlib.
+
+The fixture is built from the column subset keepalive_ping_stats.SQL actually names, which
+doubles as the contract: if the real table loses one of these, this fails to build.
+"""
+import os, sqlite3, sys, tempfile, unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import keepalive_ping_stats as ps
+
+REAL = dict(keepalive=0, max_tokens=32000, stream=1, messages=12, tokens_before=48000,
+            mode="active", cache_miss_reason="hit", output_tokens=400, cg_latency_ms=3.0,
+            ttfb_ms=900.0, cache_read=48000, cache_write=0, cache_write_1h=0, fresh_input=20,
+            cost_usd=0.12, upstream_ms=4000.0, status=200, model="aws/claude-sonnet-5",
+            agent="claude-code", keepalive_pings=0, keepalive_saved_usd=0.0,
+            keepalive_strategy_id=None)
+PING = dict(keepalive=1, max_tokens=1, stream=0, messages=0, tokens_before=0, mode="",
+            cache_miss_reason="", output_tokens=1, cg_latency_ms=0.0, ttfb_ms=0.0,
+            cache_read=48000, cache_write=0, cache_write_1h=0, fresh_input=4,
+            cost_usd=0.0073, upstream_ms=1500.0, status=200, model="aws/claude-sonnet-5",
+            agent="claude-code", keepalive_pings=0, keepalive_saved_usd=0.0,
+            keepalive_strategy_id=None)
+
+
+def db_with(rows):
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE requests (id INTEGER PRIMARY KEY, ts INTEGER, "
+                "tenant_id TEXT, session_id TEXT, " +
+                ", ".join(f"{c} {'TEXT' if c in ('model','agent','mode','cache_miss_reason','keepalive_strategy_id') else 'REAL' if c in ('cost_usd','upstream_ms','cg_latency_ms','ttfb_ms','keepalive_saved_usd') else 'INTEGER'}"
+                          for c in ps.COLS if c not in ("id", "ts", "tenant_id", "session_id")) + ")")
+    for i, r in enumerate(rows, 1):
+        r = dict(r, id=r.get("id", i))
+        con.execute(f"INSERT INTO requests ({','.join(ps.COLS)}) VALUES ({','.join('?' * len(ps.COLS))})",
+                    [r[c] for c in ps.COLS])
+    con.commit()
+    con.close()
+    return path
+
+
+def row(kind, ts, tenant="acme", session="s1", **kw):
+    return dict(dict(REAL if kind == "real" else PING), ts=ts, tenant_id=tenant,
+                session_id=session, **kw)
+
+
+class TestCollect(unittest.TestCase):
+    def collect(self, rows, raw=True):
+        path = db_with(rows)
+        try:
+            out, audit = ps.collect(path, 0, raw)
+        finally:
+            os.unlink(path)
+        return {p["ping_id"]: p for p in out}, audit
+
+    def test_one_ping_between_two_real_requests(self):
+        # real @ t=0, ping starts at t=280s and takes 1.5s, real again 20 min later.
+        pings, audit = self.collect([
+            row("real", 1_000_000, id=1),
+            row("ping", 1_000_000 + 281_500, id=2),
+            row("real", 1_000_000 + 1_200_000, id=3, cache_read=48000, cache_miss_reason="hit",
+                keepalive_pings=1, keepalive_saved_usd=0.66),
+        ])
+        self.assertEqual(audit["pings"], 1)
+        p = pings[2]
+        # gap_before is measured from the ping's START (ts - upstream_ms), which is what the
+        # keeper's Idle and the provider's lifetime are both measured from: 281.5 - 1.5 = 280.
+        self.assertAlmostEqual(p["gap_before_s"], 280.0, places=3)
+        self.assertAlmostEqual(p["gap_before_raw_s"], 281.5, places=3)
+        self.assertAlmostEqual(p["gap_before_prev_real_s"], 280.0, places=3)
+        self.assertEqual(p["prev_id"], 1)
+        self.assertEqual(p["prev_is_ping"], 0)
+        self.assertAlmostEqual(p["gap_after_s"], 1_200_000 / 1000.0 - 280.0, places=3)
+        self.assertEqual(p["next_id"], 3)
+        self.assertEqual(p["ping_cache_hit"], 1)
+        self.assertEqual(p["ping_wrote_more_than_read"], 0)
+        self.assertEqual(p["next_real_cache_hit"], 1)
+        self.assertEqual(p["next_real_credited"], 1)
+        self.assertEqual(p["ping_seq"], 1)
+        self.assertEqual(p["pings_in_span"], 1)
+        self.assertEqual(p["fingerprint_ok"], 1)
+        self.assertEqual((p["no_prev_row"], p["no_next_row"]), (0, 0))
+
+    def test_two_pings_in_one_span_chain_and_share_the_span(self):
+        pings, _ = self.collect([
+            row("real", 0, id=1),
+            row("ping", 281_000, id=2),
+            row("ping", 561_000, id=3),
+            row("real", 900_000, id=4, cache_read=0, cache_write=48000, cache_miss_reason="ttl_expiry"),
+        ])
+        a, b = pings[2], pings[3]
+        self.assertEqual((a["ping_seq"], a["pings_in_span"]), (1, 2))
+        self.assertEqual((b["ping_seq"], b["pings_in_span"]), (2, 2))
+        # The second ping's immediate predecessor is the FIRST PING, 280s of idle earlier
+        # — start to start, so the first ping's own 1.5s round trip does not eat into it;
+        # its distance to the last real request is the whole span.
+        self.assertEqual(b["prev_id"], 2)
+        self.assertEqual(b["prev_is_ping"], 1)
+        self.assertAlmostEqual(b["gap_before_s"], 280.0, places=3)
+        self.assertAlmostEqual(b["gap_before_prev_real_s"], 559.5, places=3)
+        self.assertEqual(b["prev_real_id"], 1)
+        # Both pings point at the same following real request, which missed anyway.
+        self.assertEqual(a["next_real_id"], 4)
+        self.assertEqual(b["next_real_id"], 4)
+        self.assertEqual(b["next_real_cache_hit"], 0)
+        self.assertEqual(b["next_real_cache_miss_reason"], "ttl_expiry")
+        self.assertEqual(a["next_id"], 3)  # the immediate next row is the other ping
+
+    def test_non_2xx_rows_are_stepped_over_not_taken_as_the_request_after(self):
+        """The shape every ping in the production export is followed by: a 400 with a single
+        message and no tokens, then the actual resumption a second later. Taking the 400 would
+        report a miss where the prefix was in fact read back token for token."""
+        pings, _ = self.collect([
+            row("real", 0, id=1),
+            row("ping", 281_000, id=2, cache_read=103254),
+            row("real", 346_000, id=3, status=400, messages=1, tokens_before=76, cache_read=0,
+                cache_write=0, cache_miss_reason="ttl_expiry", output_tokens=0, cost_usd=0.0),
+            row("real", 347_000, id=4, cache_read=103254, cache_write=52, cache_miss_reason="hit"),
+        ])
+        p = pings[2]
+        self.assertEqual(p["next_id"], 3)             # the immediate next row is still reported
+        self.assertEqual(p["next_real_id"], 4)        # ...but the request AFTER is the 2xx one
+        self.assertEqual(p["next_real_cache_hit"], 1)
+        self.assertEqual(p["next_real_cache_miss_reason"], "hit")
+        self.assertEqual(p["nonok_rows_after"], 1)
+        self.assertAlmostEqual(p["gap_after_next_real_s"], 347.0 - 279.5, places=3)
+
+    def test_non_2xx_before_a_ping_is_not_the_message_before(self):
+        pings, _ = self.collect([
+            row("real", 0, id=1),
+            row("real", 200_000, id=2, status=400, messages=1, tokens_before=76, cache_read=0),
+            row("ping", 281_000, id=3),
+        ])
+        p = pings[3]
+        self.assertEqual(p["prev_id"], 2)             # immediate predecessor, whatever it was
+        self.assertEqual(p["prev_real_id"], 1)        # the last request that reached the provider
+        self.assertAlmostEqual(p["gap_before_prev_real_s"], 279.5, places=3)
+        self.assertEqual(p["nonok_rows_before"], 1)
+
+    def test_late_ping_that_wrote_instead_of_reading(self):
+        pings, _ = self.collect([
+            row("real", 0, id=1),
+            row("ping", 281_000, id=2, cache_read=0, cache_write=48000, cost_usd=0.09),
+        ])
+        p = pings[2]
+        self.assertEqual(p["ping_cache_hit"], 0)
+        self.assertEqual(p["ping_wrote_more_than_read"], 1)
+        self.assertEqual(p["no_next_row"], 1)
+        self.assertIsNone(p["gap_after_s"])
+        self.assertIsNone(p["next_real_cache_hit"])
+
+    def test_ping_with_no_preceding_row_reports_blank_not_zero(self):
+        pings, _ = self.collect([row("ping", 500_000, id=1), row("real", 900_000, id=2)])
+        p = pings[1]
+        self.assertEqual(p["no_prev_row"], 1)
+        self.assertIsNone(p["gap_before_s"])
+        self.assertIsNone(p["gap_before_prev_real_s"])
+        self.assertIsNone(p["prev_real_id"])
+
+    def test_unpriced_ping_is_flagged_not_averaged_as_free(self):
+        pings, _ = self.collect([row("real", 0, id=1),
+                                 row("ping", 281_000, id=2, cost_usd=0.0)])
+        self.assertEqual(pings[2]["ping_cost_unpriced"], 1)
+
+    def test_identification_audit_counts_both_directions(self):
+        # id=3 is flagged but shaped like agent traffic; id=4 is shaped like a ping but not
+        # flagged. Both are counted, neither is silently folded into the metrics.
+        _, audit = self.collect([
+            row("real", 0, id=1),
+            row("ping", 281_000, id=2),
+            row("real", 400_000, id=3, keepalive=1),
+            row("ping", 500_000, id=4, keepalive=0),
+            row("real", 900_000, id=5),
+        ])
+        self.assertEqual(audit["flagged_not_fingerprinted"], 1)
+        self.assertEqual(audit["fingerprinted_not_flagged"], 1)
+
+    def test_same_session_id_under_two_tenants_does_not_bleed(self):
+        pings, _ = self.collect([
+            row("real", 0, tenant="acme", id=1),
+            row("ping", 281_000, tenant="acme", id=2),
+            row("real", 100_000, tenant="globex", id=3),
+            row("ping", 381_000, tenant="globex", id=4),
+        ])
+        self.assertEqual(pings[2]["prev_id"], 1)
+        self.assertEqual(pings[4]["prev_id"], 3)
+        self.assertAlmostEqual(pings[4]["gap_before_s"], 279.5, places=3)
+
+    def test_blank_session_ids_are_excluded(self):
+        _, audit = self.collect([row("real", 0, session="", id=1),
+                                 row("ping", 281_000, session="", id=2)])
+        self.assertEqual(audit["pings"], 0)
+
+    def test_pseudonymized_by_default(self):
+        pings, _ = self.collect([row("real", 0, id=1), row("ping", 281_000, id=2)], raw=False)
+        p = pings[2]
+        self.assertEqual(p["tenant"], "t01")
+        self.assertNotEqual(p["session"], "s1")
+        self.assertEqual(len(p["session"]), 12)
+
+
+class TestSummarize(unittest.TestCase):
+    def test_reports_miss_count_and_percentage(self):
+        import pandas as pd
+        rows = [dict.fromkeys(ps.OUT_COLS, 0) for _ in range(4)]
+        for i, r in enumerate(rows):
+            r.update(ping_id=i, tenant="t01", session="abc", ping_ts_ms=1_700_000_000_000,
+                     ping_seq=1, pings_in_span=1, status=200, fingerprint_ok=1,
+                     ping_cost_usd=0.01, gap_before_s=280.0, gap_after_s=600.0,
+                     next_real_cache_hit=1, next_real_credited=1,
+                     next_real_cache_miss_reason="hit")
+        rows[0]["ping_cache_hit"] = 0                       # a miss
+        rows[0]["ping_wrote_more_than_read"] = 1            # ...that wrote
+        for r in rows[1:]:
+            r["ping_cache_hit"] = 1
+        out = ps.summarize(pd.DataFrame(rows))
+        self.assertIn("4 pings", out)
+        self.assertIn("25.00%", out)                        # 1 of 4 missed
+        self.assertIn("cache MISS (cache_read = 0) in total", out)
+        self.assertIn("total spent on pings", out)
+
+    def test_late_pings_are_not_printed_as_a_subset_of_misses(self):
+        """A ping can read something and still write more, so "wrote instead of read" is not a
+        subset of "missed". The production window had 21 late against 20 misses, which the old
+        indented shape rendered as a contradiction."""
+        import pandas as pd
+        rows = [dict.fromkeys(ps.OUT_COLS, 0) for _ in range(3)]
+        for i, r in enumerate(rows):
+            r.update(ping_id=i, tenant="t01", session="abc", ping_ts_ms=1_700_000_000_000,
+                     ping_seq=1, status=200, fingerprint_ok=1, gap_before_s=280.0)
+        rows[0].update(ping_cache_hit=0, ping_wrote_more_than_read=1)   # missed and wrote
+        rows[1].update(ping_cache_hit=1, ping_wrote_more_than_read=1)   # hit but wrote MORE
+        rows[2].update(ping_cache_hit=1, ping_wrote_more_than_read=0)   # clean
+        out = ps.summarize(pd.DataFrame(rows))
+        self.assertIn("partial: read, but wrote MORE than it read", out)
+        self.assertIn("wrote a new entry, read nothing", out)
+        # one miss of three, while TWO of three wrote more than they read: the miss total is
+        # printed as its own line rather than as a parent the late count hangs under.
+        miss = [l for l in out.splitlines() if "cache MISS (cache_read = 0) in total" in l][0]
+        self.assertRegex(miss, r"\s1\s+33\.33%")
+        self.assertNotIn("of which wrote", out)
+
+    def test_flags_fingerprint_disagreement_loudly(self):
+        import pandas as pd
+        r = dict.fromkeys(ps.OUT_COLS, 0)
+        r.update(ping_id=1, tenant="t01", session="abc", ping_ts_ms=1_700_000_000_000,
+                 ping_seq=1, status=200, fingerprint_ok=0)
+        self.assertIn("WARNING", ps.summarize(pd.DataFrame([r])))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/deploy/harbor/test_keepalive_ping_stats.py
+++ b/deploy/harbor/test_keepalive_ping_stats.py
@@ -12,6 +12,12 @@ import os, sqlite3, sys, tempfile, unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import keepalive_ping_stats as ps
 
+try:
+    import pandas  # noqa: F401
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
+
 REAL = dict(keepalive=0, max_tokens=32000, stream=1, messages=12, tokens_before=48000,
             mode="active", cache_miss_reason="hit", output_tokens=400, cg_latency_ms=3.0,
             ttfb_ms=900.0, cache_read=48000, cache_write=0, cache_write_1h=0, fresh_input=20,
@@ -202,8 +208,27 @@ class TestCollect(unittest.TestCase):
         self.assertNotEqual(p["session"], "s1")
         self.assertEqual(len(p["session"]), 12)
 
+    def test_5xx_ping_has_no_usage_and_is_not_flagged_unpriced(self):
+        # Docstring calls this case out: a 5xx ping is recorded, with status >= 500 and no
+        # usage. It has genuinely nothing to price, so it must NOT land in ping_cost_unpriced
+        # -- that flag is for a $0.00 row that DID move tokens.
+        pings, _ = self.collect([
+            row("real", 0, id=1),
+            row("ping", 281_000, id=2, status=500, cache_read=0, cache_write=0,
+                output_tokens=0, cost_usd=0.0),
+        ])
+        p = pings[2]
+        self.assertEqual(p["status"], 500)
+        self.assertEqual(p["ping_cost_unpriced"], 0)
+
+    def test_session_with_no_pings_contributes_no_output_rows(self):
+        _, audit = self.collect([row("real", 0, id=1), row("real", 300_000, id=2)])
+        self.assertEqual(audit["pings"], 0)
+        self.assertEqual(audit["rows_scanned"], 0)
+
 
 class TestSummarize(unittest.TestCase):
+    @unittest.skipUnless(HAS_PANDAS, "pandas not installed")
     def test_reports_miss_count_and_percentage(self):
         import pandas as pd
         rows = [dict.fromkeys(ps.OUT_COLS, 0) for _ in range(4)]
@@ -223,6 +248,7 @@ class TestSummarize(unittest.TestCase):
         self.assertIn("cache MISS (cache_read = 0) in total", out)
         self.assertIn("total spent on pings", out)
 
+    @unittest.skipUnless(HAS_PANDAS, "pandas not installed")
     def test_late_pings_are_not_printed_as_a_subset_of_misses(self):
         """A ping can read something and still write more, so "wrote instead of read" is not a
         subset of "missed". The production window had 21 late against 20 misses, which the old
@@ -244,6 +270,7 @@ class TestSummarize(unittest.TestCase):
         self.assertRegex(miss, r"\s1\s+33\.33%")
         self.assertNotIn("of which wrote", out)
 
+    @unittest.skipUnless(HAS_PANDAS, "pandas not installed")
     def test_flags_fingerprint_disagreement_loudly(self):
         import pandas as pd
         r = dict.fromkeys(ps.OUT_COLS, 0)


### PR DESCRIPTION
## What this adds

Two files under `deploy/harbor/`, alongside the existing `kv_ttl_*` analysis scripts:

- **`keepalive_ping_stats.py`** — produces one row per idle keep-alive ping over a window of
  history, answering four questions per ping: did the ping itself hit the provider cache, how
  many seconds after the previous request did it fire, did the request that followed it hit and
  how long after, and what did the ping cost. Plus a summariser over that table.
- **`test_keepalive_ping_stats.py`** — 14 tests against a synthetic `requests` table. No
  production access, no network.

Nothing existing is modified. No Go code, no schema change, no runtime path is touched — this is
read-only analysis of rows the service already writes.

## Why

`proxy/keepalive.go` carries a detailed account of what the mechanism is worth, sourced from a
replay (`TestKeepAliveOnProductionSnapshot`). What we did not have was a way to ask the same
questions of *what actually shipped*, per ping, against the live ledger — in particular whether a
given ping read the entry it was meant to refresh, and whether the request it was protecting then
hit. The dashboard reports pings in aggregate (count and cost); `keepalive_saved_usd` reports the
service's own attribution. Neither answers "did this ping work, and how close was it".

## Identifying our own pings

`requests.keepalive = 1`. This is exact in one direction and a lower bound in the other, and the
distinction is documented at the top of the script because it changes how a count is read:

- **No false positives.** `KeepAlive: true` is set in exactly one non-test place in the service,
  `proxy/keepalive.go` (`record1`), and nothing ever `UPDATE`s the column afterwards — the
  strategy backfill writes `keepalive_strategy_id` only. No benchmark, simulation or campaign
  path writes a ping row. Rows predating the mechanism read `0` by the `ALTER TABLE` default, and
  correctly so: the column and the emitter shipped in the same commit (#86).
- **False negatives, all of them outside the table.** A ping refused by the tenant rate limiter,
  failed in transport, or answered 4xx returns before `record1`, so it never becomes a row. The
  table holds pings that were sent *and* answered non-4xx; `KeepAliveStats` on `/stats` holds what
  was attempted.

The collector does not take the flag on trust. It also evaluates an independent structural
fingerprint of the row shape `record1` produces — `max_tokens=1`, `stream=0`, and zero for
`messages`, `tokens_before`, `mode`, `cache_miss_reason`, `cg_latency_ms`, `ttfb_ms` — in both
directions, and prints any disagreement as a number. Over 1,038 production pings it reported
`0` flagged rows whose shape disagrees and `0` unflagged rows shaped like a ping.

## Two correctness traps this had to handle

Both were found by running against real rows, and both silently invert a headline number.

**1. `ts` means different things on the two row types.** A real request's `ts` is its *start*
(`proxy/dashcapture.go`, `TS: c.start.UnixMilli()`); a ping's is stamped in `record1`, *after* the
round trip. Every gap here is therefore start-to-start, which is also the footing
`CachePolicy.Idle` and the provider's lifetime rule both use. It matters: corrected, `gap_before_s`
clusters at 270–272s on a 270s-Idle account with a 1.6s spread; uncorrected it scatters over
273–288s, the noise being the ping's own round trip, which reaches 28s at p95.

**2. A non-2xx row must not be taken as "the request after the ping".** In production, a ping is
frequently followed within about a second by a status-400 row carrying a single message and no
tokens, with the actual resumption arriving next. Those rows still receive a `cache_miss_reason`
from `AttributeCache`. On the first sample checked, taking the immediate next row reported 0 of 4
following requests hitting; the truth was 2 of 4, both reading the ping's prefix back token for
token. The collector steps over non-2xx rows to find the neighbouring agent request, keeps the
immediate neighbour's id alongside it, and counts what it stepped over.

## How to use it

The two subcommands split because the database is readable only by the account the service runs
as, and that account has no site-packages:

```sh
# 1. collect -- stdlib only, runs as the service account. One CSV row per ping.
sudo -u cg /usr/bin/python3 keepalive_ping_stats.py collect --out /var/tmp/pings.csv

# 2. stats -- loads that CSV into a DataFrame and prints the tables. Needs pandas.
python3 keepalive_ping_stats.py stats /var/tmp/pings.csv
```

`WHERE keepalive = 1` has no supporting index, so an unbounded run is a full scan of the live
file. Pass `--since-ms <epoch ms>` to bound it, which lets the query use `idx_requests_ts`.

There is a second source that needs no privileged access, and it is how the script was developed
and validated: a session export bundle, one directory per session each holding a `turns.csv` that
is `SELECT * FROM requests`.

```sh
python3 keepalive_ping_stats.py collect --export <bundle.zip|dir> --out pings.csv
```

Account ids are pseudonymised (`t01`, `t02`, …) and session ids hashed unless `--raw-ids` is
passed. No message content is read — `request_content` is never queried.

Tests:

```sh
python3 deploy/harbor/test_keepalive_ping_stats.py     # or run under pytest
```

## How to read the results

`collect` prints three lines to stderr: how many pings it found, the identification audit in both
directions, and the window the table covers versus the first recorded ping — so a count is read
against the history that could have contained pings rather than against "all time".

`stats` prints four blocks:

- **AVERAGES.** Watch the `n` column; it differs per row. `gap_before_s` is the configured `Idle`
  recovered from data. `gap_before_prev_real_s` skips back past intervening pings, so on a second
  ping it measures the whole span rather than the inter-ping step. `gap_after_next_real_s` is the
  one that answers "when did the human come back". `ping_cost_usd` is heavily right-skewed, so
  read the median next to the mean.
- **WHAT THE PING DID** — four *disjoint* outcomes with spend against each. A ping can read
  something and still write more than it read, so "wrote instead of read" is not a subset of
  "missed"; they are printed as separate buckets for that reason. `wrote a new entry, read
  nothing` is the failure `keepalive.go` calls the mechanism being wrong rather than expensive.
- **THE REQUEST AFTER THE PING.** The `HIT` line is what happened; the `credited` line is the
  service's own attribution, which a non-2xx row arriving first can consume. Expect them to
  disagree. The `cache_miss_reason` breakdown separates "came back too late" (`ttl_expiry`) from
  "the prefix moved" (`prefix_change`) from "a different model" (`cold_start`, which with the
  session already seen means `!seenModel` and is not addressable by pinging).
- **BY PING POSITION**, then a **timing self-check**. The self-check is the cheap evidence that
  identification and the `ts` correction are both right: the share of gaps within ±12s of the
  median is the band a 2s sweep firing one tick after `Idle` produces. It also names its two
  tails, because both have a known cause — a negative gap is a ping that was still in flight when
  a request arrived, and a gap near 2× the median is one whose preceding attempt advanced the
  timer without writing a row.

## Evidence

`14/14` tests pass. Run against the live ledger for 2026-08-23..09-02: 1,038 recorded pings across
255 sessions and 15 accounts, `$150.87` of ping spend, identification audit clean in both
directions, and `91.8%` of gaps inside the ±12s band. The same code over a session export bundle
reproduces its rows identically.

CI does not currently run Python, so `test_keepalive_ping_stats.py` is a manual gate; it is
stdlib-only apart from the two summariser tests, so it runs anywhere the collector does.
