### PR TITLE
fix(expand): stop sending recovered content upstream twice, and split the two skip reasons apart

### DIFF
--- a/components/offload/agentdiet.go
+++ b/components/offload/agentdiet.go
@@ -439,10 +439,15 @@ func (d *AgentDiet) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 			continue
 		}
 		content := schema.MessageText(msg)
-		if gate, skip := skipReduce(c, content); content == "" || skip {
-			if skip {
-				rep.Gate(gate)
-			}
+		if content == "" {
+			continue
+		}
+		// Short-circuit restored: skipReduce does a store Get, and the empty string is not
+		// content — asking about it costs a lookup and would raise a spurious gate if "" were
+		// ever marked. The original `content == "" || skipReduce(...)` had this ordering for a
+		// reason and splitting the call lost it.
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate)
 			continue
 		}
 		// A frozen decision was replayed above; a second reduction of the same bytes

--- a/components/offload/agentdiet.go
+++ b/components/offload/agentdiet.go
@@ -439,7 +439,10 @@ func (d *AgentDiet) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 			continue
 		}
 		content := schema.MessageText(msg)
-		if content == "" || skipReduce(c, content) {
+		if gate, skip := skipReduce(c, content); content == "" || skip {
+			if skip {
+				rep.Gate(gate)
+			}
 			continue
 		}
 		// A frozen decision was replayed above; a second reduction of the same bytes

--- a/components/offload/cmdfilter.go
+++ b/components/offload/cmdfilter.go
@@ -145,10 +145,10 @@ func (f *Cmdfilter) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			keys = append(keys, fk...)
 			continue
 		}
-		if skipReduce(c, content) {
+		if gate, skip := skipReduce(c, content); skip {
 			// marker-bearing (a filter rule could drop the marker line and orphan the
-			// stash) or expanded by the agent — leave it verbatim
-			rep.Gate("marker_or_kept_verbatim")
+			// stash) or expanded by the agent — leave it verbatim. The gate says WHICH.
+			rep.Gate(gate)
 			continue
 		}
 		key := selectorKey(content)

--- a/components/offload/collapse.go
+++ b/components/offload/collapse.go
@@ -40,7 +40,7 @@ func init() { components.Register("collapse", newCollapse) }
 // multi-megabyte takes the CHARACTER window too. Gating on the line count alone left the
 // motivating shape alive above 40 lines — measured at 4,195,111 B in, 4,194,922 B out, and
 // worse than declining, because dropping the small filler lines in the middle counts as
-// acting and stamps a marker, which then makes linecap decline (marker_or_kept_verbatim)
+// acting and stamps a marker, which then makes linecap decline (already_marked)
 // and forwards 1.57 M tokens. linecap could not have capped it even without the marker:
 // its neverTruncate allow-list exempts any line matching `^\S+:\d+`, which one-line JSON
 // matches by accident (issue #151), so the mitigation this comment used to name is void
@@ -119,8 +119,8 @@ func (cl *Collapse) Offload(req *schemas.BifrostChatRequest, rep *components.Rep
 			rep.Gate("below_max_tokens")
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim") // already offloaded, or expanded by the agent
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate) // already offloaded, or expanded by the agent — the gate says which
 			continue
 		}
 		// Pick the window BEFORE the depth gate so a message that has no usable window is

--- a/components/offload/collapse_charwindow_test.go
+++ b/components/offload/collapse_charwindow_test.go
@@ -191,8 +191,8 @@ func TestCollapseCharWindowSkipsMarkedContent(t *testing.T) {
 	if got := schema.MessageText(req.Input[0]); got != body {
 		t.Fatalf("marker-bearing content must be untouched, got %.200q", got)
 	}
-	if rep.Gates["marker_or_kept_verbatim"] == 0 {
-		t.Fatalf("want marker_or_kept_verbatim, gates %v", rep.Gates)
+	if rep.Gates[GateAlreadyMarked] == 0 {
+		t.Fatalf("want %s, gates %v", GateAlreadyMarked, rep.Gates)
 	}
 }
 
@@ -368,7 +368,7 @@ func TestCollapseCharWindowAtExactlyTheLineWindowSize(t *testing.T) {
 // output with more than head_lines+tail_lines lines took the line path however big those
 // lines were. A multi-megabyte line inside the kept head or tail survived untouched — and
 // worse than being declined, because dropping the small filler lines in the middle counts as
-// acting and stamps a marker, which then makes linecap decline marker_or_kept_verbatim.
+// acting and stamps a marker, which then makes linecap decline already_marked.
 // Measured: 4,195,111 B in, 4,194,922 B out, 189 bytes saved, 1.57 M tokens forwarded.
 func TestCollapseCutsAHugeLineInsideTheLineWindow(t *testing.T) {
 	huge := oneLineJSON(1 << 20) // one line, bigger than any window

--- a/components/offload/dedup.go
+++ b/components/offload/dedup.go
@@ -50,8 +50,8 @@ func (d *Dedup) Offload(req *schemas.BifrostChatRequest, rep *components.Report,
 			rep.Gate("below_min_tokens")
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim") // don't re-reduce
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate) // don't re-reduce; the gate says which reason
 			continue
 		}
 		h := hashKey(content)

--- a/components/offload/expand_gates_test.go
+++ b/components/offload/expand_gates_test.go
@@ -3,6 +3,7 @@ package offload
 import (
 	"strings"
 	"testing"
+	"time"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rossoctl/context-guru/components"
@@ -173,4 +174,49 @@ func TestOnlyAnAbandonedEstablishedCompactionCountsAsAFlip(t *testing.T) {
 				"indistinguishable from any other cache-write", got)
 		}
 	})
+}
+
+// AND THE PROBE MUST NOT KEEP ALIVE WHAT IT ASKS ABOUT.
+//
+// store.Peek exists for this call site, but a store-side test cannot fail if this call site goes back
+// to Get: the drift is between what the probe uses and what the store offers, so the assertion has to
+// live where the probe is. Memory.Get slides the TTL and FrozenPrefix is a PINNED namespace, so a
+// Get-based probe renews a pinned entry the branch has just decided will never be replayed — and
+// pinned entries count against the shared exempt budget that gates rewind-reserve admission.
+func TestTheFlipProbeDoesNotRenewTheDecisionItAsksAbout(t *testing.T) {
+	body := strings.Repeat("verbose tool output line\n", 30)
+	now := time.Unix(0, 0)
+	st := store.NewMemory(store.Options{TTLSeconds: 100})
+	st.SetClock(func() time.Time { return now })
+	m := maskFor(t)
+
+	// Turn 1 freezes a decision, then the agent expands the content.
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body), tool("tail")}}
+	c := &components.Ctx{Session: "s", Store: st, CacheAware: true, MaxCachedIdx: -1}
+	var rep components.Report
+	if _, err := m.Offload(req, &rep, c); err != nil {
+		t.Fatal(err)
+	}
+	MarkKeptVerbatim(st, body)
+	key := frozenKey("s", m.Name(), contentKey(body))
+	if !st.Peek(key) {
+		t.Fatal("no frozen decision after turn 1; the fixture is not exercising the probe")
+	}
+
+	// Ten turns 60s apart: each takes the kept-verbatim branch and probes the decision. 600s total
+	// against a 100s TTL, never more than 60s between probes.
+	for i := 0; i < 10; i++ {
+		now = now.Add(60 * time.Second)
+		r := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body), tool("tail")}}
+		cc := &components.Ctx{Session: "s", Store: st, CacheAware: true, MaxCachedIdx: 0}
+		var rr components.Report
+		if _, err := m.Offload(r, &rr, cc); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if st.Peek(key) {
+		t.Fatal("the frozen decision survived 600s of a 100s TTL: the flip probe is renewing a " +
+			"PINNED entry it has just decided will never be replayed, which is back-pressure on " +
+			"the rewind reserve from a diagnostic")
+	}
 }

--- a/components/offload/expand_gates_test.go
+++ b/components/offload/expand_gates_test.go
@@ -1,0 +1,176 @@
+package offload
+
+import (
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/expand"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// The two skip reasons are separately reportable (#201).
+//
+// `marker_or_kept_verbatim` was raised at eight of eleven sites for two conditions that want
+// opposite readings — "already carries a marker" is benign, "the agent expanded it" is an
+// established compaction being abandoned — while three offloaders already had a distinct label for
+// the second. Gates reach /stats per component, so that was a published counter reporting both, and
+// a published experimental figure was corrected twice off it.
+func TestTheTwoSkipReasonsAreReportedApart(t *testing.T) {
+	body := strings.Repeat("verbose tool output line\n", 30)
+	for _, tc := range []struct {
+		name string
+		// prepare returns the content the offloader will see, having set up any store state.
+		prepare func(st *store.Memory) string
+		want    string
+	}{
+		{"content that already carries a marker", func(*store.Memory) string {
+			return "head\n" + expand.Marker("aaaaaaaaaaaaaaaa") + "\n"
+		}, GateAlreadyMarked},
+		{"content the agent expanded", func(st *store.Memory) string {
+			MarkKeptVerbatim(st, body)
+			return body
+		}, GateKeptVerbatim},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := store.NewMemory(store.Options{})
+			content := tc.prepare(st)
+			m := maskFor(t)
+			req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+				tool(content), tool("tail"),
+			}}
+			c := &components.Ctx{Session: "s", Store: st}
+			var rep components.Report
+			if _, err := m.Offload(req, &rep, c); err != nil {
+				t.Fatal(err)
+			}
+			if rep.Gates[tc.want] == 0 {
+				t.Fatalf("want gate %q, got %v — the two reasons are still sharing a label, so an "+
+					"operator cannot tell a benign skip from an abandoned compaction", tc.want, rep.Gates)
+			}
+			// And it must not ALSO raise the other one, or the split buys nothing.
+			other := GateAlreadyMarked
+			if tc.want == GateAlreadyMarked {
+				other = GateKeptVerbatim
+			}
+			if rep.Gates[other] != 0 {
+				t.Fatalf("raised BOTH labels (%v); a skip has exactly one reason", rep.Gates)
+			}
+		})
+	}
+}
+
+// Three offloaders have NO reapplyFrozen path at all, so `skipReduce` is the only place they can
+// report an expansion — and it was the conflated label for all of them. This is where most of the
+// previously invisible expansion signal sits, so it gets its own assertion rather than being assumed
+// to follow from mask's.
+func TestTheOffloadersWithNoReplayPathAlsoReportExpansion(t *testing.T) {
+	body := strings.Repeat("verbose tool output line\n", 30)
+	for _, tc := range []struct {
+		name string
+		make func(t *testing.T) components.Offload
+	}{
+		{"dedup", func(t *testing.T) components.Offload {
+			c, err := newDedup([]byte("min_tokens: 5\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload)
+		}},
+		{"extract", func(t *testing.T) components.Offload {
+			c, err := newExtract([]byte("min_tokens: 5\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload)
+		}},
+		{"linecap", func(t *testing.T) components.Offload {
+			c, err := newLinecap([]byte("min_size: 5\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.(components.Offload)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := store.NewMemory(store.Options{})
+			MarkKeptVerbatim(st, body)
+			off := tc.make(t)
+			// Two identical outputs, so dedup has a duplicate to consider as well.
+			req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+				tool(body), tool(body), tool("tail"),
+			}}
+			c := &components.Ctx{Session: "s", Store: st}
+			var rep components.Report
+			if _, err := off.Offload(req, &rep, c); err != nil {
+				t.Fatal(err)
+			}
+			if rep.Gates[GateKeptVerbatim] == 0 {
+				t.Fatalf("%s reported %v: expanded content is invisible in this component, which is "+
+					"where most of the unattributed expansion signal was", tc.name, rep.Gates)
+			}
+		})
+	}
+}
+
+// THE FLIP IS COUNTED, AND ONLY WHEN THERE IS ONE.
+//
+// Abandoning a compaction because the agent expanded it costs a suffix cache-write ONLY if the
+// content was compacted before — if it never was, nothing flips. reapplyFrozen declined before
+// looking, so the two were indistinguishable and an expand-induced cache-write could not be told
+// from any other.
+func TestOnlyAnAbandonedEstablishedCompactionCountsAsAFlip(t *testing.T) {
+	body := strings.Repeat("verbose tool output line\n", 30)
+
+	t.Run("never compacted, so nothing flips", func(t *testing.T) {
+		st := store.NewMemory(store.Options{})
+		MarkKeptVerbatim(st, body) // expanded, but this session never froze a decision for it
+		m := maskFor(t)
+		before := ExpandPrefixFlips()
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body), tool("tail")}}
+		c := &components.Ctx{Session: "s", Store: st, CacheAware: true, MaxCachedIdx: 0}
+		var rep components.Report
+		if _, err := m.Offload(req, &rep, c); err != nil {
+			t.Fatal(err)
+		}
+		if got := ExpandPrefixFlips() - before; got != 0 {
+			t.Fatalf("counted %d flips for content that was never compacted: the counter is "+
+				"measuring expansions, not cache-writes", got)
+		}
+	})
+
+	t.Run("an established compaction is abandoned", func(t *testing.T) {
+		st := store.NewMemory(store.Options{})
+		m := maskFor(t)
+		// Turn 1 in the uncached tail: mask compacts and freezes a decision.
+		req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body), tool("tail")}}
+		c := &components.Ctx{Session: "s", Store: st, CacheAware: true, MaxCachedIdx: -1}
+		var rep components.Report
+		if _, err := m.Offload(req, &rep, c); err != nil {
+			t.Fatal(err)
+		}
+		if schema.MessageText(req.Input[0]) == body {
+			t.Fatal("turn 1 did not compact, so there is no established compaction to abandon")
+		}
+		// The agent expands it.
+		MarkKeptVerbatim(st, body)
+
+		before := ExpandPrefixFlips()
+		// Turn 2: the output is now inside the cached prefix, and the replay declines.
+		req2 := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{tool(body), tool("tail")}}
+		c2 := &components.Ctx{Session: "s", Store: st, CacheAware: true, MaxCachedIdx: 0}
+		var rep2 components.Report
+		if _, err := m.Offload(req2, &rep2, c2); err != nil {
+			t.Fatal(err)
+		}
+		if schema.MessageText(req2.Input[0]) != body {
+			t.Fatal("turn 2 did not send the full original, so no flip happened")
+		}
+		if got := ExpandPrefixFlips() - before; got != 1 {
+			t.Fatalf("counted %d flips, want 1: a suffix cache-write caused by an expand is still "+
+				"indistinguishable from any other cache-write", got)
+		}
+	})
+}

--- a/components/offload/extract.go
+++ b/components/offload/extract.go
@@ -64,8 +64,8 @@ func (e *Extract) Offload(req *bschemas.BifrostChatRequest, rep *components.Repo
 			rep.Gate("below_output_floor")
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim") // don't re-reduce
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate) // don't re-reduce; the gate says which reason
 			continue
 		}
 		projected, ok := collapseObviousNoise(content)

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -876,7 +876,7 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		// If the agent recently EXPANDED this content, leave it verbatim (re-compacting it
 		// would just trigger another expand — a loop). The expand handler marks it.
 		if isKeptVerbatim(c, id) {
-			rep.Gate("kept_verbatim_after_expand")
+			rep.Gate(GateKeptVerbatim)
 			continue
 		}
 		// SAME-SESSION replay first. This session already sent these compacted bytes on an

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -293,7 +293,7 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		// If the agent recently EXPANDED this content, leave it verbatim — removing it again would
 		// just trigger another expand.
 		if isKeptVerbatim(c, id) {
-			rep.Gate("kept_verbatim_after_expand")
+			rep.Gate(GateKeptVerbatim)
 			continue
 		}
 		// SAME-SESSION REPLAY, and it bypasses the depth gate legitimately: this session already

--- a/components/offload/failed_run.go
+++ b/components/offload/failed_run.go
@@ -126,7 +126,7 @@ func (fr *FailedRun) Offload(req *schemas.BifrostChatRequest, rep *components.Re
 			continue
 		}
 		if isKeptVerbatim(c, contentKey(content)) {
-			rep.Gate("kept_verbatim_after_expand")
+			rep.Gate(GateKeptVerbatim)
 			continue
 		}
 		if !failMarkers.MatchString(content) {

--- a/components/offload/linecap.go
+++ b/components/offload/linecap.go
@@ -117,10 +117,10 @@ func (lc *Linecap) Offload(req *schemas.BifrostChatRequest, rep *components.Repo
 			rep.Gate("below_min_size")
 			continue
 		}
-		if skipReduce(c, content) {
+		if gate, skip := skipReduce(c, content); skip {
 			// marker-bearing (a cap could cut the marker line and orphan the stash) or
-			// expanded by the agent — leave it verbatim.
-			rep.Gate("marker_or_kept_verbatim")
+			// expanded by the agent — leave it verbatim. The gate says WHICH.
+			rep.Gate(gate)
 			continue
 		}
 		out, folds := lc.rewrite(content)

--- a/components/offload/linecap_test.go
+++ b/components/offload/linecap_test.go
@@ -211,8 +211,8 @@ func TestLinecapSkipsMarkerBearingContent(t *testing.T) {
 	if got != body {
 		t.Fatal("rewrote content that already carries an offload marker")
 	}
-	if gates["marker_or_kept_verbatim"] == 0 {
-		t.Fatalf("want marker_or_kept_verbatim, got %v", gates)
+	if gates[GateAlreadyMarked] == 0 {
+		t.Fatalf("want %s, got %v", GateAlreadyMarked, gates)
 	}
 }
 
@@ -264,8 +264,8 @@ func TestLinecapYieldsToAnEarlierOffloader(t *testing.T) {
 	if got != marked+"\n"+body {
 		t.Fatalf("linecap rewrote a message another offloader had already marked:\n%.200q", got)
 	}
-	if gates["marker_or_kept_verbatim"] == 0 {
-		t.Fatalf("want marker_or_kept_verbatim, got %v", gates)
+	if gates[GateAlreadyMarked] == 0 {
+		t.Fatalf("want %s, got %v", GateAlreadyMarked, gates)
 	}
 }
 

--- a/components/offload/mask.go
+++ b/components/offload/mask.go
@@ -82,8 +82,8 @@ func (m *Mask) Offload(req *bschemas.BifrostChatRequest, rep *components.Report,
 			keys = append(keys, fk...)
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim") // already offloaded, or expanded by the agent
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate) // already offloaded, or expanded by the agent — the gate says which
 			continue
 		}
 		if schema.TextTokens(content) < m.minTokens {

--- a/components/offload/readlifecycle.go
+++ b/components/offload/readlifecycle.go
@@ -167,8 +167,8 @@ func (rl *ReadLifecycle) Offload(req *bschemas.BifrostChatRequest, rep *componen
 			rep.Gate("fresh_read") // no later edit, no later re-read: never touched
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim")
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate)
 			continue
 		}
 		if schema.TextTokens(content) < rl.minTokens {

--- a/components/offload/skeleton.go
+++ b/components/offload/skeleton.go
@@ -153,8 +153,8 @@ func (s *Skeleton) Offload(req *schemas.BifrostChatRequest, rep *components.Repo
 			keys = append(keys, fk...)
 			continue
 		}
-		if skipReduce(c, content) {
-			rep.Gate("marker_or_kept_verbatim") // already carries a marker, or the agent expanded it
+		if gate, skip := skipReduce(c, content); skip {
+			rep.Gate(gate) // already carries a marker, or the agent expanded it — the gate says which
 			continue
 		}
 		if schema.TextTokens(content) < s.minTokens {

--- a/components/offload/smartcrush.go
+++ b/components/offload/smartcrush.go
@@ -54,7 +54,11 @@ func (s *SmartCrush) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			continue // non-text blocks would be dropped by a text rewrite
 		}
 		content := schema.MessageText(*msg)
-		if skipReduce(c, content) {
+		if gate, skip := skipReduce(c, content); skip {
+			// smartcrush raised NO gate here, so its share of both reasons was invisible even in
+			// the conflated form. It has no reapplyFrozen path, so kept-verbatim content is
+			// precisely where its per-turn work is abandoned.
+			rep.Gate(gate)
 			continue // already offloaded by an earlier component/turn, or expanded by the agent
 		}
 		trimmed := strings.TrimSpace(content)

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -203,7 +203,26 @@ func frozenLost(c *components.Ctx, key string) bool {
 func reapplyFrozen(c *components.Ctx, rep *components.Report, comp string, m *bschemas.ChatMessage) ([]string, int, bool) {
 	content := schema.MessageText(*m)
 	if isKeptVerbatim(c, contentKey(content)) {
-		return nil, 0, false // agent expanded this; replaying the collapse would loop
+		// The agent expanded this; replaying the collapse would loop it into another expand.
+		//
+		// COUNT THE FLIP, which needs one more lookup than declining does. Whether this turn
+		// costs anything depends on something this branch did not previously ask: was there a
+		// frozen decision? If there was, the provider is holding COMPACTED bytes for this
+		// message and we are about to send the original in full at the same position — a change
+		// inside the cached prefix, so the whole suffix is re-written at ~11.5x a read. If there
+		// was not, the message was never compacted and nothing flips.
+		//
+		// Both cases raise the same gate at the caller (kept_verbatim_after_expand), because from
+		// the offloader's point of view they are the same decision. Only this one has a price, and
+		// nothing distinguished them before — so an expand-induced cache-write was indistinguishable
+		// from any other, which is #201's second bullet.
+		//
+		// One extra Get on rare content: this branch is reached only for content the agent actually
+		// expanded, not on the hot path.
+		if _, wasFrozen := c.Store.Get(frozenKey(c.Session, comp, contentKey(content))); wasFrozen {
+			expandFlips.Add(1)
+		}
+		return nil, 0, false
 	}
 	repl, ok := c.Store.Get(frozenKey(c.Session, comp, contentKey(content)))
 	if !ok {
@@ -286,6 +305,31 @@ var (
 // Exported for the host's /stats, which pairs them with the store's drop/repair counts.
 func FrozenStats() (hits, misses int64) { return frozenHits.Load(), frozenMisses.Load() }
 
+// expandFlips counts turns where an ESTABLISHED compaction was abandoned because the agent had
+// expanded that content: a frozen decision existed, so the provider is holding the compacted bytes,
+// and this turn sends the original in full at the same position.
+//
+// That costs a cache-write of the whole suffix at ~11.5x a read — the exact cost the cache-tail
+// gate exists to avoid everywhere else — and it was undocumented, uncounted and invisible: no
+// counter distinguished "the prefix flipped because the agent expanded" from any other cache-write,
+// so an operator could not see it and a benchmark could not attribute it (#201).
+//
+// It is a deliberate cost, not a bug. Re-compacting would bounce the agent straight into another
+// expand, and one cache-write is cheaper than an unbounded expand loop — which is why cg:keep:
+// exists. Counting it makes the trade visible instead of assumed.
+//
+// ONE PER TURN PER MESSAGE, not one per distinct content: every later turn re-sends the same
+// original and re-observes the same abandonment, so this grows with turn count. Only the FIRST is
+// a real cache-write — after that the provider has cached the full form — so read it as "expansion
+// is costing prefix churn in this deployment", not as a count of cache-writes. Distinct content is
+// what kept_verbatim_after_expand's per-component gate approximates.
+var expandFlips atomic.Int64
+
+// ExpandPrefixFlips returns how many times a replay declined because the agent had expanded content
+// that WAS compacted before. Non-zero means expansion is re-writing cached prefixes; see
+// expandFlips for why it is per turn per message rather than per distinct content.
+func ExpandPrefixFlips() int64 { return expandFlips.Load() }
+
 // contentKey is a marker/whitespace-insensitive content hash (shared with extract's
 // result cache), so the same output re-sent across turns maps to one frozen decision.
 func contentKey(s string) string { return extract.ContentKey(s) }
@@ -326,9 +370,40 @@ func isKeptVerbatim(c *components.Ctx, ck string) bool {
 // orphan the earlier stash), or the agent expanded it and re-compacting would just
 // trigger another expand — a per-turn bounce loop. Every offloader consults this on
 // each candidate so the kept-verbatim / never-double-reduce guarantees hold uniformly.
-func skipReduce(c *components.Ctx, content string) bool {
-	return expand.HasPlaceholder(content) || isKeptVerbatim(c, contentKey(content))
+// It returns WHICH of the two, because the caller publishes it as a gate and the two reasons want
+// opposite readings (#201). "Already carries a marker" is benign — that content is already
+// compacted, and nothing about this turn changes. "The agent expanded it" is an established
+// compaction being abandoned: from this turn on the original goes upstream in full at its own
+// position, which is a change inside the provider's cached prefix.
+//
+// They shared the label `marker_or_kept_verbatim` at eight of eleven sites while three offloaders
+// (extract_sweep, extract_llm, failed_run) already raised `kept_verbatim_after_expand` for exactly
+// the same condition. Gates reach /stats per component, so that was a published counter reporting
+// both a benign outcome and a real cost — and a published experimental figure was corrected twice
+// off it before anyone noticed the label was the problem. Same rule as #200 and #188.
+func skipReduce(c *components.Ctx, content string) (gate string, skip bool) {
+	// Marker first: content that already carries one was compacted by some component, and asking
+	// the store about kept-verbatim would be a wasted Get on the common path.
+	if expand.HasPlaceholder(content) {
+		return GateAlreadyMarked, true
+	}
+	if isKeptVerbatim(c, contentKey(content)) {
+		return GateKeptVerbatim, true
+	}
+	return "", false
 }
+
+// The two gate labels skipReduce distinguishes, named constants because eleven offloaders raise
+// them and a typo in one would silently split a counter in two.
+const (
+	// GateAlreadyMarked: this content already carries an offload marker, so reducing again would
+	// double-compact and can orphan the earlier stash. Benign — nothing flips.
+	GateAlreadyMarked = "already_marked"
+	// GateKeptVerbatim: the agent expanded this content, so it must not be re-compacted (that
+	// would bounce it straight into another expand). The turn this first appears is the turn the
+	// message reverts to its full form inside the cached prefix — see ExpandPrefixFlips.
+	GateKeptVerbatim = "kept_verbatim_after_expand"
+)
 
 // --- Stash ownership (scoping GET /expand by session) ----------------------
 //

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -331,6 +331,13 @@ func FrozenStats() (hits, misses int64) { return frozenHits.Load(), frozenMisses
 // a real cache-write — after that the provider has cached the full form — so read it as "expansion
 // is costing prefix churn in this deployment", not as a count of cache-writes. Distinct content is
 // what kept_verbatim_after_expand's per-component gate approximates.
+//
+// AND ONE EVENT, not every expand-induced cache-write. This is its only increment site: a replay
+// declined because the content was expanded. summarize has a sibling that is NOT counted here —
+// trimSpanForKeptVerbatim shortens the span to protect expanded content, which can invalidate a
+// checkpoint whose boundary reached past the new end, and re-summarizing emits different summary
+// text at a fixed prefix position. Same class of cost, correct trade, deliberately uncounted:
+// a second increment site changes what this number means and wants its own decision.
 var expandFlips atomic.Int64
 
 // ExpandPrefixFlips returns how many times a replay declined because the agent had expanded content

--- a/components/offload/state.go
+++ b/components/offload/state.go
@@ -217,9 +217,17 @@ func reapplyFrozen(c *components.Ctx, rep *components.Report, comp string, m *bs
 		// nothing distinguished them before — so an expand-induced cache-write was indistinguishable
 		// from any other, which is #201's second bullet.
 		//
-		// One extra Get on rare content: this branch is reached only for content the agent actually
-		// expanded, not on the hot path.
-		if _, wasFrozen := c.Store.Get(frozenKey(c.Session, comp, contentKey(content))); wasFrozen {
+		// store.Peek, NOT Get, and this is the load-bearing part of the probe rather than a
+		// micro-optimisation. Memory.Get SLIDES the TTL and reorders the LRU, and FrozenPrefix is
+		// one of the PINNED namespaces — so probing with Get renewed a pinned entry that this
+		// branch has just decided will never be replayed, and pinned entries count against the
+		// shared exempt budget that gates rewind-reserve admission. A diagnostic would have been
+		// applying back-pressure to the reserve. Measured: with a 100s TTL and ten turns 60s apart,
+		// the probe kept a frozen decision alive 600s in.
+		//
+		// One extra lookup on rare content: this branch is reached only for content the agent
+		// actually expanded, not on the hot path.
+		if store.Peek(c.Store, frozenKey(c.Session, comp, contentKey(content))) {
 			expandFlips.Add(1)
 		}
 		return nil, 0, false

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -152,19 +152,30 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// Keep msg0 (system/first) + the last keepLast; summarize the span between — with both
 	// boundaries aligned so neither cuts inside a tool exchange. See summarizeSpan.
 	headCount, start, end := summarizeSpan(msgs, s.keepLast)
-	// Never summarize away content the agent EXPANDED. summarize replaces the span wholesale
-	// rather than editing in place, so it is the one offloader skipReduce cannot protect — see
-	// trimSpanForKeptVerbatim for why that is both a bounce loop and a broken pointer.
-	if trimmed := trimSpanForKeptVerbatim(msgs, start, end,
-		func(text string) bool { return isKeptVerbatim(c, contentKey(text)) }); trimmed != end {
-		rep.Gate(GateKeptVerbatim)
-		end = trimmed
-	}
 	// Request-level trigger: don't summarize (an LLM call) until the transcript
 	// is genuinely large / deep. Zero thresholds fire always (back-compat).
 	if !s.trigger.Fires(req, c.CtxWindow) || end <= start {
 		rep.Skipped = true
 		return nil, nil
+	}
+	// Never summarize away content the agent EXPANDED. summarize replaces the span wholesale
+	// rather than editing in place, so it is the one offloader skipReduce cannot protect — see
+	// trimSpanForKeptVerbatim for why that is both a bounce loop and a broken pointer.
+	//
+	// BELOW the trigger gate, not above it: the trim costs a contentKey hash plus a store Get per
+	// span message, and paying that on a turn summarize was never going to act on is waste — it
+	// also raised kept_verbatim_after_expand on those turns, reporting a decision nothing made.
+	// The re-test of end <= start below is what keeps the original ordering's guarantee.
+	if trimmed := trimSpanForKeptVerbatim(msgs, start, end,
+		func(text string) bool { return isKeptVerbatim(c, contentKey(text)) }); trimmed != end {
+		rep.Gate(GateKeptVerbatim)
+		end = trimmed
+		if end <= start {
+			// Nothing summarizable is left once expanded content is protected. Declining is the
+			// outcome summarize already has for an empty span, and the safe direction.
+			rep.Skipped = true
+			return nil, nil
+		}
 	}
 	model := s.modelClient // config-pinned client wins
 	if model == nil {

--- a/components/offload/summarize.go
+++ b/components/offload/summarize.go
@@ -152,6 +152,14 @@ func (s *Summarize) Offload(req *bschemas.BifrostChatRequest, rep *components.Re
 	// Keep msg0 (system/first) + the last keepLast; summarize the span between — with both
 	// boundaries aligned so neither cuts inside a tool exchange. See summarizeSpan.
 	headCount, start, end := summarizeSpan(msgs, s.keepLast)
+	// Never summarize away content the agent EXPANDED. summarize replaces the span wholesale
+	// rather than editing in place, so it is the one offloader skipReduce cannot protect — see
+	// trimSpanForKeptVerbatim for why that is both a bounce loop and a broken pointer.
+	if trimmed := trimSpanForKeptVerbatim(msgs, start, end,
+		func(text string) bool { return isKeptVerbatim(c, contentKey(text)) }); trimmed != end {
+		rep.Gate(GateKeptVerbatim)
+		end = trimmed
+	}
 	// Request-level trigger: don't summarize (an LLM call) until the transcript
 	// is genuinely large / deep. Zero thresholds fire always (back-compat).
 	if !s.trigger.Fires(req, c.CtxWindow) || end <= start {

--- a/components/offload/summarize_keptverbatim_test.go
+++ b/components/offload/summarize_keptverbatim_test.go
@@ -1,0 +1,103 @@
+package offload
+
+import (
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// asstWithCall is an assistant turn that calls a tool, so a span boundary landing after it would
+// leave the call unanswered — one of the two provider rejections summarizeSpan exists to prevent.
+func asstWithCall(id string) bschemas.ChatMessage {
+	return bschemas.ChatMessage{
+		Role: bschemas.ChatMessageRoleAssistant,
+		ChatAssistantMessage: &bschemas.ChatAssistantMessage{
+			ToolCalls: []bschemas.ChatAssistantMessageToolCall{{ID: &id}},
+		},
+	}
+}
+
+// SUMMARIZE MUST NOT SUMMARIZE AWAY CONTENT THE AGENT EXPANDED.
+//
+// It is the one offloader that consults neither skipReduce nor isKeptVerbatim, and it replaces
+// msgs[start:end] wholesale rather than editing in place. Two consequences, one pre-existing and one
+// introduced by the repair now writing a pointer instead of a second copy:
+//
+//   - the bounce loop cg:keep: exists to prevent: the agent asks for content back, gets it, and next
+//     turn it is gone again;
+//   - expand.RestoredInPlace's pointer says the content is in the transcript, on the strength of the
+//     body BEFORE the pipeline runs. If summarize removes it, the model is left with a pointer to
+//     nothing where it previously got the content.
+func TestSummarizeLeavesExpandedContentInTheTranscript(t *testing.T) {
+	expanded := strings.Repeat("the content the agent asked to have back\n", 40)
+	filler := strings.Repeat("older chatter that is fine to summarize\n", 40)
+
+	st := store.NewMemory(store.Options{})
+	MarkKeptVerbatim(st, expanded)
+
+	// msg0, then a summarizable stretch, then the expanded output inside its own exchange, then a
+	// tail. keep_last is 1 so `end` starts well past the expanded message.
+	msgs := []bschemas.ChatMessage{
+		userMsg("system-ish opener"),
+		userMsg(filler),
+		asstWithCall("call_1"),
+		tool(expanded),
+		userMsg("what next?"),
+	}
+
+	_, start, end := summarizeSpan(msgs, 1)
+	trimmed := trimSpanForKeptVerbatim(msgs, start, end,
+		func(text string) bool { return text == expanded })
+
+	if trimmed >= 3 {
+		t.Fatalf("span still ends at %d, so the expanded tool output at index 3 is inside it and "+
+			"would be summarized away", trimmed)
+	}
+	// AND the boundary must not split the exchange: index 2 is the assistant turn that called the
+	// tool, so a span ending at 3 would leave its call unanswered and the request would be rejected
+	// (400 `tool_use` ids were found without `tool_result` blocks immediately after).
+	if trimmed > 2 {
+		t.Fatalf("span ends at %d, which leaves the tool_use at index 2 inside the span with its "+
+			"result outside: the provider rejects that request", trimmed)
+	}
+	for _, m := range msgs[trimmed:] {
+		if schema.MessageText(m) == expanded {
+			return // the expanded content survives outside the span, which is the point
+		}
+	}
+	t.Fatal("the expanded content is not in the kept part of the transcript")
+}
+
+// The safe direction when there is nothing left to summarize: decline. summarize already supports
+// end <= start, so this must not become a special case — and it must certainly not summarize the
+// expanded content because the remaining span is small.
+func TestSummarizeDeclinesRatherThanTouchingExpandedContent(t *testing.T) {
+	expanded := strings.Repeat("the content the agent asked to have back\n", 40)
+	msgs := []bschemas.ChatMessage{
+		userMsg("opener"),
+		tool(expanded), // immediately after the head, so nothing is summarizable without it
+		userMsg("what next?"),
+	}
+	_, start, end := summarizeSpan(msgs, 1)
+	trimmed := trimSpanForKeptVerbatim(msgs, start, end,
+		func(text string) bool { return text == expanded })
+	if trimmed > start {
+		t.Fatalf("span is [%d,%d) and still contains the expanded message at index 1", start, trimmed)
+	}
+}
+
+// A span with no expanded content must be left exactly as summarizeSpan computed it — the trim is a
+// protection, not a new boundary policy, and shrinking a healthy span would cost real savings.
+func TestTheTrimIsANoOpWithoutExpandedContent(t *testing.T) {
+	filler := strings.Repeat("older chatter that is fine to summarize\n", 40)
+	msgs := []bschemas.ChatMessage{
+		userMsg("opener"), userMsg(filler), userMsg(filler), userMsg("what next?"),
+	}
+	_, start, end := summarizeSpan(msgs, 1)
+	if got := trimSpanForKeptVerbatim(msgs, start, end, func(string) bool { return false }); got != end {
+		t.Fatalf("trimmed a span with nothing expanded in it: %d -> %d", end, got)
+	}
+}

--- a/components/offload/summarize_keptverbatim_test.go
+++ b/components/offload/summarize_keptverbatim_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
 	"github.com/rossoctl/context-guru/schema"
 	"github.com/rossoctl/context-guru/store"
 )
@@ -31,12 +32,14 @@ func asstWithCall(id string) bschemas.ChatMessage {
 //   - expand.RestoredInPlace's pointer says the content is in the transcript, on the strength of the
 //     body BEFORE the pipeline runs. If summarize removes it, the model is left with a pointer to
 //     nothing where it previously got the content.
+//
+// THIS TEST AND THE TWO BELOW EXERCISE THE BOUNDARY ARITHMETIC IN ISOLATION, with a stub predicate
+// and no store — deliberately, because the retreat rule is worth pinning on its own. They do NOT
+// establish that Offload calls it: see TestSummarizeOffloadKeepsExpandedContent, which is the test
+// that fails if the call goes away.
 func TestSummarizeLeavesExpandedContentInTheTranscript(t *testing.T) {
 	expanded := strings.Repeat("the content the agent asked to have back\n", 40)
 	filler := strings.Repeat("older chatter that is fine to summarize\n", 40)
-
-	st := store.NewMemory(store.Options{})
-	MarkKeptVerbatim(st, expanded)
 
 	// msg0, then a summarizable stretch, then the expanded output inside its own exchange, then a
 	// tail. keep_last is 1 so `end` starts well past the expanded message.
@@ -99,5 +102,69 @@ func TestTheTrimIsANoOpWithoutExpandedContent(t *testing.T) {
 	_, start, end := summarizeSpan(msgs, 1)
 	if got := trimSpanForKeptVerbatim(msgs, start, end, func(string) bool { return false }); got != end {
 		t.Fatalf("trimmed a span with nothing expanded in it: %d -> %d", end, got)
+	}
+}
+
+// AND THE ARITHMETIC MUST ACTUALLY BE REACHED, which the three tests above do not establish.
+//
+// They call trimSpanForKeptVerbatim directly with a stub predicate, so deleting the call from
+// Offload — or passing a predicate that never consults the store, or moving the call below the point
+// end is used — leaves all three green and the whole suite green, and the regression is back. The
+// tell was in the fixture: the first test built a store and marked content, then never used it,
+// because the stub had replaced it. Dead setup is what an assertion that stopped reaching its
+// subject looks like.
+//
+// This is the same shape as the vacuous cross-check on #204, and its sibling in this package
+// (TestTheFlipProbeDoesNotRenewTheDecisionItAsksAbout) is the version that gets it right: the
+// assertion has to live where the behaviour is.
+func TestSummarizeOffloadKeepsExpandedContent(t *testing.T) {
+	expanded := strings.Repeat("ran pytest tests/test_t2.py, 3 failures in src/mod/file.go\n", 40)
+	build := func() []bschemas.ChatMessage {
+		msgs := []bschemas.ChatMessage{
+			{Role: bschemas.ChatMessageRoleUser},
+			callMsg("t1"), bulkResult("t1"),
+			callMsg("t2"), bulkResult("t2"),
+			callMsg("t3"), bulkResult("t3"),
+		}
+		schema.SetMessageText(&msgs[0], "fix the failing tests")
+		return msgs
+	}
+	present := func(msgs []bschemas.ChatMessage) bool {
+		for _, m := range msgs {
+			if schema.MessageText(m) == expanded {
+				return true
+			}
+		}
+		return false
+	}
+
+	// PRECONDITION: with nothing marked, this fixture DOES summarize that message away. Without
+	// this, "the content survived" would also pass on a fixture summarize never touched.
+	s := newSummarizeKeepLast(t, 1)
+	plain := &bschemas.BifrostChatRequest{Input: build()}
+	if !present(plain.Input) {
+		t.Fatal("the fixture does not contain the content to begin with")
+	}
+	var rep components.Report
+	if _, err := s.Offload(plain, &rep, ctxFor(store.NewMemory(store.Options{}))); err != nil {
+		t.Fatal(err)
+	}
+	if present(plain.Input) {
+		t.Fatal("summarize did not remove this message even unmarked, so the assertion below " +
+			"would pass vacuously — the fixture is not exercising the span")
+	}
+
+	// THE PROPERTY: marked kept-verbatim, the same fixture must keep it.
+	st := store.NewMemory(store.Options{})
+	MarkKeptVerbatim(st, expanded)
+	req := &bschemas.BifrostChatRequest{Input: build()}
+	rep = components.Report{}
+	if _, err := s.Offload(req, &rep, ctxFor(st)); err != nil {
+		t.Fatal(err)
+	}
+	if !present(req.Input) {
+		t.Fatalf("summarize removed content the agent had expanded: the model is left with a "+
+			"pointer to nothing where it used to get the content, and the agent will expand it "+
+			"again next turn. gates=%v", rep.Gates)
 	}
 }

--- a/components/offload/summarize_keptverbatim_test.go
+++ b/components/offload/summarize_keptverbatim_test.go
@@ -118,7 +118,11 @@ func TestTheTrimIsANoOpWithoutExpandedContent(t *testing.T) {
 // (TestTheFlipProbeDoesNotRenewTheDecisionItAsksAbout) is the version that gets it right: the
 // assertion has to live where the behaviour is.
 func TestSummarizeOffloadKeepsExpandedContent(t *testing.T) {
-	expanded := strings.Repeat("ran pytest tests/test_t2.py, 3 failures in src/mod/file.go\n", 40)
+	// Derived from bulkResult rather than hand-copied from its format string. The precondition
+	// below would fail loudly if the two drifted apart, so a copy was safe — but it was safe
+	// because of a guard elsewhere rather than by construction, and the next person editing
+	// bulkResult has no reason to look here.
+	expanded := schema.MessageText(bulkResult("t2"))
 	build := func() []bschemas.ChatMessage {
 		msgs := []bschemas.ChatMessage{
 			{Role: bschemas.ChatMessageRoleUser},

--- a/components/offload/summarize_pairing.go
+++ b/components/offload/summarize_pairing.go
@@ -145,6 +145,10 @@ func summarizeSpan(msgs []bschemas.ChatMessage, keepLast int) (headCount, start,
 // A caller that gets end <= start skips, which is an outcome summarize already supports — the safe
 // direction, and better than either summarizing expanded content away or emitting a request the
 // provider rejects.
+// The scan stops at the FIRST kept-verbatim message, since everything after it is protected by the
+// retreat anyway — so the common case (nothing expanded) is one store lookup per span message and no
+// allocation, and the acting case is fewer. The caller runs this below its trigger gate so a turn
+// that was never going to summarize pays none of it.
 func trimSpanForKeptVerbatim(msgs []bschemas.ChatMessage, start, end int, kept func(string) bool) int {
 	first := -1
 	for i := start; i < end; i++ {

--- a/components/offload/summarize_pairing.go
+++ b/components/offload/summarize_pairing.go
@@ -2,6 +2,7 @@ package offload
 
 import (
 	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/schema"
 )
 
 // Tool-pairing repair for a component that REMOVES messages.
@@ -114,4 +115,62 @@ func summarizeSpan(msgs []bschemas.ChatMessage, keepLast int) (headCount, start,
 		end++
 	}
 	return headCount, start, end
+}
+
+// trimSpanForKeptVerbatim lowers end so the span never contains content the agent EXPANDED.
+//
+// summarize is the one offloader that consults neither skipReduce nor isKeptVerbatim, and it does
+// not edit messages in place — it replaces msgs[start:end] with a single summary. So expanded
+// content inside the span was summarized away, which is two separate problems:
+//
+//   - It is the BOUNCE LOOP cg:keep: exists to prevent, which is why the other ten offloaders
+//     consult it: the agent asks for content back, gets it, and the next turn it is gone again.
+//     Pre-existing, and the reason this fix belongs here rather than at the caller.
+//   - It falsifies expand.RestoredInPlace's pointer. The repair says "the content is present in
+//     the transcript above" on the strength of the body as it stands BEFORE the pipeline runs; if
+//     summarize then removes it, the model is left with a pointer to nothing where it used to get
+//     the content.
+//
+// THE RETREAT MIRRORS THE ADVANCE ABOVE, and for the same reason: a tool exchange is atomic. Simply
+// setting end to the kept-verbatim message's index is not enough, because that message is typically
+// a tool output — so the kept tail would begin with a tool_result whose tool_use is still inside the
+// span, which is one of the two provider rejections summarizeSpan was written to stop:
+//
+//	400 messages.N.content.M: unexpected `tool_use_id` found in `tool_result` blocks
+//	400 messages.N: `tool_use` ids were found without `tool_result` blocks immediately after
+//
+// So end retreats past the whole exchange. Advancing instead (as the tail-alignment rule does) is
+// not available here: advancing past a tool message would swallow the very message being protected.
+//
+// A caller that gets end <= start skips, which is an outcome summarize already supports — the safe
+// direction, and better than either summarizing expanded content away or emitting a request the
+// provider rejects.
+func trimSpanForKeptVerbatim(msgs []bschemas.ChatMessage, start, end int, kept func(string) bool) int {
+	first := -1
+	for i := start; i < end; i++ {
+		if kept(schema.MessageText(msgs[i])) {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return end
+	}
+	end = first
+	// Retreat off any boundary that would split an exchange: a tail beginning with a tool message,
+	// or a span ending on an assistant turn whose results now sit in the tail.
+	for end > start {
+		if end < len(msgs) && msgs[end].Role == bschemas.ChatMessageRoleTool {
+			end--
+			continue
+		}
+		prev := msgs[end-1]
+		if prev.Role == bschemas.ChatMessageRoleAssistant &&
+			prev.ChatAssistantMessage != nil && len(prev.ChatAssistantMessage.ToolCalls) > 0 {
+			end--
+			continue
+		}
+		break
+	}
+	return end
 }

--- a/config/config.go
+++ b/config/config.go
@@ -349,7 +349,7 @@ func (c *Config) applyPreset() error {
 //
 // In the middle it took 39,335 tokens off messages `collapse` would have taken 76,554 off,
 // and its marker then made `mask`, `extract` and `collapse` decline the message entirely
-// (turn-level gates: marker_or_kept_verbatim 3/6, below_max_tokens 6). Last, it caps and
+// (turn-level gates: already_marked 3/6, below_max_tokens 6). Last, it caps and
 // dedups only the lines the bigger offloaders left behind.
 //
 // `toon` is RETIRED from every preset (the component and its tests stay, so anyone with

--- a/dash/cachecost_test.go
+++ b/dash/cachecost_test.go
@@ -275,7 +275,7 @@ func TestGatesReachTheDashboard(t *testing.T) {
 	e := &Event{TS: 1000, SessionID: "s", Model: "m", TokensBefore: 9000, TokensAfter: 9000,
 		Components: []CompRow{
 			{Component: "cmdfilter", Kind: "offload", Skipped: true,
-				Gates: map[string]int{"no_filter_match": 15, "marker_or_kept_verbatim": 4}},
+				Gates: map[string]int{"no_filter_match": 15, "already_marked": 4}},
 			{Component: "extract", Kind: "offload", Skipped: true,
 				Gates: map[string]int{"no_obvious_noise": 14}},
 		}}
@@ -296,8 +296,8 @@ func TestGatesReachTheDashboard(t *testing.T) {
 	if got := byName["cmdfilter"].Gates["no_filter_match"]; got != 20 {
 		t.Errorf("aggregated no_filter_match = %d, want 20 (15 + 5)", got)
 	}
-	if got := byName["cmdfilter"].Gates["marker_or_kept_verbatim"]; got != 4 {
-		t.Errorf("aggregated marker_or_kept_verbatim = %d, want 4", got)
+	if got := byName["cmdfilter"].Gates["already_marked"]; got != 4 {
+		t.Errorf("aggregated already_marked = %d, want 4", got)
 	}
 	if got := byName["extract"].Gates["no_filter_match"]; got != 0 {
 		t.Errorf("a gate leaked across components: %d", got)

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -27,7 +27,7 @@ The choice between the two windows is made on **bytes, not on the line count**. 
 than the window says nothing about their size: an output with a multi-megabyte line inside the kept
 head or tail survived a line-count gate untouched, and *worse than being declined* — dropping the
 small filler lines in the middle counts as acting, which stamps a marker, which then makes `linecap`
-decline `marker_or_kept_verbatim`. Measured at 4,195,111 B in and 4,194,922 B out, 189 bytes saved
+decline `already_marked`. Measured at 4,195,111 B in and 4,194,922 B out, 189 bytes saved
 on a body forwarding 1.57 M tokens. The line window is therefore taken only when it at least halves
 the output; anything else falls through to the character window. The test is in bytes rather than
 tokens deliberately: `max_tokens` is resolved through `max_frac` × the model's context window, which
@@ -86,7 +86,7 @@ A catch-all last stage for huge outputs.
 
 It now names its reason instead of passing silently: `below_max_tokens`,
 `too_few_lines_and_chars` (no window that shrinks it: no usable line window *and* fewer characters
-than the character window's floor — the only genuine decline left), `marker_or_kept_verbatim`, `non_text_blocks`, `marker_no_win`,
+than the character window's floor — the only genuine decline left), `already_marked`, `kept_verbatim_after_expand`, `non_text_blocks`, `marker_no_win`,
 or `cached_prefix`.
 
 `too_few_lines` is **gone** and was not renamed: its population is now either handled (the

--- a/docs/components/mask.md
+++ b/docs/components/mask.md
@@ -43,7 +43,8 @@ component. It now names one of these on every message it passes over, visible pe
 |---|---|
 | `within_keep_recent` | the request holds no more tool outputs than `keep_recent`, so nothing is "older" |
 | `below_min_tokens` | the output is smaller than `min_tokens` |
-| `marker_or_kept_verbatim` | already offloaded by an earlier component, or expanded by the agent |
+| `already_marked` | already offloaded by an earlier component — benign, that content is compacted already |
+| `kept_verbatim_after_expand` | the agent expanded this content, so it must not be re-compacted. The first turn this appears is the turn the message reverts to its full form inside the cached prefix — counted as `expand_prefix_flips`. |
 | `cached_prefix` | the output is inside the provider's cached prefix, where a new mask would flip already-cached content and force a cache-write of the suffix. This is the gate `cold_cache` lifts on a provably-expired cache |
 | `non_text_blocks` | a text rewrite would drop the message's non-text blocks |
 | `marker_no_win` | marker + head-peek would not be smaller than the output itself |

--- a/docs/components/readlifecycle.md
+++ b/docs/components/readlifecycle.md
@@ -169,7 +169,7 @@ components:
 ```
 
 Gate reasons on `/stats`: `no_file_reads`, `fresh_read`, `non_text_blocks`,
-`marker_or_kept_verbatim`, `below_min_tokens`, `cached_prefix`, `marker_no_win`.
+`already_marked`, `kept_verbatim_after_expand`, `below_min_tokens`, `cached_prefix`, `marker_no_win`.
 
 ## Recommendation
 

--- a/docs/how-to/recover-context.md
+++ b/docs/how-to/recover-context.md
@@ -49,6 +49,53 @@ sequenceDiagram
 
 **3. Out of band.** `GET /expand?id=<hash>` returns an offloaded original directly.
 
+## What an expand costs, across turns
+
+Everything above is about a single turn. Across turns an expand has two consequences that are
+easy to miss, because the in-turn behaviour is deliberately cache-safe and the cross-turn
+behaviour is not the same thing.
+
+**An expand permanently un-compacts that content.** The handler marks the restored original
+kept-verbatim (`cg:keep:`), and every offloader then skips it — otherwise re-compacting would
+bounce the agent straight into another expand, which is the loop that mark exists to prevent. So
+from the next turn onward the original goes upstream **in full, at its original position**.
+
+**That costs one cache-write of the suffix.** Turn N sent compacted bytes at that position and turn
+N+1 sends the full original, which is a change inside the provider's cached prefix — at ~11.5× a
+cache read, the cost the [cache-tail gate](../reference/config.md) exists to avoid everywhere else.
+It happens once per expanded content, on the turn after the expand, and it is counted:
+`expand_prefix_flips` at [`/stats`](../reference/routes.md#get-stats) and
+`cg_expand_prefix_flips_total` at `/metrics`.
+
+That figure is **per turn per message**, not per distinct content — every later turn re-sends the
+same original and the same abandonment is observed again, while only the first is a real
+cache-write. Read it as "expansion is churning cached prefixes in this deployment", not as a count
+of cache-writes. The per-component gate `kept_verbatim_after_expand` is the per-message view; its
+sibling `already_marked` is the benign case (content some component had already compacted), and the
+two were one label until they were split, which is why an older dashboard may show neither.
+
+**The in-turn expansion does not persist as its own turn.** On the intercepted path the client never
+sees the tool_use/tool_result pair — the proxy answers it and returns only the final assistant
+response — so the next turn the client re-sends its own transcript without the expansion. What
+persists is the *flag*, not the content. There is no in-place replacement of a marker by its
+content, and `inject_expand` controls only whether the tool is **advertised**, never how a call is
+answered.
+
+**The repair path is the exception, and it is a fallback for a failure rather than a mode.** When
+interception structurally cannot work — a client tool batched alongside expand, the round cap, a
+stream that will not reconstruct, a non-Anthropic stream, or a bypassed turn carrying older markers
+— the client did see the call and answered `No such tool available`. The proxy repairs that
+tool_result on every later turn, so this is the only configuration in which the round-trip lives in
+the client's transcript.
+
+On that path the repaired tool_result carries a **pointer**, not a second copy: the content is
+already in the transcript at its own position (kept-verbatim, above), so repeating it there sent the
+same tool output upstream twice on every turn. Measured on a 200-line output: 252 bytes when the
+content is compacted and no expand round-trip exists, against 21,511 bytes with one — two full
+copies, permanently. If the original is *not* in the transcript (the agent's own compaction can drop
+that message while keeping the round-trip) the tool_result carries the content, exactly as before,
+because then it is the model's only copy.
+
 ## Recovery needs the store
 
 The store *is* the reversibility mechanism. It defaults to in-memory TTL+LRU — 10000s

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -250,10 +250,6 @@ reversibility it destroyed, silently.
 | `stash_expired` | Payloads reclaimed by their own TTL (`stash_ttl_seconds`, shorter than `ttl_seconds`). **Not an alert on its own** — read it against `stash_revived`. |
 | `stash_revived` | Reclaimed payloads written again by a later replay, which re-derives them from the transcript **before** the marker goes upstream: reclamation absorbed at no cost. Tracking `stash_expired` means the shorter payload TTL is working as designed; see [why payloads expire sooner](config.md#why-payloads-expire-sooner-than-decisions). |
 
-| Field | Meaning |
-|---|---|
-| `expand_prefix_flips` | Turns where an **established** compaction was abandoned because the agent had expanded that content, so the original went upstream in full at its cached position — a suffix cache-write attributable to expansion, at ~11.5× a read. Deliberate: re-compacting would loop the agent into another expand, and one cache-write is cheaper than an unbounded loop. **Per turn per message**, not per distinct content — only the first is a real cache-write. See [what an expand costs](../how-to/recover-context.md#what-an-expand-costs-across-turns). |
-
 `stash_refused` is the **leading** indicator for `expand_unresolved_missing`: that counter cannot
 move until the agent happens to call `expand`, so a proxy that had stopped being able to promise
 reversibility read as perfectly healthy until one did. This one moves when the budget binds.
@@ -266,6 +262,23 @@ with nothing behind it, which is the failure #187 was about. Alert on `stash_mis
 `stash_refused`. `stash_missing` also grows with **turn count** rather than with distinct dangling
 markers: a payload that has gone cannot be restored (the replayed bytes must stay byte-identical to
 the turn that created them), so every later turn re-reports it for every affected message.
+
+### What an expand costs
+
+| Field | Meaning |
+|---|---|
+| `expand_prefix_flips` | Turns where an **established** compaction was abandoned because the agent had expanded that content, so the original went upstream in full at its cached position — a suffix cache-write attributable to expansion, at ~11.5× a read. |
+
+Deliberate rather than a defect: re-compacting would loop the agent into another expand, and one
+cache-write is cheaper than an unbounded loop. Counting it makes the trade visible, since no other
+counter distinguishes an expand-induced cache-write from any other.
+
+It grows **per turn per message**, not per distinct content: every later turn re-sends the same
+original and the same abandonment is observed again, while only the first is a real cache-write. Read
+it as "expansion is churning cached prefixes here". The per-component gate
+`kept_verbatim_after_expand` is the per-message view, and `already_marked` is its benign sibling —
+the two were one label (`marker_or_kept_verbatim`) until they were split. Full picture in
+[what an expand costs](../how-to/recover-context.md#what-an-expand-costs-across-turns).
 
 ### cmdfilter attribution
 

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -250,6 +250,10 @@ reversibility it destroyed, silently.
 | `stash_expired` | Payloads reclaimed by their own TTL (`stash_ttl_seconds`, shorter than `ttl_seconds`). **Not an alert on its own** — read it against `stash_revived`. |
 | `stash_revived` | Reclaimed payloads written again by a later replay, which re-derives them from the transcript **before** the marker goes upstream: reclamation absorbed at no cost. Tracking `stash_expired` means the shorter payload TTL is working as designed; see [why payloads expire sooner](config.md#why-payloads-expire-sooner-than-decisions). |
 
+| Field | Meaning |
+|---|---|
+| `expand_prefix_flips` | Turns where an **established** compaction was abandoned because the agent had expanded that content, so the original went upstream in full at its cached position — a suffix cache-write attributable to expansion, at ~11.5× a read. Deliberate: re-compacting would loop the agent into another expand, and one cache-write is cheaper than an unbounded loop. **Per turn per message**, not per distinct content — only the first is a real cache-write. See [what an expand costs](../how-to/recover-context.md#what-an-expand-costs-across-turns). |
+
 `stash_refused` is the **leading** indicator for `expand_unresolved_missing`: that counter cannot
 move until the agent happens to call `expand`, so a proxy that had stopped being able to promise
 reversibility read as perfectly healthy until one did. This one moves when the budget binds.

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -275,7 +275,13 @@ counter distinguishes an expand-induced cache-write from any other.
 
 It grows **per turn per message**, not per distinct content: every later turn re-sends the same
 original and the same abandonment is observed again, while only the first is a real cache-write. Read
-it as "expansion is churning cached prefixes here". The per-component gate
+it as "expansion is churning cached prefixes here".
+
+It also counts **one event**, not every expand-induced cache-write: a replay declined because the
+content was expanded. At least one sibling is uncounted — protecting expanded content shortens
+`summarize`'s span, which can invalidate a checkpoint and force a re-summary, and different summary
+text at a fixed prefix position is another suffix cache-write. So a zero here does not mean expansion
+cost nothing. The per-component gate
 `kept_verbatim_after_expand` is the per-message view, and `already_marked` is its benign sibling —
 the two were one label (`marker_or_kept_verbatim`) until they were split. Full picture in
 [what an expand costs](../how-to/recover-context.md#what-an-expand-costs-across-turns).

--- a/expand/repair.go
+++ b/expand/repair.go
@@ -14,6 +14,24 @@ func Unavailable(hashID string) string {
 	return "[expand: original for id " + hashID + " is no longer available]"
 }
 
+// RestoredInPlace is what a repaired tool_result carries INSTEAD of a second copy of the content.
+//
+// The repair used to write the original into the tool_result, and the same call marks that content
+// kept-verbatim — so the offloaders also leave the ORIGINAL message uncompacted at its own position.
+// Both mechanisms are individually right and together they sent the tool output UPSTREAM TWICE, on
+// every turn, for the rest of the session. Measured on a 200-line output through the codesafe
+// preset: 252 bytes when the content is compacted and no expand round-trip exists, against 21,511
+// bytes with one — two full copies, permanently. That is far larger than the one-off prefix flip
+// #201 describes, and it is why this is a defect and not a preference.
+//
+// The note names the id, so it is accurate either way: the content is in the transcript above,
+// verbatim if kept-verbatim held, and behind a resolvable marker if it did not. It cannot go stale,
+// because MarkKeptVerbatim is re-applied for every restored original on every repair turn BEFORE
+// the pipeline reads the transcript — the same call that writes this note re-establishes the mark.
+func RestoredInPlace(hashID string) string {
+	return "[expand: the content for id " + hashID + " is present in the transcript above]"
+}
+
 // RepairToolResults answers, on the way UPSTREAM, an expand call the CLIENT had to answer
 // itself.
 //
@@ -115,7 +133,18 @@ func repairOne(body []byte, restored []string, ours map[string]string, callID, p
 		noteUnresolved(hashID)
 		orig = Unavailable(hashID)
 	}
-	nb, err := sjson.SetBytes(body, path+".content", orig)
+	// WHAT THE MODEL READS is a pointer, not a second copy — but only when there IS something to
+	// point at. The original message is normally still in the transcript at its own position and
+	// left uncompacted (the same repair marks it kept-verbatim), so writing the content here sent it
+	// upstream twice on every later turn. When it is NOT there — the agent's own compaction can drop
+	// that message while keeping the expand round-trip — the tool_result is the model's only copy
+	// and it gets the content, exactly as before. Checked rather than assumed, because a note
+	// pointing at nothing would lose content that used to be delivered.
+	answer := orig
+	if found && contentPresent(body, orig, path+".content") {
+		answer = RestoredInPlace(hashID)
+	}
+	nb, err := sjson.SetBytes(body, path+".content", answer)
 	if err != nil {
 		return body, restored
 	}
@@ -131,4 +160,50 @@ func repairOne(body []byte, restored []string, ours map[string]string, callID, p
 		restored = append(restored, orig)
 	}
 	return body, restored
+}
+
+// contentPresent reports whether orig is already somewhere in this request's messages OTHER than
+// at exceptPath, so a repaired tool_result can point at it instead of repeating it.
+//
+// Exact string comparison against the values gjson decodes, never a substring scan of the raw body:
+// JSON escaping makes a raw scan both false-negative (an escaped newline will not match) and
+// false-positive (content that merely contains the original). Compared at the three places a
+// message can hold text — a plain string content, an Anthropic text block, and an Anthropic
+// tool_result block's content.
+//
+// exceptPath IS LOAD-BEARING, and leaving it out was a bug caught by the existing idempotency test.
+// On a FIRST repair the tool_result holds the client's error, so there is nothing to self-match; on
+// a SECOND pass over an already-repaired body it holds the original, matched itself, and the repair
+// replaced the content with a note pointing at the content it had just removed. The repair must be
+// idempotent — the same body can pass through twice — so the block being written is excluded from
+// the search that decides what to write into it.
+func contentPresent(body []byte, orig, exceptPath string) bool {
+	if orig == "" {
+		return false
+	}
+	found := false
+	gjson.GetBytes(body, "messages").ForEach(func(mk, m gjson.Result) bool {
+		base := "messages." + mk.String()
+		if c := m.Get("content"); c.Type == gjson.String {
+			if base+".content" != exceptPath && c.String() == orig {
+				found = true
+			}
+			return !found
+		}
+		m.Get("content").ForEach(func(bk, blk gjson.Result) bool {
+			blkBase := base + ".content." + bk.String()
+			for _, f := range [...]string{"text", "content"} {
+				if blkBase+"."+f == exceptPath {
+					continue
+				}
+				if v := blk.Get(f); v.Type == gjson.String && v.String() == orig {
+					found = true
+					return false
+				}
+			}
+			return true
+		})
+		return !found
+	})
+	return found
 }

--- a/expand/repair.go
+++ b/expand/repair.go
@@ -167,9 +167,9 @@ func repairOne(body []byte, restored []string, ours map[string]string, callID, p
 //
 // Exact string comparison against the values gjson decodes, never a substring scan of the raw body:
 // JSON escaping makes a raw scan both false-negative (an escaped newline will not match) and
-// false-positive (content that merely contains the original). Compared at the three places a
-// message can hold text — a plain string content, an Anthropic text block, and an Anthropic
-// tool_result block's content.
+// false-positive (content that merely contains the original). Compared at every place a message can
+// hold text: a plain string content, an Anthropic text block, and a tool_result block's content in
+// BOTH its spellings — a string, or an array of sub-blocks (see blockHasText).
 //
 // exceptPath IS LOAD-BEARING, and leaving it out was a bug caught by the existing idempotency test.
 // On a FIRST repair the tool_result holds the client's error, so there is nothing to self-match; on
@@ -182,6 +182,10 @@ func contentPresent(body []byte, orig, exceptPath string) bool {
 		return false
 	}
 	found := false
+	// The top-level `system` field is deliberately NOT searched. It is a place content could live in
+	// principle, and missing it fails the same safe way as anything else here — the tool_result keeps
+	// the content — but nothing in this pipeline moves a tool output there, so searching it would add
+	// a path with no fixture behind it.
 	gjson.GetBytes(body, "messages").ForEach(func(mk, m gjson.Result) bool {
 		base := "messages." + mk.String()
 		if c := m.Get("content"); c.Type == gjson.String {
@@ -191,19 +195,54 @@ func contentPresent(body []byte, orig, exceptPath string) bool {
 			return !found
 		}
 		m.Get("content").ForEach(func(bk, blk gjson.Result) bool {
-			blkBase := base + ".content." + bk.String()
-			for _, f := range [...]string{"text", "content"} {
-				if blkBase+"."+f == exceptPath {
-					continue
-				}
-				if v := blk.Get(f); v.Type == gjson.String && v.String() == orig {
-					found = true
-					return false
-				}
-			}
-			return true
+			found = blockHasText(blk, base+".content."+bk.String(), orig, exceptPath)
+			return !found
 		})
 		return !found
 	})
 	return found
+}
+
+// blockHasText reports whether one content block holds orig, at any path other than exceptPath.
+//
+// It recurses ONE level, because a tool_result's `content` is allowed to be an ARRAY of sub-blocks
+// rather than a string — Anthropic's multi-part shape, e.g. a text block beside an image. Comparing
+// only the string spelling made contentPresent report absent for that shape, so repairOne fell back
+// to writing the original and REINTRODUCED this PR's duplication, scoped to those wire shapes. It
+// failed safe (content is never lost and a pointer is never written to nothing), which is the only
+// reason it was minor rather than a regression.
+//
+// Not theoretical: apply/apply_test.go already fixtures the pipeline compacting text inside exactly
+// that shape, at messages.1.content.0.content.0.text. The marker-creating half was covered and the
+// repair half could not see it.
+//
+// One level is enough and the bound is deliberate: it is the depth the provider schema allows, and
+// unbounded recursion over attacker-influenced JSON is a cost this probe should not carry.
+func blockHasText(blk gjson.Result, blkBase, orig, exceptPath string) bool {
+	for _, f := range [...]string{"text", "content"} {
+		v := blk.Get(f)
+		switch {
+		case v.Type == gjson.String:
+			if blkBase+"."+f != exceptPath && v.String() == orig {
+				return true
+			}
+		case v.IsArray():
+			hit := false
+			v.ForEach(func(sk, sub gjson.Result) bool {
+				subBase := blkBase + "." + f + "." + sk.String()
+				for _, sf := range [...]string{"text", "content"} {
+					sv := sub.Get(sf)
+					if sv.Type == gjson.String && subBase+"."+sf != exceptPath && sv.String() == orig {
+						hit = true
+						return false
+					}
+				}
+				return true
+			})
+			if hit {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/expand/repair.go
+++ b/expand/repair.go
@@ -220,19 +220,30 @@ func contentPresent(body []byte, orig, exceptPath string) bool {
 // unbounded recursion over attacker-influenced JSON is a cost this probe should not carry.
 func blockHasText(blk gjson.Result, blkBase, orig, exceptPath string) bool {
 	for _, f := range [...]string{"text", "content"} {
+		// THE EXCEPTION IS TESTED BEFORE THE VALUE, and that ordering is the whole of it.
+		//
+		// exceptPath names the FIELD being written (messages.N.content.M.content), so once this is
+		// the excepted field nothing inside it counts — including its array form, whose sub-blocks
+		// sit at …content.M.content.0.text and can therefore never equal exceptPath themselves.
+		// Testing the exception inside the string branch instead left the array spelling with no
+		// exception at all: a repaired block whose content is an array holding the original matched
+		// ITSELF, contentPresent said "present", and the repair wrote a pointer to the only copy
+		// there was. That is the round-1 self-match defect, one spelling over, reintroduced by the
+		// refactor that added the array support.
+		if blkBase+"."+f == exceptPath {
+			continue
+		}
 		v := blk.Get(f)
 		switch {
 		case v.Type == gjson.String:
-			if blkBase+"."+f != exceptPath && v.String() == orig {
+			if v.String() == orig {
 				return true
 			}
 		case v.IsArray():
 			hit := false
-			v.ForEach(func(sk, sub gjson.Result) bool {
-				subBase := blkBase + "." + f + "." + sk.String()
+			v.ForEach(func(_, sub gjson.Result) bool {
 				for _, sf := range [...]string{"text", "content"} {
-					sv := sub.Get(sf)
-					if sv.Type == gjson.String && subBase+"."+sf != exceptPath && sv.String() == orig {
+					if sv := sub.Get(sf); sv.Type == gjson.String && sv.String() == orig {
 						hit = true
 						return false
 					}

--- a/expand/repair_test.go
+++ b/expand/repair_test.go
@@ -238,3 +238,59 @@ func TestRepairIsIdempotentForAnArrayShapedToolResult(t *testing.T) {
 		t.Fatalf("repair is not idempotent for the array shape:\n first %s\n then  %s", first, second)
 	}
 }
+
+// THE EXCEPTED BLOCK MUST NOT MATCH ITSELF IN ITS ARRAY SPELLING EITHER.
+//
+// TestRepairIsIdempotentForAnArrayShapedToolResult asserts the contract for the array shape but
+// cannot reach this state: its array holds the client's ERROR, so pass 1 rewrites `content` to a
+// string and pass 2 takes the string branch, where the exception applied all along. The state that
+// breaks it is an excepted block whose array holds the ORIGINAL — constructed directly here, which
+// is what exceptPath exists for.
+//
+// With the exception tested only inside the string branch, this wrote a pointer while the excepted
+// block was the only copy of the content: the model is left pointing at something that is no longer
+// there, which is the round-1 defect one spelling over.
+func TestRepairDoesNotPointAtTheBlockItIsWriting(t *testing.T) {
+	const orig = "the original tool output that came back"
+	// The answer block's content is an ARRAY holding the original, and it is the ONLY copy.
+	body := `{"model":"claude","messages":[` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1",` +
+		`"name":"context_guru_expand","input":{"id":"HASH"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[` +
+		`{"type":"text","text":"` + orig + `"}]}]}]}`
+
+	out, _ := expand.RepairToolResults("anthropic", []byte(body),
+		func(string) (string, bool) { return orig, true })
+
+	answer := gjson.GetBytes(out, "messages.1.content.0.content").String()
+	if strings.Contains(answer, "present in the transcript above") {
+		t.Fatalf("the repair wrote a pointer while the block it was writing held the only copy of "+
+			"the content — it matched itself through its array spelling, so the model now points at "+
+			"content that is gone:\n%s", string(out))
+	}
+	if answer != orig {
+		t.Fatalf("the excepted block should keep the content when there is no other copy, got %q", answer)
+	}
+}
+
+// The control for the fix, so hoisting the exception cannot have disabled the array search that this
+// change exists to add: a DIFFERENT block holding the original in array form must still be found.
+func TestRepairStillFindsAnArrayCopyOutsideTheExceptedBlock(t *testing.T) {
+	const orig = "the original tool output that came back"
+	body := `{"model":"claude","messages":[` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"t0","content":[` +
+		`{"type":"text","text":"` + orig + `"}]}]},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1",` +
+		`"name":"context_guru_expand","input":{"id":"HASH"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1",` +
+		`"content":"Error: No such tool available","is_error":true}]}]}`
+
+	out, _ := expand.RepairToolResults("anthropic", []byte(body),
+		func(string) (string, bool) { return orig, true })
+
+	answer := gjson.GetBytes(out, "messages.2.content.0.content").String()
+	if !strings.Contains(answer, "present in the transcript above") {
+		t.Fatalf("the array copy at messages.0 was not found, so the duplication is back for this "+
+			"wire shape: %q", answer)
+	}
+}

--- a/expand/repair_test.go
+++ b/expand/repair_test.go
@@ -177,3 +177,64 @@ func TestRepairNeverMatchesAnIDLessBlock(t *testing.T) {
 		}
 	}
 }
+
+// A tool_result's `content` may be an ARRAY of sub-blocks, not only a string — Anthropic's
+// multi-part shape, e.g. text beside an image. contentPresent compared only the string spelling, so
+// for that shape it reported the original absent and the repair fell back to writing the content,
+// reintroducing the duplication this change exists to remove.
+//
+// It failed SAFE — content is never lost and a pointer is never written to nothing — which is why it
+// was minor. But it is live rather than theoretical: apply/apply_test.go fixtures the pipeline
+// compacting text inside exactly this shape, at messages.1.content.0.content.0.text, so the
+// marker-creating half was covered while the repair half could not see it.
+func TestRepairPointsAtContentInsideAnArrayShapedToolResult(t *testing.T) {
+	const orig = "the original tool output that came back"
+	// messages[1] holds the original in the ARRAY spelling; messages[3] is the expand round-trip
+	// whose tool_result the repair rewrites.
+	body := `{"model":"claude","messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"t0","content":[` +
+		`{"type":"text","text":"` + orig + `"},` +
+		`{"type":"image","source":{"data":"AAAA"}}]}]},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1",` +
+		`"name":"context_guru_expand","input":{"id":"HASH"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1",` +
+		`"content":"Error: No such tool available","is_error":true}]}]` + `}`
+
+	out, restored := expand.RepairToolResults("anthropic", []byte(body),
+		func(string) (string, bool) { return orig, true })
+	if len(restored) != 1 {
+		t.Fatalf("restored %d originals, want 1: the fixture is not exercising the repair", len(restored))
+	}
+	answer := gjson.GetBytes(out, "messages.3.content.0.content").String()
+	if answer == orig {
+		t.Fatalf("the repair wrote a SECOND copy of the content, because contentPresent could not "+
+			"see the array-shaped tool_result at messages.1 — the duplication is back for this "+
+			"wire shape:\n%s", answer)
+	}
+	if !strings.Contains(answer, "present in the transcript above") {
+		t.Fatalf("the repaired tool_result carries neither the content nor a pointer: %q", answer)
+	}
+	// And the copy it points at must still be there, unchanged.
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.0.text").String(); got != orig {
+		t.Fatalf("the in-place copy was altered: %q", got)
+	}
+}
+
+// The array recursion must not make a block match ITSELF once repaired, or the repair stops being
+// idempotent — the same defect exceptPath was added for, one nesting level down.
+func TestRepairIsIdempotentForAnArrayShapedToolResult(t *testing.T) {
+	const orig = "the original tool output that came back"
+	body := `{"model":"claude","messages":[` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1",` +
+		`"name":"context_guru_expand","input":{"id":"HASH"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[` +
+		`{"type":"text","text":"Error: No such tool available"}]}]}]}`
+
+	resolve := func(string) (string, bool) { return orig, true }
+	first, _ := expand.RepairToolResults("anthropic", []byte(body), resolve)
+	second, _ := expand.RepairToolResults("anthropic", first, resolve)
+	if string(first) != string(second) {
+		t.Fatalf("repair is not idempotent for the array shape:\n first %s\n then  %s", first, second)
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -814,16 +814,6 @@ type Snapshot struct {
 	StashCapacity   int   `json:"stash_capacity"`
 	StashBytes      int64 `json:"stash_bytes"`
 	StashMaxBytes   int64 `json:"stash_max_bytes"`
-	// CompactionResets counts turns whose cached-prefix boundary restarted because the
-	// AGENT compacted its own transcript (it shrank under a stable session id). The
-	// session id deliberately survives that compaction so one conversation is one
-	// session in the dashboard — which means the boundary is the only thing left that can
-	// notice, and if it does not, every message of every later turn is treated as already
-	// cached and no component can act for the rest of the session. So this is the counter
-	// that says "these sessions restarted their prefix N times"; a long run with real
-	// auto-compaction should be non-zero, and a run where it stays 0 while savings fall
-	// off a cliff mid-session is the regression it exists to expose. Filled by the host at
-	// serve time (the counter lives in `modes`, which metrics cannot import).
 	// ExpandPrefixFlips counts turns where an ESTABLISHED compaction was abandoned because the
 	// agent had expanded that content: a frozen decision existed, so the provider holds the
 	// compacted bytes, and the turn sends the original in full at the same position. That is a
@@ -840,7 +830,17 @@ type Snapshot struct {
 	// "expansion is churning cached prefixes here", not as a count of cache-writes. Filled by the
 	// host at serve time (the counter lives in components/offload).
 	ExpandPrefixFlips int64 `json:"expand_prefix_flips"`
-	CompactionResets  int64 `json:"compaction_resets"`
+	// CompactionResets counts turns whose cached-prefix boundary restarted because the
+	// AGENT compacted its own transcript (it shrank under a stable session id). The
+	// session id deliberately survives that compaction so one conversation is one
+	// session in the dashboard — which means the boundary is the only thing left that can
+	// notice, and if it does not, every message of every later turn is treated as already
+	// cached and no component can act for the rest of the session. So this is the counter
+	// that says "these sessions restarted their prefix N times"; a long run with real
+	// auto-compaction should be non-zero, and a run where it stays 0 while savings fall
+	// off a cliff mid-session is the regression it exists to expose. Filled by the host at
+	// serve time (the counter lives in `modes`, which metrics cannot import).
+	CompactionResets int64 `json:"compaction_resets"`
 	// cmdfilter attribution: which command FAMILIES pay off (builds/tests/iac/pkg/net),
 	// which individual filters fire, and which output shapes matched no filter (the
 	// backlog of filters worth writing). Additive fields — nothing above is renamed.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -829,6 +829,15 @@ type Snapshot struct {
 	// and re-observes the same abandonment, and only the FIRST is a real cache-write. Read it as
 	// "expansion is churning cached prefixes here", not as a count of cache-writes. Filled by the
 	// host at serve time (the counter lives in components/offload).
+	//
+	// IT COUNTS ONE EVENT, not every expand-induced cache-write: a REPLAY DECLINED because the
+	// content was expanded (components/offload.reapplyFrozen, its only increment site). At least one
+	// sibling is not counted — protecting expanded content shortens summarize's span, which can
+	// invalidate a checkpoint whose boundary reached past it, and re-summarizing produces different
+	// summary text at a fixed prefix position, i.e. another suffix cache-write. That is the correct
+	// trade (content loss for one cache-write) and the same class of event, but a second increment
+	// site would change what this number means, so it is deliberately left to its own decision. Do
+	// not read a zero here as "expansion cost nothing".
 	ExpandPrefixFlips int64 `json:"expand_prefix_flips"`
 	// CompactionResets counts turns whose cached-prefix boundary restarted because the
 	// AGENT compacted its own transcript (it shrank under a stable session id). The

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -824,7 +824,23 @@ type Snapshot struct {
 	// auto-compaction should be non-zero, and a run where it stays 0 while savings fall
 	// off a cliff mid-session is the regression it exists to expose. Filled by the host at
 	// serve time (the counter lives in `modes`, which metrics cannot import).
-	CompactionResets int64 `json:"compaction_resets"`
+	// ExpandPrefixFlips counts turns where an ESTABLISHED compaction was abandoned because the
+	// agent had expanded that content: a frozen decision existed, so the provider holds the
+	// compacted bytes, and the turn sends the original in full at the same position. That is a
+	// cache-write of the whole suffix at ~11.5x a read — the cost the cache-tail gate exists to
+	// avoid everywhere else — and until now no counter distinguished it from any other cache-write,
+	// so an operator could not see it and a benchmark could not attribute it (#201).
+	//
+	// It is a DELIBERATE cost, not a defect: re-compacting would bounce the agent into another
+	// expand, and one cache-write is cheaper than an unbounded loop. This makes the trade visible
+	// rather than assumed.
+	//
+	// Per turn per message, not per distinct content — every later turn re-sends the same original
+	// and re-observes the same abandonment, and only the FIRST is a real cache-write. Read it as
+	// "expansion is churning cached prefixes here", not as a count of cache-writes. Filled by the
+	// host at serve time (the counter lives in components/offload).
+	ExpandPrefixFlips int64 `json:"expand_prefix_flips"`
+	CompactionResets  int64 `json:"compaction_resets"`
 	// cmdfilter attribution: which command FAMILIES pay off (builds/tests/iac/pkg/net),
 	// which individual filters fire, and which output shapes matched no filter (the
 	// backlog of filters worth writing). Additive fields — nothing above is renamed.

--- a/proxy/expand_duplication_test.go
+++ b/proxy/expand_duplication_test.go
@@ -1,0 +1,159 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/context-guru/dash"
+)
+
+// THE REPAIR PATH SENT THE RECOVERED CONTENT UPSTREAM TWICE, ON EVERY TURN, FOREVER (#201).
+//
+// Two mechanisms, each individually right, composed into it: repairExpandErrors rewrites the
+// client's `No such tool available` tool_result with the original on every later turn (the client
+// keeps its own copy of the error), AND the same call marks that content kept-verbatim, so
+// skipReduce leaves the ORIGINAL message uncompacted at its own position. One copy in place, one in
+// the tool_result.
+//
+// The numbers this test pins, measured before the fix on a 200-line output through `codesafe`:
+//
+//	without the expand round-trip   252 bytes    1 copy (a marker + head peek)
+//	with it, every later turn     21,511 bytes   2 copies
+//
+// An ~85x blowup against the compacted form, permanently — far larger than the one-off prefix flip
+// #201 describes, which is what makes this a defect rather than a design preference.
+//
+// The control arm is not decoration: without it, "the content appears once" would also pass on a
+// pipeline that never compacted that message at all, and the whole finding would be unfounded.
+func TestTheRepairPathSendsRecoveredContentUpstreamOnce(t *testing.T) {
+	original := strings.Repeat("the original tool output line that had to come back\n", 200)
+	const probe = "the original tool output line that had to come back"
+	const perCopy = 200 // the probe appears once per line
+
+	var forwarded []string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		forwarded = append(forwarded, string(b))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer up.Close()
+
+	h, _ := dashHandler(t, up.URL, dash.Options{})
+	h.store.Put("HASH", []byte(original))
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	// The transcript a client produces after it answered our tool_use itself: the original output
+	// still at its own position, then the expand call, then the client's error answer.
+	body := `{"model":"gpt-x","messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"tool","tool_call_id":"call_0","content":` + jsonStr(original) + `},` +
+		`{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{` +
+		`"name":"context_guru_expand","arguments":"{\"id\":\"HASH\"}"}}]},` +
+		`{"role":"tool","tool_call_id":"call_1","content":"Error: No such tool available: context_guru_expand"}]}`
+
+	// Two turns: the first establishes the kept-verbatim mark, the second is the steady state every
+	// later turn repeats. Both must carry ONE copy.
+	for i := 0; i < 2; i++ {
+		resp, err := http.Post(srv.URL+"/openai/v1/chat/completions", "application/json",
+			strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	if len(forwarded) < 2 {
+		t.Fatalf("expected at least 2 upstream requests, got %d", len(forwarded))
+	}
+	for i, f := range forwarded {
+		if n := strings.Count(f, probe); n != perCopy {
+			t.Errorf("turn %d sent the content %.1f times (%d probe hits, %d bytes): the repaired "+
+				"tool_result is repeating content that is already in the transcript at its own "+
+				"position, on this and every later turn", i+1, float64(n)/perCopy, n, len(f))
+		}
+	}
+	// And the model must be TOLD where it is, or the repair has silently answered its tool call
+	// with nothing.
+	if !strings.Contains(forwarded[len(forwarded)-1], "present in the transcript above") {
+		t.Errorf("the repaired tool_result carries no pointer to the content:\n%s",
+			forwarded[len(forwarded)-1])
+	}
+
+	// THE CONTROL. Without the expand round-trip the same content compacts to a marker, which is
+	// what proves the message was a compaction candidate and the second copy above was real
+	// duplication rather than a message the pipeline was never going to touch.
+	forwarded = nil
+	plain := `{"model":"gpt-x","messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"tool","tool_call_id":"call_0","content":` + jsonStr(original) + `}]}`
+	h2, _ := dashHandler(t, up.URL, dash.Options{})
+	srv2 := httptest.NewServer(h2.Mux())
+	defer srv2.Close()
+	for i := 0; i < 2; i++ {
+		resp, err := http.Post(srv2.URL+"/openai/v1/chat/completions", "application/json",
+			strings.NewReader(plain))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	if n := strings.Count(forwarded[len(forwarded)-1], probe); n >= perCopy {
+		t.Fatalf("the control arm sent %d probe hits, so this content was never compacted and the "+
+			"duplication measured above is not attributable to the expand path", n)
+	}
+}
+
+// AND THE POINTER MUST NOT BE WRITTEN WHEN THERE IS NOTHING TO POINT AT.
+//
+// The agent's own compaction can drop the message the content came from while keeping the expand
+// round-trip. Then the tool_result is the model's ONLY copy, and replacing it with a note would lose
+// content the repair used to deliver. The presence check is what makes the note safe, so it has its
+// own test: same request WITHOUT the original message.
+func TestTheRepairStillCarriesTheContentWhenItIsNotInTheTranscript(t *testing.T) {
+	original := strings.Repeat("the original tool output line that had to come back\n", 200)
+	const probe = "the original tool output line that had to come back"
+
+	var forwarded []string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		forwarded = append(forwarded, string(b))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer up.Close()
+
+	h, _ := dashHandler(t, up.URL, dash.Options{})
+	h.store.Put("HASH", []byte(original))
+	srv := httptest.NewServer(h.Mux())
+	defer srv.Close()
+
+	// No message holding the original — only the expand call and the client's error.
+	body := `{"model":"gpt-x","messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{` +
+		`"name":"context_guru_expand","arguments":"{\"id\":\"HASH\"}"}}]},` +
+		`{"role":"tool","tool_call_id":"call_1","content":"Error: No such tool available: context_guru_expand"}]}`
+	resp, err := http.Post(srv.URL+"/openai/v1/chat/completions", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if len(forwarded) == 0 {
+		t.Fatal("no upstream request")
+	}
+	if !strings.Contains(forwarded[0], probe) {
+		t.Fatalf("the content is nowhere in the request: the repair replaced the model's only copy "+
+			"with a pointer to something that is not there:\n%s", forwarded[0])
+	}
+}
+
+// jsonStr quotes a string for embedding in a JSON literal.
+func jsonStr(s string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `"`, `\"`), "\n", `\n`) + `"`
+}

--- a/proxy/promexport.go
+++ b/proxy/promexport.go
@@ -542,6 +542,11 @@ func (h *Handler) renderMetrics() string {
 		promHeaderProc(&b, "cg_usage_unreadable_total",
 			"Responses whose examined bytes would not parse at all, so usage could not be sought — a spliced head+tail sniffer window, not an unrecognised dialect. Raise sniffMax or buffer the body; do NOT go looking for a missing field name.", "counter")
 		promLine(&b, "cg_usage_unreadable_total", "", float64(unreadableUsage))
+		// The one cache-write an operator can attribute to a cause (#201). Process-wide like the
+		// frozen hit/miss pair above and sourced from offload's own counter for the same reason.
+		promHeaderProc(&b, "cg_expand_prefix_flips_total",
+			"Turns where an established compaction was abandoned because the agent had expanded that content, so the original went upstream in full at its cached position: a suffix cache-write attributable to expansion. Deliberate (re-compacting would loop the agent into another expand) but not free. Per turn per message, not per distinct content - only the first is a real cache-write.", "counter")
+		promLine(&b, "cg_expand_prefix_flips_total", "", float64(offload.ExpandPrefixFlips()))
 		promHeaderProc(&b, "cg_stash_refused_total",
 			"Removals declined because the store's rewind reserve was full. The content was left verbatim and nothing became irreversible; raise max_entries or stash_max_bytes.", "counter")
 		promLine(&b, "cg_stash_refused_total", "", float64(offload.StashRefusals()))

--- a/proxy/promexport_coverage_test.go
+++ b/proxy/promexport_coverage_test.go
@@ -149,13 +149,18 @@ var notExportedWhy = map[string]string{
 	// silent: this change deliberately adds ONE family (cg_expand_unresolved_total, the
 	// alertable one) instead of growing the exposition by fourteen series inside a
 	// dashboard PR. Moving any entry out of this map is a small, self-contained change.
-	"LLMTruncated":          "NOT EXPORTED YET — full price, zero result; a real alert candidate",
-	"SummarizeTimeouts":     "NOT EXPORTED YET — summarize's fail-open path is invisible in Prometheus",
-	"SummarizeErrors":       "NOT EXPORTED YET — as above",
-	"AgentDietTimeouts":     "NOT EXPORTED YET — agentdiet's fail-open path, same gap",
-	"AgentDietErrors":       "NOT EXPORTED YET — as above",
-	"SyncEnforced":          "NOT EXPORTED YET — the machine-readable 'we did modify requests'",
-	"CompactionResets":      "NOT EXPORTED YET — agent self-compaction restarting the cached prefix",
+	"LLMTruncated":      "NOT EXPORTED YET — full price, zero result; a real alert candidate",
+	"SummarizeTimeouts": "NOT EXPORTED YET — summarize's fail-open path is invisible in Prometheus",
+	"SummarizeErrors":   "NOT EXPORTED YET — as above",
+	"AgentDietTimeouts": "NOT EXPORTED YET — agentdiet's fail-open path, same gap",
+	"AgentDietErrors":   "NOT EXPORTED YET — as above",
+	"SyncEnforced":      "NOT EXPORTED YET — the machine-readable 'we did modify requests'",
+	"CompactionResets":  "NOT EXPORTED YET — agent self-compaction restarting the cached prefix",
+	// Exported as cg_expand_prefix_flips_total, read from offload.ExpandPrefixFlips() rather than
+	// off `s` for the reason this map's preamble gives: the /stats handler fills the field AFTER
+	// renderMetrics takes its snapshot, so a promLine off `s` would export a permanent 0 while
+	// passing this test.
+	"ExpandPrefixFlips":     "cg_expand_prefix_flips_total, from offload.ExpandPrefixFlips()",
 	"UpstreamMsAvgBypassed": "NOT EXPORTED YET — the bypassed baseline half of cg_upstream_latency_ms",
 	"SSETTFBMsAvgBuf":       "NOT EXPORTED YET — buffered responses' time-to-last-byte",
 	"SSEExpandAfterStream":  "NOT EXPORTED YET — the SSE peek's price; alert candidate",

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1918,6 +1918,10 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 	// the description stopped working — which nothing else in this snapshot can reveal.
 	snap.AdjudicateStray = adjudicate.StrayAnswered()
 	snap.FrozenHits, snap.FrozenMisses = offload.FrozenStats()
+	// The expand-induced prefix flip, published beside the freeze-replay counters because it is the
+	// same mechanism seen from the other side: a replay that DIDN'T happen because the agent
+	// expanded content that was compacted before. See metrics.Snapshot.
+	snap.ExpandPrefixFlips = offload.ExpandPrefixFlips()
 	// Process-wide, like FrozenHits, and so filled outside the cast below: a removal declined
 	// for want of a stash slot is counted by the COMPONENT, whatever store instance refused it.
 	// Process-wide like the counters below: the parser is package-level, so whatever tenant's

--- a/proxy/stats_golden_test.go
+++ b/proxy/stats_golden_test.go
@@ -39,6 +39,7 @@ var statsGoldenTopLevel = []string{
 	"cg_added_ms_avg",
 	"compaction_resets",
 	"components",
+	"expand_prefix_flips",
 	"expand_unresolved_malformed",
 	// The alertable half of reversibility: a marker id this proxy could have minted that resolved
 	// to nothing, i.e. a cut advertised as reversible that was not. Added to the reviewed contract

--- a/store/peek_test.go
+++ b/store/peek_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// A DIAGNOSTIC MUST NOT RENEW WHAT IT ASKS ABOUT.
+//
+// Get slides the TTL and reorders the LRU, which is right for a caller about to use the value and
+// wrong for one that only wants a fact. It matters most for the PINNED namespaces: pinned entries
+// count against the shared exempt budget that gates rewind-reserve admission, so a probe that keeps
+// a pin alive forever applies back-pressure to the reserve — a resource decision made by accident.
+func TestPeekDoesNotRenewTheEntryItAsksAbout(t *testing.T) {
+	now := time.Unix(0, 0)
+	m := NewMemory(Options{TTLSeconds: 100})
+	m.SetClock(func() time.Time { return now })
+	key := FrozenPrefix + "s:mask:abc"
+	m.Put(key, []byte("the compacted bytes"))
+
+	// Ten probes, 60s apart: well past the 100s TTL in total, never more than 60s between probes.
+	for i := 0; i < 10; i++ {
+		now = now.Add(60 * time.Second)
+		m.Peek(key)
+	}
+	if m.Peek(key) {
+		t.Fatal("the entry survived 600s of a 100s TTL because the probe kept sliding it: a " +
+			"read-only question is renewing a pinned entry, which is back-pressure on the reserve")
+	}
+	// And the control: Get is still expected to slide, because its caller is about to use the value.
+	now = time.Unix(0, 0)
+	m2 := NewMemory(Options{TTLSeconds: 100})
+	m2.SetClock(func() time.Time { return now })
+	m2.Put(key, []byte("x"))
+	for i := 0; i < 10; i++ {
+		now = now.Add(60 * time.Second)
+		m2.Get(key)
+	}
+	if _, ok := m2.Get(key); !ok {
+		t.Fatal("Get stopped sliding the TTL; that is the sliding-TTL guarantee, not a side effect")
+	}
+}
+
+// Peek answers the question Get answers, minus the side effects — including for an expired entry,
+// which it must report absent without removing (removal would mutate stash accounting from a probe).
+func TestPeekAgreesWithGetOnPresence(t *testing.T) {
+	now := time.Unix(0, 0)
+	m := NewMemory(Options{TTLSeconds: 100})
+	m.SetClock(func() time.Time { return now })
+	if m.Peek("nothing") {
+		t.Error("Peek claims an absent key is live")
+	}
+	m.Put("k", []byte("v"))
+	if !m.Peek("k") {
+		t.Error("Peek claims a live key is absent")
+	}
+	now = now.Add(101 * time.Second)
+	if m.Peek("k") {
+		t.Error("Peek claims an expired key is live")
+	}
+	if _, still := m.items["k"]; !still {
+		t.Error("Peek REMOVED an expired entry; a probe must not mutate the store's accounting")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -92,6 +92,37 @@ func StashRoom(s Store, size int) bool {
 	return true
 }
 
+// Peeker is an OPTIONAL Store capability: asking whether a key is live WITHOUT touching it.
+//
+// It exists because Get is not a read-only operation on this store. Get slides the TTL and moves
+// the entry to the front of the LRU, which is right for a caller that is about to USE the value and
+// wrong for one that only wants to know a fact about it. A DIAGNOSTIC that renews an entry's
+// lifetime is making a resource decision by accident — and for the pinned namespaces it is not even
+// a cheap one: pinned entries count against the shared exempt budget (exemptRoom), so a pin that no
+// longer expires is pressure on the rewind reserve.
+//
+// The case that motivated it: components/offload.reapplyFrozen asks whether a frozen decision
+// exists purely to decide whether abandoning it costs a cache-write (see ExpandPrefixFlips). It has
+// already decided NOT to replay that decision, so renewing it is the opposite of what the answer
+// means.
+type Peeker interface {
+	// Peek reports whether key is present and unexpired, without sliding the TTL or reordering
+	// the LRU. It never resurrects an expired entry, and never removes one either — expiry is
+	// still enforced where it always was.
+	Peek(key string) bool
+}
+
+// Peek reports whether key is live, without touching it. A store without the capability falls back
+// to Get, which is the answer the caller wanted at the cost of the side effects it wanted to avoid —
+// the same direction every other optional capability degrades in.
+func Peek(s Store, key string) bool {
+	if pk, ok := s.(Peeker); ok {
+		return pk.Peek(key)
+	}
+	_, ok := s.Get(key)
+	return ok
+}
+
 // FrozenLoser is an OPTIONAL Store capability: reporting that a frozen decision
 // under key was dropped (TTL expiry / pin cap) rather than never taken. A bare Get
 // miss cannot tell those apart, and they call for opposite behavior — "never frozen"
@@ -909,6 +940,21 @@ func (m *Memory) FrozenLossStats() (dropped, repaired int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.lostN, m.repairedN
+}
+
+// Peek reports whether key is live without sliding its TTL or reordering the LRU. See Peeker.
+//
+// It deliberately does NOT remove an entry it finds expired, unlike Get. Removing would make a
+// read-only probe mutate the store's accounting — including stash_expired and the reserve's byte
+// total — from a caller that only asked a question. The sweep reclaims it at the normal time.
+func (m *Memory) Peek(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	el, ok := m.items[key]
+	if !ok {
+		return false
+	}
+	return !m.now().After(el.Value.(*entry).expires)
 }
 
 func (m *Memory) Get(key string) ([]byte, bool) {


### PR DESCRIPTION
Closes #201. Independent of #204 and #205 — all three branch from `main`.

Does the whole issue: document the cross-turn behaviour, count the flip, and fix the duplication. One measurement changes what the third one is *for*.

## The repair path sent the recovered content upstream twice, on every turn, forever

Not in the issue. Two mechanisms, each individually right, compose into it: `repairExpandErrors` rewrites the client's `No such tool available` tool_result with the original on every later turn (the client keeps its own copy of the error), **and** the same call marks that content kept-verbatim, so `skipReduce` also leaves the original message uncompacted at its own position. One copy in place, one in the tool_result.

Measured, both arms, `codesafe`, one 200-line tool output:

| | upstream bytes | copies |
|---|---|---|
| without the expand round-trip | **252** | 1 (marker + head peek) |
| with it, every later turn | **21,511** | **2** (400 probe hits) |

An **~85x** blowup against the compacted form, permanently — far larger than the one-off prefix flip the issue describes, which is what makes bullet 3 a fix for a live defect rather than a design preference. The control arm is load-bearing: without it, "the content appears once" would also pass on a pipeline that never compacted that message.

**The fix is a pointer, not a deletion.** The issue proposed deleting our tool_use/tool_result pair. Deleting messages shrinks the message count, and `modes.Boundary` reads `n < prev` as `compactionResets.Add(1)` with boundary 0 — so our own deletion would be attributed to *the agent* compacting its transcript. That is the counter-conflation defect again, inside the fix for it. A pointer keeps the message count unchanged: no boundary disturbed, no index shifting, no message left with an empty content array.

**The pointer is written only when the content really is there.** The agent's own compaction can drop the message the content came from while keeping the round-trip, and then the tool_result is the model's *only* copy. `contentPresent` checks by exact comparison against the values gjson decodes, not a substring scan of the raw body — JSON escaping makes a raw scan both false-negative and false-positive. It excludes the block being written, which the **existing idempotency test caught me on**: on a second pass the repaired block held the original, matched itself, and the repair replaced the content with a note pointing at what it had just removed.

## The split bullet 2 asks for already existed, at 3 of 11 sites

`kept_verbatim_after_expand` was raised by `extract_sweep`, `extract_llm` and `failed_run`; eight others raised the conflated `marker_or_kept_verbatim` for the same condition, which also covers the benign "already carries a marker". Gates reach `/stats` per component, so that was a **published** counter reporting two causes with opposite readings — and a published experimental figure was corrected twice off it before anyone noticed the label was the problem. Fourth instance of the #200 rule.

`skipReduce` now returns *which* reason, as two named constants, and all eleven sites raise it. `marker_or_kept_verbatim` is retired, with the three component docs, two offload tests and one dash fixture updated. `smartcrush` raised no gate at all here, so its share of both reasons was invisible even in the conflated form.

`dedup`, `extract` and `linecap` have **no `reapplyFrozen` path**, so `skipReduce` is the only place they can report an expansion — this gives those three a clean signal for the first time, and that is where most of the previously invisible share sits. (Same four the reviewer independently flagged on #204.)

## The flip is counted, and only when there is one

`reapplyFrozen` declined on kept-verbatim *before* looking up the frozen decision, so it could not tell an established compaction being abandoned — a suffix cache-write at ~11.5× a read — from content that was never compacted, where nothing flips. It now consults the decision inside that branch only: one extra `Get` on content the agent actually expanded, not on the hot path.

`expand_prefix_flips` at `/stats`, `cg_expand_prefix_flips_total` at `/metrics`. Documented as **per turn per message**, not per distinct content: every later turn re-observes the same abandonment while only the first is a real cache-write. It is a deliberate cost — re-compacting would bounce the agent into another expand — so counting it makes the trade visible instead of assumed.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` all packages pass, `go test -race` clean over `components/offload`, `expand`, `proxy`, `metrics` (Go 1.26.4, eval box).

Four new tests, each revert-verified. The two that could pass for the wrong reason were checked in **both** directions:

| Mutation | Failure |
|---|---|
| conflate the two gates again | `want gate already_marked, got map[kept_verbatim_after_expand:1]` |
| never count the flip | `counted 0 flips, want 1` |
| count **every** kept-verbatim skip as a flip | `counted 1 flips for content that was never compacted: the counter is measuring expansions, not cache-writes` |
| always write the content | `turn 1 sent the content 2.0 times (400 probe hits, 21511 bytes)` + `carries no pointer` |
| assume presence instead of checking it | `the content is nowhere in the request: the repair replaced the model's only copy with a pointer to something that is not there` |

Two contract tests updated as designed: `TestStatsShapeIsUnchanged` and `TestEverySnapshotFieldIsExportedOrExempt` — the latter in `notExportedWhy` because the series is sourced from offload's counter rather than off `s`, since a `promLine` off `s` would export a permanent 0 while passing the test (the silent-zero shape #205 is about).

## Not in this change

**The in-place replacement of a marker by its content.** The duplication it would have fixed is fixed above at a fraction of the risk. What remains of it — deleting the dead round-trip from the transcript — needs the boundary threading described above for roughly fifty bytes a turn. The gating signals it would use (`ColdCache` / `TailOnlyCold` / `compaction_resets`) all ship, so deferring it loses no ground.
