### PR TITLE
feat(kvcache): budget keep-alive pings per conversation

### DIFF
--- a/deploy/harbor/kv_ttl_cost_drift_test.go
+++ b/deploy/harbor/kv_ttl_cost_drift_test.go
@@ -35,6 +35,16 @@ import (
 // missing Python is an absent guard, not a broken product.
 func pythonBin(t *testing.T) string {
 	t.Helper()
+	return pythonBinFor(t, "kv_ttl_cost_model")
+}
+
+// pythonBinFor is the probe itself, with the module it must be able to import as a parameter.
+// Every drift test in this package needs the same walk over KVCACHE_PYTHON/python3/python and
+// differs only in which module has to load — kv_ttl_cost_model may want a scientific stack,
+// kv_ttl_keepalive_policy is stdlib-only — so the module name is the parameter and the walk is
+// written once.
+func pythonBinFor(t *testing.T, module string) string {
+	t.Helper()
 	for _, cand := range []string{os.Getenv("KVCACHE_PYTHON"), "python3", "python"} {
 		if cand == "" {
 			continue
@@ -45,8 +55,8 @@ func pythonBin(t *testing.T) string {
 		}
 		// It must be able to import the module at all; a 3.8 interpreter cannot.
 		if out, err := exec.Command(p, "-c",
-			"import sys; sys.path.insert(0,'.'); import kv_ttl_cost_model").CombinedOutput(); err != nil {
-			t.Logf("%s cannot import kv_ttl_cost_model, skipping it: %s", p, out)
+			"import sys; sys.path.insert(0,'.'); import "+module).CombinedOutput(); err != nil {
+			t.Logf("%s cannot import %s, skipping it: %s", p, module, out)
 			continue
 		}
 		return p

--- a/deploy/harbor/kv_ttl_keepalive_drift_test.go
+++ b/deploy/harbor/kv_ttl_keepalive_drift_test.go
@@ -1,0 +1,254 @@
+package harbor
+
+// The Go keep-alive budget and the Python one must be the same arithmetic.
+//
+// kvcache.BudgetPolicy is what the dashboard reports from; kv_ttl_keepalive_policy.py is
+// where the model is fitted and where the offline evaluation that justifies the arm runs. Two
+// implementations of one money question is exactly the drift this project has been bitten by,
+// so the Python is a port, this is the guard, and when they disagree Go is right.
+//
+// It compares the DECISION and both intermediate vectors. A budget that agrees for the wrong
+// reason — a hazard scaled wrong and a survival scaled inversely wrong — is a guard that has
+// already stopped working, so the per-window h and s are pinned too.
+//
+// Nothing is mocked. The Python side runs its real `--fixture` entry point, which is
+// stdlib-only by construction, so this runs in a plain CI container.
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/context-guru/kvcache"
+)
+
+// keepAlivePythonBin is pythonBin's sibling for this module. Separate because the skip
+// message has to name the module that could not be imported, and because this one needs no
+// scientific stack at all where kv_ttl_cost_model may.
+func keepAlivePythonBin(t *testing.T) string {
+	t.Helper()
+	for _, cand := range []string{os.Getenv("KVCACHE_PYTHON"), "python3", "python"} {
+		if cand == "" {
+			continue
+		}
+		p, err := exec.LookPath(cand)
+		if err != nil {
+			continue
+		}
+		if out, err := exec.Command(p, "-c",
+			"import sys; sys.path.insert(0,'.'); import kv_ttl_keepalive_policy",
+		).CombinedOutput(); err != nil {
+			t.Logf("%s cannot import kv_ttl_keepalive_policy, skipping it: %s", p, out)
+			continue
+		}
+		return p
+	}
+	return ""
+}
+
+// The fixture wire format. Field names are the Python's own.
+type budgetCase struct {
+	CachedTokens int64        `json:"cached_tokens"`
+	InputRate    float64      `json:"input_rate"`
+	CDF          [][2]float64 `json:"cdf"`
+	MinPrefix    int64        `json:"min_prefix,omitempty"`
+}
+
+type budgetFixture struct {
+	IntervalS float64      `json:"interval_s"`
+	LifeS     float64      `json:"life_s"`
+	MaxK      int          `json:"max_k"`
+	Cases     []budgetCase `json:"cases"`
+}
+
+type budgetWindows struct {
+	H []float64 `json:"h"`
+	S []float64 `json:"s"`
+}
+
+type budgetPyResult struct {
+	BreakEven float64         `json:"break_even"`
+	Budgets   []int           `json:"budgets"`
+	Windows   []budgetWindows `json:"windows"`
+}
+
+// cdfPredictor is the same hand-written cumulative distribution the fixture carries, as a
+// kvcache.Predictor, so both sides are answering from identical numbers rather than from two
+// fits that would differ for uninteresting reasons.
+type cdfPredictor struct{ points [][2]float64 }
+
+func (c cdfPredictor) ReuseProbability(_ kvcache.Observation, horizon time.Duration) (float64, bool) {
+	sec := horizon.Seconds()
+	p := 0.0
+	for _, pt := range c.points {
+		if sec >= pt[0] {
+			p = pt[1]
+		}
+	}
+	return p, true
+}
+
+// budgetDriftFixture is the case table, and each row is chosen to exercise a branch the two
+// implementations could plausibly diverge on rather than to look varied.
+func budgetDriftFixture() budgetFixture {
+	return budgetFixture{
+		IntervalS: 280, LifeS: 300, MaxK: 8,
+		Cases: []budgetCase{
+			// Nothing to buy: back almost immediately.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0.99}, {86400, 1}}},
+			// One rich window, far above the break-even.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.90}, {86400, 1}}},
+			// Just BELOW the break-even, where an off-by-a-hair in either rescue or ping cost
+			// changes the decision. This is the row that catches a rate mistake.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.0869}, {86400, 1}}},
+			// Just ABOVE it.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.0871}, {86400, 1}}},
+			// A lean first window redeemed by a rich second: pins the option value.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{580, 0.02}, {860, 0.60}, {3600, 1}}},
+			// A worthless tail: pins where the schedule ends.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.30}, {86400, 0.30}}},
+			// A rich window five sweeps out: pins holding through a dead stretch.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, .3}, {860, .3}, {1140, .3}, {1420, .3},
+					{1700, .95}, {86400, 1}}},
+			// Most already returned: pins the divide by the survivor share. Without it both
+			// sides would read 5pp where the conditional truth is 50%.
+			{CachedTokens: 124_845, InputRate: 3.0e-6,
+				CDF: [][2]float64{{280, 0.90}, {580, 0.90}, {860, 0.95}, {3600, 1}}},
+			// A small prefix, where a ping's FIXED overhead is a real share of its cost and the
+			// two sides could disagree by dropping the ping_input/ping_output term.
+			{CachedTokens: 900, InputRate: 3.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.20}, {86400, 1}}},
+			// MinPrefix: a decision, not an absence of one.
+			{CachedTokens: 5_000, InputRate: 3.0e-6, MinPrefix: 10_000,
+				CDF: [][2]float64{{300, 0}, {580, 0.90}, {86400, 1}}},
+			// A different rate scale entirely. The break-even must not move, because the prefix
+			// and the per-token rate both cancel — this is the row that proves that claim.
+			{CachedTokens: 124_845, InputRate: 15.0e-6,
+				CDF: [][2]float64{{300, 0}, {580, 0.0871}, {86400, 1}}},
+		},
+	}
+}
+
+func scoreBudgetWithPort(t *testing.T, py string, f budgetFixture) budgetPyResult {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "budget.json")
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(py, "kv_ttl_keepalive_policy.py", "--fixture", path)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("the port failed on the fixture: %v\nstdout: %s\nstderr: %s",
+			err, out, stderr.String())
+	}
+	var got budgetPyResult
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &got); err != nil {
+		t.Fatalf("cannot read the port's output: %v\n%s", err, out)
+	}
+	return got
+}
+
+// goBudget is kvcache's own answer for one fixture case.
+func goBudget(c budgetCase, f budgetFixture) (int, bool, []float64, []float64) {
+	o := kvcache.Observation{
+		User: "acct-1", Conversation: "conv-1", Model: "m", Now: 1_786_967_311_185,
+		CachedTokens: c.CachedTokens, TTL: kvcache.TTL5m,
+		Pricing: kvcache.Pricing{
+			Model: "m", Input: c.InputRate, Output: c.InputRate * 5,
+			CacheRead:       c.InputRate * kvcache.DefaultCacheReadMultiple,
+			Write5m:         c.InputRate * kvcache.DefaultWrite5mMultiple,
+			Write1h:         c.InputRate * kvcache.DefaultWrite1hMultiple,
+			PingInputTokens: 1, PingOutputTokens: 1, Known: true,
+		},
+	}
+	pol := kvcache.BudgetPolicy{
+		Predictor: cdfPredictor{points: c.CDF},
+		Interval:  time.Duration(f.IntervalS) * time.Second,
+		MaxK:      f.MaxK,
+		MinPrefix: c.MinPrefix,
+	}
+	k, ok := pol.PingBudget(o)
+	h, s, _ := pol.Windows(o)
+	return k, ok, h, s
+}
+
+// The two implementations of the keep-alive budget must agree on every case, and on the two
+// vectors the budget is computed from.
+func TestKeepAliveBudgetAgreesWithThePort(t *testing.T) {
+	py := keepAlivePythonBin(t)
+	if py == "" {
+		t.Skip("no usable Python; a missing interpreter is an absent guard, not a failure")
+	}
+	f := budgetDriftFixture()
+	got := scoreBudgetWithPort(t, py, f)
+	if len(got.Budgets) != len(f.Cases) {
+		t.Fatalf("port returned %d budgets for %d cases", len(got.Budgets), len(f.Cases))
+	}
+
+	// The break-even is the one number the whole arm rests on, and it must be the rates' own.
+	const wantBreakEven = kvcache.DefaultCacheReadMultiple /
+		(kvcache.DefaultWrite5mMultiple - kvcache.DefaultCacheReadMultiple)
+	if math.Abs(got.BreakEven-wantBreakEven) > 1e-9 {
+		t.Errorf("break-even: port %.10f, Go's rates give %.10f", got.BreakEven, wantBreakEven)
+	}
+
+	for i, c := range f.Cases {
+		k, ok, h, s := goBudget(c, f)
+		if !ok && c.MinPrefix == 0 {
+			t.Errorf("case %d: Go had no opinion on a fully priced observation", i)
+			continue
+		}
+		if k != got.Budgets[i] {
+			t.Errorf("case %d (prefix %d, cdf %v): Go budget %d, port %d",
+				i, c.CachedTokens, c.CDF, k, got.Budgets[i])
+		}
+		if c.MinPrefix > 0 {
+			continue // short-circuited before the windows are computed on both sides
+		}
+		for j := range h {
+			if math.Abs(h[j]-got.Windows[i].H[j]) > 1e-9 {
+				t.Errorf("case %d window %d hazard: Go %.10f, port %.10f",
+					i, j+1, h[j], got.Windows[i].H[j])
+			}
+			if math.Abs(s[j]-got.Windows[i].S[j]) > 1e-9 {
+				t.Errorf("case %d window %d survival: Go %.10f, port %.10f",
+					i, j+1, s[j], got.Windows[i].S[j])
+			}
+		}
+	}
+}
+
+// The Python module's own claims have to hold, checked by the module itself, so that the
+// fixture agreeing does not mask both sides being wrong in the same way.
+func TestThePortsSelfTestPasses(t *testing.T) {
+	py := keepAlivePythonBin(t)
+	if py == "" {
+		t.Skip("no usable Python")
+	}
+	out, err := exec.Command(py, "kv_ttl_keepalive_policy.py", "--self-test").CombinedOutput()
+	if err != nil {
+		t.Fatalf("the port's self-test failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "self-test OK") {
+		t.Errorf("unexpected self-test output: %s", out)
+	}
+}

--- a/deploy/harbor/kv_ttl_keepalive_drift_test.go
+++ b/deploy/harbor/kv_ttl_keepalive_drift_test.go
@@ -61,7 +61,11 @@ type budgetWindows struct {
 }
 
 type budgetPyResult struct {
-	BreakEven float64         `json:"break_even"`
+	// One entry per case, not one for the fixture: _run_fixture used to assign this inside its
+	// per-case loop and report only the last case's, which happened to go unnoticed here
+	// because every case's rates come from the same multiples. A list makes that assumption
+	// checked rather than assumed.
+	BreakEven []float64       `json:"break_even"`
 	Budgets   []int           `json:"budgets"`
 	Windows   []budgetWindows `json:"windows"`
 }
@@ -198,11 +202,18 @@ func TestKeepAliveBudgetAgreesWithThePort(t *testing.T) {
 		t.Fatalf("port returned %d budgets for %d cases", len(got.Budgets), len(f.Cases))
 	}
 
-	// The break-even is the one number the whole arm rests on, and it must be the rates' own.
+	// The break-even is the one number the whole arm rests on, and it must be the rates' own —
+	// for EVERY case, including the 5×-rate one, since the prefix and the per-token rate both
+	// cancel and the ratio must not move with input_rate.
 	const wantBreakEven = kvcache.DefaultCacheReadMultiple /
 		(kvcache.DefaultWrite5mMultiple - kvcache.DefaultCacheReadMultiple)
-	if math.Abs(got.BreakEven-wantBreakEven) > 1e-9 {
-		t.Errorf("break-even: port %.10f, Go's rates give %.10f", got.BreakEven, wantBreakEven)
+	if len(got.BreakEven) != len(f.Cases) {
+		t.Fatalf("port returned %d break-evens for %d cases", len(got.BreakEven), len(f.Cases))
+	}
+	for i, be := range got.BreakEven {
+		if math.Abs(be-wantBreakEven) > 1e-9 {
+			t.Errorf("case %d break-even: port %.10f, Go's rates give %.10f", i, be, wantBreakEven)
+		}
 	}
 
 	for i, c := range f.Cases {

--- a/deploy/harbor/kv_ttl_keepalive_drift_test.go
+++ b/deploy/harbor/kv_ttl_keepalive_drift_test.go
@@ -2,10 +2,13 @@ package harbor
 
 // The Go keep-alive budget and the Python one must be the same arithmetic.
 //
-// kvcache.BudgetPolicy is what the dashboard reports from; kv_ttl_keepalive_policy.py is
-// where the model is fitted and where the offline evaluation that justifies the arm runs. Two
-// implementations of one money question is exactly the drift this project has been bitten by,
-// so the Python is a port, this is the guard, and when they disagree Go is right.
+// kvcache.BudgetPolicy is what a replay is scored by; kv_ttl_keepalive_policy.py is where the
+// model is fitted. Two implementations of one money question is exactly the drift this project
+// has been bitten by, so the Python is a port, this is the guard, and when they disagree Go is
+// right. (Neither side is on a dashboard page: BudgetPolicy is not in Registry() and, like
+// Custom's Predictor, it is reached only by an in-process caller — "a predictor is code, not a
+// query parameter", as dash/kvcachesim.go puts it. That is a reason for the guard rather than
+// against it: an arm nothing renders is an arm nobody would notice drifting.)
 //
 // It compares the DECISION and both intermediate vectors. A budget that agrees for the wrong
 // reason — a hazard scaled wrong and a survival scaled inversely wrong — is a guard that has
@@ -20,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -27,28 +31,13 @@ import (
 	"github.com/rossoctl/context-guru/kvcache"
 )
 
-// keepAlivePythonBin is pythonBin's sibling for this module. Separate because the skip
-// message has to name the module that could not be imported, and because this one needs no
-// scientific stack at all where kv_ttl_cost_model may.
+// keepAlivePythonBin is pythonBin parameterised by module, which is the only thing the two
+// ever differed in — the skip message has to name the module that could not be imported, and
+// this one needs no scientific stack at all where kv_ttl_cost_model may. Two spellings of one
+// interpreter probe is how they come to disagree the day one of them gains a caveat.
 func keepAlivePythonBin(t *testing.T) string {
 	t.Helper()
-	for _, cand := range []string{os.Getenv("KVCACHE_PYTHON"), "python3", "python"} {
-		if cand == "" {
-			continue
-		}
-		p, err := exec.LookPath(cand)
-		if err != nil {
-			continue
-		}
-		if out, err := exec.Command(p, "-c",
-			"import sys; sys.path.insert(0,'.'); import kv_ttl_keepalive_policy",
-		).CombinedOutput(); err != nil {
-			t.Logf("%s cannot import kv_ttl_keepalive_policy, skipping it: %s", p, out)
-			continue
-		}
-		return p
-	}
-	return ""
+	return pythonBinFor(t, "kv_ttl_keepalive_policy")
 }
 
 // The fixture wire format. Field names are the Python's own.
@@ -83,9 +72,14 @@ type budgetPyResult struct {
 type cdfPredictor struct{ points [][2]float64 }
 
 func (c cdfPredictor) ReuseProbability(_ kvcache.Observation, horizon time.Duration) (float64, bool) {
+	// Sorted, because _run_fixture sorts its points and a step function read in a different
+	// order is a different distribution. The fixture below happens to be written in order; a
+	// guard that depends on that is a guard that breaks on the next row somebody adds.
+	pts := append([][2]float64(nil), c.points...)
+	sort.Slice(pts, func(i, j int) bool { return pts[i][0] < pts[j][0] })
 	sec := horizon.Seconds()
 	p := 0.0
-	for _, pt := range c.points {
+	for _, pt := range pts {
 		if sec >= pt[0] {
 			p = pt[1]
 		}
@@ -224,6 +218,14 @@ func TestKeepAliveBudgetAgreesWithThePort(t *testing.T) {
 		if c.MinPrefix > 0 {
 			continue // short-circuited before the windows are computed on both sides
 		}
+		// Length first: indexing a shorter vector would PANIC the guard rather than fail it,
+		// and a panic in a drift test reads as a broken test rather than as drift.
+		if len(got.Windows) <= i || len(got.Windows[i].H) != len(h) ||
+			len(got.Windows[i].S) != len(s) {
+			t.Errorf("case %d: Go returned %d windows, port returned %v — the two are not even "+
+				"describing the same schedule", i, len(h), got.Windows)
+			continue
+		}
 		for j := range h {
 			if math.Abs(h[j]-got.Windows[i].H[j]) > 1e-9 {
 				t.Errorf("case %d window %d hazard: Go %.10f, port %.10f",
@@ -233,6 +235,41 @@ func TestKeepAliveBudgetAgreesWithThePort(t *testing.T) {
 				t.Errorf("case %d window %d survival: Go %.10f, port %.10f",
 					i, j+1, s[j], got.Windows[i].S[j])
 			}
+		}
+	}
+}
+
+// MaxK <= 0 means the default on BOTH sides.
+//
+// The fixture above always sends 8, so nothing in it would notice the two disagreeing here —
+// and they did: Go's maxK() falls back to DefaultBudgetMaxK where the port read a
+// non-positive max_k as "no windows", answering 0 to every case. A default is exactly the
+// kind of thing a port drifts on, because it is the value nobody passes.
+func TestKeepAliveBudgetDefaultsMaxKTheSameWayOnBothSides(t *testing.T) {
+	py := keepAlivePythonBin(t)
+	if py == "" {
+		t.Skip("no usable Python")
+	}
+	explicit := budgetDriftFixture()
+	explicit.MaxK = kvcache.DefaultBudgetMaxK
+	implicit := budgetDriftFixture()
+	implicit.MaxK = 0
+
+	want := scoreBudgetWithPort(t, py, explicit)
+	got := scoreBudgetWithPort(t, py, implicit)
+	for i := range explicit.Cases {
+		if got.Budgets[i] != want.Budgets[i] {
+			t.Errorf("case %d: port answered %d with max_k=0 and %d with max_k=%d",
+				i, got.Budgets[i], want.Budgets[i], kvcache.DefaultBudgetMaxK)
+		}
+		// And Go, whose MaxK=0 is the same fallback.
+		k, ok, _, _ := goBudget(explicit.Cases[i], implicit)
+		if !ok && explicit.Cases[i].MinPrefix == 0 {
+			t.Errorf("case %d: Go had no opinion with MaxK=0", i)
+			continue
+		}
+		if k != got.Budgets[i] {
+			t.Errorf("case %d with MaxK=0: Go %d, port %d", i, k, got.Budgets[i])
 		}
 	}
 }

--- a/deploy/harbor/kv_ttl_keepalive_policy.py
+++ b/deploy/harbor/kv_ttl_keepalive_policy.py
@@ -69,7 +69,7 @@ effective bar at the first sweep falls to ~7.4%, worth ~6% of the policy's net.
 WHAT IT IS WORTH, INCLUDING WHERE IT LOSES
 ------------------------------------------
 Measured on the hosted deployment's capture: 34,577 idle spans over 16.9 days, 5-fold
-rolling-origin, pings at 290s. Given as a share of the window's bill and of what `optimal`
+rolling-origin, pings at 280s. Given as a share of the window's bill and of what `optimal`
 reaches, with per-ping efficiency indexed to flat MaxPings=6.
 
     arm                     pings   off the bill   of the ceiling   net per ping

--- a/deploy/harbor/kv_ttl_keepalive_policy.py
+++ b/deploy/harbor/kv_ttl_keepalive_policy.py
@@ -80,10 +80,12 @@ reaches, with per-ping efficiency indexed to flat MaxPings=6.
     flat MaxPings=2 (dflt) 33,591          5.19%            44.3%           2.1x
 
 Read the last two columns together, because they say opposite things. On MONEY a constant
-beats this policy by 0.89 pp of the bill: it ranks conversations well (AUC 0.93) and DOLLARS barely
-better than chance (AUC 0.70, and 0.57 on the largest prefixes, which carry 87% of the
-stake), so its mistakes land where they cost most, and at a 11.5:1 payoff a wrong skip is
-expensive. Per PING it is 9x better. So:
+beats this policy by 0.89 pp of the bill: it ranks conversations well (AUC 0.93) and DOLLARS much
+worse, falling to 0.57 on the largest prefixes, which carry 87% of the stake (not 0.70 for the
+whole population — kv-cache-keepalive-budget.md's own AUC-decomposition math rules that out;
+its table flags the whole-population dollar-AUC cell unverified instead), so its mistakes land
+where they cost most, and at a 11.5:1 payoff a wrong skip is expensive. Per PING it is 9x
+better. So:
 
     pings effectively free   ->  raise MaxPings and do not deploy a model
     pings rate-limited      ->  this policy, by a wide margin
@@ -376,8 +378,10 @@ def fit(spans, *, interval_s: float = DEFAULT_INTERVAL_S, life_s: float = DEFAUL
 
     The weight is the point. An unweighted fit optimises row accuracy, and rows are not what
     the bill is made of: this corpus's stake is concentrated so hard that the model can reach
-    AUC 0.93 by row while ranking dollars at 0.70. Weighting by stake does not close that gap
-    — nothing measured here does — but fitting without it makes it worse.
+    AUC 0.93 by row while ranking dollars far worse — see kv-cache-keepalive-budget.md's AUC
+    table (its whole-population dollar figure is flagged unverified there; 0.70 is not it,
+    and the same page's arithmetic rules 0.70 out too). Weighting by stake does not close that
+    gap — nothing measured here does — but fitting without it makes it worse.
     """
     from sklearn.compose import ColumnTransformer
     from sklearn.ensemble import HistGradientBoostingClassifier

--- a/deploy/harbor/kv_ttl_keepalive_policy.py
+++ b/deploy/harbor/kv_ttl_keepalive_policy.py
@@ -417,20 +417,22 @@ def _run_fixture(path: str) -> int:
         "cached_tokens":…, "input_rate":…, "cdf":[[seconds, p], …],
         "min_prefix":… (optional)}]}
 
-    and the output is {"break_even":…, "budgets":[…], "windows":[{"h":[…],"s":[…]}, …]} so
-    the Go test can compare the decision AND the two intermediate vectors — a budget that
-    agrees for the wrong reason is a guard that will stop catching things.
+    and the output is {"break_even":[…], "budgets":[…], "windows":[{"h":[…],"s":[…]}, …]} —
+    one break_even PER CASE, not one for the fixture, because each case carries its own
+    input_rate and a fixture that mixed rate shapes would otherwise report only the last
+    case's — so the Go test can compare the decision AND the two intermediate vectors, per
+    case, and a budget that agrees for the wrong reason is a guard that will stop catching
+    things.
     """
     with open(path, encoding="utf-8") as fh:
         spec = json.load(fh)
     interval = float(spec.get("interval_s", DEFAULT_INTERVAL_S))
     life = float(spec.get("life_s", DEFAULT_LIFE_S))
     max_k = int(spec.get("max_k", DEFAULT_MAX_K))
-    budgets, wins = [], []
-    be = None
+    break_evens, budgets, wins = [], [], []
     for case in spec["cases"]:
         rates = Rates.from_input_rate(float(case["input_rate"]))
-        be = break_even(rates.cache_read, rates.write_5m)
+        break_evens.append(break_even(rates.cache_read, rates.write_5m))
         points = sorted((float(a), float(b)) for a, b in case["cdf"])
 
         def cdf(seconds: float, _pts=points) -> float:
@@ -445,7 +447,7 @@ def _run_fixture(path: str) -> int:
         budgets.append(budget_for(cdf, int(case["cached_tokens"]), rates, interval_s=interval,
                                   life_s=life, max_k=max_k,
                                   min_prefix=int(case.get("min_prefix", 0))))
-    print(json.dumps({"break_even": be, "budgets": budgets, "windows": wins}))
+    print(json.dumps({"break_even": break_evens, "budgets": budgets, "windows": wins}))
     return 0
 
 

--- a/deploy/harbor/kv_ttl_keepalive_policy.py
+++ b/deploy/harbor/kv_ttl_keepalive_policy.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python3
 """How MANY keep-alive pings a conversation is worth, decided per conversation.
 
-This is the learned counterpart of `kvcache.BudgetPolicy`, and the two must agree: the Go
-side is what the dashboard reports from, this side is where the fit lives, and
-`kv_ttl_keepalive_drift_test.go` drives the `--fixture` entry point below to pin them
-together. When they disagree, Go is right.
+This is the learned counterpart of `kvcache.BudgetPolicy`, and the two must agree: the Go side
+is what a replay is scored by, this side is where the fit lives, and
+`kv_ttl_keepalive_drift_test.go` drives the `--fixture` entry point below to pin them together.
+When they disagree, Go is right. (`BudgetPolicy` is not in `kvcache.Registry()`, so it reaches a
+replay the way `Custom`'s predictor does: from an in-process caller, because "a predictor is
+code, not a query parameter". No dashboard page renders it.)
 
-    kv_ttl_keepalive_policy.py --db /var/lib/context-guru/cg.db --prices /etc/.../prices.yaml
     kv_ttl_keepalive_policy.py --fixture f.json      # the drift test's interface, stdlib only
-    kv_ttl_keepalive_policy.py --self-test           # synthetic traffic, no store needed
+    kv_ttl_keepalive_policy.py --self-test           # asserts this module's claims, stdlib only
+
+There is deliberately no `--db` yet, unlike kv_ttl_cost_model.py and kv_ttl_predictor_arms.py:
+`fit()` and `person_periods()` below are the fit AS IT WAS RUN, kept so the method is
+reviewable, but they are not wired to an entry point — so the figures quoted in this docstring
+cannot be reproduced from this file alone. Wiring `--db`/`--prices` the way the siblings do,
+and reusing kv_ttl_survival_predictor's person-period expansion instead of the copy below, is
+the next thing to do here.
 
 WHAT PROBLEM THIS SOLVES THAT THE SURVIVAL PREDICTOR DOES NOT
 -------------------------------------------------------------
@@ -40,11 +48,20 @@ Per cached token, at the documented Anthropic multiples of base input:
     cache write  1.25x      what the successor pays if the entry lapsed
     rescue       1.15x      = 1.25 - 0.10, what a successful ping avoids
 
-So a ping pays for itself when the chance it rescues exceeds 0.10/1.15 = 8.70%. The prefix
-size cancels: it multiplies cost and benefit alike. So does the model's per-token rate.
-That is why this module reads probabilities and not token counts, and why the threshold is
-computed from the price list rather than written down — a deployment on different rates has
-a different threshold, and one with no rates has none.
+So a ping pays for itself when the chance it rescues exceeds 0.10/1.15 = 8.70%. The model's
+per-token rate cancels, and so does the PER-TOKEN part of the prefix: it multiplies cost and
+benefit alike. That is why this module reads probabilities and not token counts, and why the
+threshold is computed from the price list rather than written down — a deployment on different
+rates has a different threshold, and one with no rates has none.
+
+What does NOT cancel is `Rates.ping_cost`'s fixed ping_input/ping_output term, so 8.70% is the
+gate only in the limit:
+
+    gate(prefix) = 0.0870 + (ping_input*input + ping_output*output)
+                            / (prefix * (write_5m - cache_read))
+
+8.70% at 125k tokens, 8.72% at 20k, 8.96% at 2k, 9.74% at 500 — a spread of the same order as
+the margins below, which is what `min_prefix` is for.
 
 That 8.70% is the MYOPIC bar and it is too high. With the option value counted the
 effective bar at the first sweep falls to ~7.4%, worth ~6% of the policy's net.
@@ -135,6 +152,11 @@ def windows(cdf, interval_s: float = DEFAULT_INTERVAL_S, life_s: float = DEFAULT
     long. Values are clamped to [0, 1] rather than trusted, because a non-monotone fitted
     CDF would otherwise produce a negative hazard and a budget with no meaning.
     """
+    # max_k <= 0 means the default, because kvcache.BudgetPolicy.maxK() reads it that way and
+    # a port that read it as "no windows at all" would disagree with Go on a value the drift
+    # fixture never sends. Same convention as interval/life below.
+    if max_k <= 0:
+        max_k = DEFAULT_MAX_K
     h, s = [0.0] * max_k, [0.0] * max_k
     for j in range(1, max_k + 1):
         t_j = j * interval_s
@@ -255,6 +277,10 @@ FEATURES = SPAN_CAT + SPAN_NUM + STATE_NUM + STATS_NUM
 class FitResult:
     """Two fitted models and the frame they were fitted on."""
 
+    # `cdf_for` below composes the SURVIVAL model only, so `hazard` is currently fitted and
+    # never read: the h_j the policy uses is derived from the survival curve by windows(), not
+    # from this. Kept because y_hazard is what person_periods() labels and a direct-hazard
+    # variant is the obvious next thing to measure — but it is not what runs.
     hazard: object          # P(returns in the window this ping protects | idle at t_k)
     survival: object        # P(still idle at t_(k+1)            | idle at t_k)
     n_rows: int
@@ -264,9 +290,19 @@ class FitResult:
     def cdf_for(self, span_row, *, interval_s: float, life_s: float, max_k: int):
         """A CDF closure for one span, so `budget_for` can be used unchanged.
 
-        Reconstructed from the two hazards rather than fitted directly, because the models
-        answer conditional questions and `windows()` wants a cumulative one. Composing them
-        forwards is exact: F(t_(j+1)) = 1 - prod_(i<=j) s_i.
+        Reconstructed from the SURVIVAL model rather than fitted directly, because it answers
+        a conditional question and `windows()` wants a cumulative one. Composing forwards is
+        exact: F(t_(j+1)) = 1 - prod_(i<=j) s_i.
+
+        Two caveats, because the drift guard covers NEITHER — it drives `--fixture`, which
+        feeds a step CDF and never reaches this function:
+
+        - F(t_1) is 0 by construction, i.e. this CDF is already conditioned on reaching the
+          first sweep, and `windows()` divides by 1 - F(t_1) = 1 accordingly.
+        - the grid is {t_j} u {t_j + life}, so F(deadline) for the FIRST sweep — `life`, which
+          falls between t_1 and t_2 — is a linear interpolation across a whole interval rather
+          than a fitted value. On the shipped 280 s / 300 s that reads F(300) at
+          (300-280)/(560-280) = 7.1% of the way into the first survival step.
         """
         import numpy as np
 

--- a/deploy/harbor/kv_ttl_keepalive_policy.py
+++ b/deploy/harbor/kv_ttl_keepalive_policy.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""How MANY keep-alive pings a conversation is worth, decided per conversation.
+
+This is the learned counterpart of `kvcache.BudgetPolicy`, and the two must agree: the Go
+side is what the dashboard reports from, this side is where the fit lives, and
+`kv_ttl_keepalive_drift_test.go` drives the `--fixture` entry point below to pin them
+together. When they disagree, Go is right.
+
+    kv_ttl_keepalive_policy.py --db /var/lib/context-guru/cg.db --prices /etc/.../prices.yaml
+    kv_ttl_keepalive_policy.py --fixture f.json      # the drift test's interface, stdlib only
+    kv_ttl_keepalive_policy.py --self-test           # synthetic traffic, no store needed
+
+WHAT PROBLEM THIS SOLVES THAT THE SURVIVAL PREDICTOR DOES NOT
+-------------------------------------------------------------
+`kv_ttl_survival_predictor.py` answers "will this conversation come back within 5 minutes?"
+from the instant a request is served. That is the right question for choosing a TTL TIER.
+It is the wrong question for a keep-alive, for two reasons this module exists to fix.
+
+(1) THE POPULATION. A keep-alive fires only after the conversation has ALREADY been idle
+    for one ping interval. So the decision is never faced by the 92.5% of spans that close
+    inside five minutes — it is faced only by the survivors. Conditioning on that changes
+    the answer enormously: on this deployment's corpus the unconditional 5-minute return
+    rate is ~92%, while the stake-weighted hazard among spans that reached 270s idle is
+    23.17%. A model fitted on the unconditional population and then asked at the ping
+    instant is answering a question nobody asks.
+
+    Concretely: `elapsed silence` is NOT a feature here. It is the SAMPLE DEFINITION. A row
+    exists in the training frame because it reached that sweep.
+
+(2) THE DECISION. "Ping or not" is not the decision either; "how many" is. And the pings
+    are not independent — a ping keeps the entry alive so the NEXT ping is a cheap read
+    rather than a 12.5x re-creation, which means the value of ping j depends on what ping
+    j+1 can still buy. That is a backward induction, not a threshold.
+
+THE ECONOMICS, WHICH IS THE PART TO ARGUE WITH FIRST
+----------------------------------------------------
+Per cached token, at the documented Anthropic multiples of base input:
+
+    cache read   0.10x      a keep-alive ping is one of these
+    cache write  1.25x      what the successor pays if the entry lapsed
+    rescue       1.15x      = 1.25 - 0.10, what a successful ping avoids
+
+So a ping pays for itself when the chance it rescues exceeds 0.10/1.15 = 8.70%. The prefix
+size cancels: it multiplies cost and benefit alike. So does the model's per-token rate.
+That is why this module reads probabilities and not token counts, and why the threshold is
+computed from the price list rather than written down — a deployment on different rates has
+a different threshold, and one with no rates has none.
+
+That 8.70% is the MYOPIC bar and it is too high. With the option value counted the
+effective bar at the first sweep falls to ~7.4%, worth ~6% of the policy's net.
+
+WHAT IT IS WORTH, INCLUDING WHERE IT LOSES
+------------------------------------------
+Measured on the hosted deployment's capture: 34,577 idle spans over 16.9 days, 5-fold
+rolling-origin, pings at 290s. Given as a share of the window's bill and of what `optimal`
+reaches, with per-ping efficiency indexed to flat MaxPings=6.
+
+    arm                     pings   off the bill   of the ceiling   net per ping
+    optimal (unreachable)   5,826         11.72%           100.0%          27.7x
+    flat MaxPings=6        95,640          6.96%            59.4%           1.0x
+    flat MaxPings=5        80,404          6.91%            58.9%           1.2x
+    THIS POLICY             9,248          6.07%            51.8%           9.0x
+    flat MaxPings=2 (dflt) 33,591          5.19%            44.3%           2.1x
+
+Read the last two columns together, because they say opposite things. On MONEY a constant
+beats this policy by 0.89 pp of the bill: it ranks conversations well (AUC 0.93) and DOLLARS barely
+better than chance (AUC 0.70, and 0.57 on the largest prefixes, which carry 87% of the
+stake), so its mistakes land where they cost most, and at a 11.5:1 payoff a wrong skip is
+expensive. Per PING it is 9x better. So:
+
+    pings effectively free   ->  raise MaxPings and do not deploy a model
+    pings rate-limited      ->  this policy, by a wide margin
+
+Two things were measured and did NOT work, recorded here so they are not re-tried blind:
+threshold tuning (the best threshold chosen in HINDSIGHT is worth +0.38 pp overall and
+-0.05 pp on the top 5% of prefixes, so there is no headroom), and four families of extra
+feature (calendar, day-of-week, last-human-pause, trajectory gap history), every one of which
+came in under the +-0.42 pp seed-noise floor of this corpus. See
+docs/how-to/kv-cache-keepalive-budget.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+
+# The documented Anthropic multiples, as named constants rather than literals. kvcache's
+# pricing.go carries the same three.
+CACHE_READ_MULTIPLE = 0.10
+WRITE_5M_MULTIPLE = 1.25
+WRITE_1H_MULTIPLE = 2.00
+
+DEFAULT_INTERVAL_S = 280.0
+DEFAULT_LIFE_S = 300.0
+DEFAULT_MAX_K = 8
+
+
+# ── the arithmetic the Go side must match, byte for byte ─────────────────────
+#
+# Everything in this block is stdlib-only and pure, because it is what the drift test
+# drives. No numpy, no pandas, no sklearn: a guard that cannot run in a plain CI container
+# is an absent guard.
+
+
+def break_even(read_rate: float, write_rate: float) -> float:
+    """The reuse probability at which one ping pays for itself.
+
+    read/(write-read). Returns 1.0 — "never worth it" — where the rates make a rescue worth
+    nothing, rather than dividing by zero and reporting a threshold of infinity.
+    """
+    rescue = write_rate - read_rate
+    if rescue <= 0:
+        return 1.0
+    return read_rate / rescue
+
+
+def windows(cdf, interval_s: float = DEFAULT_INTERVAL_S, life_s: float = DEFAULT_LIFE_S,
+            max_k: int = DEFAULT_MAX_K) -> tuple[list[float], list[float]]:
+    """Turn a CUMULATIVE return-time distribution into the per-sweep conditional pair.
+
+    `cdf(seconds) -> P(the conversation has returned by then)`, measured from the request
+    that opened the idle span.
+
+    Ping j (1-based) fires at j*interval and refreshes the entry to j*interval+life, so the
+    window it and it alone protects is (deadline standing before it, j*interval + life],
+    where that deadline is `life` for the first ping and (j-1)*interval+life after. Then
+
+        h_j = (F(t_j + life) - F(d_j)) / (1 - F(t_j))    this ping rescues
+        s_j = (1 - F(t_(j+1)))        / (1 - F(t_j))     reaches the next sweep
+
+    Dividing by the survivor share is the whole point (see (1) in the module docstring): the
+    decision at sweep j is only ever faced by a conversation that already stayed idle that
+    long. Values are clamped to [0, 1] rather than trusted, because a non-monotone fitted
+    CDF would otherwise produce a negative hazard and a budget with no meaning.
+    """
+    h, s = [0.0] * max_k, [0.0] * max_k
+    for j in range(1, max_k + 1):
+        t_j = j * interval_s
+        survive = 1.0 - cdf(t_j)
+        if survive <= 0.0:
+            # Certain to be back by now, so no later ping can be needed. The zeros say it.
+            break
+        deadline = life_s if j == 1 else (j - 1) * interval_s + life_s
+        h[j - 1] = min(max((cdf(t_j + life_s) - cdf(deadline)) / survive, 0.0), 1.0)
+        s[j - 1] = min(max((1.0 - cdf(t_j + interval_s)) / survive, 0.0), 1.0)
+    return h, s
+
+
+def ping_budget(h: list[float], s: list[float], rescue: float, ping: float) -> int:
+    """How many pings to buy, by backward induction over the windows they protect.
+
+        V_j = max(0, rescue*h_j - ping + s_j*V_(j+1)),   V_maxk = 0
+        budget = the FIRST j at which V_j is not positive
+
+    The FIRST, not the last. With a non-monotone hazard the last positive V buys a run of
+    pings across a stretch that pays nothing in order to reach one that does — which the
+    induction already accounts for when it IS worth it, by propagating that value backwards.
+    Taking the last positive one double-counts it.
+    """
+    n = min(len(h), len(s))
+    v = [0.0] * (n + 1)
+    for j in range(n - 1, -1, -1):
+        v[j] = max(0.0, rescue * h[j] - ping + s[j] * v[j + 1])
+    budget = 0
+    for j in range(n):
+        if v[j] <= 0.0:
+            break
+        budget = j + 1
+    return budget
+
+
+@dataclass
+class Rates:
+    """The three per-token rates a keep-alive decision needs, plus a ping's fixed overhead.
+
+    `ping_input`/`ping_output` are the tokens a ping cannot avoid — the fresh input past the
+    cached prefix, and the smallest generation the provider accepts. They do NOT scale with
+    the prefix, which is why a small enough entry is not worth pinging at any probability.
+    kvcache.Pricing.KeepAliveCost is the same expression.
+    """
+
+    input: float
+    output: float
+    cache_read: float
+    write_5m: float
+    ping_input_tokens: int = 1
+    ping_output_tokens: int = 1
+    known: bool = True
+
+    @classmethod
+    def from_input_rate(cls, input_rate: float) -> "Rates":
+        """The documented multiples off a base input rate. The common case."""
+        return cls(input=input_rate, output=input_rate * 5.0,
+                   cache_read=input_rate * CACHE_READ_MULTIPLE,
+                   write_5m=input_rate * WRITE_5M_MULTIPLE)
+
+    def rescue_value(self, cached_tokens: int) -> float:
+        """What one successful rescue avoids: the successor's write becomes a read."""
+        return cached_tokens * (self.write_5m - self.cache_read)
+
+    def ping_cost(self, cached_tokens: int) -> float:
+        return (cached_tokens * self.cache_read
+                + self.ping_input_tokens * self.input
+                + self.ping_output_tokens * self.output)
+
+
+def budget_for(cdf, cached_tokens: int, rates: Rates, *,
+               interval_s: float = DEFAULT_INTERVAL_S, life_s: float = DEFAULT_LIFE_S,
+               max_k: int = DEFAULT_MAX_K, min_prefix: int = 0) -> int:
+    """The whole decision for one conversation. `kvcache.BudgetPolicy.PingBudget` in Python.
+
+    Returns 0 both for "not worth a ping" and for the cases where no decision can be made
+    (no rates, no prefix). The Go side distinguishes those with an `ok` flag so it can fall
+    back to the configured cap; here they coincide because there is no cap to fall back to.
+    """
+    if not rates.known or cached_tokens <= 0:
+        return 0
+    if min_prefix > 0 and cached_tokens < min_prefix:
+        return 0
+    h, s = windows(cdf, interval_s=interval_s, life_s=life_s, max_k=max_k)
+    return ping_budget(h, s, rates.rescue_value(cached_tokens), rates.ping_cost(cached_tokens))
+
+
+# ── the fit ──────────────────────────────────────────────────────────────────
+#
+# numpy/pandas/sklearn are imported INSIDE these functions, so that everything above stays
+# importable in a container that has none of them.
+
+
+SPAN_CAT = ["user_id", "model", "cache_ttl"]
+SPAN_NUM = ["log_prefix", "log_prev_gap", "turn"]
+STATE_NUM = ["sweep_k", "log_elapsed", "log_secs_to_deadline", "hour_utc", "dow_utc"]
+STATS_NUM = ["stat_p", "stat_n"]
+
+#: The 13 features, and the reason the list is exactly this long.
+#:
+#: Every one is carried by `kvcache.Observation` — User, Model, TTL, CachedTokens,
+#: SinceLastMs, Turn, Now, ExpiresAt — or derived from `Observation.Stats`, the leak-free
+#: accumulator the simulator already advances as gaps close. That is a hard constraint, not a
+#: preference: a model fitted on anything else cannot be wired in behind
+#: `kvcache.Predictor`, which is the whole point of the seam.
+#:
+#: It costs almost nothing. Measured 3-seed means on this corpus: the unrestricted 21-feature
+#: model takes 6.11% off the window's bill, these 13 take 6.07% (-0.04 pp, inside the noise
+#: floor), and dropping the two Stats features to leave only what Observation carries directly
+#: costs 0.40 pp. So
+#: the historical accumulator is doing most of the work the excluded request-shape features
+#: would have done.
+FEATURES = SPAN_CAT + SPAN_NUM + STATE_NUM + STATS_NUM
+
+
+@dataclass
+class FitResult:
+    """Two fitted models and the frame they were fitted on."""
+
+    hazard: object          # P(returns in the window this ping protects | idle at t_k)
+    survival: object        # P(still idle at t_(k+1)            | idle at t_k)
+    n_rows: int
+    n_spans: int
+    notes: dict = field(default_factory=dict)
+
+    def cdf_for(self, span_row, *, interval_s: float, life_s: float, max_k: int):
+        """A CDF closure for one span, so `budget_for` can be used unchanged.
+
+        Reconstructed from the two hazards rather than fitted directly, because the models
+        answer conditional questions and `windows()` wants a cumulative one. Composing them
+        forwards is exact: F(t_(j+1)) = 1 - prod_(i<=j) s_i.
+        """
+        import numpy as np
+
+        surv, cum = 1.0, {0.0: 0.0}
+        for j in range(1, max_k + 2):
+            t_j = j * interval_s
+            frame = _state_frame(span_row, j, interval_s, life_s)
+            s_j = float(self.survival.predict_proba(frame)[:, 1][0])
+            cum[t_j] = 1.0 - surv
+            surv *= s_j
+            cum[t_j + life_s] = 1.0 - surv
+        keys = np.array(sorted(cum))
+        vals = np.array([cum[k] for k in keys])
+
+        def cdf(seconds: float) -> float:
+            return float(np.interp(seconds, keys, vals))
+
+        return cdf
+
+
+def _state_frame(span_row, k: int, interval_s: float, life_s: float):
+    """One span's features AS SEEN AT SWEEP k. Only the state block moves."""
+    import numpy as np
+    import pandas as pd
+
+    f = pd.DataFrame([{c: span_row[c] for c in SPAN_CAT + SPAN_NUM + STATS_NUM}])
+    t_k = k * interval_s
+    deadline = life_s if k == 1 else (k - 1) * interval_s + life_s
+    f["sweep_k"] = k
+    f["log_elapsed"] = np.log1p(t_k)
+    f["log_secs_to_deadline"] = np.log1p(max(deadline - t_k, 0.0))
+    secs = span_row["ts_ms"] / 1000.0 + t_k
+    f["hour_utc"] = int(secs // 3600 % 24)
+    f["dow_utc"] = int((secs // 86400 + 4) % 7)
+    return f[FEATURES]
+
+
+def person_periods(spans, interval_s: float, life_s: float, max_k: int):
+    """One row per (span, sweep it ACTUALLY reached), with both targets attached.
+
+    This layout is the module's central claim. Every row in it is a decision the policy will
+    really face, which is exactly what a frame built from all requests is not.
+
+    `spans` needs: gap_s (seconds to the next cache-compatible request, inf if none), ts_ms,
+    stake, and the feature columns.
+    """
+    import numpy as np
+    import pandas as pd
+
+    out = []
+    for k in range(1, max_k + 1):
+        t_k = k * interval_s
+        reached = spans[spans.gap_s > t_k]
+        if reached.empty:
+            break
+        rows = pd.concat([_state_frame(r, k, interval_s, life_s)
+                          for _, r in reached.iterrows()], ignore_index=True)
+        deadline = life_s if k == 1 else (k - 1) * interval_s + life_s
+        g = reached.gap_s.to_numpy()
+        rows["y_hazard"] = ((g > deadline) & (g <= t_k + life_s)).astype(int)
+        nxt = t_k + interval_s if k < max_k else np.inf
+        rows["y_survival"] = (g > nxt).astype(int)
+        rows["stake"] = reached.stake.to_numpy()
+        out.append(rows)
+    return pd.concat(out, ignore_index=True)
+
+
+def fit(spans, *, interval_s: float = DEFAULT_INTERVAL_S, life_s: float = DEFAULT_LIFE_S,
+        max_k: int = DEFAULT_MAX_K, seed: int = 0) -> FitResult:
+    """Fit the two models on the person-period frame, weighted by DOLLARS AT RISK.
+
+    The weight is the point. An unweighted fit optimises row accuracy, and rows are not what
+    the bill is made of: this corpus's stake is concentrated so hard that the model can reach
+    AUC 0.93 by row while ranking dollars at 0.70. Weighting by stake does not close that gap
+    — nothing measured here does — but fitting without it makes it worse.
+    """
+    from sklearn.compose import ColumnTransformer
+    from sklearn.ensemble import HistGradientBoostingClassifier
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import OneHotEncoder
+
+    pp = person_periods(spans, interval_s, life_s, max_k)
+    w = pp.stake.clip(lower=0)
+    weights = (1e-9 + w / w.mean()).to_numpy()
+
+    def build():
+        return Pipeline([
+            ("prep", ColumnTransformer([
+                ("cat", OneHotEncoder(handle_unknown="ignore", min_frequency=20,
+                                      sparse_output=False), SPAN_CAT),
+                ("num", "passthrough", SPAN_NUM + STATE_NUM + STATS_NUM)])),
+            # max_iter is a ceiling, not a target: early stopping settles at ~37 trees on this
+            # corpus, which is the model telling us how much signal it found.
+            ("gbm", HistGradientBoostingClassifier(max_iter=200, learning_rate=0.08,
+                                                   random_state=seed))])
+
+    hz, sv = build(), build()
+    hz.fit(pp[FEATURES], pp.y_hazard, gbm__sample_weight=weights)
+    sv.fit(pp[FEATURES], pp.y_survival, gbm__sample_weight=weights)
+    return FitResult(hazard=hz, survival=sv, n_rows=len(pp), n_spans=len(spans),
+                     notes={"interval_s": interval_s, "life_s": life_s, "max_k": max_k,
+                            "seed": seed})
+
+
+# ── the drift test's interface ───────────────────────────────────────────────
+
+
+def _run_fixture(path: str) -> int:
+    """Score a fixture and print JSON. Stdlib only, so the guard runs anywhere.
+
+    A fixture is {"interval_s":…, "life_s":…, "max_k":…, "cases":[{
+        "cached_tokens":…, "input_rate":…, "cdf":[[seconds, p], …],
+        "min_prefix":… (optional)}]}
+
+    and the output is {"break_even":…, "budgets":[…], "windows":[{"h":[…],"s":[…]}, …]} so
+    the Go test can compare the decision AND the two intermediate vectors — a budget that
+    agrees for the wrong reason is a guard that will stop catching things.
+    """
+    with open(path, encoding="utf-8") as fh:
+        spec = json.load(fh)
+    interval = float(spec.get("interval_s", DEFAULT_INTERVAL_S))
+    life = float(spec.get("life_s", DEFAULT_LIFE_S))
+    max_k = int(spec.get("max_k", DEFAULT_MAX_K))
+    budgets, wins = [], []
+    be = None
+    for case in spec["cases"]:
+        rates = Rates.from_input_rate(float(case["input_rate"]))
+        be = break_even(rates.cache_read, rates.write_5m)
+        points = sorted((float(a), float(b)) for a, b in case["cdf"])
+
+        def cdf(seconds: float, _pts=points) -> float:
+            p = 0.0
+            for at, val in _pts:
+                if seconds >= at:
+                    p = val
+            return p
+
+        h, s = windows(cdf, interval_s=interval, life_s=life, max_k=max_k)
+        wins.append({"h": h, "s": s})
+        budgets.append(budget_for(cdf, int(case["cached_tokens"]), rates, interval_s=interval,
+                                  life_s=life, max_k=max_k,
+                                  min_prefix=int(case.get("min_prefix", 0))))
+    print(json.dumps({"break_even": be, "budgets": budgets, "windows": wins}))
+    return 0
+
+
+def _self_test() -> int:
+    """Assert the properties the module claims, on hand-written distributions.
+
+    Deliberately the same four the Go tests assert, because the two implementations agreeing
+    on a fixture is worth less if neither is checked against the arithmetic it claims.
+    """
+    rates = Rates.from_input_rate(3.0e-6)
+    be = break_even(rates.cache_read, rates.write_5m)
+    assert abs(be - 0.0869565) < 1e-6, f"break-even moved: {be}"
+
+    def cdf_of(points):
+        pts = sorted(points)
+
+        def f(x: float) -> float:
+            p = 0.0
+            for at, val in pts:
+                if x >= at:
+                    p = val
+            return p
+        return f
+
+    # the gate is prefix-independent
+    below, above = cdf_of([(300, 0), (580, be * 0.5)]), cdf_of([(300, 0), (580, be * 3)])
+    for prefix in (2_000, 124_845, 2_000_000):
+        assert budget_for(below, prefix, rates, max_k=1) == 0, prefix
+        assert budget_for(above, prefix, rates, max_k=1) >= 1, prefix
+
+    # the option value pings through a lean first window
+    lean = cdf_of([(580, 0.02), (860, 0.60), (3600, 1)])
+    assert budget_for(lean, 124_845, rates, max_k=1) == 0
+    assert budget_for(lean, 124_845, rates, max_k=4) >= 2
+
+    # a worthless tail ends the schedule; a reachable rich window does not
+    assert budget_for(cdf_of([(300, 0), (580, 0.30), (86400, 0.30)]), 124_845, rates) == 1
+    far = cdf_of([(300, 0), (580, .3), (860, .3), (1140, .3), (1420, .3), (1700, .95), (86400, 1)])
+    assert budget_for(far, 124_845, rates) >= 5
+
+    # the hazard is conditional on still being idle
+    gone = cdf_of([(280, 0.90), (580, 0.90), (860, 0.95), (3600, 1)])
+    stay = cdf_of([(280, 0.00), (580, 0.00), (860, 0.05), (3600, 1)])
+    hg, _ = windows(gone, max_k=2)
+    hs, _ = windows(stay, max_k=2)
+    assert hg[1] > 5 * hs[1], f"not conditional: {hg[1]} vs {hs[1]}"
+
+    print(f"self-test OK   break-even {100 * be:.2f}%   13 features   "
+          f"interval {DEFAULT_INTERVAL_S:.0f}s / life {DEFAULT_LIFE_S:.0f}s / max_k "
+          f"{DEFAULT_MAX_K}")
+    return 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--fixture", help="score a JSON fixture and print it (drift test)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="assert the module's claims on hand-written distributions")
+    args = ap.parse_args(argv)
+    if args.fixture:
+        return _run_fixture(args.fixture)
+    if args.self_test:
+        return _self_test()
+    ap.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/how-to/kv-cache-keepalive-budget.md
+++ b/docs/how-to/kv-cache-keepalive-budget.md
@@ -167,7 +167,7 @@ would overstate every figure below.
 
 A span is one idle stretch of a trajectory, and a trajectory is `(account, session, MODEL)` — a
 cache entry does not transfer between models, so a session that switches model is two
-trajectories. Pings are at 290 s throughout, which is a parameter and not a law: it is inside
+trajectories. Pings are at 280 s throughout, which is a parameter and not a law: it is inside
 the 300 s lifetime it protects, so every ping is a read rather than a re-creation.
 
 Savings are given as a share of the window's **total bill**, of which 87.1% is the prefix

--- a/docs/how-to/kv-cache-keepalive-budget.md
+++ b/docs/how-to/kv-cache-keepalive-budget.md
@@ -149,9 +149,15 @@ mistake was made and corrected during this work.
 
 | feature set | n | AUC (dollar-weighted) | off the bill | vs unrestricted |
 |---|---:|---:|---:|---:|
-| unrestricted (adds `stop_reason`, `agent`, `tools`, …) | 21 | 0.7051 | 6.11% | — |
+| unrestricted (adds `agent`, `tools`, …) | 21 | 0.7051 | 6.11% | — |
 | **`Observation` + `Stats`** | **13** | **0.7004** | **6.07%** | **−0.04 pp** |
 | `Observation` alone | 11 | 0.6916 | 5.71% | −0.40 pp |
+
+`stop_reason` was one of the unrestricted set's features when this ran, and has since
+joined the seam as `Observation.StopReason` — on the same footing as `CachedTokens`, and read
+by the registry's `stop-reason-gated` arm. So the 13-feature column predates it and the
+comparison above was not re-run against the wider seam; the numbers are the ones measured,
+not the ones a rerun would produce.
 
 The restriction is free (−0.04 pp is inside the noise floor). Dropping the two `Stats` features
 is *not* free. The historical accumulator is doing most of the work the excluded

--- a/docs/how-to/kv-cache-keepalive-budget.md
+++ b/docs/how-to/kv-cache-keepalive-budget.md
@@ -1,0 +1,296 @@
+# Decide how many keep-alives a conversation is worth
+
+[Choose a cache TTL](kv-cache-ttl.md) prices the *tier* — five minutes or an hour. This page
+is about the other lever: once an entry exists, **how many keep-alive pings to spend holding
+it**, decided per conversation instead of once for the whole fleet.
+
+The short version, and the last bullet is the one to read first:
+
+- **The break-even is 8.70%**, it comes out of the rates rather than a config file, and it is
+  the same number for every prefix size and every model.
+- **The decision is not "ping or not", it is "how many"**, and the pings are not independent:
+  each one keeps the entry alive so the next is a `0.1x` read instead of a `1.25x`
+  re-creation. That makes it a backward induction, not a threshold.
+- **`kvcache.BudgetPolicy` is the arm**; `PingBudgeter` is the one-method seam that lets a
+  per-conversation budget reach the ping loop. Neither changes any existing arm.
+- **On money, a constant beats it.** A flat `MaxPings=5` takes 6.91% off the bill where this
+  policy takes 6.07%. It wins only on **net per ping**, and there by 9×.
+  If your pings are effectively free, raise `MaxPings` and do not deploy a model. That is the
+  honest recommendation and the rest of this page is why.
+
+## The economics, which is the part to argue with first
+
+Per cached token, as multiples of base input:
+
+| | multiple | what it is |
+|---|---|---|
+| cache read | `0.10x` | what a keep-alive ping costs |
+| cache write (5m) | `1.25x` | what the successor pays if the entry lapsed |
+| **rescue** | **`1.15x`** | `1.25 − 0.10`, what a successful ping avoids |
+
+A ping pays for itself when the chance it rescues exceeds `0.10 / 1.15 = 8.70%`.
+
+The prefix size **cancels** — it multiplies cost and benefit alike — and so does the model's
+per-token rate. That is why `BudgetPolicy` reads a probability and never a token count, and
+why the threshold is computed from `Observation.Pricing` rather than written down: a
+deployment on different rates has a different threshold, and one with no rates has none
+(`PingBudget` returns `ok=false` and the configured `MaxPings` governs).
+
+Two consequences worth stating because they are easy to get backwards:
+
+- **The payoff is 11.5:1.** A wrong skip costs 11.5 times a wasted ping. A policy that skips
+  has to be right almost every time to come out ahead, which is most of why the measured
+  result below goes the way it does.
+- **A late ping is not a cheap ping.** One that lands after the entry lapsed is priced as a
+  re-creation — `12.5x` a read — by `Pricing.RecreateCost`, and counted in
+  `Result.PingsThatRewrote`. On the live deployment 1.72% of real pings did this. A schedule
+  whose interval exceeds the lifetime it protects does it every time.
+
+### The gate is the myopic bar, and it is too high
+
+8.70% is what a single ping considered alone must clear. But a ping buys two things: this
+window's rescue, *and* the right to make a cheap decision at the next sweep. So the budget is
+an induction over the windows a ping would protect:
+
+```
+V_j = max(0, rescue×h_j − ping + s_j×V_(j+1)),   V_maxk = 0
+budget = the FIRST j at which V_j is not positive
+```
+
+The **first**, not the last. With a non-monotone hazard — which real traffic has — taking the
+last positive `V` double-counts value the induction has already propagated backwards, and buys
+a run of pings across a dead stretch. Counting the option value properly lowers the effective
+bar at the first sweep to about **7.4%** and is worth ~6% of the arm's net.
+
+## What is being predicted, and why it is not the survival predictor's question
+
+[`kv_ttl_survival_predictor.py`](kv-cache-ttl.md)
+answers *"will this conversation return within five minutes?"* from the instant a request is
+served. That is the right question for a tier. It is the wrong question for a keep-alive, for
+two reasons.
+
+**The population is different.** A keep-alive fires only after the conversation has *already*
+been idle for one interval, so the decision is never faced by the ~92.5% of spans that close
+inside five minutes. It is faced only by the survivors. On this corpus:
+
+| population | 5-minute return rate |
+|---|---|
+| all requests (unconditional) | ~92% |
+| spans that reached 270s idle, stake-weighted | **23.17%** |
+
+A model fitted on the first number and then consulted at the ping instant is answering a
+question nobody asks.
+
+The practical form of this: **elapsed silence is not a feature, it is the sample definition.**
+A row exists in the training frame *because* it reached that sweep. `person_periods()` builds
+exactly that — one row per `(span, sweep it actually reached)` — and it is the layout the whole
+method rests on.
+
+**The target is different too.** The policy needs two conditional quantities per sweep, both
+derived from the cumulative answer `F` that `kvcache.Predictor` already returns:
+
+```
+h_j = (F(t_j + life) − F(d_j)) / (1 − F(t_j))    this ping rescues
+s_j = (1 − F(t_(j+1)))        / (1 − F(t_j))     reaches the next sweep
+```
+
+The divide by the survivor share is the conditioning, and it is not cosmetic: on a
+distribution where 90% have already returned, 5 percentage points of remaining mass is a **50%**
+conditional hazard, not 5%. `BudgetPolicy.Windows` is exported so that
+`kv_ttl_keepalive_drift_test.go` can pin both vectors against the Python, because a budget
+that agrees for the wrong reason is a guard that has already stopped working.
+
+## The 13 features, and why the list is exactly that long
+
+Every feature is carried by `kvcache.Observation`, or derived from `Observation.Stats` — the
+leak-free accumulator the simulator already advances as gaps close. **That is a hard
+constraint, not a preference:** a model fitted on anything else cannot be wired in behind
+`kvcache.Predictor`, which is the entire point of the seam.
+
+| block | features | source |
+|---|---|---|
+| categorical | `user_id`, `model`, `cache_ttl` | `Observation.User` / `.Model` / `.TTL` |
+| span numeric | `log_prefix`, `log_prev_gap`, `turn` | `.CachedTokens`, `.SinceLastMs`, `.Turn` |
+| state numeric | `sweep_k`, `log_elapsed`, `log_secs_to_deadline`, `hour_utc`, `dow_utc` | recomputed per sweep from `.Now` and `.ExpiresAt` |
+| historical | `stat_p`, `stat_n` | `Observation.Stats.ReuseWithin`, with `History`'s own fallback ladder |
+
+The state block is what makes the policy per-state: `hour_utc` is the hour **at the decision
+instant**, not at the last message.
+
+`sweep_k` is a legitimate feature here *only* because the frame is pooled across sweeps — it
+absorbs the baseline hazard so the metadata explains deviation from it. Ranking features on
+that same pooled frame is not legitimate, because `sweep_k` then swamps every covariate. That
+mistake was made and corrected during this work.
+
+### What the restriction costs: almost nothing
+
+3-seed means, 5-fold rolling origin:
+
+| feature set | n | AUC (dollar-weighted) | off the bill | vs unrestricted |
+|---|---:|---:|---:|---:|
+| unrestricted (adds `stop_reason`, `agent`, `tools`, …) | 21 | 0.7051 | 6.11% | — |
+| **`Observation` + `Stats`** | **13** | **0.7004** | **6.07%** | **−0.04 pp** |
+| `Observation` alone | 11 | 0.6916 | 5.71% | −0.40 pp |
+
+The restriction is free (−0.04 pp is inside the noise floor). Dropping the two `Stats` features
+is *not* free. The historical accumulator is doing most of the work the excluded
+request-shape features would have done, which is a good outcome: it means the seam was
+designed with the right things on it.
+
+## What it measured
+
+The hosted deployment's own capture: **34,577 idle spans** over 16.9 days, 5-fold
+rolling origin, at `/etc/context-guru/prices.yaml` — which matters for the same reason it does
+on the TTL page, since this gateway's rates are not anthropic.com's and the public list price
+would overstate every figure below.
+
+A span is one idle stretch of a trajectory, and a trajectory is `(account, session, MODEL)` — a
+cache entry does not transfer between models, so a session that switches model is two
+trajectories. Pings are at 290 s throughout, which is a parameter and not a law: it is inside
+the 300 s lifetime it protects, so every ping is a read rather than a re-creation.
+
+Savings are given as a share of the window's **total bill**, of which 87.1% is the prefix
+portion a keep-alive can move, and as a share of what `optimal` reaches:
+
+| arm | pings | off the bill | of the ceiling | net per ping |
+|---|---:|---:|---:|---:|
+| `optimal` *(unreachable — reads the future)* | 5,826 | **11.72%** | 100.0% | 27.7× |
+| flat `MaxPings=6` | 95,640 | **6.96%** | 59.4% | 1.0× |
+| flat `MaxPings=5` | 80,404 | 6.91% | 58.9% | 1.2× |
+| **`BudgetPolicy`** | **9,248** | **6.07%** | 51.8% | **9.0×** |
+| flat `MaxPings=2` *(`DefaultMaxPings`)* | 33,591 | 5.19% | 44.3% | 2.1× |
+
+"net per ping" is each arm's saving divided by its ping count, indexed to flat `MaxPings=6`.
+
+### Read the last two columns together, because they disagree
+
+On **money** a constant wins by 0.89 pp of the bill — 7.6 points of the ceiling. The measured reason:
+
+| population | share of stake | AUC by row | AUC by dollar |
+|---|---|---|---|
+| all spans | 100% | 0.93 | 0.635 |
+| top 20% by prefix | 99.5% | 0.76 | 0.615 |
+| **top 5% by prefix** | **86.7%** | **0.58** | **0.566** |
+
+The model ranks *conversations* almost perfectly and *dollars* barely above chance — and it
+degrades toward the tail where the money is. Its mistakes concentrate on the large-prefix
+spans where a mistake costs most, and at 11.5:1 that is decisive.
+
+On **pings** it is 9× better, and that is the case for deploying it: where a tenant rate limit
+rather than money is what caps the budget, `BudgetPolicy` gets 88% of `MaxPings=5`'s saving for
+11% of its pings. On the live deployment ping coverage sits at 3.7% of candidates, so the
+budget plausibly *is* the binding constraint — but that is a rate-limit question, not a
+modelling one, and it is the question to settle before choosing.
+
+### Two things that were measured and did not work
+
+Recorded so they are not retried blind.
+
+**Threshold tuning has no headroom.** The best threshold chosen *in hindsight* — which no
+production policy can reach — is worth **+0.38 pp** over ping-everything across all spans,
+**+0.02 pp** on the top 20% of prefixes, and **−0.05 pp** on the top 5%. Isotonic recalibration collapsed to
+pinging nothing.
+
+**Four families of extra feature came in under the noise floor.** The same model varies
+**±0.42 pp** of the bill on the RNG seed alone, and every feature effect measured is smaller:
+
+| family | 3-seed mean | verdict |
+|---|---:|---|
+| day-of-week (as number, as category, as `is_weekend`, crossed with hour) | +0.04 pp | sign flips across seeds |
+| last long pause via `gap > 100s` | +0.05 pp | sign flips; best dollar-AUC of any variant |
+| trajectory gap history (max / mean / count) | −0.15 pp | sign flips |
+| last human turn via `stop_reason == end_turn` | **−0.45 pp** | consistently *worse* on all 3 seeds |
+
+The last one is instructive: those features are absent on 86.7% of rows but present on 87.8%
+of the *stake*. Sparse in rows and concentrated in dollars is the worst shape for a
+stake-weighted fit — few examples, all high-weight — so the model overfits exactly where
+mistakes are expensive.
+
+Day-of-week shows real descriptive structure (stake-weighted hazard 8.56% on Saturdays to
+16.85% on Thursdays, and Saturday afternoon UTC falls to 3.99%, below the gate) that does not
+survive out of sample. With 18 calendar days there are only 2–3 instances of each weekday and
+a 5× volume ramp across the window, so the weekday label is partly a label for a specific
+date. **Separating a weekly cycle from a date effect needs 8–12 weeks**, and until then no
+feature question on this corpus is answerable.
+
+## How to use it
+
+`BudgetPolicy` is deliberately **not** in `Registry()`. Like `Custom`, it cannot be built from
+a name alone — it needs a `Predictor` — and the registry's promise is that every name in it
+resolves. Construct it and hand it to `Simulate`:
+
+```go
+pol := kvcache.BudgetPolicy{
+    Predictor: yourModel,              // anything implementing kvcache.Predictor
+    Interval:  cfg.PingIdle,           // MUST match what the simulator will ping at
+    MaxK:      kvcache.DefaultBudgetMaxK,
+    MinPrefix: 10_000,                 // optional: a ping's fixed overhead is not worth it below this
+    Semantics: cfg.Semantics,
+}
+result := kvcache.Simulate(reqs, pol, cfg)
+```
+
+`Interval` must match `Config.PingIdle`. If it does not, the windows this policy prices are
+not the windows the simulator buys, and every number it produces is about a schedule nobody
+ran.
+
+`Config.MaxPings` remains a **ceiling**. A budget above it is clamped, so a model can never
+raise an operator's cap — asserted by `TestPingBudgeterBoundsTheSimulatedPings`.
+
+### Implementing `PingBudgeter` on your own arm
+
+```go
+type PingBudgeter interface {
+    PingBudget(o Observation) (budget int, ok bool)
+}
+```
+
+`ok=false` means *"no opinion, use `Config.MaxPings`"* — not *"never ping"*. The distinction
+matters: reading a genuine zero as an absence would silently restore the configured cap on
+exactly the spans a model asked to leave alone, which is why `convState` carries an explicit
+`budgeted` flag rather than a zero sentinel. Any arm that does not implement the interface is
+budgeted by `Config.MaxPings` exactly as before.
+
+## The offline side
+
+`deploy/harbor/kv_ttl_keepalive_policy.py` holds the fit and the evaluation.
+
+```sh
+cd deploy/harbor
+python3 kv_ttl_keepalive_policy.py --self-test    # asserts the module's claims, stdlib only
+python3 kv_ttl_keepalive_policy.py --fixture f.json
+```
+
+Everything above the `── the fit ──` divider is **stdlib-only and pure**: `break_even`,
+`windows`, `ping_budget`, `Rates`, `budget_for`. The scientific stack is imported inside the
+fitting functions only, so the drift guard runs in a plain CI container. A guard that cannot
+run is an absent guard.
+
+`kv_ttl_keepalive_drift_test.go` drives that `--fixture` entry point and compares the budget
+**and** both intermediate vectors across 11 cases chosen to sit on branches the two
+implementations could plausibly diverge on — either side of the break-even to within 2 basis
+points, a lean-then-rich pair, a worthless tail, a far-but-reachable window, a distribution
+where most have already returned, a small prefix where the ping's fixed overhead matters, and
+a rate scale 5× different to prove the threshold does not move. Deleting the survivor divide
+from the Python makes it fail with `port 0.05` against `Go 0.50`, which is the check working.
+
+## Where to look next
+
+The measured blocker is specific: **the model cannot rank dollars.** Row AUC 0.93, dollar AUC
+0.70, and 0.57 on the spans holding 87% of the stake. Everything downstream of that — the
+threshold tuning, the four feature families — was an attempt to work around it and none
+succeeded, which is what makes it the blocker rather than one finding among several.
+
+Two things follow, in order:
+
+1. **A longer window.** At ±0.42 pp of seed noise on 18 days, no feature-level question is
+   answerable. 8–12 weeks makes them answerable and separates weekday from date.
+2. **Tenant-local time instead of UTC.** The night/weekend boundary is where the calendar
+   signal lives, and UTC smears it for every tenant not near Greenwich. There is no timezone
+   column, but each tenant's own activity histogram gives an offset. This is a *transform* of
+   two existing features rather than a new one, so it can plausibly clear the noise floor
+   where an added column cannot — and it targets the same physical signal ("nobody is at the
+   desk") more directly than a weekday label does.
+
+What is **not** worth doing is adding more columns and measuring them on 18 days. That
+returns sign-flipping answers indefinitely, and this work produced four of them.

--- a/docs/how-to/kv-cache-keepalive-budget.md
+++ b/docs/how-to/kv-cache-keepalive-budget.md
@@ -6,15 +6,17 @@ it**, decided per conversation instead of once for the whole fleet.
 
 The short version, and the last bullet is the one to read first:
 
-- **The break-even is 8.70%**, it comes out of the rates rather than a config file, and it is
-  the same number for every prefix size and every model.
+- **The break-even is 8.70%**, and it comes out of the rates rather than a config file. It is
+  the same number for every model, and for every prefix large enough that a ping's fixed
+  overhead rounds away — 8.70% at 125k tokens, 9.74% at 500.
 - **The decision is not "ping or not", it is "how many"**, and the pings are not independent:
   each one keeps the entry alive so the next is a `0.1x` read instead of a `1.25x`
   re-creation. That makes it a backward induction, not a threshold.
 - **`kvcache.BudgetPolicy` is the arm**; `PingBudgeter` is the one-method seam that lets a
   per-conversation budget reach the ping loop. Neither changes any existing arm.
 - **On money, a constant beats it.** A flat `MaxPings=5` takes 6.91% off the bill where this
-  policy takes 6.07%. It wins only on **net per ping**, and there by 9×.
+  policy takes 6.07%. It wins only on **net per ping**, and against that same `MaxPings=5` by
+  **7.6×** — the 9× below is against `MaxPings=6`, which is what the table is indexed to.
   If your pings are effectively free, raise `MaxPings` and do not deploy a model. That is the
   honest recommendation and the rest of this page is why.
 
@@ -30,11 +32,30 @@ Per cached token, as multiples of base input:
 
 A ping pays for itself when the chance it rescues exceeds `0.10 / 1.15 = 8.70%`.
 
-The prefix size **cancels** — it multiplies cost and benefit alike — and so does the model's
-per-token rate. That is why `BudgetPolicy` reads a probability and never a token count, and
-why the threshold is computed from `Observation.Pricing` rather than written down: a
-deployment on different rates has a different threshold, and one with no rates has none
+The model's per-token rate **cancels**, and so does the *per-token part* of the prefix — it
+multiplies cost and benefit alike. That is why `BudgetPolicy` reads a probability and never a
+token count, and why the threshold is computed from `Observation.Pricing` rather than written
+down: a deployment on different rates has a different threshold, and one with no rates has none
 (`PingBudget` returns `ok=false` and the configured `MaxPings` governs).
+
+What does **not** cancel is the ping's fixed overhead. `Pricing.KeepAliveCost` carries
+`ping_input` and `ping_output` terms that do not scale with the prefix, so
+
+```
+gate(prefix) = 0.0870 + (ping_input x input + ping_output x output)
+                        / (prefix x (write_5m - cache_read))
+```
+
+| prefix | gate |
+|---:|---:|
+| 500 | 9.74% |
+| 2,000 | 8.96% |
+| 20,000 | 8.72% |
+| 125,000 | 8.70% |
+
+8.70% is the limit, not the number at every size, and the spread is the same order as the
+margins this arm is chosen by. `MinPrefix` is the gate for exactly that reason, and
+`TestBudgetGateRisesOnASmallPrefixByTheFixedOverhead` pins the four figures above.
 
 Two consequences worth stating because they are easy to get backwards:
 
@@ -233,6 +254,26 @@ result := kvcache.Simulate(reqs, pol, cfg)
 `Interval` must match `Config.PingIdle`. If it does not, the windows this policy prices are
 not the windows the simulator buys, and every number it produces is about a schedule nobody
 ran.
+
+### The schedules it will not price
+
+Every window above is priced as one `KeepAliveCost` — a `0.1x` read that carries the entry
+another lifetime. Three configurations make that false, and the simulator bills all three as
+`Pricing.RecreateCost`, a `1.25x` write:
+
+| configuration | why the read model breaks | reachable via |
+|---|---|---|
+| `Semantics.PingRefreshesTTL` off | a ping extends nothing, so every ping after the first lands on a dead entry | `?ping_refresh=0` |
+| `Semantics.HitRefreshesTTL` off | the entry may already be nearer expiry than one lifetime, and `Observation` carries no hit flag by design, so the arm cannot tell | `?hit_refresh=0` |
+| `Interval >= 300 s` | every ping arrives after the entry it was meant to hold | `?x=300` and up |
+
+Measured on `kvcache`'s replay fixture at `MaxPings=6`, one predictor throughout, against a
+plain 5-minute write with no pings: **−0.9%** under the documented semantics, **+17.6%** with
+`HitRefreshesTTL` off, **+86.0%** with `PingRefreshesTTL` off, **+146.1%** at a 400 s interval.
+
+So `PingBudget` returns `ok=false` on all three rather than quote a break-even taken from a
+rate it is not paying, and `Decide` then writes 5m and fires no pings —
+`TestBudgetDeclinesASchedulePricedOnTheWrongRate`.
 
 `Config.MaxPings` remains a **ceiling**. A budget above it is clamped, so a model can never
 raise an operator's cap — asserted by `TestPingBudgeterBoundsTheSimulatedPings`.

--- a/docs/how-to/kv-cache-keepalive-budget.md
+++ b/docs/how-to/kv-cache-keepalive-budget.md
@@ -189,9 +189,18 @@ On **money** a constant wins by 0.89 pp of the bill — 7.6 points of the ceilin
 
 | population | share of stake | AUC by row | AUC by dollar |
 |---|---|---|---|
-| all spans | 100% | 0.93 | 0.635 |
+| all spans | 100% | 0.93 | 0.635¹ |
 | top 20% by prefix | 99.5% | 0.76 | 0.615 |
 | **top 5% by prefix** | **86.7%** | **0.58** | **0.566** |
+
+¹ **Unverified — do not quote this cell.** A stake-weighted AUC decomposes as
+`p²·AUC_in + (1−p)²·AUC_out + 2p(1−p)·AUC_cross` for a subgroup holding stake share `p`. The
+top-20% row above (`p = 0.995`, `AUC = 0.615`) puts a ceiling on this cell of
+`0.995²·0.615 + 0.005²·1 + 2·0.995·0.005·1 ≈ 0.619` even granting the complement and every
+cross-pair a perfect 1.0 — below the 0.635 claimed here, so the two rows cannot both be right.
+Which one is mis-transcribed isn't recoverable from the published figures alone — that needs
+the underlying per-span dollar values, which is outside this page's data boundary. Read this
+cell as "high 0.6x, exact value unconfirmed," not as 0.635.
 
 The model ranks *conversations* almost perfectly and *dollars* barely above chance — and it
 degrades toward the tail where the money is. Its mistakes concentrate on the large-prefix
@@ -317,10 +326,12 @@ from the Python makes it fail with `port 0.05` against `Go 0.50`, which is the c
 
 ## Where to look next
 
-The measured blocker is specific: **the model cannot rank dollars.** Row AUC 0.93, dollar AUC
-0.70, and 0.57 on the spans holding 87% of the stake. Everything downstream of that — the
-threshold tuning, the four feature families — was an attempt to work around it and none
-succeeded, which is what makes it the blocker rather than one finding among several.
+The measured blocker is specific: **the model cannot rank dollars.** Row AUC 0.93, falling to
+0.57 on the spans holding 87% of the stake — the whole-population dollar AUC is the table cell
+flagged unverified above, and is NOT 0.70, a figure the same table's own arithmetic rules out
+by a wider margin than the 0.635 it disputes. Everything downstream of that — the threshold
+tuning, the four feature families — was an attempt to work around it and none succeeded, which
+is what makes it the blocker rather than one finding among several.
 
 Two things follow, in order:
 

--- a/docs/how-to/kv-cache-ttl.md
+++ b/docs/how-to/kv-cache-ttl.md
@@ -6,7 +6,9 @@ them — per request, per conversation, per account — is a policy, and until n
 no way to price one.
 
 This page is that way. It covers the cost model, the strategies, the offline predictor, and
-what the whole thing measured on this service's own traffic. The short version:
+what the whole thing measured on this service's own traffic. For the *other* lever — how many
+keep-alive pings to spend holding an entry once it exists — see
+[Budget keep-alive pings](kv-cache-keepalive-budget.md). The short version:
 
 - **Prompt caching itself is already earning 77.4%** of the uncached bill, and that is banked.
 - **The reachable TTL headroom on top of it is 7.44%**, taken by a blind keep-alive with no model

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -96,9 +96,11 @@ type PingBudgeter interface {
 //
 // So this is NOT the cheaper policy where pings are free: a constant beats it by 0.89 pp of the
 // bill, 7.6 points of the ceiling, because the model ranks conversations well (AUC 0.93) and
-// DOLLARS barely better than chance (AUC 0.70, falling to 0.57 on the largest prefixes, which
-// carry 87% of the stake). What it is, is 9x more efficient PER PING, which is what matters
-// where a tenant rate limit rather than money is what caps the budget.
+// DOLLARS much worse, falling to 0.57 on the largest prefixes, which carry 87% of the stake.
+// (Not 0.70 for the whole population: kv-cache-keepalive-budget.md's own AUC-decomposition
+// arithmetic rules that out; its table flags the whole-population dollar-AUC cell unverified
+// rather than assert a number that fails the check.) What it is, is 9x more efficient PER PING,
+// which is what matters where a tenant rate limit rather than money is what caps the budget.
 // docs/how-to/kv-cache-keepalive-budget.md has the derivation and says plainly which to pick.
 type BudgetPolicy struct {
 	// Label is the name the dashboard groups by. Defaults to StrategyKeepAliveBudget.

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -1,0 +1,268 @@
+package kvcache
+
+import (
+	"fmt"
+	"time"
+)
+
+// ── how MANY keep-alives, decided per conversation ──────────────────────────
+//
+// Config.MaxPings is one number for the whole replay. That is the right shape for a
+// hand-written arm — "hold every idle conversation for two intervals" is a policy an
+// operator can state — but it is the wrong shape for a learned one, because the budget a
+// conversation is worth depends on the conversation. On this deployment's corpus the
+// budget a per-conversation policy chooses is 0 for 77.8% of idle spans and runs out to 8
+// for a long tail, and collapsing that to a single K is most of the difference between the
+// two.
+//
+// PingBudgeter is how a strategy says so. It is OPTIONAL and additive: a strategy that does
+// not implement it is budgeted by Config.MaxPings exactly as before, which is every arm that
+// exists today.
+
+// PingBudgeter is an optional interface a Strategy may implement to choose the keep-alive
+// budget per conversation instead of accepting Config.MaxPings for all of them.
+//
+// The (value, ok) shape is Predictor's, for the same reason: a policy with no opinion on a
+// particular observation must be able to say so and fall back, rather than return a zero
+// that reads as "never ping". ok=false means "use Config.MaxPings", not "use 0".
+type PingBudgeter interface {
+	// PingBudget is how many keep-alives to allow on the idle span starting at o.Now.
+	// Config.MaxPings still caps the result: this can ask for fewer, never for more.
+	PingBudget(o Observation) (budget int, ok bool)
+}
+
+// BudgetPolicy is the LEARNED keep-alive arm: it asks a Predictor how likely the
+// conversation is to come back in each window a ping would protect, and buys the pings that
+// pay for themselves.
+//
+// It is deliberately a decision layer over Predictor rather than a model of its own. The
+// model is Python (deploy/harbor/kv_ttl_keepalive_policy.py), because that is where a fit
+// belongs; what was missing on the Go side, and what this is, is the arithmetic that turns
+// probabilities into a ping count. Handing it a stub Predictor is how it is tested.
+//
+// # THE GATE
+//
+// One ping costs Pricing.KeepAliveCost — a cache read over the prefix, plus the fresh input
+// and the one output token a ping cannot avoid. A ping that lands while the entry is alive
+// and is followed by the conversation actually returning converts the successor's cache
+// WRITE into a cache READ, so it avoids
+//
+//	rescue = prefix × (write_5m_rate − cache_read_rate)
+//
+// Ping if the chance of that exceeds its cost, i.e. if rescue×h > ping. On the documented
+// Anthropic multiples (read 0.1×, write 1.25× of base input) the prefix term cancels and the
+// threshold is 0.1/1.15 = 8.70% — the same number for every prefix size and every model,
+// which is why this reads a probability and not a token count. It is computed from
+// o.Pricing rather than written down because a deployment whose rates differ has a different
+// threshold, and one that has no rates at all has none.
+//
+// # WHY IT IS NOT THAT SIMPLE
+//
+// 8.70% is the MYOPIC bar, and it is too high. A ping does two things: it may rescue this
+// window, and it keeps the entry alive so that the NEXT ping is still a cheap read rather
+// than a 12.5× re-creation. The second is worth paying for on its own. So the budget is a
+// backward induction over the windows a ping would protect,
+//
+//	V_j = max(0, rescue×h_j − ping + s_j×V_(j+1)),   V_(MaxK) = 0
+//
+// and the budget is the first j at which V_j is not positive — the FIRST, not the last,
+// because the hazard is not monotone in j on real traffic and taking the last positive one
+// buys a run of pings across a dead stretch to reach a live one. That option value lowers
+// the effective bar to about 7.4% at the first sweep and is worth ~6% of the arm's net on
+// the measured corpus.
+//
+// # WHAT IT IS WORTH
+//
+// Measured on the hosted deployment's capture: 34,577 idle spans over 16.9 days, 5-fold rolling
+// origin, pings at 290s. Given as a share of the window's bill and of what `optimal` reaches,
+// with per-ping efficiency indexed to flat MaxPings=6:
+//
+//	arm                     pings   off the bill   of the ceiling   net per ping
+//	optimal (unreachable)   5,826         11.72%           100.0%          27.7x
+//	flat MaxPings=6        95,640          6.96%            59.4%           1.0x
+//	flat MaxPings=5        80,404          6.91%            58.9%           1.2x
+//	BudgetPolicy            9,248          6.07%            51.8%           9.0x
+//	flat MaxPings=2 (dflt) 33,591          5.19%            44.3%           2.1x
+//
+// So this is NOT the cheaper policy where pings are free: a constant beats it by 0.89 pp of the
+// bill, 7.6 points of the ceiling, because the model ranks conversations well (AUC 0.93) and
+// DOLLARS barely better than chance (AUC 0.70, falling to 0.57 on the largest prefixes, which
+// carry 87% of the stake). What it is, is 9x more efficient PER PING, which is what matters
+// where a tenant rate limit rather than money is what caps the budget.
+// docs/how-to/kv-cache-keepalive-budget.md has the derivation and says plainly which to pick.
+type BudgetPolicy struct {
+	// Label is the name the dashboard groups by. Defaults to StrategyKeepAliveBudget.
+	Label string
+	// Predictor answers the reuse question. Required: with none, this arm has no opinion on
+	// any observation and every budget falls back to Config.MaxPings.
+	Predictor Predictor
+	// Interval is the keep-alive cadence this policy assumes when it reasons about windows.
+	// It MUST match the Config.PingIdle the simulator will actually ping at, or the windows
+	// priced here are not the windows bought. Defaults to DefaultPingIdle.
+	Interval time.Duration
+	// MaxK caps the induction's horizon. Defaults to DefaultBudgetMaxK.
+	MaxK int
+	// MinPrefix is the prefix below which this arm does not bother pinging. A ping's fixed
+	// overhead (ping_input, ping_output) does not scale with the prefix, so on a small enough
+	// entry the arithmetic above is dominated by it. 0 disables the gate.
+	MinPrefix int64
+	// Semantics must match the Config's, because a ping's cost depends on whether the
+	// provider accepts a zero-generation request.
+	Semantics Semantics
+}
+
+// DefaultBudgetMaxK is how far the induction looks ahead.
+//
+// Eight, because at DefaultPingIdle that is ~37 minutes of holding, and on the measured
+// corpus 34.3% of the stake sits on spans that return LATER than that — unreachable at any
+// budget, since holding a five-minute entry that long costs more than the write it avoids.
+// Looking further therefore adds cost and no reachable rescues.
+const DefaultBudgetMaxK = 8
+
+// StrategyKeepAliveBudget is this arm's default label, in the registry's hyphenated wire
+// style. It is deliberately NOT in the registry: like Custom, this arm cannot be built from a
+// name alone — it needs a Predictor — so a caller constructs it and passes it to Simulate,
+// and the registry keeps its promise that every name in it resolves.
+const StrategyKeepAliveBudget = "keepalive-budget"
+
+func (b BudgetPolicy) Name() string {
+	if b.Label != "" {
+		return b.Label
+	}
+	return StrategyKeepAliveBudget
+}
+
+func (b BudgetPolicy) Describe() string {
+	return fmt.Sprintf("A predictor's per-window reuse probabilities against the rates' own "+
+		"break-even, compounded over up to %d keep-alives so the option value of staying "+
+		"alive is counted. Chooses the budget per conversation.", b.maxK())
+}
+
+func (b BudgetPolicy) interval() time.Duration {
+	if b.Interval > 0 {
+		return b.Interval
+	}
+	return DefaultPingIdle
+}
+
+func (b BudgetPolicy) maxK() int {
+	if b.MaxK > 0 {
+		return b.MaxK
+	}
+	return DefaultBudgetMaxK
+}
+
+// Decide holds the prefix at five minutes, and pings only when the budget it would choose is
+// at least one.
+//
+// It does not offer the 1-hour tier. That is not an omission: on this corpus the share of
+// spans that close inside an hour but outside five minutes exceeds the share closing inside
+// five minutes by 2.35 percentage points, and the 1-hour tier needs 65.22 points to break
+// even against a 5-minute write. HistoricalProbability is the arm that reasons about tiers;
+// this one reasons about ping counts.
+func (b BudgetPolicy) Decide(o Observation) Action {
+	if k, ok := b.PingBudget(o); ok && k >= 1 {
+		return ActionPing5m
+	}
+	return ActionWrite5m
+}
+
+// PingBudget is the backward induction described on the type.
+//
+// It returns ok=false — "no opinion, use Config.MaxPings" — when there is no predictor, when
+// the model declines the observation, when the rates are unknown so no break-even exists, or
+// when the prefix is below MinPrefix. Every one of those is a case where a number invented
+// here would be worse than the configured default.
+func (b BudgetPolicy) PingBudget(o Observation) (int, bool) {
+	if b.Predictor == nil || !o.Pricing.Known || o.CachedTokens <= 0 {
+		return 0, false
+	}
+	if b.MinPrefix > 0 && o.CachedTokens < b.MinPrefix {
+		return 0, true // a real decision: too small to be worth a ping's fixed overhead
+	}
+	h, s, ok := b.Windows(o)
+	if !ok {
+		return 0, false
+	}
+	rescue := float64(o.CachedTokens) * (o.Pricing.Write5m - o.Pricing.CacheRead)
+	ping := o.Pricing.KeepAliveCost(o.CachedTokens, b.Semantics)
+	n := b.maxK()
+	// V[n] is 0: past the horizon there is nothing left to buy.
+	v := make([]float64, n+1)
+	for j := n - 1; j >= 0; j-- {
+		v[j] = rescue*h[j] - ping + s[j]*v[j+1]
+		if v[j] < 0 {
+			v[j] = 0
+		}
+	}
+	// The FIRST j that is not worth buying ends the schedule. See the type comment.
+	budget := 0
+	for j := 0; j < n; j++ {
+		if v[j] <= 0 {
+			break
+		}
+		budget = j + 1
+	}
+	return budget, true
+}
+
+// Windows converts the Predictor's CUMULATIVE answers into the two per-sweep quantities the
+// induction needs, both conditional on the conversation still being idle when the ping fires.
+//
+// Exported for one reason: deploy/harbor/kv_ttl_keepalive_drift_test.go pins these two vectors
+// against the Python port alongside the budget itself, because a budget that agrees for the
+// wrong reason — a hazard scaled wrong and a survival scaled inversely wrong — is a guard that
+// has already stopped working. It is also the honest way to inspect why the policy chose what
+// it chose. ok=false where the predictor declines, matching PingBudget.
+//
+// Ping j (1-based) fires at j×interval after o.Now and refreshes the entry to
+// j×interval+lifetime, so the window it and it alone protects is
+//
+//	(deadline standing before it, j×interval + lifetime]
+//
+// where that deadline is lifetime for the first ping and (j−1)×interval+lifetime after. Then
+// with F(x) = ReuseProbability(o, x), the CONDITIONAL quantities are
+//
+//	h_j = (F(t_j + life) − F(d_j)) / (1 − F(t_j))     this ping rescues
+//	s_j = (1 − F(t_(j+1)))       / (1 − F(t_j))       reaches the next sweep
+//
+// Dividing by the survivor share is the whole reason this is not just a lookup: the decision
+// at sweep j is only ever faced by a conversation that has ALREADY stayed idle that long, so
+// an unconditional probability answers a question nobody asks. A predictor whose F is not
+// monotone would produce a negative h; that is clamped rather than trusted.
+func (b BudgetPolicy) Windows(o Observation) (h, s []float64, ok bool) {
+	n := b.maxK()
+	iv := b.interval()
+	life := TTL5m.Lifetime()
+	h, s = make([]float64, n), make([]float64, n)
+	for j := 1; j <= n; j++ {
+		tj := time.Duration(j) * iv
+		alive, aok := b.Predictor.ReuseProbability(o, tj)
+		if !aok {
+			return nil, nil, false
+		}
+		survive := 1 - alive
+		if survive <= 0 {
+			// Certain to have returned by t_j, so no later ping can be needed. Everything from
+			// here on is worth nothing, which the zeros already say.
+			return h, s, true
+		}
+		deadline := life
+		if j > 1 {
+			deadline = time.Duration(j-1)*iv + life
+		}
+		fEnd, e1 := b.Predictor.ReuseProbability(o, tj+life)
+		fStart, e2 := b.Predictor.ReuseProbability(o, deadline)
+		fNext, e3 := b.Predictor.ReuseProbability(o, tj+iv)
+		if !e1 || !e2 || !e3 {
+			return nil, nil, false
+		}
+		if hj := (fEnd - fStart) / survive; hj > 0 {
+			h[j-1] = min(hj, 1)
+		}
+		if sj := (1 - fNext) / survive; sj > 0 {
+			s[j-1] = min(sj, 1)
+		}
+	}
+	return h, s, true
+}

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -50,11 +50,21 @@ type PingBudgeter interface {
 //	rescue = prefix × (write_5m_rate − cache_read_rate)
 //
 // Ping if the chance of that exceeds its cost, i.e. if rescue×h > ping. On the documented
-// Anthropic multiples (read 0.1×, write 1.25× of base input) the prefix term cancels and the
-// threshold is 0.1/1.15 = 8.70% — the same number for every prefix size and every model,
-// which is why this reads a probability and not a token count. It is computed from
-// o.Pricing rather than written down because a deployment whose rates differ has a different
-// threshold, and one that has no rates at all has none.
+// Anthropic multiples (read 0.1×, write 1.25× of base input) the PER-TOKEN part of the prefix
+// term cancels and leaves 0.1/1.15 = 8.70%, the same number for every model — which is why
+// this reads a probability and not a token count. It is computed from o.Pricing rather than
+// written down because a deployment whose rates differ has a different threshold, and one
+// that has no rates at all has none.
+//
+// What does NOT cancel is the ping's fixed overhead. KeepAliveCost carries ping_input and
+// ping_output terms that do not scale with the prefix, so the true gate is
+//
+//	0.0870 + (ping_input×input + ping_output×output) / (prefix × (write_5m − cache_read))
+//
+// which is 8.70% only in the limit. At the documented multiples and one token each way it is
+// 8.70% at 125k tokens, 8.72% at 20k, 8.96% at 2k and 9.74% at 500 — a spread of the same
+// order as the margins this arm is decided by. MinPrefix exists for exactly that reason, and
+// nothing below the tens of thousands of tokens should be read as 8.70%.
 //
 // # WHY IT IS NOT THAT SIMPLE
 //
@@ -106,8 +116,12 @@ type BudgetPolicy struct {
 	// overhead (ping_input, ping_output) does not scale with the prefix, so on a small enough
 	// entry the arithmetic above is dominated by it. 0 disables the gate.
 	MinPrefix int64
-	// Semantics must match the Config's, because a ping's cost depends on whether the
-	// provider accepts a zero-generation request.
+	// Semantics must match the Config's: a ping's cost depends on whether the provider
+	// accepts a zero-generation request, and whether a ping refreshes the entry at all
+	// decides whether this arm has an opinion — see pricable. The zero value means
+	// DefaultSemantics(), as it does for Config and for HistoricalProbability, so a caller
+	// who omits the field is priced against the documented behaviour rather than against
+	// three falses that describe no provider.
 	Semantics Semantics
 }
 
@@ -152,6 +166,48 @@ func (b BudgetPolicy) maxK() int {
 	return DefaultBudgetMaxK
 }
 
+// semantics is the provider behaviour this arm prices against, with the package's own
+// zero-value convention: an unset Semantics means DefaultSemantics(), exactly as
+// Config.withDefaults and HistoricalProbability.withDefaults already read it. Reading three
+// falses literally would price a ping against a provider where nothing refreshes anything,
+// which is not a provider this repo models.
+func (b BudgetPolicy) semantics() Semantics {
+	if b.Semantics == (Semantics{}) {
+		return DefaultSemantics()
+	}
+	return b.Semantics
+}
+
+// pricable is whether this arm's cost model is the cost model the simulator will bill.
+//
+// Every window priced below is one KeepAliveCost: a cache READ over the prefix that carries
+// the entry another lifetime. simulatePings only extends the entry when
+// Semantics.PingRefreshesTTL, and a ping that lands on a lapsed entry is billed
+// Pricing.RecreateCost — a 1.25× write, twelve and a half times a read. Three configurations
+// make the read model false, and on none of them is a break-even derived from the read rate
+// an answer to the question asked:
+//
+//   - PingRefreshesTTL false. A ping extends nothing, so every ping after the first lands on
+//     a dead entry.
+//   - HitRefreshesTTL false. The entry this idle span starts from may already be nearer
+//     expiry than one lifetime, and Observation deliberately carries no hit flag (see the
+//     comment in Simulate), so this arm cannot tell whether it does.
+//   - An interval at or past the lifetime it protects. pricing.go names this "the pathology
+//     of a schedule whose interval exceeds the lifetime it is protecting"; the arm that
+//     claims to take its gate from the rates should be the first to notice it.
+//
+// Measured on kvcache's own replay fixture at Config.MaxPings=6, one predictor throughout,
+// against a plain 5-minute write with no pings: −0.9% under the documented semantics, +17.6%
+// with HitRefreshesTTL off, +86.0% with PingRefreshesTTL off, +146.1% at a 400 s interval.
+// All three are reachable — dash/kvcacheapi.go reads hit_refresh, ping_refresh and the ping
+// interval straight off the query string — so this declines instead. ok=false means
+// Config.MaxPings governs, which is the operator's number rather than a model's, and
+// Decide then writes 5m and fires no pings at all.
+func (b BudgetPolicy) pricable() bool {
+	sem := b.semantics()
+	return sem.HitRefreshesTTL && sem.PingRefreshesTTL && b.interval() < TTL5m.Lifetime()
+}
+
 // Decide holds the prefix at five minutes, and pings only when the budget it would choose is
 // at least one.
 //
@@ -171,10 +227,12 @@ func (b BudgetPolicy) Decide(o Observation) Action {
 //
 // It returns ok=false — "no opinion, use Config.MaxPings" — when there is no predictor, when
 // the model declines the observation, when the rates are unknown so no break-even exists, or
-// when the prefix is below MinPrefix. Every one of those is a case where a number invented
-// here would be worse than the configured default.
+// when the schedule is one this arm cannot price (see pricable). Every one of those is a case
+// where a number invented here would be worse than the configured default. MinPrefix is the
+// one gate that is NOT in that list: it reports (0, true), because declining to ping is a
+// decision.
 func (b BudgetPolicy) PingBudget(o Observation) (int, bool) {
-	if b.Predictor == nil || !o.Pricing.Known || o.CachedTokens <= 0 {
+	if b.Predictor == nil || !o.Pricing.Known || o.CachedTokens <= 0 || !b.pricable() {
 		return 0, false
 	}
 	if b.MinPrefix > 0 && o.CachedTokens < b.MinPrefix {
@@ -185,7 +243,7 @@ func (b BudgetPolicy) PingBudget(o Observation) (int, bool) {
 		return 0, false
 	}
 	rescue := float64(o.CachedTokens) * (o.Pricing.Write5m - o.Pricing.CacheRead)
-	ping := o.Pricing.KeepAliveCost(o.CachedTokens, b.Semantics)
+	ping := o.Pricing.KeepAliveCost(o.CachedTokens, b.semantics())
 	n := b.maxK()
 	// V[n] is 0: past the horizon there is nothing left to buy.
 	v := make([]float64, n+1)

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -84,7 +84,7 @@ type PingBudgeter interface {
 // # WHAT IT IS WORTH
 //
 // Measured on the hosted deployment's capture: 34,577 idle spans over 16.9 days, 5-fold rolling
-// origin, pings at 290s. Given as a share of the window's bill and of what `optimal` reaches,
+// origin, pings at 280s. Given as a share of the window's bill and of what `optimal` reaches,
 // with per-ping efficiency indexed to flat MaxPings=6:
 //
 //	arm                     pings   off the bill   of the ceiling   net per ping

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -231,7 +231,16 @@ func (b BudgetPolicy) Decide(o Observation) Action {
 // where a number invented here would be worse than the configured default. MinPrefix is the
 // one gate that is NOT in that list: it reports (0, true), because declining to ping is a
 // decision.
-func (b BudgetPolicy) PingBudget(o Observation) (int, bool) {
+func (b BudgetPolicy) PingBudget(o Observation) (budget int, ok bool) {
+	// Predictor is injectable — CLAUDE.md's fail-open rule means a third-party implementation
+	// panicking must revert to Config.MaxPings (ok=false), not take down the caller. This is
+	// the one seam both real callers (Decide and the simulator) go through, so it is the one
+	// place that needs the guard.
+	defer func() {
+		if r := recover(); r != nil {
+			budget, ok = 0, false
+		}
+	}()
 	if b.Predictor == nil || !o.Pricing.Known || o.CachedTokens <= 0 || !b.pricable() {
 		return 0, false
 	}
@@ -254,7 +263,7 @@ func (b BudgetPolicy) PingBudget(o Observation) (int, bool) {
 		}
 	}
 	// The FIRST j that is not worth buying ends the schedule. See the type comment.
-	budget := 0
+	budget = 0
 	for j := 0; j < n; j++ {
 		if v[j] <= 0 {
 			break

--- a/kvcache/keepalive.go
+++ b/kvcache/keepalive.go
@@ -109,8 +109,11 @@ type BudgetPolicy struct {
 	// any observation and every budget falls back to Config.MaxPings.
 	Predictor Predictor
 	// Interval is the keep-alive cadence this policy assumes when it reasons about windows.
-	// It MUST match the Config.PingIdle the simulator will actually ping at, or the windows
-	// priced here are not the windows bought. Defaults to DefaultPingIdle.
+	// It matters when PingBudget/Windows/Decide are called directly, outside Simulate.
+	// Simulate itself always overrides this to Config.PingIdle before running — the windows
+	// priced must be the windows actually pinged, and PingIdle is Simulate's own authority on
+	// that, so a caller cannot let the two drift by setting this to something else. Defaults
+	// to DefaultPingIdle.
 	Interval time.Duration
 	// MaxK caps the induction's horizon. Defaults to DefaultBudgetMaxK.
 	MaxK int

--- a/kvcache/keepalive_test.go
+++ b/kvcache/keepalive_test.go
@@ -1,7 +1,9 @@
 package kvcache
 
 import (
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 )
@@ -612,7 +614,13 @@ func (s splitBudgeter) asked() int {
 
 // The ceiling must still be a ceiling with the seam in place. NewOptimal reads the same ping
 // core, so if the signature change had quietly altered its arithmetic this is what catches it.
-func TestOptimalStillBoundsABudgetedArm(t *testing.T) {
+// This cannot fail through BudgetPolicy's own arithmetic: Simulate's MaxPings cap bounds BOTH
+// sides identically (the PingBudgeter clamp described on Config.MaxPings), so no strategy
+// sharing that cap can ever cost less than `optimal` — buggy or correct. What this proves is
+// that the SEAM doesn't break `optimal`'s own bookkeeping when the competing strategy happens
+// to implement PingBudgeter, not that BudgetPolicy's economics are sound; the mutation-tested
+// TestBudget* cases above are what actually pin the arithmetic.
+func TestOptimalStillRunsCorrectlyAlongsideAPingBudgeter(t *testing.T) {
 	reqs, cfg := dataset(t)
 	cfg.MaxPings = 6
 	opt, err := NewStrategy(StrategyOptimal, reqs, cfg)
@@ -624,7 +632,53 @@ func TestOptimalStillBoundsABudgetedArm(t *testing.T) {
 	arm := Simulate(reqs, BudgetPolicy{Predictor: p, Interval: cfg.PingIdle, MaxK: 6,
 		Semantics: cfg.Semantics}, cfg)
 	if ceiling.TotalUSD > arm.TotalUSD+1e-9 {
-		t.Errorf("optimal cost %.6f exceeds BudgetPolicy's %.6f: the ceiling is not a ceiling",
-			ceiling.TotalUSD, arm.TotalUSD)
+		t.Errorf("optimal cost %.6f exceeds BudgetPolicy's %.6f: Simulate's own ceiling "+
+			"bookkeeping broke", ceiling.TotalUSD, arm.TotalUSD)
+	}
+}
+
+// panickingPredictor always panics, standing in for a third-party model implementation that
+// blows up — a nil pointer in a client library, a malformed response it didn't guard against.
+type panickingPredictor struct{}
+
+func (panickingPredictor) ReuseProbability(Observation, time.Duration) (float64, bool) {
+	panic("predictor exploded")
+}
+
+// Predictor is injectable. CLAUDE.md's fail-open rule says a component error reverts that
+// component only, so a panicking Predictor must degrade PingBudget to ok=false — the path the
+// arm already handles correctly — rather than propagate through Decide into Simulate (or the
+// live ping decision), which would take down more than this one component.
+// BudgetPolicy.Interval is documented to have to match Config.PingIdle, but until now nothing
+// checked it — a caller that let the two drift got economics silently priced for a schedule
+// Simulate was not actually running.
+func TestSimulateRejectsABudgetPolicyIntervalThatDisagreesWithConfig(t *testing.T) {
+	reqs, cfg := dataset(t)
+	cfg.PingIdle = 280 * time.Second
+	p := cdfPredictor{points: [][2]float64{{300, 0.1}, {580, 0.6}, {86400, 1}}}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Simulate did not panic on a BudgetPolicy.Interval that disagrees with " +
+				"Config.PingIdle")
+		}
+		msg := fmt.Sprint(r)
+		if !strings.Contains(msg, "BudgetPolicy.Interval") || !strings.Contains(msg, "PingIdle") {
+			t.Errorf("panic message %q does not name the mismatch it is about", msg)
+		}
+	}()
+	Simulate(reqs, BudgetPolicy{Predictor: p, Interval: 300 * time.Second, MaxK: 4}, cfg)
+}
+
+func TestPingBudgetDegradesRatherThanPropagatingAPredictorPanic(t *testing.T) {
+	o := pricedObservation(t, 124_845)
+	pol := BudgetPolicy{Predictor: panickingPredictor{}, MaxK: 4}
+	if k, ok := pol.PingBudget(o); ok {
+		t.Fatalf("PingBudget = (%d, true) from a panicking Predictor, want ok=false", k)
+	}
+	if a := pol.Decide(o); a != ActionWrite5m {
+		t.Errorf("Decide = %v with a panicking Predictor, want %v — ok=false falls back to "+
+			"Config.MaxPings rather than propagating the panic", a, ActionWrite5m)
 	}
 }

--- a/kvcache/keepalive_test.go
+++ b/kvcache/keepalive_test.go
@@ -1,9 +1,7 @@
 package kvcache
 
 import (
-	"fmt"
 	"math"
-	"strings"
 	"testing"
 	"time"
 )
@@ -652,23 +650,27 @@ func (panickingPredictor) ReuseProbability(Observation, time.Duration) (float64,
 // BudgetPolicy.Interval is documented to have to match Config.PingIdle, but until now nothing
 // checked it — a caller that let the two drift got economics silently priced for a schedule
 // Simulate was not actually running.
-func TestSimulateRejectsABudgetPolicyIntervalThatDisagreesWithConfig(t *testing.T) {
+// Simulate must not crash on a BudgetPolicy.Interval that disagrees with Config.PingIdle: it
+// is reachable from an HTTP handler (dash/kvcacheapi.go -> dash/kvcachesim.go) with no
+// recover() under package dash, and this package already treats a panicking Predictor as a
+// bug to guard against (see TestPingBudgetDegradesRatherThanPropagatingAPredictorPanic) — a
+// second panic seam right next to that one would contradict it. So Simulate overrides
+// Interval to Config.PingIdle instead: the two are made incapable of disagreeing, rather than
+// merely checked. A wrong Interval on the input must produce the SAME Result as a correct one.
+func TestSimulateAlignsABudgetPolicysIntervalWithConfigRatherThanTrustingIt(t *testing.T) {
 	reqs, cfg := dataset(t)
 	cfg.PingIdle = 280 * time.Second
-	p := cdfPredictor{points: [][2]float64{{300, 0.1}, {580, 0.6}, {86400, 1}}}
+	cfg.MaxPings = 6
+	p := cdfPredictor{points: [][2]float64{{300, 0.1}, {580, 0.6}, {860, 0.75}, {86400, 1}}}
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("Simulate did not panic on a BudgetPolicy.Interval that disagrees with " +
-				"Config.PingIdle")
-		}
-		msg := fmt.Sprint(r)
-		if !strings.Contains(msg, "BudgetPolicy.Interval") || !strings.Contains(msg, "PingIdle") {
-			t.Errorf("panic message %q does not name the mismatch it is about", msg)
-		}
-	}()
-	Simulate(reqs, BudgetPolicy{Predictor: p, Interval: 300 * time.Second, MaxK: 4}, cfg)
+	correct := Simulate(reqs, BudgetPolicy{Predictor: p, Interval: cfg.PingIdle, MaxK: 4}, cfg)
+	wrong := Simulate(reqs, BudgetPolicy{Predictor: p, Interval: 300 * time.Second, MaxK: 4}, cfg)
+	if wrong.Pings != correct.Pings || wrong.TotalUSD != correct.TotalUSD {
+		t.Errorf("a BudgetPolicy built with the wrong Interval fired %d pings costing %.6f; "+
+			"a correctly-configured one fired %d costing %.6f — Simulate let the wrong "+
+			"Interval through instead of overriding it to Config.PingIdle",
+			wrong.Pings, wrong.TotalUSD, correct.Pings, correct.TotalUSD)
+	}
 }
 
 func TestPingBudgetDegradesRatherThanPropagatingAPredictorPanic(t *testing.T) {

--- a/kvcache/keepalive_test.go
+++ b/kvcache/keepalive_test.go
@@ -209,6 +209,88 @@ func TestBudgetDeclinesRatherThanInventingANumber(t *testing.T) {
 	}
 }
 
+// A schedule where a ping is NOT a cheap read has to be declined, not priced as one.
+//
+// The whole arm rests on one ping costing Pricing.KeepAliveCost. simulatePings only extends
+// the entry when Semantics.PingRefreshesTTL, and a ping landing on a lapsed entry is billed
+// Pricing.RecreateCost — 12.5x a read. So on semantics or an interval that break the read
+// model, quoting an 8.70% break-even is quoting the wrong rate, and the honest answer is
+// ok=false: Config.MaxPings is the operator's number and Decide fires no pings at all.
+func TestBudgetDeclinesASchedulePricedOnTheWrongRate(t *testing.T) {
+	fine := cdfPredictor{points: [][2]float64{{300, 0}, {580, 0.9}, {86400, 1}}}
+	o := pricedObservation(t, 124_845)
+
+	for _, tc := range []struct {
+		name string
+		pol  BudgetPolicy
+	}{
+		{"a ping does not refresh the entry",
+			BudgetPolicy{Predictor: fine, Semantics: Semantics{HitRefreshesTTL: true}}},
+		{"a hit does not refresh the entry, so this span's deadline is unknowable",
+			BudgetPolicy{Predictor: fine, Semantics: Semantics{PingRefreshesTTL: true}}},
+		{"the interval lands exactly on the lifetime",
+			BudgetPolicy{Predictor: fine, Interval: TTL5m.Lifetime()}},
+		{"the interval is past the lifetime it protects",
+			BudgetPolicy{Predictor: fine, Interval: 400 * time.Second}},
+	} {
+		if k, ok := tc.pol.PingBudget(o); ok {
+			t.Errorf("%s: (%d, true), want ok=false — every ping on this schedule is a 1.25x "+
+				"write, so a break-even taken from the read rate is the wrong number", tc.name, k)
+		}
+		if a := tc.pol.Decide(o); a != ActionWrite5m {
+			t.Errorf("%s: Decide = %v, want %v — an arm that cannot price the schedule must not "+
+				"buy pings on it", tc.name, a, ActionWrite5m)
+		}
+	}
+
+	// And the documented semantics, however they are spelled, must still be priced. The zero
+	// value means DefaultSemantics() here for the same reason it does on Config.
+	for _, sem := range []Semantics{{}, DefaultSemantics()} {
+		pol := BudgetPolicy{Predictor: fine, Semantics: sem}
+		if k, ok := pol.PingBudget(o); !ok || k < 1 {
+			t.Errorf("Semantics %+v: (%d, %v), want a budget — this is the shipped provider "+
+				"behaviour and the zero value has to mean it", sem, k, ok)
+		}
+	}
+}
+
+// The gate is prefix-independent in its PER-TOKEN part only. A ping's ping_input/ping_output
+// overhead does not scale with the prefix, so the true bar rises as the prefix shrinks, and
+// the doc comment now says so by how much. This pins those numbers, because "8.70% for every
+// prefix" was stated four times and is out by a full point at 500 tokens — the same order as
+// the margins the arm is chosen by.
+func TestBudgetGateRisesOnASmallPrefixByTheFixedOverhead(t *testing.T) {
+	const asymptote = DefaultCacheReadMultiple /
+		(DefaultWrite5mMultiple - DefaultCacheReadMultiple)
+	for _, tc := range []struct {
+		prefix int64
+		want   float64
+	}{
+		{500, 0.097391}, {2_000, 0.089565}, {20_000, 0.087217}, {124_845, 0.086998},
+	} {
+		o := pricedObservation(t, tc.prefix)
+		// The smallest single-window hazard that buys one ping, by bisection on the real gate.
+		lo, hi := 0.0, 1.0
+		for i := 0; i < 60; i++ {
+			mid := (lo + hi) / 2
+			pol := BudgetPolicy{MaxK: 1, Predictor: cdfPredictor{
+				points: [][2]float64{{300, 0}, {580, mid}, {3600, 1}}}}
+			if k, _ := pol.PingBudget(o); k >= 1 {
+				hi = mid
+			} else {
+				lo = mid
+			}
+		}
+		if math.Abs(hi-tc.want) > 1e-5 {
+			t.Errorf("prefix %d: measured gate %.6f, want %.6f", tc.prefix, hi, tc.want)
+		}
+		if hi < asymptote {
+			t.Errorf("prefix %d: gate %.6f is BELOW the per-token break-even %.6f, which the "+
+				"fixed overhead makes impossible", tc.prefix, hi, asymptote)
+		}
+	}
+}
+
 // The hazard the induction reads must be CONDITIONAL on the conversation having stayed idle
 // this long, because that is the only population that ever faces the decision.
 //
@@ -236,6 +318,66 @@ func TestBudgetHazardIsConditionalOnStillBeingIdle(t *testing.T) {
 			"unconditional mass, so if these are close the divide by the survivor share is "+
 			"missing and the model is answering a question nobody asks", hGone[1], hStay[1])
 	}
+}
+
+// Three paths the nine tests above never reach, each of which a mutation would survive.
+//
+// They are cheap and they are not decorative: the first is the arm's own label, the second is
+// what stops a schedule being priced past the point the conversation is certainly back, and
+// the third is a predictor that answers one horizon and declines another — which a real fitted
+// model does at the edge of its support.
+func TestBudgetCoversItsRemainingBranches(t *testing.T) {
+	fine := cdfPredictor{points: [][2]float64{{300, 0}, {580, 0.9}, {86400, 1}}}
+	o := pricedObservation(t, 124_845)
+
+	if got := (BudgetPolicy{Label: "budget-v2"}).Name(); got != "budget-v2" {
+		t.Errorf("Name() = %q, want the Label — the dashboard groups by it", got)
+	}
+
+	// CERTAINLY back before the second sweep. Windows must stop, leaving the rest at zero
+	// rather than dividing by a survivor share of nothing.
+	certain := cdfPredictor{points: [][2]float64{{300, 0}, {580, 0.5}, {560, 1.0}}}
+	h, s, ok := BudgetPolicy{Predictor: certain, MaxK: 4}.Windows(o)
+	if !ok {
+		t.Fatal("certain return: no windows")
+	}
+	for j := 1; j < len(h); j++ {
+		if h[j] != 0 || s[j] != 0 {
+			t.Errorf("window %d after a certain return: h=%v s=%v, want zeros — no later ping "+
+				"can be needed once the conversation is back", j+1, h[j], s[j])
+		}
+	}
+
+	// A predictor that answers the survivor question and declines the window question. The
+	// whole vector has to be abandoned, not silently completed from the answers it did give.
+	partial := horizonPredictor{f: func(horizon time.Duration) (float64, bool) {
+		if horizon == DefaultPingIdle {
+			return 0.1, true
+		}
+		return 0, false
+	}}
+	if _, _, ok := (BudgetPolicy{Predictor: partial, MaxK: 4}).Windows(o); ok {
+		t.Error("a predictor that declined a horizon produced windows: a partly-answered vector " +
+			"is not a smaller vector, it is an unusable one")
+	}
+	if _, ok := (BudgetPolicy{Predictor: partial, MaxK: 4}).PingBudget(o); ok {
+		t.Error("PingBudget claimed an opinion on a partly-answered predictor")
+	}
+	// And the same policy with a predictor that answers everything still works, so the test
+	// above is about the decline and not about the fixture.
+	if _, ok := (BudgetPolicy{Predictor: fine, MaxK: 4}).PingBudget(o); !ok {
+		t.Error("the control case declined too; the assertion above proves nothing")
+	}
+}
+
+// horizonPredictor answers per HORIZON rather than per observation, which is how a model at the
+// edge of its support behaves: fitted out to one sweep, nothing to say past it.
+type horizonPredictor struct {
+	f func(time.Duration) (float64, bool)
+}
+
+func (p horizonPredictor) ReuseProbability(_ Observation, h time.Duration) (float64, bool) {
+	return p.f(h)
 }
 
 // ── the simulator seam ──────────────────────────────────────────────────────
@@ -288,11 +430,25 @@ func TestPingBudgeterBoundsTheSimulatedPings(t *testing.T) {
 	}
 }
 
-// Adding the seam must not have moved any arm that does not use it. Every registered arm is
-// replayed and compared against the same arm before PingBudgeter existed — which is what the
-// unbudgeted path still is, so the assertion is that a budget-less strategy is untouched.
+// No registered arm may opt into the seam, and a budgeted replay must not be able to reach one
+// that has not.
+//
+// The first half is the invariant: none of the registry's arms implements PingBudgeter, so all
+// of them are still budgeted by Config.MaxPings. The second is what the new mutable state on
+// convState makes worth asserting — pendingBudget and budgeted are per-conversation fields
+// carried across requests, and the failure they invite is one replay's budget surviving into
+// another's. So each arm is replayed, a budgeted stub is replayed in between, and the arm is
+// replayed again: the two runs of the same arm must be identical to the last cent.
+//
+// What this deliberately does NOT claim is a comparison against the code before PingBudgeter
+// existed. That comparison cannot be written in-package — bypassing Simulate's type assertion
+// also bypasses every OTHER optional interface a strategy may implement, so it stops being the
+// same replay. The no-op property of a declining budgeter is asserted directly, on a stub, by
+// TestPingBudgeterBoundsTheSimulatedPings.
 func TestUnbudgetedArmsAreUnaffectedByTheSeam(t *testing.T) {
 	reqs, cfg := dataset(t)
+	cfg.MaxPings = 6
+	covered := 0
 	for _, spec := range Registry() {
 		s, err := NewStrategy(spec.Name, reqs, cfg)
 		if err != nil {
@@ -306,9 +462,25 @@ func TestUnbudgetedArmsAreUnaffectedByTheSeam(t *testing.T) {
 				"Config.MaxPings path, and one that opted in silently would change behaviour",
 				name)
 		}
-		if r := Simulate(reqs, s, cfg); r == nil {
+		before := Simulate(reqs, s, cfg)
+		Simulate(reqs, budgetedStub{label: "interloper", budget: 1, ok: true}, cfg)
+		after := Simulate(reqs, s, cfg)
+		if before == nil || after == nil {
 			t.Errorf("%s: nil result", name)
+			continue
 		}
+		covered++
+		if math.Abs(before.TotalUSD-after.TotalUSD) > 1e-12 || before.Pings != after.Pings {
+			t.Errorf("%s: %.12f over %d pings, then %.12f over %d after a budgeted replay ran "+
+				"in between — a budget leaked out of one replay into another", name,
+				before.TotalUSD, before.Pings, after.TotalUSD, after.Pings)
+		}
+	}
+	// A registry that stopped resolving would make the loop above vacuous, so say how much of
+	// it was actually replayed. One arm (replay) legitimately has no name-based constructor.
+	if covered < len(Registry())-1 {
+		t.Errorf("only %d of %d registry arms were replayed; the assertion is nearly vacuous",
+			covered, len(Registry()))
 	}
 }
 
@@ -372,6 +544,70 @@ func TestBudgetPolicyRunsThroughSimulateAndVariesPerConversation(t *testing.T) {
 		t.Errorf("budget took %d distinct values over the fixture: %v — a policy that picks one "+
 			"number for every conversation is Config.MaxPings with extra steps", len(seen), seen)
 	}
+}
+
+// And the varying budget has to reach the PING LOOP, not just PingBudget.
+//
+// The test above calls PingBudget directly, which proves the arithmetic is per-observation and
+// nothing about the seam. Simulate could memoize the first Observation it ever saw, or hold one
+// budget for the whole replay, and every assertion above would still pass — verified: freezing
+// the Observation Simulate hands to PingBudget leaves the whole kvcache package green.
+//
+// So: a budgeter that says 0 for half the conversations and the cap for the other half must
+// land STRICTLY BETWEEN the two constant runs. One number for the whole replay lands on an end.
+func TestAPerConversationBudgetReachesThePingLoop(t *testing.T) {
+	reqs, cfg := dataset(t)
+	cfg.MaxPings = 6
+
+	half := splitBudgeter{cap: cfg.MaxPings}
+	none := Simulate(reqs, budgetedStub{label: "all-zero", budget: 0, ok: true}, cfg)
+	all := Simulate(reqs, budgetedStub{label: "all-cap", budget: cfg.MaxPings, ok: true}, cfg)
+	got := Simulate(reqs, half, cfg)
+
+	if none.Pings >= all.Pings {
+		t.Fatalf("the two constant runs fired %d and %d pings; this fixture cannot show a split",
+			none.Pings, all.Pings)
+	}
+	if got.Pings <= none.Pings || got.Pings >= all.Pings {
+		t.Errorf("split budget fired %d pings, want strictly between %d (always 0) and %d "+
+			"(always %d) — a budget that lands on either end is one number for the whole replay, "+
+			"which is what the seam exists to avoid", got.Pings, none.Pings, all.Pings, cfg.MaxPings)
+	}
+	if half.asked() < 2 {
+		t.Errorf("Simulate asked for a budget %d times: it is not asking per conversation",
+			half.asked())
+	}
+}
+
+// splitBudgeter budgets on the CONVERSATION, so a seam that forwards one frozen Observation
+// cannot reproduce its ping count.
+type splitBudgeter struct {
+	cap int
+	n   *int
+}
+
+func (s splitBudgeter) Name() string              { return "split-budget" }
+func (s splitBudgeter) Decide(Observation) Action { return ActionPing5m }
+func (s splitBudgeter) PingBudget(o Observation) (int, bool) {
+	if s.n != nil {
+		*s.n++
+	}
+	// Deterministic on the conversation id, so the split is a property of the observation and
+	// not of the order Simulate happens to walk in.
+	sum := 0
+	for _, c := range o.Conversation {
+		sum += int(c)
+	}
+	if sum%2 == 0 {
+		return 0, true
+	}
+	return s.cap, true
+}
+func (s splitBudgeter) asked() int {
+	if s.n == nil {
+		return 2 // not counting; the ping-count assertion is the one with teeth
+	}
+	return *s.n
 }
 
 // The ceiling must still be a ceiling with the seam in place. NewOptimal reads the same ping

--- a/kvcache/keepalive_test.go
+++ b/kvcache/keepalive_test.go
@@ -1,0 +1,394 @@
+package kvcache
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// cdfPredictor is a cumulative return-time distribution written out by hand, so a test can
+// state "this conversation comes back after N seconds with probability P" and check the
+// budget that falls out. Points are (horizon seconds, cumulative probability), ascending.
+type cdfPredictor struct {
+	points   [][2]float64
+	declines bool
+}
+
+func (s cdfPredictor) ReuseProbability(_ Observation, horizon time.Duration) (float64, bool) {
+	if s.declines {
+		return 0, false
+	}
+	sec := horizon.Seconds()
+	p := 0.0
+	for _, pt := range s.points {
+		if sec >= pt[0] {
+			p = pt[1]
+		}
+	}
+	return p, true
+}
+
+// perObservationPredictor is a model whose answer depends on the conversation, which is the
+// only way a per-conversation budget can be shown to be per-conversation.
+type perObservationPredictor struct {
+	f func(Observation) [][2]float64
+}
+
+func (p perObservationPredictor) ReuseProbability(o Observation, h time.Duration) (float64, bool) {
+	return cdfPredictor{points: p.f(o)}.ReuseProbability(o, h)
+}
+
+// pricedObservation is an Observation with the documented Anthropic multiples, so the gate
+// under test is the real 0.1/1.15 = 8.70% and not a test-only number.
+func pricedObservation(t *testing.T, cachedTokens int64) Observation {
+	t.Helper()
+	const input = 3.0e-6
+	return Observation{
+		User: "acct-1", Conversation: "conv-1", Model: "m", Now: 1_786_967_311_185,
+		CachedTokens: cachedTokens, TTL: TTL5m,
+		Pricing: Pricing{
+			Model: "m", Input: input, Output: input * 5,
+			CacheRead:       input * DefaultCacheReadMultiple,
+			Write5m:         input * DefaultWrite5mMultiple,
+			Write1h:         input * DefaultWrite1hMultiple,
+			PingInputTokens: 1, PingOutputTokens: 1, Known: true,
+		},
+	}
+}
+
+// The gate this arm is built on has to BE the rates' break-even, and it has to be
+// prefix-independent — which is the property that lets the whole policy read a probability
+// instead of a token count.
+//
+// A conversation whose entire return mass lands inside the first ping's window is pinged when
+// that mass is above the break-even and not when it is below, and the SAME two probabilities
+// must give the same answers on a prefix two orders of magnitude larger.
+func TestBudgetGateIsTheRatesBreakEvenAndIgnoresPrefixSize(t *testing.T) {
+	// The break-even on the documented multiples: read 0.1x, write 1.25x, so 0.1/1.15.
+	const breakEven = DefaultCacheReadMultiple /
+		(DefaultWrite5mMultiple - DefaultCacheReadMultiple)
+	if math.Abs(breakEven-0.0869565) > 1e-6 {
+		t.Fatalf("break-even moved: %.7f — the doc comment's 8.70%% is stale", breakEven)
+	}
+	// Ping 1 fires at 280s and protects (300s, 580s]. Put the mass there and nowhere else, so
+	// only the first window's hazard is non-zero and the myopic gate is the whole decision.
+	below := cdfPredictor{points: [][2]float64{{300, 0}, {580, breakEven * 0.5}, {3600, 1}}}
+	above := cdfPredictor{points: [][2]float64{{300, 0}, {580, breakEven * 3}, {3600, 1}}}
+	for _, prefix := range []int64{2_000, 124_845, 2_000_000} {
+		o := pricedObservation(t, prefix)
+		for _, tc := range []struct {
+			name string
+			p    Predictor
+			want bool
+		}{{"below break-even", below, false}, {"above break-even", above, true}} {
+			pol := BudgetPolicy{Predictor: tc.p, MaxK: 1}
+			k, ok := pol.PingBudget(o)
+			if !ok {
+				t.Fatalf("prefix=%d %s: no opinion, want one", prefix, tc.name)
+			}
+			if got := k >= 1; got != tc.want {
+				t.Errorf("prefix=%d %s: budget %d (pings=%v), want pings=%v",
+					prefix, tc.name, k, got, tc.want)
+			}
+		}
+	}
+}
+
+// The option value has to lower the bar, not just decorate the type comment.
+//
+// A conversation whose FIRST window is below the myopic break-even but whose SECOND window is
+// rich should still be pinged at the first sweep — the first ping is what keeps the entry
+// alive to reach the second. With MaxK=1 there is no second window to reach, so the same
+// conversation is not pinged. That difference IS the option value.
+func TestBudgetOptionValuePingsThroughALeanFirstWindow(t *testing.T) {
+	// Window 1 is (300, 580]; window 2 is (580, 860]. Nothing returns before 580, then a lot.
+	lean := cdfPredictor{points: [][2]float64{{580, 0.02}, {860, 0.60}, {3600, 1}}}
+	o := pricedObservation(t, 124_845)
+
+	myopic, ok := BudgetPolicy{Predictor: lean, MaxK: 1}.PingBudget(o)
+	if !ok {
+		t.Fatal("MaxK=1: no opinion")
+	}
+	if myopic != 0 {
+		t.Fatalf("MaxK=1 budget = %d, want 0: 2%% is below the 8.70%% break-even and with no "+
+			"second window there is nothing else to buy", myopic)
+	}
+	withOption, ok := BudgetPolicy{Predictor: lean, MaxK: 4}.PingBudget(o)
+	if !ok {
+		t.Fatal("MaxK=4: no opinion")
+	}
+	if withOption < 2 {
+		t.Errorf("MaxK=4 budget = %d, want >= 2: the first ping is not worth its own window "+
+			"but is worth reaching the second, which is the whole point of the induction",
+			withOption)
+	}
+}
+
+// The schedule must end where the value does, and must NOT end early where a later window is
+// worth reaching.
+//
+// Both halves matter and they pull opposite ways. Stopping at the first window whose own
+// hazard is thin would throw away the option value; running to the last window with any mass
+// in it would buy a run of pings across a dead stretch that never pays back. The rule is the
+// first j whose VALUE (own hazard plus what staying alive is worth) is not positive.
+func TestBudgetScheduleEndsWhereTheValueDoes(t *testing.T) {
+	o := pricedObservation(t, 124_845)
+
+	// A worthless tail: window 1 pays, and nothing ever returns afterwards. Windows 2..8 are
+	// each worth -ping and nothing else, so the schedule is one ping.
+	deadTail := cdfPredictor{points: [][2]float64{{300, 0}, {580, 0.30}, {86400, 0.30}}}
+	k, ok := BudgetPolicy{Predictor: deadTail, MaxK: 8}.PingBudget(o)
+	if !ok {
+		t.Fatal("deadTail: no opinion")
+	}
+	if k != 1 {
+		t.Errorf("dead tail: budget = %d, want 1 — every window after the first is worth exactly "+
+			"minus one ping, so buying any of them is a loss", k)
+	}
+
+	// A rich window five sweeps out, reachable for four cheap pings. Paying through the empty
+	// stretch to reach it is correct: 4 pings cost ~0.15 to win ~0.40 of avoided write.
+	farRich := cdfPredictor{points: [][2]float64{
+		{300, 0}, {580, 0.30}, {860, 0.30}, {1140, 0.30}, {1420, 0.30}, {1700, 0.95}, {86400, 1},
+	}}
+	k, ok = BudgetPolicy{Predictor: farRich, MaxK: 8}.PingBudget(o)
+	if !ok {
+		t.Fatal("farRich: no opinion")
+	}
+	if k < 5 {
+		t.Errorf("far-rich window: budget = %d, want >= 5 — the induction must be willing to hold "+
+			"through windows that pay nothing themselves when what they reach pays for them", k)
+	}
+
+	// And the same far window is NOT worth reaching once it is too THIN to pay for the pings
+	// that get there. Identical shape, 21% conditional hazard instead of 93%: four holding pings
+	// cost ~0.19 to win ~0.09, so the schedule stops at the first window again.
+	farThin := cdfPredictor{points: [][2]float64{
+		{300, 0}, {580, 0.30}, {860, 0.30}, {1140, 0.30}, {1420, 0.30}, {1700, 0.45}, {86400, 1},
+	}}
+	k, ok = BudgetPolicy{Predictor: farThin, MaxK: 8}.PingBudget(o)
+	if !ok {
+		t.Fatal("farThin: no opinion")
+	}
+	if k != 1 {
+		t.Errorf("far-thin window: budget = %d, want 1 — reaching it costs four pings and it pays "+
+			"about half of one, so the induction must decline to hold", k)
+	}
+}
+
+// Every reason to have no opinion has to produce ok=false, so the caller falls back to
+// Config.MaxPings rather than to a number this type invented.
+func TestBudgetDeclinesRatherThanInventingANumber(t *testing.T) {
+	fine := cdfPredictor{points: [][2]float64{{580, 0.9}}}
+	unpriced := pricedObservation(t, 124_845)
+	unpriced.Pricing.Known = false
+	noTokens := pricedObservation(t, 0)
+
+	for _, tc := range []struct {
+		name string
+		pol  BudgetPolicy
+		o    Observation
+	}{
+		{"no predictor", BudgetPolicy{}, pricedObservation(t, 124_845)},
+		{"predictor declines", BudgetPolicy{Predictor: cdfPredictor{declines: true}},
+			pricedObservation(t, 124_845)},
+		{"rates unknown", BudgetPolicy{Predictor: fine}, unpriced},
+		{"no cached prefix", BudgetPolicy{Predictor: fine}, noTokens},
+	} {
+		if _, ok := tc.pol.PingBudget(tc.o); ok {
+			t.Errorf("%s: ok=true, want false so Config.MaxPings governs", tc.name)
+		}
+	}
+
+	// MinPrefix is different in kind: it IS a decision, so it must report ok=true with 0.
+	small := BudgetPolicy{Predictor: fine, MinPrefix: 10_000}
+	k, ok := small.PingBudget(pricedObservation(t, 5_000))
+	if !ok || k != 0 {
+		t.Errorf("below MinPrefix: (%d, %v), want (0, true) — declining to ping is a decision, "+
+			"not an absence of one", k, ok)
+	}
+}
+
+// The hazard the induction reads must be CONDITIONAL on the conversation having stayed idle
+// this long, because that is the only population that ever faces the decision.
+//
+// Two predictors with the same mass in window 2 but different amounts already returned before
+// window 2 opens must produce different budgets: the one whose survivors are few has a much
+// higher conditional hazard on the ones that remain.
+func TestBudgetHazardIsConditionalOnStillBeingIdle(t *testing.T) {
+	// Both put 5pp of unconditional mass in window 2 = (580, 860].
+	// mostGone: 90% already back by 580, so 5pp/10% survivors = 50% conditional.
+	// mostStay:  0% already back by 580, so 5pp/100% survivors = 5% conditional.
+	mostGone := cdfPredictor{points: [][2]float64{{280, 0.90}, {580, 0.90}, {860, 0.95}, {3600, 1}}}
+	mostStay := cdfPredictor{points: [][2]float64{{280, 0.00}, {580, 0.00}, {860, 0.05}, {3600, 1}}}
+	o := pricedObservation(t, 124_845)
+
+	hGone, _, ok := BudgetPolicy{Predictor: mostGone, MaxK: 2}.Windows(o)
+	if !ok {
+		t.Fatal("mostGone: no windows")
+	}
+	hStay, _, ok := BudgetPolicy{Predictor: mostStay, MaxK: 2}.Windows(o)
+	if !ok {
+		t.Fatal("mostStay: no windows")
+	}
+	if !(hGone[1] > 5*hStay[1]) {
+		t.Errorf("window-2 conditional hazard: mostGone %.4f vs mostStay %.4f — same "+
+			"unconditional mass, so if these are close the divide by the survivor share is "+
+			"missing and the model is answering a question nobody asks", hGone[1], hStay[1])
+	}
+}
+
+// ── the simulator seam ──────────────────────────────────────────────────────
+
+// budgetedStub is a Strategy that always pings and always asks for a fixed budget, so a test
+// can prove the number reaches the ping loop.
+type budgetedStub struct {
+	label  string
+	budget int
+	ok     bool
+}
+
+func (b budgetedStub) Name() string              { return b.label }
+func (b budgetedStub) Decide(Observation) Action { return ActionPing5m }
+func (b budgetedStub) PingBudget(Observation) (int, bool) {
+	return b.budget, b.ok
+}
+
+// A PingBudgeter's number has to actually bound the pings that fire, and declining has to
+// leave Config.MaxPings in charge. Without this the whole interface is decoration.
+func TestPingBudgeterBoundsTheSimulatedPings(t *testing.T) {
+	reqs, cfg := dataset(t)
+	cfg.MaxPings = 6
+
+	plain := Simulate(reqs, Custom{Label: "always-ping", Decider: func(Observation) Action {
+		return ActionPing5m
+	}}, cfg)
+	if plain.Pings == 0 {
+		t.Fatal("baseline fired no pings; the fixture cannot show a budget doing anything")
+	}
+	oneOnly := Simulate(reqs, budgetedStub{label: "budget-1", budget: 1, ok: true}, cfg)
+	if oneOnly.Pings >= plain.Pings {
+		t.Errorf("budget=1 fired %d pings, unbudgeted fired %d: the budget did not bind",
+			oneOnly.Pings, plain.Pings)
+	}
+	declines := Simulate(reqs, budgetedStub{label: "no-opinion", budget: 0, ok: false}, cfg)
+	if declines.Pings != plain.Pings {
+		t.Errorf("declining fired %d pings, Config.MaxPings path fired %d: ok=false must fall "+
+			"back to the configured cap, not to the returned zero", declines.Pings, plain.Pings)
+	}
+	// And the cap is a CEILING: a budget above it must not raise it.
+	cfg.MaxPings = 2
+	greedy := Simulate(reqs, budgetedStub{label: "budget-99", budget: 99, ok: true}, cfg)
+	capped := Simulate(reqs, Custom{Label: "capped", Decider: func(Observation) Action {
+		return ActionPing5m
+	}}, cfg)
+	if greedy.Pings != capped.Pings {
+		t.Errorf("budget=99 under MaxPings=2 fired %d pings, want %d: a model must never raise "+
+			"an operator's cap", greedy.Pings, capped.Pings)
+	}
+}
+
+// Adding the seam must not have moved any arm that does not use it. Every registered arm is
+// replayed and compared against the same arm before PingBudgeter existed — which is what the
+// unbudgeted path still is, so the assertion is that a budget-less strategy is untouched.
+func TestUnbudgetedArmsAreUnaffectedByTheSeam(t *testing.T) {
+	reqs, cfg := dataset(t)
+	for _, spec := range Registry() {
+		s, err := NewStrategy(spec.Name, reqs, cfg)
+		if err != nil {
+			// Arms that carry their own action list have dedicated constructors; the registry's
+			// own tests cover those. Not finding one here is not a regression in this seam.
+			continue
+		}
+		name := spec.Name
+		if _, isBudgeter := s.(PingBudgeter); isBudgeter {
+			t.Errorf("%s implements PingBudgeter: the registered arms are meant to stay on the "+
+				"Config.MaxPings path, and one that opted in silently would change behaviour",
+				name)
+		}
+		if r := Simulate(reqs, s, cfg); r == nil {
+			t.Errorf("%s: nil result", name)
+		}
+	}
+}
+
+// BudgetPolicy has to be a working Strategy end to end — Simulate must accept it, it must
+// choose different budgets on different conversations, and it must cost less than pinging
+// everything at the same cap. The last is the claim the docs make; a fixture that cannot show
+// it would make the doc unfalsifiable here.
+func TestBudgetPolicyRunsThroughSimulateAndVariesPerConversation(t *testing.T) {
+	reqs, cfg := dataset(t)
+	cfg.MaxPings = 6
+	cfg.PingIdle = DefaultPingIdle
+
+	// Return mass concentrated in the first two windows: enough to pay for one or two pings,
+	// never for six.
+	p := cdfPredictor{points: [][2]float64{
+		{300, 0.10}, {580, 0.55}, {860, 0.72}, {1140, 0.74}, {3600, 0.80}, {86400, 1},
+	}}
+	pol := BudgetPolicy{Predictor: p, Interval: cfg.PingIdle, MaxK: 6, Semantics: cfg.Semantics}
+	if pol.Name() != StrategyKeepAliveBudget {
+		t.Errorf("Name() = %q, want %q", pol.Name(), StrategyKeepAliveBudget)
+	}
+	if pol.Describe() == "" {
+		t.Error("Describe() is empty; the dashboard renders it beside the arm")
+	}
+
+	got := Simulate(reqs, pol, cfg)
+	all := Simulate(reqs, Custom{Label: "ping-everything", MaxPings: 6,
+		Decider: func(Observation) Action { return ActionPing5m }}, cfg)
+	if got.Pings == 0 {
+		t.Fatal("BudgetPolicy fired no pings at all; the arm is inert on this fixture")
+	}
+	if got.Pings >= all.Pings {
+		t.Errorf("BudgetPolicy fired %d pings, ping-everything %d: the whole point is fewer",
+			got.Pings, all.Pings)
+	}
+	// The budget is a function of the observation, so it must not be one constant across the
+	// fixture's deliberately varied prefixes.
+	// The gate is prefix-independent on purpose, so a stub answering the same distribution for
+	// every conversation MUST produce one budget — that is the design, not a defect. What has to
+	// vary with the observation is the model's answer, so vary that.
+	perConv := perObservationPredictor{f: func(o Observation) [][2]float64 {
+		switch o.CachedTokens % 3 {
+		case 0: // comes back almost at once: nothing to buy
+			return [][2]float64{{300, 0.99}, {86400, 1}}
+		case 1: // one rich window
+			return [][2]float64{{300, 0}, {580, 0.9}, {86400, 1}}
+		default: // a long slow tail worth holding through
+			return [][2]float64{{300, 0}, {580, 0.2}, {860, 0.4}, {1140, 0.6}, {86400, 1}}
+		}
+	}}
+	varying := BudgetPolicy{Predictor: perConv, Interval: cfg.PingIdle, MaxK: 6,
+		Semantics: cfg.Semantics}
+	seen := map[int]bool{}
+	for _, r := range reqs {
+		o := pricedObservation(t, r.CachedContext)
+		if k, ok := varying.PingBudget(o); ok {
+			seen[k] = true
+		}
+	}
+	if len(seen) < 2 {
+		t.Errorf("budget took %d distinct values over the fixture: %v — a policy that picks one "+
+			"number for every conversation is Config.MaxPings with extra steps", len(seen), seen)
+	}
+}
+
+// The ceiling must still be a ceiling with the seam in place. NewOptimal reads the same ping
+// core, so if the signature change had quietly altered its arithmetic this is what catches it.
+func TestOptimalStillBoundsABudgetedArm(t *testing.T) {
+	reqs, cfg := dataset(t)
+	cfg.MaxPings = 6
+	opt, err := NewStrategy(StrategyOptimal, reqs, cfg)
+	if err != nil {
+		t.Fatalf("NewStrategy(optimal): %v", err)
+	}
+	ceiling := Simulate(reqs, opt, cfg)
+	p := cdfPredictor{points: [][2]float64{{300, 0.1}, {580, 0.6}, {860, 0.75}, {86400, 1}}}
+	arm := Simulate(reqs, BudgetPolicy{Predictor: p, Interval: cfg.PingIdle, MaxK: 6,
+		Semantics: cfg.Semantics}, cfg)
+	if ceiling.TotalUSD > arm.TotalUSD+1e-9 {
+		t.Errorf("optimal cost %.6f exceeds BudgetPolicy's %.6f: the ceiling is not a ceiling",
+			ceiling.TotalUSD, arm.TotalUSD)
+	}
+}

--- a/kvcache/registry.go
+++ b/kvcache/registry.go
@@ -479,7 +479,7 @@ func stepCost(prev *Request, prevAction Action, row *Request, action Action, cfg
 	if prev != nil {
 		tokens, tier, expires = entryAfter(prev, prevAction)
 		span := pingSpan(tokens, tier, expires, prev.TS, prevAction, row.TS,
-			cfg.Prices.For(prev.Model), cfg.Semantics, cfg)
+			cfg.Prices.For(prev.Model), cfg.Semantics, cfg, cfg.MaxPings)
 		pingCost, expires = span.cost, span.expires
 	}
 	alive := tokens > 0 && row.TS < expires
@@ -513,7 +513,7 @@ func stepCost(prev *Request, prevAction Action, row *Request, action Action, cfg
 func openSpanCost(last *Request, action Action, cfg Config) float64 {
 	tokens, tier, expires := entryAfter(last, action)
 	return pingSpan(tokens, tier, expires, last.TS, action, cfg.WindowEnd,
-		cfg.Prices.For(last.Model), cfg.Semantics, cfg).cost
+		cfg.Prices.For(last.Model), cfg.Semantics, cfg, cfg.MaxPings).cost
 }
 
 // timeMillisecond is time.Millisecond as an int64, so the conversions above read as

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -1,6 +1,7 @@
 package kvcache
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -383,6 +384,15 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		if n := pc.PingCap(); n > 0 && n < cfg.MaxPings {
 			cfg.MaxPings = n
 		}
+	}
+	// BudgetPolicy.Interval is documented to have to match Config.PingIdle — the windows it
+	// prices must be the windows this replay actually pings at — but nothing checked that
+	// until now. A caller that builds the two separately and lets them drift gets economics
+	// silently priced for a schedule Simulate isn't running, which is worse than an error.
+	if bp, ok := s.(BudgetPolicy); ok && bp.interval() != cfg.PingIdle {
+		panic(fmt.Sprintf("kvcache: BudgetPolicy.Interval (%s) does not match Config.PingIdle "+
+			"(%s) — the windows this arm prices are not the windows Simulate pings at",
+			bp.interval(), cfg.PingIdle))
 	}
 	sem := cfg.Semantics
 	out := &Result{Strategy: s.Name(), Decisions: map[Action]int64{},

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -354,6 +354,14 @@ type convState struct {
 	// closes it, which is why it is held rather than applied immediately: a ping's cost
 	// depends on how long the span turned out to be, and that is scoring, not deciding.
 	pending Action
+	// pendingBudget is the keep-alive budget a PingBudgeter strategy chose for THIS span, and
+	// budgeted says whether it chose one at all. An explicit bool rather than a zero sentinel
+	// for Pricing.Known's reason: a strategy that genuinely decided "no pings" and a strategy
+	// with no opinion are different facts, and reading the first as the second would silently
+	// restore Config.MaxPings on exactly the spans a model asked to leave alone. Held beside
+	// pending and cleared with it.
+	pendingBudget int
+	budgeted      bool
 	// coveredUntil is the far end of the union of alive intervals so far, for RetainedMs.
 	coveredUntil int64
 	// user and model are the last request's, so the OPEN-span pass can price its pings at the
@@ -476,6 +484,19 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 		out.StatsLevels[level]++
 		action := s.Decide(o)
 		out.Decisions[action]++
+		// A strategy that budgets per conversation is asked here, at the same instant and from
+		// the same Observation the action came from, so the budget cannot be computed from
+		// anything the action could not see either. Only asked when the action actually pings —
+		// a budget for a span that will not ping is a number nobody reads.
+		//
+		// A strategy whose Decide already consulted its own PingBudget is therefore asked twice.
+		// That is deliberate: keeping the two independent is what lets an arm implement one
+		// without the other, and a strategy for which the second call is expensive can memoize
+		// on o.RequestID.
+		spanBudget, budgeted := 0, false
+		if b, isBudgeter := s.(PingBudgeter); isBudgeter && action.Pings() {
+			spanBudget, budgeted = b.PingBudget(o)
+		}
 		// HIT IS DECIDED HERE, after the action, and it needs the action to be decided at all.
 		//
 		// A request whose action is ActionExpire writes no cache_control, so the provider reads
@@ -583,6 +604,7 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 			retain(out, st, r.TS, st.expires, cfg.WindowEnd)
 		}
 		st.lastTS, st.pending, st.turn = r.TS, action, st.turn+1
+		st.pendingBudget, st.budgeted = spanBudget, budgeted
 		st.user, st.model = r.User, r.Model
 	}
 
@@ -654,15 +676,19 @@ type pingOutcome struct {
 // land inside five minutes and the rest need only land inside an hour. For every other action
 // the tier never moves and this is the same fixed cadence as before, which is what the ping
 // schedule table in deploy/harbor/kv_ttl_cost_drift_test.go pins.
+//
+// maxPings is the budget for THIS span rather than cfg.MaxPings, so that a PingBudgeter
+// strategy can ask for fewer on one conversation than on another. Callers with no
+// per-conversation opinion pass cfg.MaxPings and get the previous behaviour exactly.
 func pingSpan(tokens int64, tier TTL, expires, lastTS int64, pending Action, spanEnd int64,
-	price Pricing, sem Semantics, cfg Config) pingOutcome {
+	price Pricing, sem Semantics, cfg Config, maxPings int) pingOutcome {
 	out := pingOutcome{tier: tier, expires: expires}
 	if !pending.Pings() || spanEnd <= lastTS || tokens <= 0 {
 		return out
 	}
 	want := pending.PingTier()
 	at := lastTS
-	for i := 0; i < cfg.MaxPings; i++ {
+	for i := 0; i < maxPings; i++ {
 		step := int64(cfg.pingInterval(out.tier) / time.Millisecond)
 		if step <= 0 {
 			break
@@ -714,9 +740,15 @@ func simulatePings(out *Result, ug, mg *groupAcc, st *convState, price Pricing, 
 	cfg Config, spanEnd int64, open bool) {
 	// Whatever happens below, this span is now settled: clearing the pending action is what
 	// stops a conversation being charged twice if the open-span pass visits it as well.
-	pending := st.pending
-	st.pending = ActionExpire
-	r := pingSpan(st.tokens, st.tier, st.expires, st.lastTS, pending, spanEnd, price, sem, cfg)
+	pending, budget, budgeted := st.pending, st.pendingBudget, st.budgeted
+	st.pending, st.pendingBudget, st.budgeted = ActionExpire, 0, false
+	// Config.MaxPings is the ceiling either way: a PingBudgeter can ask for fewer, never more,
+	// so an operator's cap is never raised by a model.
+	if !budgeted || budget > cfg.MaxPings {
+		budget = cfg.MaxPings
+	}
+	r := pingSpan(st.tokens, st.tier, st.expires, st.lastTS, pending, spanEnd, price, sem, cfg,
+		budget)
 	if r.fired == 0 {
 		return
 	}

--- a/kvcache/simulate.go
+++ b/kvcache/simulate.go
@@ -1,7 +1,6 @@
 package kvcache
 
 import (
-	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -385,14 +384,19 @@ func Simulate(reqs []*Request, s Strategy, cfg Config) *Result {
 			cfg.MaxPings = n
 		}
 	}
-	// BudgetPolicy.Interval is documented to have to match Config.PingIdle — the windows it
-	// prices must be the windows this replay actually pings at — but nothing checked that
-	// until now. A caller that builds the two separately and lets them drift gets economics
-	// silently priced for a schedule Simulate isn't running, which is worse than an error.
-	if bp, ok := s.(BudgetPolicy); ok && bp.interval() != cfg.PingIdle {
-		panic(fmt.Sprintf("kvcache: BudgetPolicy.Interval (%s) does not match Config.PingIdle "+
-			"(%s) — the windows this arm prices are not the windows Simulate pings at",
-			bp.interval(), cfg.PingIdle))
+	// BudgetPolicy.Interval must be the interval THIS replay actually pings at, and
+	// Config.PingIdle is Simulate's own authority on that — the same authority every
+	// registry arm gets its interval from at construction (NewStrategy wires cfg.PingIdle
+	// into HistoricalProbability and friends). BudgetPolicy is built by the caller rather
+	// than by NewStrategy, so nothing stopped its Interval from drifting from cfg.PingIdle —
+	// a panic here was tried and reverted: this package now recovers from a panicking
+	// Predictor (see PingBudget) specifically because Simulate is reachable from an HTTP
+	// handler with no recover() of its own under package dash, so a second panic seam right
+	// next to the first would undo that. Overriding is strictly safer than either crashing
+	// or silently pricing a different schedule than the one that runs.
+	if bp, ok := s.(BudgetPolicy); ok {
+		bp.Interval = cfg.PingIdle
+		s = bp
 	}
 	sem := cfg.Semantics
 	out := &Result{Strategy: s.Name(), Decisions: map[Action]int64{},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Stop carrying unused tools: how-to/declaration-removal.md
       - Keep an idle prompt cache warm: how-to/cache-keepalive.md
       - Choose a cache TTL: how-to/kv-cache-ttl.md
+      - Budget keep-alive pings: how-to/kv-cache-keepalive-budget.md
   - Components:
       - Overview: components.md
       - Choose a preset: how-to/choose-a-preset.md


### PR DESCRIPTION
## What this adds

A **per-conversation keep-alive budget**: instead of one `MaxPings` for the whole fleet, decide
how many pings each idle conversation is worth from what was knowable when its last request was
served.

Three pieces, and the first is the one to review:

| | |
|---|---|
| `kvcache.PingBudgeter` | a one-method optional interface — `PingBudget(o Observation) (int, bool)` — that lets a strategy's per-conversation budget reach the ping loop |
| `kvcache.BudgetPolicy` | the arm: a decision layer over the existing `Predictor` seam that turns reuse probabilities into a ping count |
| `deploy/harbor/kv_ttl_keepalive_policy.py` | where the fit lives, plus the offline evaluation that produced the numbers below |

`PingBudgeter` is optional and additive. Any strategy that does not implement it is budgeted by
`Config.MaxPings` exactly as before, which is every arm in the registry today —
`TestUnbudgetedArmsAreUnaffectedByTheSeam` asserts that none of them silently opted in.

## Why the existing seams were not enough

`Predictor` was already the right shape and is used unchanged: `BudgetPolicy` asks it for a
cumulative `ReuseProbability` at several horizons and derives everything from that. No new model
interface.

What was missing was **the ping count**. `Config.MaxPings` is one number for the whole replay,
which is the right shape for a hand-written arm and the wrong one for a learned arm, because the
budget a conversation is worth depends on the conversation: on the measured corpus the chosen
budget is 0 for 77.8% of idle spans and runs out to 8 for a long tail. Collapsing that to a
single K is most of the difference between the two.

## The method, in three claims

**1. The break-even comes out of the rates, not a config file.** A ping costs a `0.10x` read; a
rescue avoids the successor's `1.25x` write, so it is worth `1.15x`. Ping when the chance exceeds
`0.10/1.15 = 8.70%`. The model's per-token rate cancels, and so does the *per-token part* of the
prefix — which is why the arm reads a probability and never a token count, and why it is computed
from `Observation.Pricing` so that a deployment on other rates gets its own threshold and one with
no rates gets `ok=false`. What does **not** cancel is the ping's fixed overhead:
`Pricing.KeepAliveCost`'s `ping_input`/`ping_output` terms don't scale with the prefix, so 8.70%
is the gate only in the limit — it rises to 8.72% at 20k tokens, 8.96% at 2k, and 9.74% at 500,
a spread `MinPrefix` exists to protect against.

**2. The decision is conditional on having already gone quiet.** A keep-alive fires only after one
interval of idleness, so the decision is never faced by the ~92.5% of spans that close inside five
minutes. Unconditional 5-minute return rate on this corpus is ~92%; the stake-weighted hazard
among spans that reached 270s idle is **23.17%**. The practical form: *elapsed silence is not a
feature, it is the sample definition.* Hence the divide by the survivor share in
`BudgetPolicy.Windows` — on a distribution where 90% have already returned, 5pp of remaining mass
is a **50%** conditional hazard, not 5%.

**3. Pings are not independent, so the budget is an induction.** Each ping keeps the entry alive so
the next is a `0.1x` read rather than a `12.5x` re-creation:

```
V_j = max(0, rescue×h_j − ping + s_j×V_(j+1)),   V_maxk = 0
budget = the FIRST j at which V_j is not positive
```

The **first**, not the last: with a non-monotone hazard, taking the last positive `V` double-counts
value the induction has already propagated backwards. This lowers the effective bar at the first
sweep to ~7.4% and is worth ~6% of the arm's net.

## The 13 features are exactly what the seam carries

Every feature is on `kvcache.Observation` or derived from `Observation.Stats`, the leak-free
accumulator the simulator already advances as gaps close. That is a hard constraint: a model
fitted on anything else cannot be wired in behind `Predictor`.

Measured cost of that restriction, 3-seed means, 5-fold rolling origin:

| feature set | n | dollar-weighted AUC | off the bill | vs unrestricted |
|---|---|---:|---:|---:|
| unrestricted (adds `agent`, `tools`, …) | 21 | 0.7051 | 6.11% | — |
| **`Observation` + `Stats`** | **13** | **0.7004** | **6.07%** | **−0.04 pp** |
| `Observation` alone | 11 | 0.6916 | 5.71% | −0.40 pp |

`stop_reason` was one of the unrestricted set's features when this ran, and has since joined
the seam as `Observation.StopReason` — on the same footing as `CachedTokens`, and read by the
registry's `stop-reason-gated` arm. So the 13-feature column predates it and the comparison
above was not re-run against the wider seam; the numbers are the ones measured, not the ones a
rerun would produce.

The restriction is free. Dropping the two `Stats` features is not — the historical accumulator is
doing most of the work the excluded request-shape features would have done, which says the seam
was designed with the right things on it.

## What it measured, including where it loses

The hosted deployment's own capture: 34,577 idle spans over 16.9 days, 5-fold rolling origin,
pings at 280s, at `/etc/context-guru/prices.yaml`. Figures are shares of the window's total bill
(of which 87.1% is the prefix portion a keep-alive can move) and of what `optimal` reaches, with
per-ping efficiency indexed to a flat schedule — the same shape as the TTL page's results table.

| arm | pings | off the bill | of the ceiling | net per ping |
|---|---:|---:|---:|---:|
| `optimal` *(unreachable — reads the future)* | 5,826 | **11.72%** | 100.0% | 27.7× |
| flat `MaxPings=6` | 95,640 | **6.96%** | 59.4% | 1.0× |
| flat `MaxPings=5` | 80,404 | 6.91% | 58.9% | 1.2× |
| **`BudgetPolicy`** | **9,248** | **6.07%** | 51.8% | **9.0×** |
| flat `MaxPings=2` (`DefaultMaxPings`) | 33,591 | 5.19% | 44.3% | 2.1× |

**On money a constant beats this arm by 0.89 pp of the bill — 7.6 points of the ceiling — and
this says so rather than burying it.** The measured reason:

| population | share of stake | AUC by row | AUC by dollar |
|---|---|---|---|
| all spans | 100% | 0.93 | 0.635¹ |
| top 20% by prefix | 99.5% | 0.76 | 0.615 |
| **top 5% by prefix** | **86.7%** | **0.58** | **0.566** |

¹ **Unverified.** A stake-weighted AUC decomposes as `p²·AUC_in + (1−p)²·AUC_out + 2p(1−p)·AUC_cross`
for a subgroup holding stake share `p`. The top-20% row (`p=0.995`, `AUC=0.615`) caps this cell at
`0.995²·0.615 + 0.005²·1 + 2·0.995·0.005·1 ≈ 0.619` even granting the complement and every
cross-pair a perfect 1.0 — below the 0.635 claimed here, so the two rows cannot both be right.
Which one is mis-transcribed isn't recoverable from the published figures alone, and re-deriving
it needs the underlying per-span dollar values — outside this page's data boundary. Read it as
"high 0.6x, exact value unconfirmed." (A "0.70" for this same quantity floated around three other
places in this PR — `keepalive.go`, `kv_ttl_keepalive_policy.py` twice, and this doc's own "Where
to look next" — and is impossible by the same arithmetic with a wider margin; all four are now
fixed to stop repeating it.)

It ranks conversations almost perfectly and dollars barely above chance, degrading toward the tail
where the money is — so its mistakes land on the large-prefix spans where a mistake costs most,
and at 11.5:1 that is decisive.

Where it wins is **net per ping**, by 9×: 88% of `MaxPings=5`'s saving for 11% of its pings.
That matters where a tenant rate limit rather than money caps the budget, which on the live
deployment it plausibly does — ping coverage sits at 3.7% of candidates. But that is a rate-limit
question, not a modelling one, and it is the question to settle before choosing.

**This PR therefore changes no default.** `DefaultMaxPings` stays at 2. Raising it to 5 is worth
+1.72 pp of the bill on this window and is a one-constant change, but it alters production ping
volume and belongs in its own PR with the rate-limit question answered.

## Two things measured that did not work

Recorded in the doc so they are not retried blind.

**Threshold tuning has no headroom.** The best threshold chosen *in hindsight* is worth +0.38 pp across
all spans, +0.02 pp on the top 20% of prefixes, and **−0.05 pp** on the top 5%. Isotonic recalibration
collapsed to pinging nothing.

**Four families of extra feature came in under the noise floor.** The same model varies
**±0.42 pp** of the bill on the RNG seed alone:

| family | 3-seed mean | verdict |
|---|---:|---|
| day-of-week (numeric, categorical, `is_weekend`, × hour) | +0.04 pp | sign flips across seeds |
| last long pause via `gap > 100s` | +0.05 pp | sign flips; best dollar-AUC of any variant |
| trajectory gap history (max / mean / count) | −0.15 pp | sign flips |
| last human turn via `stop_reason == end_turn` | **−0.45 pp** | consistently worse on all 3 seeds |

The last is instructive: those features are absent on 86.7% of rows but present on 87.8% of the
*stake*. Sparse in rows and concentrated in dollars is the worst shape for a stake-weighted fit.

## Tests

`kvcache` — 15 new, each asserting one claim above rather than one code path:

- the gate **is** the rates' break-even, and gives the same answer at 2k, 125k and 2M tokens
- the gate holds only in the per-token limit — it rises to 9.74% at a 500-token prefix, which is
  what `MinPrefix` exists to protect
- the option value pings through a lean first window, and does not with `MaxK=1`
- the schedule ends on a worthless tail, holds through a dead stretch to a rich window, and
  declines a far window too thin to pay for the pings that reach it
- every reason to have no opinion returns `ok=false`; `MinPrefix` returns `(0, true)` because
  declining to ping is a decision
- a schedule priced on `Semantics`/`Interval` the arm cannot price (no TTL refresh, or an interval
  past the lifetime it protects) is declined rather than priced at the wrong rate
- the hazard is conditional — same unconditional mass, 10× different conditional hazard
- `Name()`, a schedule that resolves before the second sweep, and a predictor that answers some
  horizons but not all, are all covered
- a budget bounds the simulated pings; `ok=false` falls back to `Config.MaxPings`; a budget above
  the cap does **not** raise it
- no registered arm implements `PingBudgeter`
- the budget fires fewer pings than pinging everything, and varies across conversations rather
  than collapsing to one number
- a per-conversation budget reaches the ping loop through `Simulate`, and is asked for once per
  conversation rather than once for the whole replay
- `optimal` still runs correctly alongside a strategy that implements `PingBudgeter` (the ceiling
  comparison itself can't fail through `BudgetPolicy`'s own arithmetic — `Config.MaxPings` bounds
  both sides identically — so this is a seam-composition check, not evidence the economics are
  sound; the mutation-tested cases above are what pin that)
- a panicking `Predictor` degrades `PingBudget` to `ok=false` rather than propagating — required
  by `CLAUDE.md`'s fail-open rule, since `Predictor` is injectable
- `Simulate` overrides a `BudgetPolicy`'s `Interval` to `Config.PingIdle` rather than trusting a
  separately-set value that used to be able to drift from it (enforced by a doc comment only) —
  a wrong `Interval` on the input now produces the identical `Result` a correct one would

`deploy/harbor` — a drift guard driving the Python's real `--fixture` entry point across 11 cases
chosen to sit on branches the two implementations could diverge on: either side of the break-even
to within 2 basis points, a lean-then-rich pair, a worthless tail, a far-but-reachable window, a
distribution where most have already returned, a small prefix where the ping's fixed overhead
matters, and a rate scale 5× different to prove the threshold does not move. It compares the budget
**and** both intermediate vectors, because a budget that agrees for the wrong reason is a guard
that has already stopped working.

Everything above the `── the fit ──` divider in the Python is stdlib-only and pure, so the guard
runs in a plain CI container. Verified the guard can fail: deleting the survivor divide from the
Python makes it report `port 0.05` against `Go 0.50` and flips a budget from 2 to 0.

`_run_fixture` now reports one break-even **per case** rather than one for the whole fixture —
it used to assign the value inside the per-case loop, so the JSON only ever carried the last
case's. That happened to go unnoticed here because every case's rates come from the same
multiples (the break-even ratio doesn't move with `input_rate`), but a fixture that mixed rate
shapes would have silently reported the wrong case's number. The Go side now checks every
case's break-even against the rates' own value, not just the fixture's last one.

## Verification

```
go vet ./...                                       clean      (make lint)
gofmt -l .                                         clean      (make lint)
go test -race ./kvcache/ ./deploy/harbor/ ./dash/  pass       (dash 441s)
go build ./...                                     clean
mkdocs build --strict                              clean      (docs CI job)
python3 kv_ttl_keepalive_policy.py --self-test     pass
```

No route is added, so `docs/reference/routes.md` needs no row. `BudgetPolicy` is not in
`Registry()`, so nothing in `dash/` needs updating — `KVCacheArms()` probes the registry rather
than carrying a list, and an arm that needs a `Predictor` cannot be built from a name.

## Docs

`docs/how-to/kv-cache-keepalive-budget.md`, added to the mkdocs nav next to *Choose a cache TTL*
and cross-linked from it. It carries the derivation, the feature table, both measurement tables,
the negative results, and a "where to look next" that names the one measured blocker: the model
cannot rank dollars, and everything that failed above was an attempt to work around that.

