### PR TITLE
test(proxy): make the dangling-marker assertion baseline-relative, not absolute

### DIFF
--- a/proxy/stashreserve_test.go
+++ b/proxy/stashreserve_test.go
@@ -71,6 +71,9 @@ func TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Captured before the request, so the dangling-marker assertion below measures what THIS
+	// fixture did rather than what the whole test binary has accumulated.
+	missingBefore := offloadStashMissing()
 	resp, err := http.Post(srv.URL+"/openai/v1/chat/completions", "application/json", strings.NewReader(string(body)))
 	if err != nil {
 		t.Fatal(err)
@@ -158,9 +161,14 @@ func TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself(t *t
 		t.Error(`/stats does not render a "stash_missing" key, so the one reserve outcome that ` +
 			`genuinely breaks reversibility is indistinguishable from the safe one`)
 	}
-	if snap.StashMissing != 0 {
-		t.Errorf("/stats stash_missing = %d in a fixture where every refusal left the content "+
-			"verbatim; a declined removal is being counted as a dangling marker", snap.StashMissing)
+	// BASELINE-RELATIVE, because StashMissing is a PROCESS-WIDE counter shared with every other
+	// test in this binary — TestStatsPublishesDanglingReplaysFromTheLiveCounter below deliberately
+	// drives it non-zero. An absolute `!= 0` therefore passed on the first run and failed on the
+	// second under -count=2, which is the class of defect #192 already documents; this assertion
+	// was a third instance of it.
+	if got := snap.StashMissing - missingBefore; got != 0 {
+		t.Errorf("/stats stash_missing moved by %d in a fixture where every refusal left the "+
+			"content verbatim; a declined removal is being counted as a dangling marker", got)
 	}
 }
 


### PR DESCRIPTION
Relates to #192.

## What this fixes

#188 added a **third** instance of the defect #192 documents, and it is mine.

`TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself` asserted `snap.StashMissing != 0` as an **absolute** value. `StashMissing` is a process-wide counter shared with every test in the binary, and `TestStatsPublishesDanglingReplaysFromTheLiveCounter` — added in the same PR, declared below it in the same file — deliberately drives it non-zero.

So it passed on the first run and failed on the second:

```
go test ./proxy/ -run "TestAnExhaustedRewindReserve|TestStatsPublishesDangling" -count=2

--- FAIL: TestAnExhaustedRewindReserveNeitherStampsUnbackedMarkersNorHidesItself
    /stats stash_missing = 1 in a fixture where every refusal left the content
    verbatim; a declined removal is being counted as a dangling marker
```

The failure message was accidentally accurate about its own confusion: on the second run it was reading a *different* test's dangling marker as this fixture's.

## The fix

Baseline-relative — captured before the request this fixture makes, so the assertion measures what the fixture did rather than what the binary has accumulated.

Worth noting the other assertions in the same file were **already** written this way (the `StashRefusals` delta, and the live-counter comparison in the test below). This one was not, which is the whole of the defect — an inconsistency inside one file rather than a missing convention.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all packages pass · the two tests pass at `-count=2`.

**Revert-verified.** Restoring the absolute form fails at `-count=2`:

```
/stats stash_missing moved by 1 in a fixture where every refusal left the content verbatim
```

The first cut of that mutation **did not compile** — reverting the assertion left `missingBefore` unused — so it was re-cut with `_ = missingBefore` to fail as a *test* rather than as a build error. A mutation that breaks the build is not a caught mutation.

## Effect on #192

Its count is accurate again. At `-count=2` the proxy package now fails only on `TestExtractEconomicsAreExported` and `TestExpandUnresolvedSeriesRender` — the two pre-existing instances that issue describes.

## How it was found

Verifying, after #188 merged, which issues its merge should have closed. It closed #187 correctly; this turned up because #192 exists and I had added tests to the package it is about, so the honest check was whether I had made it worse. I had.
