### PR TITLE
fix(proxy): tell an unreadable usage block apart from a provider that reported none, and record the shape once

### DIFF
--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -169,6 +169,14 @@ Only the last two are failures, and only they are counted — the number an oper
 confirm accounting is healthy must not be incremented by it being broken. The reason for every
 miss, benign ones included, rides on the `cg.request` log line as `usage_miss`.
 
+**Which of the two you can even get depends on the response path**, and this has already misled
+two readers, so: `unreadable_body` can arise **only** on the sniffed path — the one taken when
+neither proxy-injected tool is advertised on the request (`proxy.go`, `if !advertised`), where usage
+is read from a bounded head+tail window instead of the whole body. When either tool *is* advertised
+— which `inject_expand: always` guarantees from the first turn — a non-streamed response is read
+whole and the window never applies, so a miss there is a dialect or a genuine absence and nothing
+else. `valid_json` in the record below settles it either way without needing to know the path.
+
 **The shape record.** On the first unaccounted response per process, `cg.usage_unaccounted` is
 logged at DEBUG with the response's **key names** — top-level keys, where a usage block was found,
 and the key names inside it — and nothing else. No values and no body: a body dump on agent traffic

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -145,7 +145,7 @@ thing and is counted separately. See [when the tiers read zero](#when-the-tiers-
 | Field | Meaning |
 |---|---|
 | `fresh_input_tokens` · `cache_read_tokens` · `cache_write_tokens` · `output_tokens` | The four billed tiers. |
-| `usage_unparsed` | Responses that carried a usage block in a **spelling this proxy does not recognise**, so the four tiers above were recorded as 0 on an otherwise healthy request. Non-zero means token accounting is offline for some route or provider. |
+| `usage_unparsed` | Responses that carried a usage block in a **spelling this proxy does not recognise**, so the four tiers above were recorded as 0 on an otherwise healthy request. Non-zero means token accounting is offline for some route or provider. Counts **responses**, not requests — one request can drive several upstream rounds through the expand loop — so do not read it as a fraction of `requests`. |
 | `usage_unreadable` | Responses whose examined bytes would not parse at all, so usage could not be sought — a spliced head+tail sniffer window rather than an unrecognised dialect. Different fix; see below. |
 | `attempted_tokens` | What compaction was **allowed** to touch this window — the uncached tail when cache-aware. |
 | `frozen_tokens` | What cache-awareness deliberately left alone. Its benefit is the cache reads that stayed cheap; this is its cost. |

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -139,15 +139,45 @@ Present only when an extraction component has recorded something. See
 ### Provider-billed token tiers, and the honest ratios
 
 Summed from response `usage` blocks, so all four are zero against an upstream that
-reports no usage.
+reports no usage — **or against one whose usage this proxy could not read**, which is a different
+thing and is counted separately. See [when the tiers read zero](#when-the-tiers-read-zero).
 
 | Field | Meaning |
 |---|---|
 | `fresh_input_tokens` · `cache_read_tokens` · `cache_write_tokens` · `output_tokens` | The four billed tiers. |
+| `usage_unparsed` | Responses that carried a usage block in a **spelling this proxy does not recognise**, so the four tiers above were recorded as 0 on an otherwise healthy request. Non-zero means token accounting is offline for some route or provider. |
+| `usage_unreadable` | Responses whose examined bytes would not parse at all, so usage could not be sought — a spliced head+tail sniffer window rather than an unrecognised dialect. Different fix; see below. |
 | `attempted_tokens` | What compaction was **allowed** to touch this window — the uncached tail when cache-aware. |
 | `frozen_tokens` | What cache-awareness deliberately left alone. Its benefit is the cache reads that stayed cheap; this is its cost. |
 | `savings_pct_attempted` | `saved ÷ attempted`. The ratio to quote: `savings_pct`'s whole-request denominator recounts the transcript every turn and trends to ~0% on a long session. `0` when nothing was attempted. |
 | `savings_pct_new_input` | `saved ÷ (fresh + cache_write + saved)` — savings as a fraction of what would newly have entered the provider. Reported as `0`, **never 100**, when the provider reported no usage: savings must not be divided by themselves. |
+
+#### When the tiers read zero
+
+Four token fields at 0 on a 200 with correct savings, correct latency and correct everything else
+used to mean **five** different things, with nothing to tell them apart:
+
+| Cause | `usage_miss` in the log | Counted | What to do |
+|---|---|---|---|
+| The provider genuinely reported no usage (an OpenAI response without `stream_options`) | `absent` | — | nothing |
+| A recognised block whose every tier is zero | `all_zero` | — | nothing; legitimate on some responses |
+| Empty response body | `no_body` | — | nothing |
+| A usage block in an **unrecognised dialect** (Bedrock Converse camelCase `usage.inputTokens`, or a nested `response.usage`) | `unparsed_dialect` | `usage_unparsed` | **alert.** Add the dialect — the DEBUG record below names it |
+| The examined bytes were not a whole document, so the block was hidden | `unreadable_body` | `usage_unreadable` | **alert.** Raise `sniffMax` or buffer the body; do *not* go hunting for a missing field name |
+
+Only the last two are failures, and only they are counted — the number an operator watches to
+confirm accounting is healthy must not be incremented by it being broken. The reason for every
+miss, benign ones included, rides on the `cg.request` log line as `usage_miss`.
+
+**The shape record.** On the first unaccounted response per process, `cg.usage_unaccounted` is
+logged at DEBUG with the response's **key names** — top-level keys, where a usage block was found,
+and the key names inside it — and nothing else. No values and no body: a body dump on agent traffic
+writes kilobytes of transcript per response, and this record cannot, by construction. It is what
+turns "usage_reported is false" into "the provider is sending camelCase", from any deployment that
+hits the gap, without a capture rig or an extra request.
+
+This ran undetected for **4,015 of 4,015 requests** in one benchmark iteration and was found two
+iterations later, in a post-mortem chasing a different question.
 
 ### SSE streaming health
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -792,14 +792,28 @@ type Snapshot struct {
 	// undecidable from data. What distinguishes "never bound" from "working" is StashRefused and
 	// StashLive against StashCapacity.
 	// Filled by the host at serve time (offload + store live below metrics).
-	StashRefused  int64 `json:"stash_refused"`
-	StashMissing  int64 `json:"stash_missing"`
-	StashExpired  int64 `json:"stash_expired"`
-	StashRevived  int64 `json:"stash_revived"`
-	StashLive     int   `json:"stash_live"`
-	StashCapacity int   `json:"stash_capacity"`
-	StashBytes    int64 `json:"stash_bytes"`
-	StashMaxBytes int64 `json:"stash_max_bytes"`
+	// UsageUnparsed and UsageUnreadable are the two ways this proxy failed to ACCOUNT a response
+	// it otherwise served perfectly: the provider sent a usage block in a spelling the parser does
+	// not recognise, or the bytes examined were not a whole document (a spliced sniffer window).
+	// Either way fresh_input_tokens / cache_read_tokens / cache_write_tokens read 0 on a healthy
+	// 200 with correct savings, correct latency and correct everything else — which ran for 4,015
+	// of 4,015 requests in one benchmark iteration and was found two iterations later, in a
+	// post-mortem chasing a different question (#200).
+	//
+	// Counted apart because the REMEDIES are opposite — add the dialect vs. stop truncating the
+	// window — and kept out of the benign cases (a provider that genuinely reported no usage, and
+	// a recognised block whose tiers are all zero), which are reported as `usage_miss` on the
+	// lifecycle log line and are not alertable. Filled by the host at serve time.
+	UsageUnparsed   int64 `json:"usage_unparsed"`
+	UsageUnreadable int64 `json:"usage_unreadable"`
+	StashRefused    int64 `json:"stash_refused"`
+	StashMissing    int64 `json:"stash_missing"`
+	StashExpired    int64 `json:"stash_expired"`
+	StashRevived    int64 `json:"stash_revived"`
+	StashLive       int   `json:"stash_live"`
+	StashCapacity   int   `json:"stash_capacity"`
+	StashBytes      int64 `json:"stash_bytes"`
+	StashMaxBytes   int64 `json:"stash_max_bytes"`
 	// CompactionResets counts turns whose cached-prefix boundary restarted because the
 	// AGENT compacted its own transcript (it shrank under a stable session id). The
 	// session id deliberately survives that compaction so one conversation is one

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -531,6 +531,17 @@ func (h *Handler) renderMetrics() string {
 		// declines the removal, whichever store instance refused the payload. This is the
 		// LEADING indicator for cg_expand_unresolved_total{cause="missing"}, which cannot move
 		// until the agent happens to call expand.
+		unparsedUsage, unreadableUsage := UsageGaps()
+		// The two accounting-outage counters (#200). Process-wide, so outside the store cast for
+		// the same reason the stash pair is: the parser is package-level.
+		promHeaderProc(&b, "cg_usage_unparsed_total",
+			"Responses that carried a usage block in a spelling this proxy does not recognise, so fresh/cache_read/cache_write tokens were recorded as 0 on an otherwise healthy request. Non-zero means token accounting is offline for some route or provider; the DEBUG record cg.usage_unaccounted names the dialect (key names only).", "counter")
+		promLine(&b, "cg_usage_unparsed_total", "", float64(unparsedUsage))
+		// Split from the above because the fix is in a different place entirely: these bytes were
+		// not a whole document, so no parser could have read them.
+		promHeaderProc(&b, "cg_usage_unreadable_total",
+			"Responses whose examined bytes would not parse at all, so usage could not be sought — a spliced head+tail sniffer window, not an unrecognised dialect. Raise sniffMax or buffer the body; do NOT go looking for a missing field name.", "counter")
+		promLine(&b, "cg_usage_unreadable_total", "", float64(unreadableUsage))
 		promHeaderProc(&b, "cg_stash_refused_total",
 			"Removals declined because the store's rewind reserve was full. The content was left verbatim and nothing became irreversible; raise max_entries or stash_max_bytes.", "counter")
 		promLine(&b, "cg_stash_refused_total", "", float64(offload.StashRefusals()))

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -102,13 +102,13 @@ var notExportedWhy = map[string]string{
 	// these AFTER renderMetrics takes its snapshot, so a promLine off `s` would export a permanent
 	// 0 while passing this test — which is precisely the silent-zero failure #200 is about, and it
 	// would be embarrassing to reproduce it in the counter meant to report it.
-	"UsageUnparsed":             "cg_usage_unparsed_total, from proxy.UsageGaps()",
-	"UsageUnreadable":           "cg_usage_unreadable_total, from proxy.UsageGaps()",
-	"StashLive":                 `cg_stash_reserve_entries{state="live"}, from store.Memory.StashStats()`,
-	"StashCapacity":             `cg_stash_reserve_entries{state="capacity"}, from store.Memory.StashStats()`,
-	"StashBytes":                `cg_stash_reserve_bytes{state="live"}, from store.Memory.StashStats()`,
-	"StashMaxBytes":             `cg_stash_reserve_bytes{state="capacity"}, from store.Memory.StashStats()`,
-	"Extract":                   "the cg_extract_* family, from metrics.ExtractSnapshot()",
+	"UsageUnparsed":   "cg_usage_unparsed_total, from proxy.UsageGaps()",
+	"UsageUnreadable": "cg_usage_unreadable_total, from proxy.UsageGaps()",
+	"StashLive":       `cg_stash_reserve_entries{state="live"}, from store.Memory.StashStats()`,
+	"StashCapacity":   `cg_stash_reserve_entries{state="capacity"}, from store.Memory.StashStats()`,
+	"StashBytes":      `cg_stash_reserve_bytes{state="live"}, from store.Memory.StashStats()`,
+	"StashMaxBytes":   `cg_stash_reserve_bytes{state="capacity"}, from store.Memory.StashStats()`,
+	"Extract":         "the cg_extract_* family, from metrics.ExtractSnapshot()",
 
 	// Not numbers. Prometheus has no string sample, and a list of names would have to
 	// become a label — which is what the cg_component_* family already is.

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -97,6 +97,13 @@ var notExportedWhy = map[string]string{
 	"StashMissing":              "cg_stash_missing_total, from offload.StashMissing()",
 	"StashExpired":              "cg_stash_expired_total, from store.Memory.StashStats()",
 	"StashRevived":              "cg_stash_revived_total, from store.Memory.StashStats()",
+	// Exported as cg_usage_unparsed_total / cg_usage_unreadable_total, but read from UsageGaps()
+	// rather than off `s` for the reason the block above this map gives: the /stats handler fills
+	// these AFTER renderMetrics takes its snapshot, so a promLine off `s` would export a permanent
+	// 0 while passing this test — which is precisely the silent-zero failure #200 is about, and it
+	// would be embarrassing to reproduce it in the counter meant to report it.
+	"UsageUnparsed":             "cg_usage_unparsed_total, from proxy.UsageGaps()",
+	"UsageUnreadable":           "cg_usage_unreadable_total, from proxy.UsageGaps()",
 	"StashLive":                 `cg_stash_reserve_entries{state="live"}, from store.Memory.StashStats()`,
 	"StashCapacity":             `cg_stash_reserve_entries{state="capacity"}, from store.Memory.StashStats()`,
 	"StashBytes":                `cg_stash_reserve_bytes{state="live"}, from store.Memory.StashStats()`,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1360,6 +1360,10 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 	// can never delay or fail a request.
 	var usage Usage
 	var usageOK bool
+	// WHY, when the answer is no. `usage_reported=false` meant five different things — two
+	// benign, three a measurement outage — and nothing distinguished them, so a run that had
+	// stopped accounting tokens on every request read as healthy (#200). See usageMiss.
+	usageWhy := usageMissNoBody
 	// status/rounds/expanded exist for the lifecycle log line: the upstream status is
 	// the one fact about a request an operator asks for first, and until now it reached
 	// the dashboard row and nothing else.
@@ -1407,7 +1411,8 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 		lg.Info("cg.request", "status", status, "serve_ms", msSince(reqStart, time.Time{}),
 			"upstream_rounds", rounds, "expands", expanded, "sse", sse, "sse_buffered", sseBuffered,
 			"fresh_input", usage.FreshInput, "cache_read", usage.CacheRead,
-			"cache_write", usage.CacheWrite, "output", usage.Output, "usage_reported", usageOK)
+			"cache_write", usage.CacheWrite, "output", usage.Output, "usage_reported", usageOK,
+			"usage_miss", usageWhy.String())
 	}()
 	for round := 0; ; round++ {
 		rounds = round + 1
@@ -1479,10 +1484,11 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			sse = sse || isSSE
 			// Stream straight through, sniffing usage from a bounded head+tail window as
 			// the bytes go by (no buffering of the whole response, no added latency).
-			first, u, ok := h.stream(w, resp)
+			first, u, why, ok := h.stream(w, resp)
 			if !sseBuffered {
 				sseFirstByte = first
 			}
+			usageWhy = why
 			if ok {
 				usage, usageOK = u, true
 			} else {
@@ -1530,10 +1536,11 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			// A raw expand call on this path is repaired on the REQUEST side instead
 			// (expand.RepairToolResults).
 			sse = true
-			first, u, ok := h.stream(w, resp)
+			first, u, why, ok := h.stream(w, resp)
 			if !sseBuffered {
 				sseFirstByte = first
 			}
+			usageWhy = why
 			if ok {
 				usage, usageOK = u, true
 			} else {
@@ -1549,10 +1556,11 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			// bail below ends the client's turn with a complete stream rather than cutting
 			// it off mid-message.
 		}
-		if u, ok := responseUsage(resp.Header.Get("Content-Type"), respBody); ok {
-			usage, usageOK = u, true
+		if u, why, ok := responseUsageWhy(resp.Header.Get("Content-Type"), respBody); ok {
+			usage, usageOK, usageWhy = u, true, why
 		} else {
 			usage.StopReason = u.StopReason // same reasoning as the stream path above
+			usageWhy = why
 		}
 		if isSSE && withheld == nil {
 			// The whole round is already on the wire. Either it never called expand, or it
@@ -1772,7 +1780,7 @@ func setUpstreamAuth(dst http.Header, up upstream) {
 //
 // It also returns the instant the client got its first byte (zero if the body was
 // empty), which is the SSE TTFB accounting in serve.
-func (h *Handler) stream(w http.ResponseWriter, resp *http.Response) (firstByte time.Time, u Usage, ok bool) {
+func (h *Handler) stream(w http.ResponseWriter, resp *http.Response) (firstByte time.Time, u Usage, why usageMiss, ok bool) {
 	defer resp.Body.Close()
 	copyHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
@@ -1795,8 +1803,11 @@ func (h *Handler) stream(w http.ResponseWriter, resp *http.Response) (firstByte 
 			break
 		}
 	}
-	u, ok = responseUsage(resp.Header.Get("Content-Type"), sn.bytes())
-	return firstByte, u, ok
+	// The window, not the response: over sniffMax each way this is head+"\n"+tail, which is not a
+	// whole JSON document. responseUsageWhy reports that as `unreadable_body` rather than as an
+	// unrecognised dialect, because the remedy is here and not in any parser.
+	u, why, ok = responseUsageWhy(resp.Header.Get("Content-Type"), sn.bytes())
+	return firstByte, u, why, ok
 }
 
 // msSince returns milliseconds from start to at (falling back to now if the
@@ -1905,6 +1916,9 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 	snap.FrozenHits, snap.FrozenMisses = offload.FrozenStats()
 	// Process-wide, like FrozenHits, and so filled outside the cast below: a removal declined
 	// for want of a stash slot is counted by the COMPONENT, whatever store instance refused it.
+	// Process-wide like the counters below: the parser is package-level, so whatever tenant's
+	// response carried the unreadable usage, this is the process's total.
+	snap.UsageUnparsed, snap.UsageUnreadable = UsageGaps()
 	snap.StashRefused = offload.StashRefusals()
 	// The dangling-marker counter, process-wide for the same reason: it is a COMPONENT that
 	// replayed a marker whose payload had gone, whichever store instance lost it. Reported

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1488,7 +1488,11 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			if !sseBuffered {
 				sseFirstByte = first
 			}
-			usageWhy = why
+			// noteUsageMiss, not a bare assignment: usageOK is sticky-true across expand rounds
+			// while this was last-write-wins, so a request whose round 1 parsed usage and whose
+			// round 2 continuation carried none logged `usage_reported=true usage_miss=absent`.
+			// A pair that can contradict itself undoes the reason for having the reason.
+			usageWhy = noteUsageMiss(usageWhy, why, usageOK || ok)
 			if ok {
 				usage, usageOK = u, true
 			} else {
@@ -1540,7 +1544,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			if !sseBuffered {
 				sseFirstByte = first
 			}
-			usageWhy = why
+			usageWhy = noteUsageMiss(usageWhy, why, usageOK || ok) // see the other stream path
 			if ok {
 				usage, usageOK = u, true
 			} else {
@@ -1557,10 +1561,10 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, provider bschema
 			// it off mid-message.
 		}
 		if u, why, ok := responseUsageWhy(resp.Header.Get("Content-Type"), respBody); ok {
-			usage, usageOK, usageWhy = u, true, why
+			usage, usageOK, usageWhy = u, true, noteUsageMiss(usageWhy, why, true)
 		} else {
 			usage.StopReason = u.StopReason // same reasoning as the stream path above
-			usageWhy = why
+			usageWhy = noteUsageMiss(usageWhy, why, usageOK)
 		}
 		if isSSE && withheld == nil {
 			// The whole round is already on the wire. Either it never called expand, or it

--- a/proxy/stats_golden_test.go
+++ b/proxy/stats_golden_test.go
@@ -121,6 +121,11 @@ var statsGoldenTopLevel = []string{
 	"top_passthrough",
 	"upstream_ms_avg",
 	"upstream_ms_avg_bypassed",
+	// The two accounting-outage counters (#200). Added to the reviewed contract rather than
+	// loosening the assertion: fresh/cache_read/cache_write reading 0 on a healthy request is
+	// exactly the kind of silence a golden test exists to make someone notice.
+	"usage_unparsed",
+	"usage_unreadable",
 	"wasted_tokens",
 }
 

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -263,6 +263,20 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss, string) {
 	// a dialect gap, so a streamed all-zero block — legitimate — read as an outage. Per-event
 	// parseUsageWhy costs nothing extra (the boolean form called it anyway) and each event's own
 	// reason is already exact.
+	// THE TWO PARSERS ARE NOT SYMMETRIC, and the asymmetry is here: this one can never return
+	// usageMissUnreadable. It only calls parseUsageWhy with a block usagePresent already accepted,
+	// and that function reaches its ValidBytes branch only when no block was found anywhere — so
+	// `worst` ranges over absent/all_zero/unparsed_dialect and nothing else. A `data:` line cut
+	// mid-JSON yields no present block, so the stream reads as "the provider streamed no usage".
+	//
+	// That leaves usage_unreadable reachable for a sniffed JSON response and structurally
+	// unreachable for a sniffed STREAM, which is where a head+tail window would hide a block —
+	// #200's own defect, in the corner this classification does not cover. Narrow in practice:
+	// Anthropic puts input_tokens in message_start at the front of the head window, so `found` is
+	// true and the answer is `parsed`. Closing it properly means passing the sniffer's own
+	// knowledge that it spliced (s.total > len(s.head)) into responseUsageWhy, which would also
+	// make the buffered case exact instead of inferred from ValidBytes. Filed rather than guessed
+	// at here.
 	worst := usageMissAbsent
 	worstPayload := "" // the event `worst` came from, so the record describes the right one
 	for _, line := range strings.Split(string(raw), "\n") {

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -240,14 +240,22 @@ func parseUsageWhy(body []byte) (Usage, usageMiss) {
 // merged across events, taking the maximum of each — a later event repeating a
 // value must not double it.
 func parseSSEUsage(raw []byte) (Usage, bool) {
-	u, why := parseSSEUsageWhy(raw)
+	u, why, _ := parseSSEUsageWhy(raw)
 	return u, why == usageMissNone
 }
 
 // parseSSEUsageWhy is parseSSEUsage plus #200's classification. An event stream that carried a
 // usage block no event of it could be read is the streamed form of the dialect gap, and it must
 // not be reported as "the provider streamed no usage" — the remedies differ.
-func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
+// The third return is the PAYLOAD OF THE EVENT THAT SET THE REASON, for the shape record.
+//
+// The record used to describe the stream's LAST data: event, which on the Anthropic-family
+// transport is `message_stop` — usage arrives in `message_start`. So a streamed unrecognised
+// dialect produced a record of the terminal event: no usage_at, no usage_keys, nothing about the
+// dialect, and it consumed one of the bounded record slots to say it. That is exactly the shape a
+// streamed Bedrock aws/claude-* response has, which is where the gap this record exists to
+// diagnose would sit. Returning it from here also collapses two walks over the transport into one.
+func parseSSEUsageWhy(raw []byte) (Usage, usageMiss, string) {
 	var out Usage
 	found := false
 	// The WORST reason any event produced, which is what makes a streamed miss as precise as a
@@ -256,6 +264,7 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 	// parseUsageWhy costs nothing extra (the boolean form called it anyway) and each event's own
 	// reason is already exact.
 	worst := usageMissAbsent
+	worstPayload := "" // the event `worst` came from, so the record describes the right one
 	for _, line := range strings.Split(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
@@ -276,6 +285,7 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 			one, why := parseUsageWhy([]byte(`{"usage":` + u.Raw + `}`))
 			if why > worst {
 				worst = why // usageMiss is ordered benign -> alertable; see its constants
+				worstPayload = payload
 			}
 			if why != usageMissNone {
 				continue
@@ -289,12 +299,12 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 		}
 	}
 	if found {
-		return out, usageMissNone
+		return out, usageMissNone, ""
 	}
 	// Every block that appeared was rejected, and `worst` says why — an unrecognised spelling is
 	// alertable, an all-zero block is not, and no block at all is `absent` because that is what
 	// `worst` starts as.
-	return out, worst
+	return out, worst, worstPayload
 }
 
 // responseUsage picks the right parser for a response's content type. The returned
@@ -318,8 +328,13 @@ func responseUsageWhy(contentType string, body []byte) (Usage, usageMiss, bool) 
 	sse := strings.Contains(contentType, "event-stream")
 	var u Usage
 	var why usageMiss
+	// doc is the JSON document the shape record should DESCRIBE, which for a stream is the one
+	// event that produced the reason rather than the whole transport or its last event.
+	doc := body
 	if sse {
-		u, why = parseSSEUsageWhy(body)
+		var judged string
+		u, why, judged = parseSSEUsageWhy(body)
+		doc = []byte(judged)
 	} else {
 		u, why = parseUsageWhy(body)
 	}
@@ -331,7 +346,9 @@ func responseUsageWhy(contentType string, body []byte) (Usage, usageMiss, bool) 
 		case usageMissUnreadable:
 			usageUnreadable.Add(1)
 		}
-		recordUsageShape(sse, body)
+		// len(body) so the record still reports the whole response's size — that is what says a
+		// window was spliced — while describing the document that actually failed to parse.
+		recordUsageShape(sse, len(body), doc)
 	}
 	return u, why, why == usageMissNone
 }
@@ -424,8 +441,8 @@ func noteUsageShape(key string) bool {
 // is false" into "the provider is sending camelCase", which is the difference between an open
 // question and a one-line fix — without needing a captured body, an instrumented capture hop, or
 // any extra request.
-func recordUsageShape(sse bool, body []byte) {
-	attrs := usageShapeAttrs(sse, body)
+func recordUsageShape(sse bool, total int, doc []byte) {
+	attrs := usageShapeAttrs(sse, total, doc)
 	if !noteUsageShape(usageShapeKey(attrs)) {
 		return
 	}
@@ -464,20 +481,24 @@ func ResetUsageShapeRecordForTest() {
 
 // usageShapeAttrs builds the shape record's key/value pairs. Separated from the logging so a test
 // can assert what it does and — more to the point — what it does NOT contain.
-func usageShapeAttrs(sse bool, body []byte) []any {
-	doc := body
-	if sse {
-		// One event, so the record describes a JSON object rather than a transport. The last
-		// data: line is where both dialects put their terminal usage.
-		doc = []byte(lastSSEPayload(body))
-	}
-	attrs := []any{"sse", sse, "bytes", len(body),
+//
+// doc is the JSON document that failed to parse: the whole body for a buffered response, and for a
+// stream the ONE EVENT the classifier judged (see parseSSEUsageWhy) rather than the transport or its
+// last event. total is the whole response's size, which is the figure that says a window was
+// spliced.
+func usageShapeAttrs(sse bool, total int, doc []byte) []any {
+	attrs := []any{"sse", sse, "bytes", total,
 		// Not parseable means the window was spliced rather than the dialect being strange —
 		// stated in the record so it cannot be misread as a field-name gap.
 		"valid_json", gjson.ValidBytes(doc),
 		"top_level_keys", objectKeys(gjson.ParseBytes(doc))}
 	for _, p := range append([]string{"usage"}, nestedUsagePaths[:]...) {
-		if u := gjson.GetBytes(doc, p); u.Exists() {
+		// usagePresent, not Exists, and for the same reason the classifier uses it: a null or empty
+		// block resolves but names no fields, so the record pointed at `usage` and printed
+		// usage_keys=[] while a real nested block held the answer — and keyed as `usage|`, which
+		// collides with a genuinely empty top-level block. The record must look where the
+		// CLASSIFIER looked.
+		if u := gjson.GetBytes(doc, p); usagePresent(u) {
 			return append(attrs, "usage_at", p, "usage_keys", objectKeys(u))
 		}
 	}
@@ -497,22 +518,6 @@ func objectKeys(v gjson.Result) []string {
 	})
 	sort.Strings(keys)
 	return keys
-}
-
-// lastSSEPayload returns the last non-empty `data:` payload in an event stream, which is where
-// both dialects put the terminal usage. Empty when there is none.
-func lastSSEPayload(body []byte) string {
-	lines := strings.Split(string(body), "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
-		if !strings.HasPrefix(line, "data:") {
-			continue
-		}
-		if p := strings.TrimSpace(strings.TrimPrefix(line, "data:")); p != "" && p != "[DONE]" {
-			return p
-		}
-	}
-	return ""
 }
 
 // stopReasonPaths are where a terminal reason lives, per dialect and per transport:

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -55,6 +55,9 @@ type Usage struct {
 // later, in a post-mortem chasing a different question.
 type usageMiss uint8
 
+// THE ORDER IS PART OF THE TYPE, ascending in severity: parseSSEUsageWhy compares two reasons
+// with `>` to keep the worst one any event of a stream produced. A new value goes at its severity
+// position, not at the end.
 const (
 	usageMissNone       usageMiss = iota // tiers were read; not a miss
 	usageMissNoBody                      // nothing to look at (empty response). BENIGN
@@ -99,6 +102,32 @@ func (m usageMiss) alertable() bool {
 // classification exists to expose, reproduced in the code meant to report it.
 var nestedUsagePaths = [...]string{"response.usage", "usageMetadata", "data.usage", "message.usage"}
 
+// usagePresent reports whether a usage block is actually THERE — an object carrying at least one
+// field — as opposed to merely resolving.
+//
+// gjson's Exists() is `Type != Null || len(Raw) != 0`, and a JSON null has Raw == "null", so
+// `"usage": null` LOOKED like a present block that no recognised spelling could read: classified
+// `unparsed_dialect`, counted as a measurement outage. OpenAI-dialect streaming sends exactly
+// `"usage": null` on every chunk unless the caller sets stream_options.include_usage, so on the
+// openai_upstream route the counter documented as "add the dialect the provider is speaking" was
+// incremented by ordinary healthy traffic.
+//
+// That is #200's own defect with the sign flipped — instead of an outage reading as healthy,
+// healthy traffic reads as an outage — and it costs the same thing: an operator who cannot tell
+// from the counter which one they have. `{}` is treated the same way for the same reason: a
+// provider that sent an empty object told us nothing, which is `absent`, not a missing spelling.
+func usagePresent(v gjson.Result) bool {
+	if !v.IsObject() {
+		return false
+	}
+	empty := true
+	v.ForEach(func(gjson.Result, gjson.Result) bool {
+		empty = false
+		return false // one field is enough
+	})
+	return !empty
+}
+
 // parseUsage extracts the four billed token tiers from a buffered response body,
 // in whichever dialect it is written. This is the number that actually matters on
 // this workload — the request is ~99.95% cached and a cache write bills ~11.5x a
@@ -125,12 +154,21 @@ func parseUsage(body []byte) (Usage, bool) {
 // responseUsage, which sees the whole response, is in a position to say anything about it.
 func parseUsageWhy(body []byte) (Usage, usageMiss) {
 	u := gjson.GetBytes(body, "usage")
-	if !u.Exists() {
+	if !usagePresent(u) {
 		// A block SOMEWHERE ELSE is a parser gap; nothing anywhere is a provider that said
 		// nothing. Distinguishing them is the point: the first is a measurement outage whose fix
 		// is a dialect, the second needs no action at all.
+		//
+		// PRECEDENCE, and it is chosen rather than accidental: a found block wins over an
+		// unparseable document. These probes run BEFORE ValidBytes below, so a spliced window that
+		// hid the top-level `usage` while leaving `response.usage` scannable is reported as a
+		// dialect gap, not as unreadable bytes. That is the right way round — a block we DID find
+		// really does mean a spelling is missing, whatever else is wrong with the bytes — and
+		// `valid_json` in the shape record tells the reader the document was also truncated. Do
+		// not "fix" this by testing ValidBytes first: that would hide a real dialect behind a
+		// transport problem.
 		for _, p := range nestedUsagePaths {
-			if gjson.GetBytes(body, p).Exists() {
+			if usagePresent(gjson.GetBytes(body, p)) {
 				return Usage{}, usageMissUnparsed
 			}
 		}
@@ -212,7 +250,12 @@ func parseSSEUsage(raw []byte) (Usage, bool) {
 func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 	var out Usage
 	found := false
-	sawBlock := false // some event HAD a usage block, whatever came of reading it
+	// The WORST reason any event produced, which is what makes a streamed miss as precise as a
+	// buffered one. The predecessor kept a bare sawBlock flag and reported every rejected block as
+	// a dialect gap, so a streamed all-zero block — legitimate — read as an outage. Per-event
+	// parseUsageWhy costs nothing extra (the boolean form called it anyway) and each event's own
+	// reason is already exact.
+	worst := usageMissAbsent
 	for _, line := range strings.Split(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
@@ -225,12 +268,16 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 		// Anthropic nests the first usage under message.usage; OpenAI puts it at the top.
 		for _, path := range []string{"usage", "message.usage"} {
 			u := gjson.Get(payload, path)
-			if !u.Exists() {
+			// usagePresent, not Exists: `"usage": null` on every chunk is what OpenAI-dialect
+			// streaming sends absent stream_options.include_usage, and it is not a block.
+			if !usagePresent(u) {
 				continue
 			}
-			sawBlock = true
-			one, ok := parseUsage([]byte(`{"usage":` + u.Raw + `}`))
-			if !ok {
+			one, why := parseUsageWhy([]byte(`{"usage":` + u.Raw + `}`))
+			if why > worst {
+				worst = why // usageMiss is ordered benign -> alertable; see its constants
+			}
+			if why != usageMissNone {
 				continue
 			}
 			found = true
@@ -241,18 +288,13 @@ func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 			out.Output = max64(out.Output, one.Output)
 		}
 	}
-	switch {
-	case found:
+	if found {
 		return out, usageMissNone
-	case sawBlock:
-		// Every block that appeared was rejected. All-zero is the benign version of that and is
-		// indistinguishable here without re-reading each one, so this stays the coarser
-		// `unparsed` rather than being split on a guess — a stream whose only usage block is
-		// all-zero over-reports by one, and a stream in an unrecognised dialect is reported at
-		// all, which it was not before.
-		return out, usageMissUnparsed
 	}
-	return out, usageMissAbsent
+	// Every block that appeared was rejected, and `worst` says why — an unrecognised spelling is
+	// alertable, an all-zero block is not, and no block at all is `absent` because that is what
+	// `worst` starts as.
+	return out, worst
 }
 
 // responseUsage picks the right parser for a response's content type. The returned
@@ -294,6 +336,25 @@ func responseUsageWhy(contentType string, body []byte) (Usage, usageMiss, bool) 
 	return u, why, why == usageMissNone
 }
 
+// noteUsageMiss folds one round's reason into the request's, so `usage_miss` cannot contradict
+// `usage_reported` on the log line.
+//
+// A request can drive several upstream rounds (the expand continuation loop). usageOK is sticky —
+// it is only ever set true and never reset, because a request whose usage was read once IS
+// accounted — but the reason was last-write-wins, so round 2 carrying no usage relabelled an
+// accounted request `absent`. The rule that removes the contradiction: once anything accounted the
+// request, the reason is `parsed`; while nothing has, keep the WORST reason seen, for the same
+// severity-ordering reason parseSSEUsageWhy keeps one.
+func noteUsageMiss(sofar, this usageMiss, accounted bool) usageMiss {
+	if accounted {
+		return usageMissNone
+	}
+	if this > sofar {
+		return this
+	}
+	return sofar
+}
+
 // The two alertable misses, counted apart because their REMEDIES are opposite: `unparsed` means
 // add the dialect the provider is speaking, `unreadable` means the bytes we looked at were not a
 // whole document (a spliced sniffer window) and the fix is upstream of any parser. A single
@@ -312,15 +373,47 @@ var (
 // dialect) and how many carried bytes it could not parse at all. Non-zero on either means
 // fresh_input_tokens / cache_read_tokens / cache_write_tokens are 0 for some route or provider
 // while everything else about the request looks healthy.
+//
+// RESPONSES, not requests, and the distinction matters when reading them against traffic: one
+// request can drive several upstream rounds through the expand continuation loop, so a single
+// unaccounted request can move these more than once. The 4,015-of-4,015 figure this was filed
+// against is a per-REQUEST count, so it is not directly comparable.
 func UsageGaps() (unparsed, unreadable int64) {
 	return usageUnparsed.Load(), usageUnreadable.Load()
 }
 
-// usageShapeOnce keeps the shape record to the FIRST alertable response per process. It is a
-// diagnostic, not a metric: one record names the gap, and one per response would put a line in
-// the log for every request of a run that has the gap on all of them (4,015 of 4,015, in the
-// iteration that motivated this).
-var usageShapeOnce sync.Once
+// One record per DISTINCT SHAPE, bounded — not one per process.
+//
+// A single process-wide sync.Once was wrong in a way that defeated the diagnostic: both alertable
+// classes shared it, so whichever response came first spent it. A spliced window followed by the
+// camelCase response produced a record about the window and left the dialect question unanswered —
+// and the dialect question is what this record exists for. A multi-provider deployment has more
+// than one answer, so "one line per process" was the wrong quantity as well as the wrong one.
+//
+// Keyed on the record's own identity (where the block was, plus its sorted key names), which is
+// exactly the granularity that distinguishes two dialects while collapsing a run that has the same
+// gap on every request: 4,015 of 4,015 identical responses still produce ONE line. Capped so a
+// pathological provider varying its keys cannot turn this into a line per request.
+const usageShapeMax = 8
+
+var (
+	usageShapeMu   sync.Mutex
+	usageShapeSeen = map[string]struct{}{}
+)
+
+// noteUsageShape reports whether this shape has not been recorded before and there is room for it.
+// Under the mutex so the reset below is not a data race — the predecessor's
+// `usageShapeOnce = sync.Once{}` raced any concurrent Do, which -race would have found the moment
+// one of those tests was marked t.Parallel().
+func noteUsageShape(key string) bool {
+	usageShapeMu.Lock()
+	defer usageShapeMu.Unlock()
+	if _, dup := usageShapeSeen[key]; dup || len(usageShapeSeen) >= usageShapeMax {
+		return false
+	}
+	usageShapeSeen[key] = struct{}{}
+	return true
+}
 
 // recordUsageShape logs the response's SHAPE — the top-level key names, plus the key names under
 // any usage block found — and nothing else.
@@ -332,15 +425,42 @@ var usageShapeOnce sync.Once
 // question and a one-line fix — without needing a captured body, an instrumented capture hop, or
 // any extra request.
 func recordUsageShape(sse bool, body []byte) {
-	usageShapeOnce.Do(func() {
-		slog.Default().Debug("cg.usage_unaccounted", usageShapeAttrs(sse, body)...)
-	})
+	attrs := usageShapeAttrs(sse, body)
+	if !noteUsageShape(usageShapeKey(attrs)) {
+		return
+	}
+	slog.Default().Debug("cg.usage_unaccounted", attrs...)
 }
 
-// ResetUsageShapeRecordForTest re-arms the once-per-process shape record. For TESTS only: the
-// record is the diagnostic this whole change exists to produce, so a test has to be able to
-// observe it, and the Once makes that a one-shot for the entire binary.
-func ResetUsageShapeRecordForTest() { usageShapeOnce = sync.Once{} }
+// usageShapeKey identifies a shape by WHERE the block was and what its fields are called — the two
+// things that differ between dialects. Deliberately not the top-level keys: those vary with the
+// response's content (an Anthropic body with a tool_use block has different top-level keys from one
+// without), so keying on them would let one dialect burn the whole budget.
+func usageShapeKey(attrs []any) string {
+	var at, keys string
+	for i := 0; i+1 < len(attrs); i += 2 {
+		switch attrs[i] {
+		case "usage_at":
+			at, _ = attrs[i+1].(string)
+		case "usage_keys":
+			if ks, ok := attrs[i+1].([]string); ok {
+				keys = strings.Join(ks, ",")
+			}
+		}
+	}
+	// No block found at all (the unreadable case) still deserves exactly one line, so it gets a
+	// stable key of its own rather than colliding with a real dialect.
+	return at + "|" + keys
+}
+
+// ResetUsageShapeRecordForTest forgets the shapes recorded so far. For TESTS only: the record is
+// the diagnostic this whole change exists to produce, so a test has to be able to observe it, and
+// the per-process bound makes that a one-shot for the entire binary otherwise.
+func ResetUsageShapeRecordForTest() {
+	usageShapeMu.Lock()
+	defer usageShapeMu.Unlock()
+	usageShapeSeen = map[string]struct{}{}
+}
 
 // usageShapeAttrs builds the shape record's key/value pairs. Separated from the logging so a test
 // can assert what it does and — more to the point — what it does NOT contain.

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -1,7 +1,11 @@
 package proxy
 
 import (
+	"log/slog"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/tidwall/gjson"
 )
@@ -40,6 +44,61 @@ type Usage struct {
 	StopReason string
 }
 
+// usageMiss says WHY no billed tiers came back, because "ok=false" meant five different things
+// and nothing distinguished them (#200). Only two of the five are benign, and the other three
+// call for THREE DIFFERENT REMEDIES — which is the whole argument for classifying rather than
+// counting: a shared signal reports "nothing to account" and "token accounting is offline" with
+// one value, and the second is silent by construction (a healthy 200, correct savings counters,
+// correct latency, and three token fields quietly at 0).
+//
+// It ran for 4,015 of 4,015 requests in one benchmark iteration and was found two iterations
+// later, in a post-mortem chasing a different question.
+type usageMiss uint8
+
+const (
+	usageMissNone       usageMiss = iota // tiers were read; not a miss
+	usageMissNoBody                      // nothing to look at (empty response). BENIGN
+	usageMissAbsent                      // no usage block anywhere we know to look. BENIGN
+	usageMissZero                        // a recognised block, every tier zero. LEGITIMATE
+	usageMissUnparsed                    // a block IS there, no recognised spelling read it
+	usageMissUnreadable                  // the bytes are not parseable, so nothing could be sought
+)
+
+// String is the reason as it appears in the lifecycle log line, so an operator reading
+// `usage_reported=false` can see which of the five it was without a body dump.
+func (m usageMiss) String() string {
+	switch m {
+	case usageMissNone:
+		return "parsed"
+	case usageMissNoBody:
+		return "no_body"
+	case usageMissAbsent:
+		return "absent"
+	case usageMissZero:
+		return "all_zero"
+	case usageMissUnparsed:
+		return "unparsed_dialect"
+	case usageMissUnreadable:
+		return "unreadable_body"
+	}
+	return "unknown"
+}
+
+// alertable reports whether this miss means TOKEN ACCOUNTING IS OFFLINE, as opposed to a
+// provider that legitimately said nothing. The two benign cases must never share a counter with
+// these, or the number an operator watches to confirm accounting is healthy is incremented by it
+// being broken.
+func (m usageMiss) alertable() bool {
+	return m == usageMissUnparsed || m == usageMissUnreadable
+}
+
+// nestedUsagePaths are places a usage block is known to live OTHER than the top level. They are
+// probed for EXISTENCE ONLY — never read — which is what keeps this dialect-agnostic: knowing
+// that a block is there is enough to say the parser has a gap, and guessing at the field names
+// inside would produce a parser that looks correct and reads zero, which is the failure this
+// classification exists to expose, reproduced in the code meant to report it.
+var nestedUsagePaths = [...]string{"response.usage", "usageMetadata", "data.usage", "message.usage"}
+
 // parseUsage extracts the four billed token tiers from a buffered response body,
 // in whichever dialect it is written. This is the number that actually matters on
 // this workload — the request is ~99.95% cached and a cache write bills ~11.5x a
@@ -57,9 +116,38 @@ type Usage struct {
 // the difference — getting this backwards double-counts the whole transcript on
 // every turn, which is exactly the kind of error a "savings" number hides.
 func parseUsage(body []byte) (Usage, bool) {
+	u, why := parseUsageWhy(body)
+	return u, why == usageMissNone
+}
+
+// parseUsageWhy is parseUsage plus the classification. Split out rather than folded in because
+// parseSSEUsage calls the boolean form per event and must not have its skips classified — only
+// responseUsage, which sees the whole response, is in a position to say anything about it.
+func parseUsageWhy(body []byte) (Usage, usageMiss) {
 	u := gjson.GetBytes(body, "usage")
 	if !u.Exists() {
-		return Usage{}, false
+		// A block SOMEWHERE ELSE is a parser gap; nothing anywhere is a provider that said
+		// nothing. Distinguishing them is the point: the first is a measurement outage whose fix
+		// is a dialect, the second needs no action at all.
+		for _, p := range nestedUsagePaths {
+			if gjson.GetBytes(body, p).Exists() {
+				return Usage{}, usageMissUnparsed
+			}
+		}
+		// And bytes we cannot parse are a THIRD thing, with its own remedy: nothing could be
+		// looked for, so "no usage block" is not a finding about the provider. This is what a
+		// spliced sniffer window looks like — head+"\n"+tail is not valid JSON — so reporting it
+		// as an unrecognised dialect would send someone hunting for a field-name gap that is not
+		// there. See sniffer.bytes.
+		//
+		// Narrower than "the response was truncated", and deliberately so: gjson SCANS rather
+		// than walking a tree, so a spliced document whose top-level `usage` survived is read
+		// correctly above and never reaches here. This fires only when the splice actually hid
+		// the block, which is the only case where anything is lost.
+		if !gjson.ValidBytes(body) {
+			return Usage{}, usageMissUnreadable
+		}
+		return Usage{}, usageMissAbsent
 	}
 	var out Usage
 	switch {
@@ -86,12 +174,20 @@ func parseUsage(body []byte) (Usage, bool) {
 		// under-reports every streamed response's output tokens.
 		out.Output = u.Get("output_tokens").Int()
 	default:
-		return Usage{}, false
+		// A usage block IS here and this parser read nothing out of it — the Bedrock Converse
+		// camelCase shape (`usage.inputTokens`) is the known instance. The DIALECT is deliberately
+		// not added here: getting the field names wrong (`cacheWriteInputTokens` vs
+		// `cacheCreationInputTokens`) yields a parser that looks correct and reads zero. What
+		// closes that gap is the shape record in responseUsage, which needs no guess.
+		return Usage{}, usageMissUnparsed
 	}
 	if out.FreshInput|out.CacheRead|out.CacheWrite|out.Output == 0 {
-		return Usage{}, false
+		// Recognised and genuinely zero, which is legitimate on some responses. Kept out of the
+		// unparsed counter, or every such response would inflate the one number that means a
+		// dialect is missing.
+		return Usage{}, usageMissZero
 	}
-	return out, true
+	return out, usageMissNone
 }
 
 // parseSSEUsage pulls usage out of a streamed response. Both dialects report it in
@@ -100,8 +196,17 @@ func parseUsage(body []byte) (Usage, bool) {
 // merged across events, taking the maximum of each — a later event repeating a
 // value must not double it.
 func parseSSEUsage(raw []byte) (Usage, bool) {
+	u, why := parseSSEUsageWhy(raw)
+	return u, why == usageMissNone
+}
+
+// parseSSEUsageWhy is parseSSEUsage plus #200's classification. An event stream that carried a
+// usage block no event of it could be read is the streamed form of the dialect gap, and it must
+// not be reported as "the provider streamed no usage" — the remedies differ.
+func parseSSEUsageWhy(raw []byte) (Usage, usageMiss) {
 	var out Usage
 	found := false
+	sawBlock := false // some event HAD a usage block, whatever came of reading it
 	for _, line := range strings.Split(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
@@ -117,6 +222,7 @@ func parseSSEUsage(raw []byte) (Usage, bool) {
 			if !u.Exists() {
 				continue
 			}
+			sawBlock = true
 			one, ok := parseUsage([]byte(`{"usage":` + u.Raw + `}`))
 			if !ok {
 				continue
@@ -129,25 +235,158 @@ func parseSSEUsage(raw []byte) (Usage, bool) {
 			out.Output = max64(out.Output, one.Output)
 		}
 	}
-	return out, found
+	switch {
+	case found:
+		return out, usageMissNone
+	case sawBlock:
+		// Every block that appeared was rejected. All-zero is the benign version of that and is
+		// indistinguishable here without re-reading each one, so this stays the coarser
+		// `unparsed` rather than being split on a guess — a stream whose only usage block is
+		// all-zero over-reports by one, and a stream in an unrecognised dialect is reported at
+		// all, which it was not before.
+		return out, usageMissUnparsed
+	}
+	return out, usageMissAbsent
 }
 
 // responseUsage picks the right parser for a response's content type. The returned
 // Usage carries the stop reason whatever `ok` says — see Usage.StopReason.
 func responseUsage(contentType string, body []byte) (Usage, bool) {
+	u, _, ok := responseUsageWhy(contentType, body)
+	return u, ok
+}
+
+// responseUsageWhy is responseUsage plus the reason, and it is the ONE place a miss is counted
+// and recorded — the whole response is in scope here, which is what it takes to say anything
+// about it (parseUsage is also called per-event by the SSE path, where a skip means nothing).
+//
+// The reason reaches the lifecycle log line beside `usage_reported`, so a deployment that has
+// quietly stopped accounting tokens says which of the five cases it is at the moment it happens,
+// instead of being reconstructed two iterations later from a cost figure.
+func responseUsageWhy(contentType string, body []byte) (Usage, usageMiss, bool) {
 	if len(body) == 0 {
-		return Usage{}, false
+		return Usage{}, usageMissNoBody, false
 	}
 	sse := strings.Contains(contentType, "event-stream")
 	var u Usage
-	var ok bool
+	var why usageMiss
 	if sse {
-		u, ok = parseSSEUsage(body)
+		u, why = parseSSEUsageWhy(body)
 	} else {
-		u, ok = parseUsage(body)
+		u, why = parseUsageWhy(body)
 	}
 	u.StopReason = responseStopReason(sse, body)
-	return u, ok
+	if why.alertable() {
+		switch why {
+		case usageMissUnparsed:
+			usageUnparsed.Add(1)
+		case usageMissUnreadable:
+			usageUnreadable.Add(1)
+		}
+		recordUsageShape(sse, body)
+	}
+	return u, why, why == usageMissNone
+}
+
+// The two alertable misses, counted apart because their REMEDIES are opposite: `unparsed` means
+// add the dialect the provider is speaking, `unreadable` means the bytes we looked at were not a
+// whole document (a spliced sniffer window) and the fix is upstream of any parser. A single
+// counter would have said "token accounting is offline" without saying which half of the stack
+// to look at.
+//
+// Neither counts the two benign cases. Every operator-facing description of them would otherwise
+// make a promise the dangerous case violates — the same reason #188 split stash_refused from
+// stash_missing, and expand/unresolved.go splits malformed from missing.
+var (
+	usageUnparsed   atomic.Int64
+	usageUnreadable atomic.Int64
+)
+
+// UsageGaps returns how many responses carried usage this proxy could not read (an unrecognised
+// dialect) and how many carried bytes it could not parse at all. Non-zero on either means
+// fresh_input_tokens / cache_read_tokens / cache_write_tokens are 0 for some route or provider
+// while everything else about the request looks healthy.
+func UsageGaps() (unparsed, unreadable int64) {
+	return usageUnparsed.Load(), usageUnreadable.Load()
+}
+
+// usageShapeOnce keeps the shape record to the FIRST alertable response per process. It is a
+// diagnostic, not a metric: one record names the gap, and one per response would put a line in
+// the log for every request of a run that has the gap on all of them (4,015 of 4,015, in the
+// iteration that motivated this).
+var usageShapeOnce sync.Once
+
+// recordUsageShape logs the response's SHAPE — the top-level key names, plus the key names under
+// any usage block found — and nothing else.
+//
+// KEY NAMES ONLY, NEVER VALUES AND NEVER THE BODY. A body dump on this workload writes several
+// kilobytes of transcript content to disk per response; a key-shape record cannot, by
+// construction. And it is the datum that actually answers the question: it turns "usage_reported
+// is false" into "the provider is sending camelCase", which is the difference between an open
+// question and a one-line fix — without needing a captured body, an instrumented capture hop, or
+// any extra request.
+func recordUsageShape(sse bool, body []byte) {
+	usageShapeOnce.Do(func() {
+		slog.Default().Debug("cg.usage_unaccounted", usageShapeAttrs(sse, body)...)
+	})
+}
+
+// ResetUsageShapeRecordForTest re-arms the once-per-process shape record. For TESTS only: the
+// record is the diagnostic this whole change exists to produce, so a test has to be able to
+// observe it, and the Once makes that a one-shot for the entire binary.
+func ResetUsageShapeRecordForTest() { usageShapeOnce = sync.Once{} }
+
+// usageShapeAttrs builds the shape record's key/value pairs. Separated from the logging so a test
+// can assert what it does and — more to the point — what it does NOT contain.
+func usageShapeAttrs(sse bool, body []byte) []any {
+	doc := body
+	if sse {
+		// One event, so the record describes a JSON object rather than a transport. The last
+		// data: line is where both dialects put their terminal usage.
+		doc = []byte(lastSSEPayload(body))
+	}
+	attrs := []any{"sse", sse, "bytes", len(body),
+		// Not parseable means the window was spliced rather than the dialect being strange —
+		// stated in the record so it cannot be misread as a field-name gap.
+		"valid_json", gjson.ValidBytes(doc),
+		"top_level_keys", objectKeys(gjson.ParseBytes(doc))}
+	for _, p := range append([]string{"usage"}, nestedUsagePaths[:]...) {
+		if u := gjson.GetBytes(doc, p); u.Exists() {
+			return append(attrs, "usage_at", p, "usage_keys", objectKeys(u))
+		}
+	}
+	return attrs
+}
+
+// objectKeys lists a JSON object's immediate key NAMES, sorted so two records compare, and
+// bounded so a pathological object cannot write an unbounded log line. Values are never touched.
+func objectKeys(v gjson.Result) []string {
+	if !v.IsObject() {
+		return nil
+	}
+	var keys []string
+	v.ForEach(func(k, _ gjson.Result) bool {
+		keys = append(keys, k.String())
+		return len(keys) < 64
+	})
+	sort.Strings(keys)
+	return keys
+}
+
+// lastSSEPayload returns the last non-empty `data:` payload in an event stream, which is where
+// both dialects put the terminal usage. Empty when there is none.
+func lastSSEPayload(body []byte) string {
+	lines := strings.Split(string(body), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if p := strings.TrimSpace(strings.TrimPrefix(line, "data:")); p != "" && p != "[DONE]" {
+			return p
+		}
+	}
+	return ""
 }
 
 // stopReasonPaths are where a terminal reason lives, per dialect and per transport:

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -140,6 +140,12 @@ func parseUsageWhy(body []byte) (Usage, usageMiss) {
 		// as an unrecognised dialect would send someone hunting for a field-name gap that is not
 		// there. See sniffer.bytes.
 		//
+		// Reachable only from the SNIFFED path — Handler.stream, taken when neither proxy-injected
+		// tool is advertised. With one advertised (inject_expand: always makes that true from the
+		// first turn) a non-streamed response is read whole and this cannot fire, which is worth
+		// knowing before treating it as a competing explanation for a miss: that mistake has been
+		// made twice, in both directions, from reading the call sites out of order.
+		//
 		// Narrower than "the response was truncated", and deliberately so: gjson SCANS rather
 		// than walking a tree, so a spliced document whose top-level `usage` survived is read
 		// correctly above and never reaches here. This fires only when the splice actually hid

--- a/proxy/usage.go
+++ b/proxy/usage.go
@@ -92,7 +92,25 @@ func (m usageMiss) String() string {
 // these, or the number an operator watches to confirm accounting is healthy is incremented by it
 // being broken.
 func (m usageMiss) alertable() bool {
-	return m == usageMissUnparsed || m == usageMissUnreadable
+	_, ok := usageCounters[m]
+	return ok
+}
+
+// usageCounters is the SINGLE SOURCE OF TRUTH for which reasons are alertable and which counter each
+// one moves. alertable() derives from it and responseUsageWhy increments through it, so the two
+// cannot drift.
+//
+// They were two independent lists — a predicate and a switch — and that is the same "two labels, one
+// condition" shape this whole change is about. Widening only the predicate, which is exactly the edit
+// someone adding a 6th usageMiss value would make, passed the entire suite: the shape record started
+// firing on the new case while no counter moved and nothing caught it. Found in review.
+//
+// A value ABSENT from this map is benign by definition: no counter, no shape record. That is the
+// decision a new value has to face, and TestEveryUsageMissIsClassifiedAsBenignOrCounted makes it
+// face it rather than defaulting.
+var usageCounters = map[usageMiss]*atomic.Int64{
+	usageMissUnparsed:   &usageUnparsed,
+	usageMissUnreadable: &usageUnreadable,
 }
 
 // nestedUsagePaths are places a usage block is known to live OTHER than the top level. They are
@@ -353,13 +371,10 @@ func responseUsageWhy(contentType string, body []byte) (Usage, usageMiss, bool) 
 		u, why = parseUsageWhy(body)
 	}
 	u.StopReason = responseStopReason(sse, body)
-	if why.alertable() {
-		switch why {
-		case usageMissUnparsed:
-			usageUnparsed.Add(1)
-		case usageMissUnreadable:
-			usageUnreadable.Add(1)
-		}
+	// One lookup drives both the counter and the record, so a reason cannot be alertable for one and
+	// not the other. See usageCounters.
+	if counter, alertable := usageCounters[why]; alertable {
+		counter.Add(1)
 		// len(body) so the record still reports the whole response's size — that is what says a
 		// window was spliced — while describing the document that actually failed to parse.
 		recordUsageShape(sse, len(body), doc)

--- a/proxy/usage_gap_test.go
+++ b/proxy/usage_gap_test.go
@@ -1,0 +1,180 @@
+package proxy
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// #200: `ok=false` from the usage parser meant five different things and nothing distinguished
+// them. Two are benign; three mean TOKEN ACCOUNTING IS OFFLINE on a request that otherwise looks
+// perfect — a healthy 200, correct savings counters, correct latency, and fresh_input_tokens /
+// cache_read_tokens / cache_write_tokens quietly at 0. It ran that way for 4,015 of 4,015
+// requests in one benchmark iteration and was found two iterations later, in a post-mortem
+// chasing a different question.
+//
+// The table is the classification's whole contract, and the two shapes marked with the issue's
+// name are the ones that were indistinguishable from "the provider said nothing".
+func TestEveryUsageOutcomeIsDistinguishable(t *testing.T) {
+	const content = "SECRET-TRANSCRIPT-CONTENT"
+	for _, tc := range []struct {
+		name string
+		ct   string
+		body string
+		want usageMiss
+	}{
+		{"anthropic snake_case", "application/json",
+			`{"usage":{"input_tokens":10,"output_tokens":2,"cache_read_input_tokens":9}}`, usageMissNone},
+		{"openai snake_case", "application/json",
+			`{"usage":{"prompt_tokens":10,"completion_tokens":2}}`, usageMissNone},
+		{"output-only delta", "application/json",
+			`{"usage":{"output_tokens":7}}`, usageMissNone},
+
+		// The gap this issue was filed for. aws/claude-* through Bedrock Converse speaks
+		// camelCase, and a block that is RIGHT THERE read as "the provider reported nothing".
+		{"bedrock converse camelCase", "application/json",
+			`{"usage":{"inputTokens":10,"outputTokens":2},"text":"` + content + `"}`, usageMissUnparsed},
+		{"nested under response", "application/json",
+			`{"response":{"usage":{"input_tokens":10}}}`, usageMissUnparsed},
+
+		// Benign, and they must NOT reach the same signal as the two above.
+		{"no usage anywhere", "application/json",
+			`{"content":[{"type":"text","text":"` + content + `"}],"stop_reason":"end_turn"}`, usageMissAbsent},
+		{"recognised but all zero", "application/json",
+			`{"usage":{"input_tokens":0,"output_tokens":0}}`, usageMissZero},
+		{"empty response", "application/json", "", usageMissNoBody},
+
+		// A THIRD failure the issue did not list, and the reason it needs its own value: over
+		// sniffMax each way, sniffer.bytes returns head+"\n"+tail, which is not a whole document.
+		// Reported as an unrecognised dialect it would send someone hunting for a field name that
+		// is not missing — the remedy is in the sniffer, not in any parser.
+		{"spliced sniffer window", "application/json",
+			`{"content":[{"text":"` + content + `"` + "\n" + `"usage":{"input_tokens":10}}`, usageMissUnreadable},
+
+		{"sse anthropic", "text/event-stream",
+			"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n", usageMissNone},
+		{"sse in an unknown dialect", "text/event-stream",
+			"data: {\"usage\":{\"inputTokens\":10}}\n", usageMissUnparsed},
+		{"sse with no usage event", "text/event-stream",
+			"data: {\"type\":\"ping\"}\n", usageMissAbsent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, why, ok := responseUsageWhy(tc.ct, []byte(tc.body))
+			if why != tc.want {
+				t.Fatalf("classified %v, want %v — %q", why, tc.want, tc.body)
+			}
+			if ok != (tc.want == usageMissNone) {
+				t.Fatalf("ok=%v disagrees with the reason %v", ok, why)
+			}
+		})
+	}
+}
+
+// The counter must not report a benign outcome and a broken promise at once — the rule
+// expand/unresolved.go and #188 both state locally, and the reason this issue exists at all. So:
+// the two alertable cases move their own counter and nothing else, and the three benign ones move
+// neither.
+func TestOnlyAnAccountingOutageMovesTheUsageCounters(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		ct, body              string
+		wantUnp, wantUnreadab int64
+	}{
+		{"an unrecognised dialect", "application/json", `{"usage":{"inputTokens":10}}`, 1, 0},
+		// The window has to be spliced in a way that actually HIDES the block: gjson scans rather
+		// than walking, so a truncated document whose top-level `usage` survives is still read
+		// correctly and is no problem at all. That is why this case is narrower than "the bytes
+		// were truncated" — see the same shape in TestEveryUsageOutcomeIsDistinguishable.
+		{"an unreadable window", "application/json",
+			`{"content":[{"text":"x"` + "\n" + `"usage":{"input_tokens":1}}`, 0, 1},
+		{"a provider that said nothing", "application/json", `{"stop_reason":"end_turn"}`, 0, 0},
+		{"a recognised all-zero block", "application/json", `{"usage":{"input_tokens":0}}`, 0, 0},
+		{"an empty body", "application/json", "", 0, 0},
+		{"a healthy response", "application/json", `{"usage":{"input_tokens":10}}`, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unpBefore, unrBefore := UsageGaps()
+			responseUsageWhy(tc.ct, []byte(tc.body))
+			unp, unr := UsageGaps()
+			if got := unp - unpBefore; got != tc.wantUnp {
+				t.Errorf("usage_unparsed moved by %d, want %d: the counter whose whole meaning is "+
+					"'a dialect is missing' is being driven by something else", got, tc.wantUnp)
+			}
+			if got := unr - unrBefore; got != tc.wantUnreadab {
+				t.Errorf("usage_unreadable moved by %d, want %d", got, tc.wantUnreadab)
+			}
+		})
+	}
+}
+
+// The shape record is what makes the dialect fix possible WITHOUT a captured body: it turns
+// "usage_reported is false" into "the provider is sending camelCase". Two properties, and the
+// second is the one that lets it ship at all.
+func TestTheShapeRecordNamesTheDialectAndCarriesNoContent(t *testing.T) {
+	const content = "SECRET-TRANSCRIPT-CONTENT-THAT-MUST-NOT-BE-LOGGED"
+	body := `{"id":"msg_1","type":"message","content":[{"type":"text","text":"` + content +
+		`"}],"usage":{"inputTokens":10,"outputTokens":2,"cacheReadInputTokens":9}}`
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	ResetUsageShapeRecordForTest()
+
+	responseUsageWhy("application/json", []byte(body))
+	got := buf.String()
+
+	// It names WHERE the block is and WHAT the provider calls the fields — the answer the dialect
+	// fix has been blocked on.
+	for _, want := range []string{"cg.usage_unaccounted", "usage_at=usage", "inputTokens",
+		"cacheReadInputTokens", "valid_json=true"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the record does not contain %q, so it does not answer which dialect this is:\n%s",
+				want, got)
+		}
+	}
+	// KEY NAMES ONLY. A body dump on this workload writes kilobytes of transcript to disk per
+	// response; this record cannot, by construction, and that is why it needs no capture rig and
+	// no operator's permission to turn on.
+	if strings.Contains(got, content) {
+		t.Fatalf("the shape record leaked response CONTENT, which is the one thing it must never "+
+			"do — a body dump was rejected for exactly this reason:\n%s", got)
+	}
+	// Values are not logged either, only names: 10 and 9 are token counts, but a value here is a
+	// precedent for logging the next one, which will be text.
+	for _, leak := range []string{"inputTokens:10", `"inputTokens":10`} {
+		if strings.Contains(got, leak) {
+			t.Errorf("the record carries a VALUE (%q), not just key names:\n%s", leak, got)
+		}
+	}
+
+	// One per process. A run with this gap has it on EVERY request — 4,015 of 4,015 in the
+	// iteration that motivated this — so a per-response record is a log line per request.
+	buf.Reset()
+	responseUsageWhy("application/json", []byte(body))
+	if strings.Contains(buf.String(), "cg.usage_unaccounted") {
+		t.Fatalf("a second unaccounted response logged a second shape record:\n%s", buf.String())
+	}
+}
+
+// The record must be useful for the SPLICED-WINDOW case too, and must say so — that is the
+// distinction between "add a dialect" and "stop truncating", which is the whole reason the two
+// counters are separate.
+func TestTheShapeRecordSaysWhenTheBytesWereNotAWholeDocument(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	ResetUsageShapeRecordForTest()
+
+	// The splice has to hide the block, or it is simply read correctly — see the note in
+	// TestOnlyAnAccountingOutageMovesTheUsageCounters.
+	responseUsageWhy("application/json",
+		[]byte(`{"content":[{"text":"x"`+"\n"+`"usage":{"input_tokens":10}}`))
+	got := buf.String()
+	if !strings.Contains(got, "valid_json=false") {
+		t.Fatalf("the record does not say the bytes would not parse, so it reads as a dialect "+
+			"problem when the fix is in the sniffer:\n%s", got)
+	}
+}

--- a/proxy/usage_gap_test.go
+++ b/proxy/usage_gap_test.go
@@ -198,6 +198,62 @@ func TestTheShapeRecordNamesTheDialectAndCarriesNoContent(t *testing.T) {
 	}
 }
 
+// THE RECORD MUST DESCRIBE THE EVENT THAT WAS UNREADABLE, not the last event of the stream.
+//
+// parseSSEUsageWhy scans every event; the record described only the final `data:` payload. On the
+// Anthropic-family transport the usage block arrives in `message_start` and the stream ENDS with
+// `message_stop`, so an unrecognised streamed dialect produced `why=unparsed_dialect` and a record
+// of the terminal event — no usage_at, no usage_keys, nothing about the dialect. Worse, it took the
+// "no block found" key slot, so the bounded budget was spent on a record that says nothing.
+//
+// That is precisely where the motivating gap would sit: a streamed Bedrock aws/claude-* response.
+// The record is this change's deliverable, so failing on that shape is failing at the one job.
+func TestTheShapeRecordDescribesTheUnreadableEventNotTheLastOne(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	ResetUsageShapeRecordForTest()
+
+	// The Anthropic-family shape: usage in the FIRST event, a terminal event carrying none.
+	stream := "data: {\"type\":\"message_start\",\"message\":{\"usage\":" +
+		"{\"inputTokens\":10,\"cacheReadInputTokens\":9}}}\n" +
+		"data: {\"type\":\"message_stop\"}\n"
+	_, why, _ := responseUsageWhy("text/event-stream", []byte(stream))
+	if why != usageMissUnparsed {
+		t.Fatalf("classified %v, want unparsed_dialect — the fixture is not exercising the gap", why)
+	}
+
+	got := buf.String()
+	for _, want := range []string{"usage_at=message.usage", "inputTokens", "cacheReadInputTokens"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the record does not contain %q: it describes the terminal event instead of "+
+				"the one no spelling could read, so a streamed dialect gap produces a record that "+
+				"names no dialect:\n%s", want, got)
+		}
+	}
+}
+
+// And the record must look where the CLASSIFIER looked. usageShapeAttrs used Exists() where
+// parseUsageWhy now uses usagePresent, so a response with a null top-level usage AND a real nested
+// one recorded `usage_at=usage usage_keys=[]` — pointing at the null, naming no fields, while the
+// nested block held the answer. It also keyed as `usage|`, colliding with a genuinely empty block.
+func TestTheShapeRecordSkipsANullBlockForTheOneThatHasTheAnswer(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	ResetUsageShapeRecordForTest()
+
+	responseUsageWhy("application/json",
+		[]byte(`{"usage":null,"response":{"usage":{"inputTokens":10,"outputTokens":2}}}`))
+	got := buf.String()
+	if !strings.Contains(got, "usage_at=response.usage") || !strings.Contains(got, "inputTokens") {
+		t.Fatalf("the record points at the null block instead of the one carrying the fields, so "+
+			"it names no dialect:\n%s", got)
+	}
+}
+
 // The record must be useful for the SPLICED-WINDOW case too, and must say so — that is the
 // distinction between "add a dialect" and "stop truncating", which is the whole reason the two
 // counters are separate.

--- a/proxy/usage_gap_test.go
+++ b/proxy/usage_gap_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -58,6 +59,24 @@ func TestEveryUsageOutcomeIsDistinguishable(t *testing.T) {
 			"data: {\"usage\":{\"inputTokens\":10}}\n", usageMissUnparsed},
 		{"sse with no usage event", "text/event-stream",
 			"data: {\"type\":\"ping\"}\n", usageMissAbsent},
+
+		// The transport axis was SAMPLED here rather than covered: usageMissZero had no streamed
+		// row, so the one value that is benign-but-block-bearing was untested on the transport
+		// where it was misclassified as a dialect gap. Same for a null field, which is what
+		// OpenAI-dialect streaming sends on every chunk without stream_options.include_usage.
+		{"sse recognised but all zero", "text/event-stream",
+			"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":0}}\n", usageMissZero},
+		{"sse with a null usage field", "text/event-stream",
+			"data: {\"choices\":[{\"delta\":{}}],\"usage\":null}\n", usageMissAbsent},
+		{"sse with an empty usage object", "text/event-stream",
+			"data: {\"usage\":{}}\n", usageMissAbsent},
+		{"a null usage field", "application/json", `{"usage":null}`, usageMissAbsent},
+		{"an empty usage object", "application/json", `{"usage":{}}`, usageMissAbsent},
+		// A stream that says nothing readable in one event and the real tiers in another must take
+		// the GOOD outcome, not the worst — `worst` is only the answer when nothing parsed.
+		{"sse null chunk then real usage", "text/event-stream",
+			"data: {\"choices\":[{\"delta\":{}}],\"usage\":null}\n" +
+				"data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n", usageMissNone},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, why, ok := responseUsageWhy(tc.ct, []byte(tc.body))
@@ -92,6 +111,27 @@ func TestOnlyAnAccountingOutageMovesTheUsageCounters(t *testing.T) {
 		{"a recognised all-zero block", "application/json", `{"usage":{"input_tokens":0}}`, 0, 0},
 		{"an empty body", "application/json", "", 0, 0},
 		{"a healthy response", "application/json", `{"usage":{"input_tokens":10}}`, 0, 0},
+
+		// THE TRANSPORT AXIS, which this table sampled rather than covered. Every row above is
+		// application/json, so the rule was asserted only where parseUsageWhy runs and never where
+		// parseSSEUsageWhy does — and the stream path is the half that broke it.
+		//
+		// `usage: null` is not a hypothetical shape. gjson's Exists() is `Type != Null ||
+		// len(Raw) != 0`, and a JSON null has Raw == "null", so a null field looked present; and
+		// OpenAI-dialect streaming sends exactly `"usage": null` on every chunk unless the caller
+		// sets stream_options.include_usage. So this row is ordinary healthy traffic on the
+		// openai_upstream route, and it was moving the counter that means "add a dialect".
+		{"a streamed null usage field", "text/event-stream",
+			"data: {\"choices\":[{\"delta\":{}}],\"usage\":null}\n", 0, 0},
+		{"a streamed all-zero block", "text/event-stream",
+			"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":0}}\n", 0, 0},
+		{"a streamed empty usage object", "text/event-stream", "data: {\"usage\":{}}\n", 0, 0},
+		{"a non-streamed null usage field", "application/json", `{"usage":null}`, 0, 0},
+		{"a non-streamed empty usage object", "application/json", `{"usage":{}}`, 0, 0},
+		// And the positive control for the transport, so "no benign row moves it" cannot pass by
+		// the classifier having stopped counting on this path altogether.
+		{"a streamed unrecognised dialect", "text/event-stream",
+			"data: {\"usage\":{\"inputTokens\":10}}\n", 1, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			unpBefore, unrBefore := UsageGaps()
@@ -176,5 +216,82 @@ func TestTheShapeRecordSaysWhenTheBytesWereNotAWholeDocument(t *testing.T) {
 	if !strings.Contains(got, "valid_json=false") {
 		t.Fatalf("the record does not say the bytes would not parse, so it reads as a dialect "+
 			"problem when the fix is in the sniffer:\n%s", got)
+	}
+}
+
+// ONE EARLIER RESPONSE MUST NOT SPEND THE DIAGNOSTIC.
+//
+// The record is the part of this change that unblocks the dialect fix, and it was gated on a single
+// process-wide sync.Once shared by both alertable classes — so whichever response came first
+// consumed it. A spliced window followed by the camelCase response produced a record about the
+// window and left the dialect question, the one the record exists to answer, unanswered.
+//
+// Worse in combination with the null-usage defect that shared this review: a benign OpenAI-dialect
+// chunk was alertable, so on any deployment carrying streamed OpenAI traffic the record was almost
+// certain to be spent on it before an interesting response ever arrived.
+func TestAnEarlierShapeDoesNotSpendTheRecordForALaterDialect(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	ResetUsageShapeRecordForTest()
+
+	// First: a spliced window, which is alertable but says nothing about any dialect.
+	responseUsageWhy("application/json",
+		[]byte(`{"content":[{"text":"x"`+"\n"+`"usage":{"input_tokens":10}}`))
+	// Then: the response whose shape somebody actually needs.
+	responseUsageWhy("application/json",
+		[]byte(`{"id":"msg_1","usage":{"inputTokens":10,"cacheReadInputTokens":9}}`))
+
+	got := buf.String()
+	if !strings.Contains(got, "inputTokens") || !strings.Contains(got, "cacheReadInputTokens") {
+		t.Fatalf("the camelCase shape was never recorded — an earlier unrelated response spent "+
+			"the one record, so the dialect question this record exists to answer is still open:\n%s", got)
+	}
+
+	// And still bounded: the SAME shape again writes nothing, so a run with the gap on every
+	// request produces one line, not one per request.
+	buf.Reset()
+	responseUsageWhy("application/json",
+		[]byte(`{"id":"msg_2","usage":{"inputTokens":11,"cacheReadInputTokens":8}}`))
+	if strings.Contains(buf.String(), "cg.usage_unaccounted") {
+		t.Fatalf("a second response of an ALREADY RECORDED shape logged again; a run with this gap "+
+			"on 4,015 of 4,015 requests would write 4,015 lines:\n%s", buf.String())
+	}
+
+	// The bound is on distinct shapes, not on responses, and it holds.
+	buf.Reset()
+	for i := 0; i < usageShapeMax+4; i++ {
+		responseUsageWhy("application/json",
+			[]byte(`{"usage":{"tokensVariant`+strconv.Itoa(i)+`":1}}`))
+	}
+	if n := strings.Count(buf.String(), "cg.usage_unaccounted"); n > usageShapeMax {
+		t.Fatalf("recorded %d shapes with a cap of %d: a provider varying its key names could "+
+			"turn the diagnostic into a line per request", n, usageShapeMax)
+	}
+}
+
+// The log line's two halves must not contradict each other across expand rounds. usageOK is
+// sticky-true — a request whose usage was read once IS accounted — while the reason was
+// last-write-wins, so a round 2 continuation carrying no usage relabelled an accounted request
+// `absent`, and `usage_reported=true usage_miss=absent` is a line that undoes the reason for
+// having the reason.
+func TestTheMissReasonNeverContradictsUsageReported(t *testing.T) {
+	// Accounted by any round => parsed, whatever a later round found.
+	if got := noteUsageMiss(usageMissNone, usageMissAbsent, true); got != usageMissNone {
+		t.Errorf("an accounted request reported %v; usage_reported=true with a miss reason is a "+
+			"self-contradicting log line", got)
+	}
+	if got := noteUsageMiss(usageMissUnparsed, usageMissAbsent, true); got != usageMissNone {
+		t.Errorf("a request accounted by a later round still reported %v", got)
+	}
+	// Unaccounted => keep the WORST reason seen, so a benign later round cannot mask a dialect gap
+	// an earlier one found.
+	if got := noteUsageMiss(usageMissUnparsed, usageMissAbsent, false); got != usageMissUnparsed {
+		t.Errorf("reported %v, want unparsed_dialect: a later benign round masked the round that "+
+			"found a dialect gap", got)
+	}
+	if got := noteUsageMiss(usageMissAbsent, usageMissUnparsed, false); got != usageMissUnparsed {
+		t.Errorf("reported %v, want unparsed_dialect", got)
 	}
 }

--- a/proxy/usage_gap_test.go
+++ b/proxy/usage_gap_test.go
@@ -351,3 +351,51 @@ func TestTheMissReasonNeverContradictsUsageReported(t *testing.T) {
 		t.Errorf("reported %v, want unparsed_dialect", got)
 	}
 }
+
+// EVERY usageMiss VALUE MUST BE A DELIBERATE CHOICE, benign or counted.
+//
+// alertable() and the counter increment used to be two independent lists — a predicate and a switch.
+// Widening only the predicate, exactly the edit someone adding a 6th value would make, passed the
+// entire suite: the shape record started firing on the new case while no counter moved. They are one
+// map now, so they cannot drift; this test covers the other half, which construction cannot — that
+// a new value is not silently benign because nobody added it anywhere.
+//
+// The failure it produces is a naming one on purpose: an unnamed value means someone added a
+// usageMiss and stopped, and the two questions to answer are "what does the log line call it" and
+// "is it alertable".
+func TestEveryUsageMissIsClassifiedAsBenignOrCounted(t *testing.T) {
+	// Benign by design — no counter, no shape record. Listed rather than derived, so adding a value
+	// here is a decision and not an omission.
+	benign := map[usageMiss]bool{
+		usageMissNone:   true,
+		usageMissNoBody: true,
+		usageMissAbsent: true,
+		usageMissZero:   true,
+	}
+	for m := usageMissNone; m <= usageMissUnreadable; m++ {
+		if got := m.String(); got == "unknown" {
+			t.Errorf("usageMiss(%d) has no name, so the log line would read `usage_miss=unknown`: "+
+				"a value was added without deciding what an operator should see", m)
+		}
+		_, counted := usageCounters[m]
+		switch {
+		case benign[m] && counted:
+			t.Errorf("%v is listed benign but has a counter: one of the two is wrong, and the "+
+				"dangerous direction is a benign outcome moving an alertable number", m)
+		case !benign[m] && !counted:
+			t.Errorf("%v is neither listed benign nor counted, so it is silently benign by "+
+				"omission — decide: add it to `benign` here, or give it a counter in usageCounters", m)
+		}
+		if counted != m.alertable() {
+			t.Errorf("%v: alertable()=%v disagrees with usageCounters membership=%v — the two have "+
+				"drifted apart again", m, m.alertable(), counted)
+		}
+	}
+	// And the map holds nothing outside the declared range, which would be an entry for a value that
+	// no longer exists.
+	for m := range usageCounters {
+		if m > usageMissUnreadable {
+			t.Errorf("usageCounters has an entry for usageMiss(%d), outside the declared values", m)
+		}
+	}
+}


### PR DESCRIPTION
Closes #200. Independent of #204 (#190) — both branch from `main`.

## The defect

`parseUsage` returning `ok=false` meant **five** different things and nothing distinguished them. Two are benign. The rest mean **token accounting is offline**, on a request that otherwise looks perfect: a healthy 200, correct savings counters, correct latency, correct everything else, and `fresh_input_tokens` / `cache_read_tokens` / `cache_write_tokens` quietly at 0.

It ran that way for **4,015 of 4,015 requests** in one benchmark iteration and was found two iterations later, in a post-mortem chasing a different question. The usage *was* in the body — LOCA priced those requests from it — so the proxy read a response that carried usage and found nothing in it.

## What is classified, and why it is not one counter

`usageMiss` names all five, and the reason rides on the `cg.request` log line as `usage_miss` so a benign miss is legible without being alertable:

| `usage_miss` | Meaning | Counted | Remedy |
|---|---|---|---|
| `absent` | no usage block anywhere we know to look | — | nothing |
| `all_zero` | recognised, every tier zero | — | nothing; legitimate |
| `no_body` | empty response | — | nothing |
| `unparsed_dialect` | a block **is** there, no recognised spelling read it | `usage_unparsed` | add the dialect |
| `unreadable_body` | the bytes were not a whole document, so the block was hidden | `usage_unreadable` | raise `sniffMax` / buffer |

The last two get counters, and **separate** ones, because their remedies are opposite: one means add the dialect the provider is speaking, the other means the bytes examined were not a whole document and the fix is upstream of any parser. One counter would have said "accounting is offline" without saying which half of the stack to look at — and putting either in with the benign cases is this issue's own defect, restated. Same argument as `expand/unresolved.go`'s malformed/missing split and #188's `stash_refused`/`stash_missing`.

## A fourth cause the issue did not list

`sniffer.bytes` returns `head + "\n" + tail` once a response passes `sniffMax` (64 KiB) each way, and that is **not valid JSON**. Reported as an unrecognised dialect it would send someone hunting for a field name that is not missing.

It is **narrower** than "the response was truncated", and the code and both test tables say so: gjson *scans* rather than walking a tree, so a spliced document whose top-level `usage` survived is read correctly and never reaches this classification. It fires only when the splice actually hid the block — the only case where anything is lost. Worth flagging because the obvious fixture (a malformed body) is read correctly and would have made the test vacuous. It did, on the first run; both tables now carry the note and the shape that genuinely hides the block.

## The shape record, which is the part that unblocks the dialect fix

On the **first** unaccounted response per process, `cg.usage_unaccounted` logs the response's **key names**: the top-level keys, where a usage block was found, and the key names inside it. No values, and never the body.

That turns "usage_reported is false" into "the provider is sending camelCase", and it needs **no captured body, no instrumented capture hop and no extra request** — so it works from any deployment that hits the gap rather than only from the one rig with a capture hop in the path. A body dump on this workload writes kilobytes of transcript content to disk per response; this record cannot, by construction, which is why it can ship on by default at DEBUG.

Once per process because a run with this gap has it on *every* request — 4,015 of 4,015 above — so a per-response record is a log line per request.

## Deliberately not here: the dialects themselves

Adding the camelCase or nested spellings needs a real response body to get the field names right. Guessing between `cacheWriteInputTokens` and `cacheCreationInputTokens` produces a parser that looks correct and reads zero — this issue's failure reproduced in the code meant to fix it. The nested paths here are probed for **existence only** and never read, which is what keeps the classification dialect-agnostic.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` all packages pass, `go test -race` clean over `proxy` and `metrics` (Go 1.26.4, eval box).

Four new tests, all revert-verified against a mutation collapsing the classification back to one undifferentiated miss:

| Test | Reverted → |
|---|---|
| `TestEveryUsageOutcomeIsDistinguishable` — 12 shapes, one per outcome per transport, incl. Bedrock camelCase and nested `response.usage` | "classified absent, want unparsed_dialect" |
| `TestOnlyAnAccountingOutageMovesTheUsageCounters` — the rule itself: alertable cases move their own counter, all four benign shapes move neither | "usage_unparsed moved by 0, want 1" |
| `TestTheShapeRecordNamesTheDialectAndCarriesNoContent` — answers the dialect question, once per process, no content and no values | the record is absent entirely |
| `TestTheShapeRecordSaysWhenTheBytesWereNotAWholeDocument` — `valid_json=false`, so a spliced window is not misread as a field-name gap | no record |

The no-content assertion was verified against a **second** mutation, because "the record does not contain this string" passes trivially when there is no record, and would also pass on a record that logged the body under a different key. With `usageShapeAttrs` changed to log the body it fails on its own subject: *"the shape record leaked response CONTENT, which is the one thing it must never do"*.

Two contract tests updated as designed: `TestStatsShapeIsUnchanged` (both fields added to the reviewed contract) and `TestEverySnapshotFieldIsExportedOrExempt` — the latter listed in `notExportedWhy` rather than read off `s`, for the reason that map's own preamble gives: the `/stats` handler fills these *after* `renderMetrics` takes its snapshot, so a `promLine` off `s` would export a permanent 0 while passing the test, which is precisely the silent-zero failure this change exists to report.

## What this unblocks

One request through a proxy on this branch produces the key-shape record, which answers the camelCase question that #199 and the `parseUsage` dialect fix are both waiting on — and #201's cost claim, which is unmeasurable while the three cache-token fields read 0. Per the validation session, no captured body or usage shape exists anywhere today (the capture hop's flap log records request metadata only; LOCA's 11 MB log has none of the twelve candidate spellings), so this is the cheapest available instrument.
