### PR TITLE
fix(sweep): stop crediting declined turns, see the prefix bust, and name the fallback failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,10 @@ site/
 # Personal/local operator notes — deployment-host facts, not repo documentation.
 # Never pushed.
 CLAUDE.local.md
+
+# SQLite databases. The proxy writes its dashboard and control DBs with default
+# names in whatever directory it is started from, so a proxy run inside a checkout
+# leaves production-shaped tenant data in the working tree, untracked but committable.
+*.db
+*.db-wal
+*.db-shm

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -882,7 +882,16 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 		}
 		if e.blockFallback {
 			r.gate("sweep_fallback_blocked")
-			r.rec.Rejection = "the prefix ask read nothing from cache and block_fallback is set; " +
+			// SAY WHICH FAILURE THIS WAS. The condition above now admits a partial hit that WROTE,
+			// and on such a call "read nothing from cache" is simply false -- CacheRead can be 39,805.
+			// This string is persisted to extraction_calls.rejection, which is the column the whole
+			// rejection taxonomy is built from and which has already been mis-analysed twice, so a
+			// wrong reason here becomes a wrong finding later.
+			why := "read nothing from cache"
+			if usage.CacheWrite > 0 {
+				why = "re-created the agent's prefix instead of reading it"
+			}
+			r.rec.Rejection = "the prefix ask " + why + " and block_fallback is set; " +
 				"declining rather than paying again for a full-price transcript read"
 			return nil, r
 		}

--- a/components/offload/extract_sweep.go
+++ b/components/offload/extract_sweep.go
@@ -271,6 +271,18 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 	var cands []sweepCand
 	var keys []string
 	changed := 0
+	// Skipped is a property of the OUTCOME, not of one exit, and this function has two: the
+	// inventory floor below returns early, and every turn outside the pre-expiry window reaches
+	// it with no candidates at all. Setting it only on the tail return made 29,321 of 29,372
+	// production rows report `mutated=1` for a component that had DECLINED -- because
+	// dash/event.go computes Mutated as !Reverted && !Skipped, and GateN is a no-op at n<=0, so
+	// those turns recorded neither a gate nor a skip. A deferred guard covers both exits and any
+	// future one; the alternative, a copy of the check at each return, is what went wrong here.
+	defer func() {
+		if changed == 0 {
+			rep.Skipped = true
+		}
+	}()
 	// eligible counts candidates that cleared every gate this component knows about. Compared with the
 	// inventory's size below, to catch a pre-filter that thinned it -- see the comment at the append
 	// site for why that is the failure worth a tripwire.
@@ -553,9 +565,6 @@ func (e *ExtractSweep) Offload(req *bschemas.BifrostChatRequest, rep *components
 		}
 	}
 
-	if changed == 0 {
-		rep.Skipped = true
-	}
 	return keys, nil
 }
 
@@ -856,8 +865,21 @@ func (e *ExtractSweep) adjudicate(req *bschemas.BifrostChatRequest, c *component
 	//
 	// Note what neither mode can do: prevent the fresh read that already happened on THIS call. The
 	// counter is what tells an operator the window is mistimed.
-	if !fellBack && usage.CacheRead == 0 {
-		r.gate("sweep_prefix_cache_read_ZERO")
+	//
+	// A WRITE trips it as surely as a zero read, and testing the read alone let the harm through.
+	// Production: three asks re-created the agent's prefix for 704,925 opus cache_write tokens,
+	// $3.42 and 73% of this component's entire spend -- and two of them had read 39,805 tokens of
+	// a stable sub-prefix, so `CacheRead == 0` was false and the counter stayed silent on $2.26 of
+	// it. A partial hit is not evidence of safety: the write is the harm, at 1.25x fresh on the
+	// AGENT's model rather than a tenth of it, and it is exactly what extract_econ.go cited when
+	// it rejected prefix reuse.
+	if !fellBack && (usage.CacheRead == 0 || usage.CacheWrite > 0) {
+		if usage.CacheWrite > 0 {
+			r.gate("sweep_prefix_cache_write")
+		}
+		if usage.CacheRead == 0 {
+			r.gate("sweep_prefix_cache_read_ZERO")
+		}
 		if e.blockFallback {
 			r.gate("sweep_fallback_blocked")
 			r.rec.Rejection = "the prefix ask read nothing from cache and block_fallback is set; " +

--- a/components/offload/extract_sweep_test.go
+++ b/components/offload/extract_sweep_test.go
@@ -23,7 +23,11 @@ import (
 type fakeAsker struct {
 	reply     string
 	cacheRead int
-	err       error
+	// cacheWrite is what the provider says it WROTE for this ask. Non-zero means the agent's own
+	// prefix was re-created at the agent model's write rate, which is the harm the component's
+	// counters exist to catch -- see TestSweepPrefixWriteTripsTheCounterEvenOnAPartialHit.
+	cacheWrite int
+	err        error
 	// viaTool reports the reply as having arrived through the proxy's structured-answer tool rather
 	// than as text, which is the one thing about a reply the parser CANNOT infer: it reads a
 	// tool_use input and a JSON array in prose identically.
@@ -40,8 +44,8 @@ func (f *fakeAsker) Ask(_ context.Context, session, ask string) (string, compone
 	if f.err != nil {
 		return "", components.PrefixUsage{}, f.err
 	}
-	return f.reply, components.PrefixUsage{CacheRead: f.cacheRead, Fresh: 40, Output: 90,
-		ViaTool: f.viaTool}, nil
+	return f.reply, components.PrefixUsage{CacheRead: f.cacheRead, CacheWrite: f.cacheWrite,
+		Fresh: 40, Output: 90, ViaTool: f.viaTool}, nil
 }
 
 func (f *fakeAsker) ask() string  { s, _ := f.lastAsk.Load().(string); return s }
@@ -912,5 +916,77 @@ func TestSweepDoesNotAttributeAReplyShapeToTheFallback(t *testing.T) {
 	if rep.Events["sweep_answered_via_tool"] != 0 || rep.Events["sweep_answered_via_prose"] != 0 {
 		t.Errorf("the fallback was attributed a reply shape it could not have had (events: %v)",
 			rep.Events)
+	}
+}
+
+// A component that DECLINED must not report itself as having mutated the request, and the inventory
+// floor is a decline. It returns early, so the tail's `changed == 0` check never saw it: 29,321 of
+// 29,372 production rows read `mutated=1, acted=0, skipped=0`, which dash/event.go's
+// `Mutated = !Reverted && !Skipped` makes impossible for a component that actually skipped. Both
+// exits are asserted, because the two reach the floor with different candidate counts and only one
+// of them records a gate at all (GateN is a no-op at n<=0).
+func TestSweepDeclinedAtInventoryFloorReportsSkipped(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		idleMs   int64
+		wantGate string
+	}{
+		// In the window, but sweepReq offers 2 candidates against the default floor of 10.
+		{"in the window, below the inventory floor", 4 * 60 * 1000, "sweep_inventory_below_min"},
+		// Outside it, phase 1 collects nothing, so BOTH counters are suppressed at zero and the
+		// only record of the turn is the window gate.
+		{"outside the window, no candidates at all", 30 * 1000, "not_in_pre_expiry_window"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			asker := &labelAsker{verdict: "drop", needed: "none"}
+			asker.cacheRead = 19595
+			e := newSweep(t, "") // defaultMinInventory, NOT newSweepSmall's floor of 1
+			req := sweepReq()
+			c := preExpiryCtx("s", asker, store.NewMemory(store.Options{}))
+			c.IdleMs = tc.idleMs
+			rep := &components.Report{}
+			if _, err := e.Offload(req, rep, c); err != nil {
+				t.Fatalf("Offload must fail open: %v", err)
+			}
+			if n := atomic.LoadInt64(&asker.calls); n != 0 {
+				t.Fatalf("a declining turn made %d asks", n)
+			}
+			if !rep.Skipped {
+				t.Errorf("a component that declined reports Skipped=false, so dash reads mutated=1 "+
+					"for a turn that changed nothing (gates: %v)", rep.Gates)
+			}
+			if rep.Gates[tc.wantGate] == 0 {
+				t.Errorf("no %s gate recorded (gates: %v)", tc.wantGate, rep.Gates)
+			}
+		})
+	}
+}
+
+// The prefix ask's whole justification is that it READS the agent's cached prefix. When the entry has
+// gone it WRITES it instead, at 1.25x fresh on the agent's own model -- 704,925 opus tokens and $3.42
+// across three production calls, 73% of this component's entire spend. Testing `CacheRead == 0` alone
+// missed two of those three: they read 39,805 tokens of a stable sub-prefix and wrote a quarter of a
+// million, so the counter stayed silent on $2.26 of the harm. A partial hit is not evidence of safety.
+func TestSweepPrefixWriteTripsTheCounterEvenOnAPartialHit(t *testing.T) {
+	asker := &labelAsker{verdict: "keep", needed: "none"}
+	asker.cacheRead = 39805 // a real partial hit, so CacheRead == 0 is FALSE
+	asker.cacheWrite = 260604
+	e := newSweepSmall(t, "")
+	rep := &components.Report{}
+	if _, err := e.Offload(sweepReq(), rep,
+		preExpiryCtx("s", asker, store.NewMemory(store.Options{}))); err != nil {
+		t.Fatal(err)
+	}
+	if n := atomic.LoadInt64(&asker.calls); n != 1 {
+		t.Fatalf("expected ONE ask, got %d (gates: %v)", n, rep.Gates)
+	}
+	if rep.Gates["sweep_prefix_cache_write"] == 0 {
+		t.Errorf("an ask that re-created the agent's prefix for %d tokens recorded nothing "+
+			"(gates: %v)", asker.cacheWrite, rep.Gates)
+	}
+	// And the pre-existing zero-read counter must NOT fire, because the read did happen. The two
+	// name different failures and collapsing them would lose the distinction the fix is for.
+	if rep.Gates["sweep_prefix_cache_read_ZERO"] != 0 {
+		t.Errorf("a partial HIT was counted as a zero read (gates: %v)", rep.Gates)
 	}
 }

--- a/components/offload/extract_sweep_test.go
+++ b/components/offload/extract_sweep_test.go
@@ -990,3 +990,48 @@ func TestSweepPrefixWriteTripsTheCounterEvenOnAPartialHit(t *testing.T) {
 		t.Errorf("a partial HIT was counted as a zero read (gates: %v)", rep.Gates)
 	}
 }
+
+// block_fallback now declines on a partial hit that WROTE, not only on a zero read, so the two cases
+// must stay distinguishable. The counters are what a reader actually gets: on this path the call row
+// is DROPPED (foldFallback returns early because the fallback deliberately never ran, so
+// rec.Component stays "" and Offload's `call.rec.Component != ""` guard discards it), which means the
+// Rejection string built alongside is unreachable today. That is a pre-existing hole of the same class
+// the comment at foldFallback documents for the no-asker path -- recorded here rather than fixed,
+// because adding a row where none existed is a behaviour change this evidence does not cover.
+func TestBlockFallbackDistinguishesAZeroReadFromAWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		read, write int
+		wantGate    string
+		notGate     string
+	}{
+		{"zero read", 0, 0, "sweep_prefix_cache_read_ZERO", "sweep_prefix_cache_write"},
+		{"partial hit that wrote", 39805, 260604, "sweep_prefix_cache_write", "sweep_prefix_cache_read_ZERO"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			asker := &labelAsker{verdict: "drop", needed: "none"}
+			asker.cacheRead, asker.cacheWrite = tc.read, tc.write
+			e := newSweepSmall(t, "block_fallback: true\n")
+			req := sweepReq()
+			original := schema.MessageText(req.Input[1])
+			rep := &components.Report{}
+			if _, err := e.Offload(req, rep,
+				preExpiryCtx("s", asker, store.NewMemory(store.Options{}))); err != nil {
+				t.Fatal(err)
+			}
+			if rep.Gates["sweep_fallback_blocked"] != 1 {
+				t.Fatalf("block_fallback did not decline (gates: %v)", rep.Gates)
+			}
+			if rep.Gates[tc.wantGate] == 0 {
+				t.Errorf("did not record %s (gates: %v)", tc.wantGate, rep.Gates)
+			}
+			if rep.Gates[tc.notGate] != 0 {
+				t.Errorf("recorded %s for the wrong failure (gates: %v)", tc.notGate, rep.Gates)
+			}
+			// And declining must leave the transcript alone, which is the point of the switch.
+			if schema.MessageText(req.Input[1]) != original {
+				t.Error("a declined ask modified a message")
+			}
+		})
+	}
+}

--- a/components/offload/extract_sweep_test.go
+++ b/components/offload/extract_sweep_test.go
@@ -992,12 +992,13 @@ func TestSweepPrefixWriteTripsTheCounterEvenOnAPartialHit(t *testing.T) {
 }
 
 // block_fallback now declines on a partial hit that WROTE, not only on a zero read, so the two cases
-// must stay distinguishable. The counters are what a reader actually gets: on this path the call row
-// is DROPPED (foldFallback returns early because the fallback deliberately never ran, so
-// rec.Component stays "" and Offload's `call.rec.Component != ""` guard discards it), which means the
-// Rejection string built alongside is unreachable today. That is a pre-existing hole of the same class
-// the comment at foldFallback documents for the no-asker path -- recorded here rather than fixed,
-// because adding a row where none existed is a behaviour change this evidence does not cover.
+// must stay distinguishable. This asserts the counters, which is one of two things a reader sees: see
+// TestBlockFallbackDecliningAWritePublishesTheCorrectRejection for the other, the Rejection string
+// itself. (549714c claimed the call row is dropped here because rec.Component stays "" -- that is only
+// true of THIS test's own `rep := &components.Report{}`. In production, pipeline.go sets
+// rep.Component = comp.Name() before Offload ever runs, and the assignment at extract_sweep.go's
+// `r.rec = components.ModelCall{Component: rep.Component, ...}` happens before this decline branch, so
+// the row survives and the Rejection string is published. See the other test for the fix.)
 func TestBlockFallbackDistinguishesAZeroReadFromAWrite(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
@@ -1033,5 +1034,35 @@ func TestBlockFallbackDistinguishesAZeroReadFromAWrite(t *testing.T) {
 				t.Error("a declined ask modified a message")
 			}
 		})
+	}
+}
+
+// The Rejection string 549714c added is published, not dropped: rep.Component is never "" in
+// production, because pipeline.go's runOne sets it (`Report{Component: comp.Name(), ...}`) before
+// calling Offload, and `r.rec = components.ModelCall{Component: rep.Component, ...}` fills rec.Component
+// from it well before this decline branch runs. So the row clears the `call.rec.Component != ""` guard
+// and lands in rep.Calls with the branched reason -- the field an operator actually reads on
+// extraction_calls.rejection, which this PR itself calls out as already mis-analysed twice.
+func TestBlockFallbackDecliningAWritePublishesTheCorrectRejection(t *testing.T) {
+	asker := &labelAsker{verdict: "drop", needed: "none"}
+	asker.cacheRead, asker.cacheWrite = 39805, 260604
+	e := newSweepSmall(t, "block_fallback: true\n")
+	// rep.Component set exactly as pipeline.go's runOne sets it, ahead of calling Offload.
+	rep := &components.Report{Component: "extract_llm_sweep"}
+	if _, err := e.Offload(sweepReq(), rep,
+		preExpiryCtx("s", asker, store.NewMemory(store.Options{}))); err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Calls) != 1 {
+		t.Fatalf("expected the declined call to be published, got %d rows", len(rep.Calls))
+	}
+	call := rep.Calls[0]
+	if call.Component == "" {
+		t.Fatal("published row has no Component, so it never clears the caller's guard")
+	}
+	const want = "the prefix ask re-created the agent's prefix instead of reading it and " +
+		"block_fallback is set; declining rather than paying again for a full-price transcript read"
+	if call.Rejection != want {
+		t.Errorf("Rejection = %q, want %q", call.Rejection, want)
 	}
 }

--- a/components/pipeline.go
+++ b/components/pipeline.go
@@ -102,6 +102,12 @@ func (p *Pipeline) runOne(comp Component, req *schemas.BifrostChatRequest, c *Ct
 			// Fail open: revert and record. A component panic never breaks the request.
 			revert()
 			rep.Reverted = true
+			// A component's own deferred Skipped-guard (see extract_sweep.go) can already have run
+			// during this same panic unwind, since Go runs defers on the way out. Clear it here so
+			// Reverted and Skipped never both end up true on one Report -- a half-state that did not
+			// exist before per-component defers started setting Skipped, and that a raw `skipped`
+			// column reader would otherwise have to know to exclude Reverted to read correctly.
+			rep.Skipped = false
 			rep.TokensBefore = baseline
 			rep.TokensAfter = baseline
 			rep.Err = fmt.Errorf("panic: %v", r)

--- a/components/pipeline_test.go
+++ b/components/pipeline_test.go
@@ -37,6 +37,17 @@ func (boom) Name() string                                              { return 
 func (boom) Enabled(*Ctx) bool                                         { return true }
 func (boom) Reformat(*schemas.BifrostChatRequest, *Report, *Ctx) error { panic("kaboom") }
 
+// boomAfterSkipped mimics a component whose own deferred Skipped-guard (the pattern
+// extract_sweep.go uses) runs during panic unwind before runOne's recover sees the Report.
+type boomAfterSkipped struct{}
+
+func (boomAfterSkipped) Name() string      { return "boomafterskipped" }
+func (boomAfterSkipped) Enabled(*Ctx) bool { return true }
+func (boomAfterSkipped) Reformat(_ *schemas.BifrostChatRequest, rep *Report, _ *Ctx) (err error) {
+	defer func() { rep.Skipped = true }()
+	panic("kaboom")
+}
+
 type grow struct{}             // grows the request — never-worse guard must revert
 func (grow) Name() string      { return "grow" }
 func (grow) Enabled(*Ctx) bool { return true }
@@ -110,6 +121,22 @@ func TestFailOpenOnPanic(t *testing.T) {
 	}
 	if !rr.Components[0].Reverted || rr.Components[0].Err == nil {
 		t.Fatalf("expected reverted+err report, got %+v", rr.Components[0])
+	}
+}
+
+// A component's deferred Skipped-guard runs during the same panic unwind that reaches runOne's
+// recover, which sets Reverted. The two must not both end up true on one Report: dash/event.go's
+// Mutated derivation and any future "count skipped rows" query would misread a reverted row as
+// also having skipped.
+func TestPanicClearsSkippedSetByTheComponentsOwnDefer(t *testing.T) {
+	req := reqWith("keep me intact")
+	rr := NewPipeline([]Component{boomAfterSkipped{}}, nil).Run(req, testCtx())
+	rep := rr.Components[0]
+	if !rep.Reverted {
+		t.Fatalf("expected reverted report, got %+v", rep)
+	}
+	if rep.Skipped {
+		t.Errorf("Reverted && Skipped both true: %+v", rep)
 	}
 }
 

--- a/config/config_more_test.go
+++ b/config/config_more_test.go
@@ -256,3 +256,72 @@ func TestCachePresetIsCachesplitAlone(t *testing.T) {
 		t.Fatalf(`PresetPipeline("cache") = %v, want [cachesplit]`, built)
 	}
 }
+
+// The housellm per-output floor is a MEASUREMENT, so this guard carries the measurement rather than
+// the number, and any future edit has to argue with the data instead of with a literal.
+//
+// Own cost per million tokens saved, by candidate size, over 873 production extraction calls:
+//
+//	<1k $79.75 · 1-2k $32.41 · 2-3k $14.27 · 3-5k $15.76 · 5-8k $10.70 · 8-15k $4.05 · >=15k $11.56
+//
+// A removed token is worth one cache_write NOW plus one cache_read on each of the k-1 LATER turns
+// that replay it, and k is not a constant: per session it ran p10 3.80 / median 27.11 / p90 70.46
+// over the 70 sessions that saved anything. At write $4.755 and read $0.3814 per MTok that is
+// $5.82 (p10) / $14.71 (median) / $31.25 (p90).
+//
+// USE THE P90 AS THE CEILING, and this is the correction the first version of this guard needed: it
+// named a constant `intervalTop` and gave it $14.71, which is the MEDIAN. With the median standing in
+// for the top the rule below selects 5000; with the real p90 it selects 2000. The number moved three
+// times on the same 873 calls -- an imported k=12 from another corpus, then k=12 again through a
+// mislabelled band, then the median through this constant's NAME -- so treat the endpoint as the part
+// most likely to be wrong.
+//
+// A LOWER BOUND, not an equality. A higher floor only ever DECLINES, so it cannot hurt the agent, and
+// the bands are non-monotonic in cost (2-3k at $14.27 is cheaper than 3-5k at $15.76) which means the
+// ordering is inside the noise of 25-359 calls per band. Asserting equality would pin the literal to
+// a rule fitting that noise; asserting the bound pins only what the measurement actually supports.
+func TestHousellmFloorClearsTheBandsThatLoseAtEveryK(t *testing.T) {
+	const p90TokenValue = 31.25 // $/MTok on a TOP-DECILE session: the ceiling, not the median
+	bands := []struct {
+		from, to int // to == 0 marks the open-ended top band
+		perMTok  float64
+	}{
+		{0, 1000, 79.75}, {1000, 2000, 32.41}, {2000, 3000, 14.27}, {3000, 5000, 15.76},
+		{5000, 8000, 10.70}, {8000, 15000, 4.05}, {15000, 0, 11.56},
+	}
+	floor := 0
+	for _, b := range bands {
+		// The open-ended band has no upper edge to raise a floor to, so it can never set one --
+		// and treating its sentinel as a token count would demand a floor of that size and
+		// silently disable the component.
+		if b.to == 0 || b.perMTok <= p90TokenValue {
+			continue
+		}
+		if b.to > floor {
+			floor = b.to // loses even on a top-decile session
+		}
+	}
+	if floor <= 0 || floor >= 15000 {
+		t.Fatalf("derived floor %d is not a real band edge; the table or the ceiling is wrong", floor)
+	}
+	cfg, err := LoadBytes([]byte("preset: housellm\n"))
+	if err != nil {
+		t.Fatalf("load housellm preset: %v", err)
+	}
+	node, ok := cfg.Components["extract_llm"]
+	if !ok {
+		t.Fatal("housellm no longer configures extract_llm; this guard is testing nothing")
+	}
+	var got struct {
+		MinTokens int `yaml:"min_tokens"`
+	}
+	if err := node.Decode(&got); err != nil {
+		t.Fatalf("decode extract_llm block: %v", err)
+	}
+	if got.MinTokens < floor {
+		t.Errorf("housellm ships min_tokens: %d, below the measured floor of %d. Bands under %d cost "+
+			"$32.41-$79.75 per MTok saved against $%.2f on even a top-decile session, so a call there "+
+			"loses money whatever k turns out to be. Move the table with a new measurement, not the "+
+			"literal alone.", got.MinTokens, floor, floor, p90TokenValue)
+	}
+}

--- a/docs/components/extract_llm_sweep.md
+++ b/docs/components/extract_llm_sweep.md
@@ -272,7 +272,7 @@ Diagnostics, all visible at `/stats` under the component and as
 is **not** a failure), `sweep_unparseable`, `sweep_reply_truncated` (a different fix from
 unparseable: raise the budget, not the prompt), `sweep_verdict_unusable`,
 `sweep_verdict_unknown_label`, `sweep_verdict_duplicate_label`, `sweep_verdict_missing`,
-`sweep_prefix_cache_read_ok`, `sweep_prefix_cache_read_ZERO`, `sweep_fallback_used`,
+`sweep_prefix_cache_read_ok`, `sweep_prefix_cache_read_ZERO`, `sweep_prefix_cache_write`, `sweep_fallback_used`,
 `sweep_fallback_blocked`, `sweep_fallback_failed`, `sweep_fallback_no_model`, `sweep_no_asker`,
 `sweep_no_prefix`, `sweep_ask_failed`, `sweep_inventory_of_one`, `sweep_kept_everything`,
 `sweep_unparseable`, `sweep_reply_truncated`, `sweep_verdict_unusable`, `sweep_verdict_unknown_label`,

--- a/internal/extract/zz_freeleg_test.go
+++ b/internal/extract/zz_freeleg_test.go
@@ -1,0 +1,101 @@
+package extract
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rossoctl/context-guru/internal/tokens"
+)
+
+// NOTE ON THE FILENAME: do not end it `..._arm_test.go`. Go reads a trailing `_arm` as the GOARCH
+// filename build constraint, so the file lands in IgnoredGoFiles on every other architecture and the
+// test silently never runs -- `go test` reports "no tests to run" and PASSES. That happened here.
+//
+// TestDeterministicOnlyArmOverCapturedBodies replays captured production candidate bodies through
+// the deterministic projection ALONE, with no model available, and writes a TSV comparing what the
+// free leg produces against what production's paid leg actually produced on the same input.
+//
+// It exists because "would the free character window have done as well?" had never been measured,
+// and it is the only arm that answers it without spending anything: with model == nil,
+// strategyOrder collapses to ["deterministic"] and no call is issued.
+//
+// It skips without CG_H0_DIR, so it costs CI nothing. To build the corpus from a dashboard DB
+// (before_gz is capped at defaultContentCap = 16<<10 BYTES, so 46.4 % of production blobs are
+// truncated and MUST be excluded -- they end with the literal marker below):
+//
+//	select request_id, seq, candidate_tokens, saved_tokens, cost_usd, latency_ms,
+//	       accepted, strategy, rejection, before_gz, after_gz
+//	  from extraction_calls where component='extract_llm' and before_gz is not null;
+//
+// write each before_gz gunzipped to <dir>/<request_id>_<seq>.before, drop any whose contents end
+// with "[truncated: content capture cap reached]", and write the metadata rows as <dir>/meta.json
+// in the h0meta shape. Compare tokens.Count(body) against candidate_tokens to confirm the
+// remainder is faithful.
+//
+// KNOWN INTERNAL-VALIDITY LIMIT, because it decides how the output may be read: the untruncated
+// population tops out at 6,405 candidate tokens, so the 8-15k band -- the only size band whose
+// measured cost per MTok saved clears break-even -- has ZERO representation, and 62 % of the
+// corpus is <=3k where the paid leg is already underwater. The comparison is therefore biased
+// TOWARD the free leg and cannot speak to the paid leg's one winning case.
+func TestDeterministicOnlyArmOverCapturedBodies(t *testing.T) {
+	dir := os.Getenv("CG_H0_DIR")
+	if dir == "" {
+		t.Skip("set CG_H0_DIR to an exported candidate corpus; see the doc comment")
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta []h0meta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatal(err)
+	}
+	// Production's own configuration: no tenant sets max_chars or rewrite, so these are the
+	// shipped defaults and the arm is comparable to the ledger it is scored against.
+	cfg := DefaultCfg()
+	cfg.Mode = "deterministic"
+	cfg.Rewrite = true
+	out, err := os.Create(filepath.Join(dir, "h0.tsv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+	fmt.Fprintln(out, "name\tprod_acc\tprod_strat\tprod_saved\tfree_ok\tbase_tok\tres_tok\tbase_chars\tres_chars\tfree_reason")
+	var ok, n int
+	for _, m := range meta {
+		body, err := os.ReadFile(filepath.Join(dir, m.Name+".before"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		n++
+		res, _, strat, reason := RunExtractionDetail(context.Background(), string(body),
+			"compact this tool output", nil, m.Cand, cfg, nil)
+		free := 0
+		if strat == "deterministic" && res != "" {
+			free, ok = 1, ok+1
+		}
+		fmt.Fprintf(out, "%s\t%d\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n", m.Name, m.Acc, m.Strat, m.Saved,
+			free, tokens.Count(string(body)), tokens.Count(res), len(body), len(res), reason)
+	}
+	if n == 0 {
+		t.Fatal("empty corpus; the arm measured nothing")
+	}
+	t.Logf("%d bodies, free leg produced an accepted result on %d; wrote %s",
+		n, ok, filepath.Join(dir, "h0.tsv"))
+}
+
+// h0meta is one row of the production ledger for the body it names.
+type h0meta struct {
+	Name  string  `json:"name"`
+	Cand  int     `json:"cand"`
+	Saved int     `json:"saved"`
+	Cost  float64 `json:"cost"`
+	Ms    float64 `json:"ms"`
+	Acc   int     `json:"acc"`
+	Strat string  `json:"strat"`
+	Rej   string  `json:"rej"`
+}


### PR DESCRIPTION
## What this changes

Three defects found while measuring `extract_llm` and `extract_llm_sweep` over the 16-day
production corpus (220,933 requests, 892 model calls). Two are telemetry, one is economics.
Every figure below carries the query or the `file:line` behind it; full working in
`cg-research/results/extractllm-findings.md` and the page at
`cg-research/artifacts/extract-llm-deep-dive.html`.

Mechanism claims are read at the **deployed** commit `3a1b438`, not at `main` — prod runs a
side branch that is 2 commits ahead of and 22 behind `main`. All three defects are live on
`main` as well, which is why they are fixed here rather than merely reported.

### 1. `ExtractSweep.Offload` reported `mutated` for turns it declined

`Offload` has two return paths and only the tail one set `rep.Skipped`. The inventory floor
returns early:

```go
if len(cands) < e.minInventory {        // defaultMinInventory = 10
    rep.GateN("sweep_inventory_below_min", len(cands))
    return keys, nil                   // never reaches the changed == 0 guard
}
```

Outside the pre-expiry window phase 1 collects no candidates at all, so `len(cands) = 0 < 10`,
the early return fires, and `dash/event.go`'s `Mutated = !Reverted && !Skipped` reads `true`.
`GateN` is a no-op at `n <= 0`, so those turns recorded neither a gate nor a skip.

**29,321 of 29,372 production rows** read `mutated=1, acted=0, skipped=0`:

```sql
select acted, mutated, skipped, count(*) n,
  sum(events like '%sweep_offered%') has_offered,
  sum(gates like '%sweep_inventory_below_min%') has_below_min,
  sum(gates like '%not_in_pre_expiry_window%') has_notwindow
from request_components where component='extract_llm_sweep' group by 1,2,3;

-- acted mutated skipped     n  offered  below_min  not_window
--   0      0       1        8      8        0          0        <- reached the ask; guard worked
--   0      1       0    29321      7        7      29310        <- the early return
--   1      1       0       43     11        0         32
```

`sweep_offered` is emitted before the floor check, so it partitions the two exits cleanly: all
8 correctly-skipped rows have it, only 7 of the 29,321 do, and those same 7 are the only ones
with a non-zero `sweep_inventory_below_min`. 29,310 + 4 + 7 = 29,321 exactly.

**No dollar figure is affected** — `acted` derives from `saved_gross` and is correct. What is
wrong is the `mutated` census: the component is credited with 29,364 mutations, of which 29,321
are a component that declined. Fixed by guarding the outcome once in a `defer`, so both exits
and any future one are covered; the duplicated tail check is what went wrong here.

### 2. `sweep_prefix_cache_read_ZERO` could not see the harm it exists to catch

The counter tested `usage.CacheRead == 0`, so a **partial** hit silenced it however large the
write. The prefix ask's whole justification is that it *reads* the agent's cached prefix; when
the entry has gone it *writes* it instead, at 1.25× fresh on the agent's own model rather than
a tenth of it — which is precisely what `extract_econ.go` cited when it rejected prefix reuse.

Three production asks did exactly that, for **704,925 opus `cache_write` tokens = $3.42 = 73 %
of this component's entire spend**. Two of the three had read 39,805 tokens of a stable
sub-prefix, so `CacheRead == 0` was false and **$2.26 of the $3.42 went uncounted**:

```
req      idle before  ask read  ask write     cost  agent's own read / write
151760         1.3 s    39,805    260,604  $1.2685      48,040 / 572,018
175582       299.4 s         0    240,309  $1.1565      42,572 / 805,897   <- only this one fired
172127       276.1 s    39,805    204,012  $0.9920           0 / 687,058
```

Now counted separately as `sweep_prefix_cache_write`, because a zero read and a non-zero write
name different failures with different fixes. The existing counter keeps its exact meaning.

Worth recording alongside the fix, since it bears on whether to re-enable the component: on all
three turns **the agent's own request also re-created its prefix**, so the sweep walked into a
miss rather than causing one. But the trigger guarantees that — `sweeping()` fires only when
`0 < CacheTTLMs − IdleMs <= 60 s`, i.e. in the last minute of the entry's life, which is when a
prefix re-read is most likely to fail. No window width fixes that; the permission to act and the
need for a live prefix are mutually exclusive by construction.

### 3. `block_fallback` said the wrong thing about which failure it declined on

Widening the condition in change 2 also put the `blockFallback` branch on the partial-hit path, where
it still wrote *"the prefix ask read nothing from cache"* — false at `CacheRead = 39,805` with a
260,604-token write. Branched, so the two cases stay distinguishable.

One thing worth stating plainly, and a correction to how this section originally described the
string's reach:

- **Correction: the string is NOT unreachable — it is live in production and is now tested.** This
  section originally claimed `rec.Component` stays `""` on this path, so `Offload` discards the row
  on its `call.rec.Component != ""` guard, and it shipped only a counters test on that premise. That
  premise held for the unit test's own `rep := &components.Report{}`, but not for production:
  `components/pipeline.go`'s `runOne` sets `Report{Component: comp.Name(), ...}` before any component
  runs, and `extract_sweep.go` assigns `r.rec = components.ModelCall{Component: rep.Component, ...}`
  before the `block_fallback` branch is ever reached. So the row survives, reaches `rep.Calls`, and
  the branched `Rejection` string is exactly what an operator reads on `extraction_calls.rejection` —
  the column this same PR calls out as already mis-analysed twice. Added
  `TestBlockFallbackDecliningAWritePublishesTheCorrectRejection`, which sets `rep.Component` the way
  the pipeline does and asserts the exact published string.
- **A policy change worth stating plainly:** `block_fallback: true` previously declined only on a
  zero read and now also declines on any partial hit that wrote. A write on the agent's own prefix
  bills at 1.25× fresh on the *agent's* model rather than a tenth of it, so declining is the point of
  the switch — but this is a change to a config-gated brake, not just a counter split.

### 4. `cg.db` and `cg-control.db` sit untracked, and `*.db` is not ignored

The proxy writes its dashboard and control DBs with default names into whatever directory it is
started from, so a proxy run inside a checkout leaves production-shaped tenant data in the working
tree — untracked, but one `git add -A` away from a repo with three remotes. Both files were **0 bytes
with no tables**, so nothing leaked this time. Three lines of `.gitignore`.

### 5. The floor guard: the measurement, not the literal — and **no literal changes**

An earlier version of this branch raised `housellm`'s `min_tokens` from 3,000 to 5,000. **Dropped.**
The guard that replaces it carries the per-band cost measurement and the per-session replay
multiplier and derives the floor from them, so the next edit has to argue with the data. It asserts
the shipped 3,000 as a **lower bound**, and it currently passes.

Two corrections are baked in because the first version of the guard had both:

- **It named a constant `intervalTop` and gave it $14.71, which is the MEDIAN token value**, not the
  ceiling. The p90 is **$31.25**. With the median standing in for the top, the same rule selects 5,000
  instead of 2,000 — it **reversed the direction of a config change**. That number has now moved three
  times on the same 873 calls: an imported k=12 from another corpus, k=12 again through a mislabelled
  band, and the median through a constant's **name**.
- **It asserted equality, not a bound.** A higher floor only ever declines, and the bands are
  non-monotonic in cost (2–3k at $14.27 is cheaper than 3–5k at $15.76), which puts the ordering
  inside the noise of 25–359 calls per band. Equality would have pinned the literal to a rule fitting
  that noise.

The open-ended top band is skipped explicitly: treating its sentinel as a token count would derive a
floor of that size and **silently disable the component**.

### 6. The deterministic-only arm, as a runnable test

The question "would the free character window have done as well as the paid model leg?" had never
been measured, and it is the one arm that answers it without spending anything: with `model == nil`,
`strategyOrder` collapses to `["deterministic"]` and no call is issued. Skips without `CG_H0_DIR`, so
it costs CI nothing; the doc comment carries the export query and both internal-validity limits.

One gotcha recorded in the source because it cost real time: **the first version of this file was
named `..._arm_test.go`, which Go reads as the GOARCH filename build constraint.** It landed in
`IgnoredGoFiles` on amd64 and `go test` reported "no tests to run" and **exited 0** — a green pass for
a test that never executed. Detect that class with
`go list -f '{{.IgnoredGoFiles}}' ./...`, never with an exit code.

## Tests

Seven, and each guarding changed logic was confirmed to **fail without its fix**:

- `TestSweepDeclinedAtInventoryFloorReportsSkipped` — both exits, table-driven. Reverted, it
  reproduces the production row shape exactly:
  `gates: map[not_in_pre_expiry_window:1]` with `Skipped=false`, which is request 141575.
- `TestSweepPrefixWriteTripsTheCounterEvenOnAPartialHit` — asserts the write counter fires on a
  39,805-token read with a 260,604-token write, **and** that the zero-read counter does not, so
  the two are not collapsed.
- `TestBlockFallbackDistinguishesAZeroReadFromAWrite` — table-driven over both cases, asserting the
  right counter fires, the wrong one does not, and a declined ask leaves the transcript untouched.
- `TestBlockFallbackDecliningAWritePublishesTheCorrectRejection` — asserts `rep.Calls` itself, with
  `rep.Component` set the way `pipeline.go` sets it in production; see the correction to section 3
  above.
- `TestPanicClearsSkippedSetByTheComponentsOwnDefer` — a component's own deferred `Skipped`-guard
  (the pattern this PR's fix #1 introduced) can run during the same panic unwind that reaches
  `runOne`'s `recover`, which sets `Reverted`. Fixed `runOne` to clear `Skipped` there, so a
  `Report` never carries both — closing a half-state fix #1's own defer made newly reachable.
- `TestHousellmFloorClearsTheBandsThatLoseAtEveryK` — passes at the shipped 3,000, and verified to
  fail at 1,000 with the derived bound of 2,000 named in the message.
- `TestDeterministicOnlyArmOverCapturedBodies` — a measurement harness rather than a guard; skips
  without its corpus.

Also added `sweep_prefix_cache_write` to the counters list in
`docs/components/extract_llm_sweep.md`, which had gone stale for this PR's own change (no code
wiring needed — `metrics/metrics.go` and `proxy/promexport.go` already iterate gates generically).

`go build ./...`, `go vet`, and `go test ./...` are green.

## Deliberately not in this PR

Five things this investigation measured and is **not** shipping. Each is in the write-up with its
query.

- **The per-output floor.** An earlier draft of this branch raised the `housellm` literal from 3,000
  to 5,000 and I committed it. **Withdrawn and dropped from the branch.** The break-even band it
  rested on was mislabelled: solving `$4.755 + (k−1)×$0.3814` for the three printed values gives
  k = 3.80 / **12.00** / 27.11, so the middle figure was not this corpus's median but the 12.0
  imported from `docs/components/extract_llm.md` and measured elsewhere. The measured band is
  **$5.82 / $14.71 / $31.25**, and at it the change is worth **+$1.27 / +$0.13 / −$1.99** — $0.13 at
  the median, on a 7 % overshoot well inside the noise of a 70-session median. The rule the guard
  encoded now selects 2,000, which the shipped 3,000 already clears. The real exposure is six
  tenants overriding `min_tokens` to 500, which is a deployment fix.
- **Routing to the free deterministic window.** A paired experiment over the 468 candidate bodies
  stored in full shows the free window removes **2.56× more tokens for $0.00**, and class-gated
  routing would avoid **$4.51 of $5.02** and 3,619 s. Declined: the window keeps a median **33.1 %**
  of characters and drops **44.2 %** of identifiers against the paid program's **30.8 %**. And the
  paired corpus **excludes the paid leg's only winning size band entirely** — max candidate is 6,405
  tokens, so the 8–15k band at $4.05/MTok has zero representation — which biases the comparison
  toward the free arm. The next measurement is reward and steps, not tokens.
- **Widening the sweep's pre-expiry window.** Struck, not deferred. Grouping its 19 firing requests
  on whether it removed anything: **7 removal turns wrote 3,363,850 agent `cache_write` tokens
  against 4 same-idle-band controls' 4,907 — 686× at comparable growth**, all ten accepted rows at
  ≤0.196 cache warmth and all four no-removal warm rows at ≥0.997, and one request that grew by
  **exactly zero tokens** and wrote 592,279. `extract_llm` refuses depth, so the sweep is the only
  component editing inside the already-cached region, and a mid-history edit re-hashes everything
  after it. Revised net **−$19.6 to −$27.2**, not the ledger's −$3.60 (attributed, not proven; n=7
  vs 4). Its own premise fails too: it fired on a **live** cache on 13 of 19 requests and on a
  genuinely expired one **once**.
- **A pre-filter for the 364 calls that bought nothing.** Scored on both sides of the ledger, no
  free content predictor pays across the band. `looksLikeFileRead` — the predicate the codebase
  already has, whose comment calls line-numbered dumps irreducible — is **net negative at every
  point**, because those are the *most* profitable class the component sees (83 calls, 71.1 %
  acceptance, 169,171 tokens saved).
- **The two Starlark-generation fixes.** 96 of 356 dead calls ($1.3356, 20 minutes of model time)
  are programs the interpreter could not run, but they are ~six distinct bugs rather than one. The
  reply-budget theory is **refuted** — only 5 of 39 cut-off replies reach 4,000 output tokens
  against a 4,096 cap; the median is 859. The two small ones are the `while`-loop refusal (8 calls)
  and taking the first fenced block rather than only a leading one (5 calls; `stripFences` at
  `internal/extract/extract.go:397` strips only a **leading** fence). Together $0.22, and every
  prompt edit re-runs the acceptance corpus by design.

## Two defects reported earlier in this investigation that turned out not to exist

Recorded because both were mine and both flattered the conclusion:

- **"`saved_usd` is gross and nothing nets the component's own spend."** `dash/query.go:876`
  computes `NetUSD = SavedUSD − LLMCostUSD` **in the deployed binary**, and `dash/ui/app.js:2602-2611`
  already flags any component whose amortised and first-removal verdicts disagree in sign — which is
  exactly this component's situation, spelled out for the operator. The figure was on the dashboard
  the whole time.
- **"269 acted rows are silently unpriced."** All 269 are non-200 requests (401/408/429/502/503) with
  every token column *and* `cost_usd` at zero. The upstream never billed them, so `Event.Price`'s
  early return is correct. I priced a "$5.69 correction" by falling through to the fresh-input branch
  on rows with no token data; a reviewer independently produced the same error at $0.90. It is a
  property of the column — `saved_gross > 0` on an unbilled request — not of either of us.

## Scope note

`extract_llm_sweep` was removed from all nine tenant configs on 2026-09-03, so changes 1 and 2 have
no effect on current production traffic. They are shipped because the code is still reachable, and
because change 2 is the instrument anyone would need before deciding whether to re-enable it — a
decision the measurement above says should be **no**.

Net cash impact of this PR: **$0.** Its value is that a component reporting a decline as a mutation,
and a tripwire that could not see the harm it was built for, are how the sweep ran for three days
unexamined.

