### PR TITLE
docs: propose a tiered pre-deployment regression gate

### DIFF
--- a/docs/proposals/deployment-gate.md
+++ b/docs/proposals/deployment-gate.md
@@ -1,0 +1,304 @@
+# Proposal: a deployment gate
+
+**Status:** proposal. Nothing here is built yet.
+
+**Problem:** commits and reviews are increasingly machine-authored, humans steer rather than
+read every diff, and there is no mechanism that says "this build is not worse than the last
+one" before it reaches `/usr/local/bin/context-guru-proxy`. CI proves the code compiles, the
+tests pass, and the binary starts. It proves nothing about the two properties the product is
+*for*.
+
+## 1. What has to be true before a deploy
+
+Three independent axes. They fail differently, they cost different amounts to check, and only
+one of them is expensive.
+
+| axis | the regression | what covers it today |
+|---|---|---|
+| **Configuration** | a default, preset, env var, route or auth class changes — or the *deployed* config stops matching what the binary reads | `pipeline_drift_test.go` (2 preset arms), `config/docdrift_test.go` (preset doc tables). Nothing checks the deployed host. |
+| **Expensiveness** | savings shrink, or cost *rises* while content falls (cache-write growth, our own LLM spend) | nothing automated |
+| **Capability** | the agent solves fewer tasks — corrupted `tool_result`, a broken expand round trip, a cache-busting splice | nothing automated |
+
+The configuration axis is the one that has already bitten this deployment, twice, in ways no
+test could see:
+
+- `key_env` on an upstream entry decides who pays, and it **wins over the code**. A
+  deployment whose `upstreams.yaml` still names it keeps billing the operator no matter what
+  the binary does. `REDEPLOY-caller-pays.md` §"Why this is a runbook and not a script" exists
+  because of that.
+- `TENANT_MONTHLY_CAP_USD` stayed in the systemd unit after the binary stopped reading it — a
+  live-looking spend control silently doing nothing.
+
+Both are "the deployed configuration and the binary's actual config surface disagree". That
+class is free to check, and is where the first work should go.
+
+A crude inventory of the current surface, taken while writing this: the tree reads **58**
+environment variables, **38** of them operator-facing (excluding `CG_TEST_*`, `CG_DIAG*`, the
+capture/child plumbing and `CONTEXT_GURU_GOLDEN`). Of those 38, **10 appear nowhere under
+`docs/`** — `CG_BASE`, `CG_FILTER_REMOVE`, `CG_LIVE`, `CG_LIVE_ARCHIVE_REMOTE`,
+`CG_LIVE_PRICE`, `CG_LIVE_RCLONE`, `CG_SMTP_LIVE_TO`, `CG_TRIGGER_CF_MAX`,
+`CHEAP_MODEL_AUTH`, `KVCACHE_PYTHON`. That is a grep, not the AST inventory §3.2 proposes, so
+treat the exact list as indicative — but a config surface a quarter of which is undocumented
+cannot be diffed against a deployed host, which is the point.
+
+## 2. Why the gate cannot be "run SWE-bench"
+
+The measured cost of the study in `docs/results/`, SWE-bench Verified, 50 tasks,
+`claude-code` on `aws/claude-sonnet-5`:
+
+| arm | billed cost | agent wall (sum) |
+|---|--:|--:|
+| baseline `off` | $31.98 | 317 min |
+| `codesmart` | $27.77 | 293 min |
+
+Two arms, one trial each, is **~$60 and ~10 h of agent wall**. The published study ran four
+arms at two trials. Per deploy, that is not a gate, it is a research budget.
+
+**But cost is the weaker of the two objections.** The stronger one is that reward is the
+*worst* signal per dollar on offer. The headline separation between arms was **43 vs 44 of
+50** — one task. On a 12-task subset at p≈0.86 the binomial sd is ≈1.2 tasks, so such a subset
+cannot distinguish an 88% pipeline from a 78% one. Spending $10 to sample the noisiest metric,
+then reading "12/12 solved" as "no capability regression", would be a gate that manufactures
+false confidence. That failure mode is worse than no gate, because a deploy proceeds on it.
+
+So the design principle is: **pay only for what cannot be measured for free, and gate hardest
+on the lowest-variance quantity available.**
+
+## 3. Tier 0 — free, every PR, in CI (seconds)
+
+Contract and configuration drift. No model, no Docker, no network.
+
+Every check below produces a **golden artifact under version control**. That is deliberate,
+and it is how the requirement "unless they need change, and that needs to be spotted as well"
+is met: an intended change shows up as a diff in the golden, in the PR, and a human or
+reviewing agent has to accept it in the commit. Silent drift becomes impossible; intended
+change becomes visible and cheap.
+
+### 3.1 Preset and pipeline drift — extend what exists
+
+`deploy/harbor/pipeline_drift_test.go` already asserts the harness arms run the shipped
+pipelines, and its own comment records why it covers `codesafe` as well as `codesmart`: the
+first version covered one preset, and the same bug was found one arm down. Generalise it to
+its natural closure — every preset named anywhere in the tree (harness arms, docs tables,
+`presetnames.go`, examples) resolves to the shipped pipeline, checked as a set in both
+directions, the way `config/docdrift_test.go` already does for the doc tables.
+
+### 3.2 Env-var contract — the `TENANT_MONTHLY_CAP_USD` gate
+
+Generate the inventory from the AST (`os.Getenv` / `os.LookupEnv` call sites), not a grep, and
+emit it as a committed artifact (`deploy/gate/golden/envvars.json`) carrying for each var:
+name, package, whether it is operator-facing, and where it is documented. Then assert:
+
+1. every operator-facing var the binary reads is documented under `docs/`;
+2. every var a shipped unit file or drop-in *sets* is one the binary reads.
+
+Check 2 is the dead-control gate, and it is the one that needs the deployed host (§6).
+
+### 3.3 Effective-config golden
+
+`cmd/context-guru-proxy/main.go:983` already assembles the **resolved** configuration for the
+dashboard's config page (`effectiveConfig`). Snapshot it for a fixed matrix of inputs (each
+preset × the default flag set × a representative config file) into goldens. Any change to any
+default — a trigger threshold, a cheap-model choice, a component's `max_tokens` — appears as a
+diff. This is the highest-value check in the proposal per hour spent, because it covers the
+whole config surface at once rather than one field at a time.
+
+### 3.4 Route and auth-class golden
+
+One table: route → authenticated? metered? loopback/CIDR-only? `proxy/security_test.go` and
+`proxy/tenancy_test.go` already assert pieces of this per route. A golden makes *losing* a
+protection visible, which per-route assertions do not — `/compact` is the example the code
+itself flags: "the most expensive route on the box was the only one with no rate limit".
+
+### 3.5 Cost-model agreement
+
+`deploy/harbor/kv_ttl_cost_drift_test.go` already holds the Python cost model to
+`kvcache.Simulate`. It belongs in the gate's tier-0 set rather than living only as a harness
+test, since every dollar figure the gate reports downstream depends on it.
+
+## 4. Tier 1 — cents, every PR touching `components/`, `apply/`, `expand/` (minutes)
+
+**This is where an expensiveness regression is actually caught**, and the reason it is cheap is
+already in the tree: `/compact` runs the pipeline and returns the rewritten body **without
+forwarding upstream**, and `deploy/harbor/replay.py` already drives it over a captured request
+stream, with a format-integrity check, explicitly "deterministically, with NO repeated
+agent/LLM spend".
+
+What is missing is not the mechanism. It is a **frozen corpus** and a **committed baseline**.
+
+### 4.1 The corpus
+
+A `CONTEXT_GURU_CAPTURE` JSONL recorded from a real baseline agent run, pinned by sha256 and
+fetched by the gate rather than committed (size, and it is real traffic — see §11). It must
+cover the shapes that carry the money: large `tool_result` blobs, repeated file reads, bash
+output, MCP tool schemas, and a realistic cached-prefix layout. A corpus on which the pipeline
+never fires measures nothing, so corpus adequacy is itself asserted: each gated component must
+act at least once, or the run fails as *unmeasured* rather than passing as *unchanged*.
+
+### 4.2 What it measures
+
+Per component and per preset: `tokens_before/after`, `saved_tokens`, `saved_tokens_unique`,
+act counts, and — the part that matters most — the **cache-tier split**. `measured-2026-08.md`
+records that 90.74% of input tokens bill as cache reads at 12.6× less than fresh input, and
+that compaction can therefore *raise* the bill while cutting content. So the gated number is
+**net dollars at the live price list, including our own LLM spend**, not a token percentage,
+plus a separate hard gate on cache-write growth (the published arms were a four-way wash within
+1.1%; a regression here is the expensive one).
+
+Two more zero-tolerance checks: every rewritten body is still structurally valid for the next
+call (`replay.py` does this), and every `<<cg:HASH>>` emitted resolves through `/expand` back to
+the original bytes. The "fail open, always" and "every lossy Offload must be reversible"
+boundaries in `CLAUDE.md` are exactly the invariants a gate should hold, and both are testable
+here for free.
+
+### 4.3 Determinism
+
+Deterministic components get **exact** baselines, zero tolerance — a 1% savings regression is
+invisible on a 12-task live run and unmissable here. The LLM components (`extract_llm`,
+`summarize`) are not deterministic; give them a recorded-response cache so this tier stays free
+and exact, and measure them live only in tier 2.
+
+## 5. Tier 2 — the live subset, per release candidate (~$10, ~1 h)
+
+Only for what replay cannot see: real prompt caching, a real agent loop, real tool use.
+
+### 5.1 Choosing the subset
+
+Not a list invented here. Select from the existing 50-task per-task record by four criteria:
+
+1. **the long tail**, where compaction matters and cache busting shows — `django__django-13128`
+   (123 steps, 10.15M cache-read, $2.99), `matplotlib__matplotlib-25775` (108 steps, $2.27),
+   `django__django-14034` (84 steps, $1.79);
+2. **tasks where the arms diverged** — `django__django-14034` went reward 1 → 0 between
+   baseline and `codesmart`, and its steps fell 84 → 28. Whatever that is, it is sensitive;
+3. **tasks where the pipeline actually fires**, from the per-component attribution in
+   `rows-*.json` / `--dump-configs`;
+4. **two cheap canaries** both arms always solved — `django__django-12050` ($0.09),
+   `django__django-15572` ($0.14). If a canary breaks, suspect the harness, not the pipeline.
+
+Criterion 3 needs data that lives on the eval box, not in this repo, so the plan includes a
+**one-off selection run** rather than a task list asserted from thin air. From the per-task cost
+table, ~12 tasks chosen this way land at **$9–11 per arm, one trial**.
+
+### 5.2 What it gates on, strongest signal first
+
+1. **Hard failures** — exceptions, upstream 4xx/5xx, malformed bodies, unresolved markers,
+   expand bounces above baseline. Near-zero variance. Any occurrence blocks.
+2. **Cost per task**, paired against the baseline task by task. Continuous, so far more powerful
+   than the binary at this sample size.
+3. **Steps and cache-hit rate** per task.
+4. **Resolved count** — blocks only on a *gross* drop (e.g. 12 → 7). A one-task move is inside
+   noise, and the report must say so rather than pretending otherwise.
+
+### 5.3 The honesty clause
+
+The report must state, in the artifact and not only in this document: *this tier detects gross
+capability breakage and cannot detect an 88% → 82% reward regression; only the full 50-task run
+can.* A gate whose green is over-read is the failure mode §2 warns about, and the
+countermeasure is a sentence in the output.
+
+## 6. Post-deploy verification
+
+`cg-gate verify-deployed --host <h>` closes the loop `REDEPLOY-caller-pays.md` walks by hand:
+
+- effective config on the host matches the tier-0 golden for the intended preset;
+- every `Environment=` in the unit and its drop-ins is a var the binary reads (§3.2);
+- `--version` matches the commit that passed the gate;
+- the runbook's own three assertions: `healthz` 200, a keyless request 401, `/stats` 403 through
+  the front end.
+
+## 7. The baseline problem — the part worth arguing about
+
+Absolute baselines rot, and not because of us: the upstream model changes, gateway routing
+changes, task images change, the price list changes. A July number is not a July-equivalent
+measurement in September.
+
+Two designs:
+
+**(a) Paired arms every run.** Run `off` and `codesmart` in the same session, gate on the
+*delta*. Immune to upstream drift. Costs 2×.
+
+**(b) Single arm against an absolute baseline, plus a drift canary.** Record in the baseline the
+model id, price-list hash, and task image digests. Before each gated run, replay one frozen
+request live with the pipeline off and assert the token accounting and price list have not
+moved. When the canary moves, the baseline is marked **stale** and the next run must be a
+re-baseline, in paired mode.
+
+**Recommendation: (b).** Steady-state cost is halved, and correctness is preserved exactly where
+it matters — the world moving is detected for cents instead of assumed away.
+
+Baseline lifecycle, either way:
+
+- lives in the repo as versioned JSON (`deploy/gate/baseline/<name>.json`) with provenance:
+  commit, model id, price hash, image digests, date, and who accepted it;
+- updated only by a PR carrying the run artifact — **never** written by the gate itself;
+- **ratchet**: the savings baseline may move up freely, and down only with a stated reason in the
+  commit. "Progress updated the baseline" and "a regression updated the baseline" must not look
+  the same in the log.
+
+## 8. The gate must be shown to fail
+
+This repo's convention is that a test is not evidence until it has been seen to fail with its
+subject reverted, and the coref-compaction branch produced three vacuous passes that motivated
+it. A *gate* has the same exposure at higher stakes, so `cg-gate selftest` is part of the
+deliverable, not a nice-to-have: it mutates each subject in turn — flip a preset component,
+delete a documented env var, degrade one component's savings, corrupt one expand marker — and
+asserts the corresponding check fails, with the failure text recorded.
+
+Related and separate: every check asserts **its subject ran**. A corpus that fails to load, a
+component that never acted, a task set that silently came back short — none of these may read as
+"no regression". The gate reports `pass` / `fail` / `unmeasured` as three distinct verdicts,
+because a counter meaning both "nothing broke" and "nothing was checked" is not a measurement.
+
+## 9. Shape of the thing
+
+`cmd/cg-gate`, in Go, in this repo — versioned with what it gates, and able to import `config`,
+`components`, `kvcache` directly rather than re-deriving them. Tier 2 keeps driving the existing
+Python harness; it works, and rewriting it would be a second implementation of the money
+question, which §3.5 exists to prevent.
+
+```
+cg-gate tier0                      # goldens + contracts (CI, free)
+cg-gate replay --corpus <sha>      # frozen-corpus savings + integrity (CI, cents)
+cg-gate live --tasks <set>         # subset, on the eval box (~$10)
+cg-gate verify-deployed --host <h> # post-deploy
+cg-gate selftest                   # prove each check can fail
+cg-gate accept-baseline <artifact> # writes the PR, not the file
+```
+
+One machine-readable verdict JSON plus a Markdown report; non-zero exit blocks. Wire tier 0 into
+`ci.yaml`, tier 1 into `ci.yaml` behind a path filter, and tier 2 + `verify-deployed` into
+`release.yaml`'s `workflow_dispatch` path — which already exists precisely so the release path
+can be exercised before there is a tag to regret.
+
+### Where it runs, and one trap to encode
+
+Tier 2 runs on the eval box. Gate runs are launched **from development sessions**, which inherit
+`ANTHROPIC_BASE_URL` pointing at Context Guru itself — and a gate that measures savings through
+a proxy that already compacted the traffic reports nonsense. The harnesses already refuse to
+start when the gateway names a context-guru route or a `cg_live_` token (`REPRODUCE.md`,
+prerequisites); `cg-gate` must adopt the same refusal and set the benchmark gateway explicitly.
+
+Separately: `deploy/eval-containers/sweep.py` hardcodes `ROOT` to one engineer's laptop path, so
+it runs nowhere else as written. Any path the gate depends on has to come from the environment or
+a config file.
+
+## 10. Phasing
+
+| phase | content | cost | value |
+|---|---|---|---|
+| 1 | tier 0 + `selftest` | free | covers the axis that has actually broken this deployment twice |
+| 2 | corpus + replay baseline | cents/run | catches expensiveness regressions with near-zero variance |
+| 3 | selection run + live baseline | one-off ~$25, then ~$10/RC | catches gross capability breakage |
+| 4 | `verify-deployed`, release checklist doc, `release.yaml` wiring | free | closes the manual runbook |
+
+Phase 1 is worth shipping alone.
+
+## 11. Decisions needed before phase 2
+
+- **Corpus provenance.** It is real traffic. Where is it hosted, what scrubbing does it get, and
+  who approves its use? Phase 2 cannot start without an answer.
+- **Budget per gated run**, which sets the task count in §5.1.
+- **Who accepts a baseline update** — and whether a reviewing agent may, or only a human.
+- **Does reward get a hard gate at all**, given §5.3, or is it advisory with the full run as the
+  only blocking authority?

--- a/docs/proposals/deployment-gate.md
+++ b/docs/proposals/deployment-gate.md
@@ -16,7 +16,7 @@ one of them is expensive.
 | axis | the regression | what covers it today |
 |---|---|---|
 | **Configuration** | a default, preset, env var, route or auth class changes — or the *deployed* config stops matching what the binary reads | `pipeline_drift_test.go` (2 preset arms), `config/docdrift_test.go` (preset doc tables). Nothing checks the deployed host. |
-| **Expensiveness** | savings shrink, or cost *rises* while content falls (cache-write growth, our own LLM spend) | nothing automated |
+| **Expensiveness** | savings shrink, or cost *rises* while content falls (cache-write growth, our own LLM spend) | nothing automated. Note the two halves need different tiers — content is free to check, billing is not (§4.2) |
 | **Capability** | the agent solves fewer tasks — corrupted `tool_result`, a broken expand round trip, a cache-busting splice | nothing automated |
 
 The configuration axis is the one that has already bitten this deployment, twice, in ways no
@@ -83,6 +83,10 @@ its natural closure — every preset named anywhere in the tree (harness arms, d
 `presetnames.go`, examples) resolves to the shipped pipeline, checked as a set in both
 directions, the way `config/docdrift_test.go` already does for the doc tables.
 
+Add one cheap assertion while there: **no shipped preset names a test-only component**
+(`testreorder`, `testrevert`, `testrewrite` are registered in the same namespace as the real
+ones, so a typo or a copy-paste can ship one).
+
 ### 3.2 Env-var contract — the `TENANT_MONTHLY_CAP_USD` gate
 
 Generate the inventory from the AST (`os.Getenv` / `os.LookupEnv` call sites), not a grep, and
@@ -132,31 +136,114 @@ A `CONTEXT_GURU_CAPTURE` JSONL recorded from a real baseline agent run, pinned b
 fetched by the gate rather than committed (size, and it is real traffic — see §11). It must
 cover the shapes that carry the money: large `tool_result` blobs, repeated file reads, bash
 output, MCP tool schemas, and a realistic cached-prefix layout. A corpus on which the pipeline
-never fires measures nothing, so corpus adequacy is itself asserted: each gated component must
-act at least once, or the run fails as *unmeasured* rather than passing as *unchanged*.
+never fires measures nothing, so corpus adequacy is itself asserted: each **in-scope** component
+(§4.3) must act at least once, or the run fails as *unmeasured* rather than passing as
+*unchanged*.
 
-### 4.2 What it measures
+The replay must also be **hermetic**. Fraction-based triggers scale with the model's context
+window, which is resolved over the network and cached (`proxy.go:1040`) — so a change in the
+model-info service silently shifts which candidates trip a trigger, and the gate reports a
+savings regression that is not one. Pin `MODEL_INFO` / `MODEL_INFO_URL` / `MODEL_PRICES` to files
+in the repo, hash them into the baseline, and point the upstream at a dead port for the
+class-A pass: nothing should call it, and a dead port turns "should not" into "cannot".
 
-Per component and per preset: `tokens_before/after`, `saved_tokens`, `saved_tokens_unique`,
-act counts, and — the part that matters most — the **cache-tier split**. `measured-2026-08.md`
-records that 90.74% of input tokens bill as cache reads at 12.6× less than fresh input, and
-that compaction can therefore *raise* the bill while cutting content. So the gated number is
-**net dollars at the live price list, including our own LLM spend**, not a token percentage,
-plus a separate hard gate on cache-write growth (the published arms were a four-way wash within
-1.1%; a regression here is the expensive one).
+One mechanical improvement over `replay.py`: it restarts the proxy per config, because `/stats`
+counters are cumulative per process. `/compact` takes a per-request pipeline override
+(`?preset=`, or `x-context-guru-pipeline`, `proxy.go:592`) and every captured row is labelled
+with the pipeline that actually ran (`notePreset`, `dashcapture.go:94`), so one process can serve
+the whole sweep and the per-request rows say *which* request changed, not merely that a total
+moved. Its restart also does `pkill -x <binary>`, which on a shared eval box kills whatever else
+is running that binary; the gate should own a uniquely-named process and kill by PID.
 
-Two more zero-tolerance checks: every rewritten body is still structurally valid for the next
-call (`replay.py` does this), and every `<<cg:HASH>>` emitted resolves through `/expand` back to
-the original bytes. The "fail open, always" and "every lossy Offload must be reversible"
-boundaries in `CLAUDE.md` are exactly the invariants a gate should hold, and both are testable
-here for free.
+### 4.2 What it measures — and what it cannot
 
-### 4.3 Determinism
+Per component and per preset: `tokens_before/after`, `saved_gross`, `saved_unique`, act counts.
+Those are exact and free.
 
-Deterministic components get **exact** baselines, zero tolerance — a 1% savings regression is
-invisible on a 12-task live run and unmissable here. The LLM components (`extract_llm`,
-`summarize`) are not deterministic; give them a recorded-response cache so this tier stays free
-and exact, and measure them live only in tier 2.
+**Dollars are not directly gateable here, and neither is cache.** The dollar valuation
+classifies each request into a billing tier from `r.cache_read` / `r.cache_write` /
+`r.fresh_input` (`dash/readvalue.go:176`), and those come from the *upstream response's* usage
+block. `/compact` never calls upstream, so all three are zero and every row classifies as
+`fresh` — the most expensive tier — systematically overstating savings. `measured-2026-08.md`
+records that 90.74% of input tokens actually bill as cache reads at 12.6× less than fresh, so
+that error is not small.
+
+So the money question splits three ways:
+
+- **content tokens removed** — exact here, zero tolerance;
+- **dollars** — computable here only under a *frozen tier mix* carried in the baseline. The same
+  assumption applied to both sides is a valid regression detector; it is **not** a claim about
+  the bill;
+- **billed tiers and cache-write growth** — tier 2 only. This is the failure mode that raises
+  the bill while cutting content, and replay can only *model* it via `kvcache.Simulate`, which
+  is why §3.5's cost-model drift test belongs in the gate.
+
+Two zero-tolerance checks do apply to everything that acts: every rewritten body is still
+structurally valid for the next call (`replay.py` does this), and every `<<cg:HASH>>` resolves
+through `/expand` back to the original bytes. The "fail open, always" and "every lossy Offload
+must be reversible" boundaries in `CLAUDE.md` are exactly the invariants a gate should hold, and
+both are free here.
+
+### 4.3 Scope: this tier gates SOME components, and the rest must be declared out
+
+The pipeline has 26 registered components. They divide by *what they depend on*, and only the
+first class is a savings-gate candidate.
+
+| class | components | savings gateable in tier 1? |
+|---|---|---|
+| **A — pure function of the request body** | `format`, `textclean`, `searchfold`, `toolschema`, `toolfilter`, `toon`, `dedup`, `mask`, `collapse`, `cmdfilter`, `linecap`, `extract`, `smartcrush`, `skeleton`, `failed_run`, `readlifecycle` | **yes, exact, $0** |
+| **B — calls a model on the request body** | `extract_llm`, `summarize`, `agentdiet` | only against recorded responses, and then the baseline is on the plumbing, not the savings (§4.4) |
+| **C — depends on live cross-turn or cache state** | `extract_llm_sweep`, `cachesplit`, `cacheinject` | **no — structurally impossible** |
+| **D — test-only** | `testreorder`, `testrevert`, `testrewrite` | n/a; tier 0 asserts no shipped preset names one |
+
+Class C is the important one, because measuring it here does not merely fail — **it passes
+vacuously**:
+
+- **`extract_llm_sweep`** asks the request's own model over its cached transcript, and
+  `prefixAsker.Ask` needs the previous turn's forwarded body from the session stash
+  (`proxy/prefixask.go:112`). A `/compact` replay forwards nothing, so nothing is ever stashed,
+  so every record is a session's first turn: `ErrNoPrefix`, refused locally, no request made
+  (`extract_sweep.go:795`). It declines on 100% of a replay corpus and removes 0 tokens. A gate
+  that included it would report `0 → 0, unchanged, pass` on a component that was entirely
+  broken.
+- **`cachesplit`** is a marker that always skips: the real edit is body-level in
+  `apply/prefixsplit.go` on the top-level `system` array, which components never see. Its
+  measured value — −34.1% cost, 0% → 96.7% cache hit — is a pure billing phenomenon.
+- **`cacheinject`** places breakpoints. Their effect exists only in the provider's cache
+  accounting.
+
+That is a real limit on the tier's authority, and it lands on the biggest measured lever in the
+product. **Tier 1 is therefore not "the expensiveness gate."** It is the savings gate for the
+16 deterministic offloaders, plus a universal integrity-and-reversibility gate, and the cache
+pair and the adjudicators are tier-2 business.
+
+The gate must carry this as an **explicit scope list**, and assert that a class-C component is
+*excluded* rather than measured. Any component that reaches replay and never acts reports
+`unmeasured`, never `pass` — the three-way verdict in §8 exists for exactly this case.
+
+**Optional extension (tier 1.5), if class B and C coverage is worth the build:** replay through
+the *chat* route against a stub upstream serving recorded responses, rather than through
+`/compact`. Forwarding populates the session stash, so `extract_llm_sweep` can act, and the
+recorded `usage` blocks supply real tiers. The honest caveat: those tiers record the *baseline*
+pipeline's cache behaviour, not the candidate's — so this reaches the sweep's decisions and
+plumbing, and still not cache economics under a changed pipeline.
+
+### 4.4 Determinism, and the limit of a recorded-response cache
+
+Class A gets **exact** baselines, zero tolerance — a 1% savings regression is invisible on a
+12-task live run and unmissable here.
+
+Class B cannot. Their output varies run to run, so an exact baseline is impossible, and a
+tolerance wide enough to absorb model variance is wide enough to hide a regression. A
+recorded-response cache makes the numbers repeatable, but then the gate is measuring a
+*recording*: it catches the plumbing breaking (candidate selection, trigger arithmetic, splice,
+marker round trip) and cannot catch the component getting worse at its job. Worth having, worth
+labelling as such in the report, and not worth confusing with a savings gate. Their savings
+belong to tier 2.
+
+Cost note: `replay.py` currently sets `CHEAP_MODEL=aws/claude-sonnet-5`. Replaying class B live
+over a few thousand records at that rate is not "cents" — a recorded-response cache is what
+keeps this tier cheap, not an aspiration.
 
 ## 5. Tier 2 — the live subset, per release candidate (~$10, ~1 h)
 
@@ -288,7 +375,7 @@ a config file.
 | phase | content | cost | value |
 |---|---|---|---|
 | 1 | tier 0 + `selftest` | free | covers the axis that has actually broken this deployment twice |
-| 2 | corpus + replay baseline | cents/run | catches expensiveness regressions with near-zero variance |
+| 2 | corpus + replay baseline | cents/run | catches content-savings regressions in the 16 class-A components with near-zero variance (§4.3) |
 | 3 | selection run + live baseline | one-off ~$25, then ~$10/RC | catches gross capability breakage |
 | 4 | `verify-deployed`, release checklist doc, `release.yaml` wiring | free | closes the manual runbook |
 
@@ -302,3 +389,6 @@ Phase 1 is worth shipping alone.
 - **Who accepts a baseline update** — and whether a reviewing agent may, or only a human.
 - **Does reward get a hard gate at all**, given §5.3, or is it advisory with the full run as the
   only blocking authority?
+- **Is tier 1.5 worth building** (§4.3)? Without it, `extract_llm_sweep` and the cache pair are
+  gated only per release candidate, at tier-2 cost — and those are the components carrying the
+  largest measured effects in the product.


### PR DESCRIPTION
Docs only — one new file under `docs/proposals/`, which is excluded from the mkdocs
nav, so no nav edit and no site change. Nothing here is built yet; this is for
argument before any code.

## Why

Commits and reviews are increasingly machine-authored and humans steer rather than
read every diff, so nothing currently asserts that a build is not worse than the last
one before it reaches `/usr/local/bin/context-guru-proxy`. CI proves the code
compiles, the tests pass and the binary starts. It proves nothing about configuration
drift, savings, or capability.

Running SWE-bench per deploy is not the answer, and the cost is the weaker half of
why. From `docs/results/`: two arms at one trial each is ~$60 and ~10 h of agent wall.
The stronger objection is that reward is the *worst* signal per dollar available — the
published arms separated 43 vs 44 of 50, so a 12-task subset (sd ≈1.2 tasks at p≈0.86)
cannot distinguish an 88% pipeline from a 78% one. A gate that samples the noisiest
metric and gets read as "no capability regression" is worse than no gate, because a
deploy proceeds on it.

So the proposal tiers by what each signal costs to measure, and gates hardest on the
lowest-variance quantity available.

## Shape

- **Tier 0 — free, every PR.** Goldens over the effective config (`main.go:983`
  already assembles it for the dashboard), the preset set, the route/auth-class table,
  and an AST-derived env-var contract. This is the axis that has actually broken this
  deployment twice: `key_env` outranking the code on who pays, and
  `TENANT_MONTHLY_CAP_USD` left in the unit after the binary stopped reading it. A
  golden diff is also how an *intended* config change gets spotted rather than
  slipping through.
- **Tier 1 — cents.** Frozen-corpus replay through `/compact`, which runs the pipeline
  with no upstream call. `deploy/harbor/replay.py` already does the middle of this;
  what is missing is a pinned corpus and a committed baseline. Scope is limited — see
  below.
- **Tier 2 — ~$10/RC.** A ~12-task SWE-bench subset selected from the existing 50-task
  record by four stated criteria, gating hardest on hard failures and per-task cost,
  and only loosely on reward.
- **Post-deploy `verify-deployed`**, which closes the loop `REDEPLOY-caller-pays.md`
  walks by hand.

## The two points most worth reviewing

**Tier 1 measures content, not money, and only for some components.** Both corrections
came from reading the code:

- The dollar valuation classifies each request into a billing tier from
  `r.cache_read` / `r.cache_write` / `r.fresh_input` (`dash/readvalue.go:176`), and
  those come from the upstream response's usage block. `/compact` never calls upstream,
  so all three are zero and every row classifies as `fresh` — the most expensive tier.
  Since 90.74% of input actually bills as cache reads at 12.6x less
  (`measured-2026-08.md`), that overstatement is large. Content tokens are exact here;
  dollars only under a frozen tier mix carried in the baseline, and explicitly not a
  claim about the bill; billed tiers and cache-write growth are tier 2 only.
- Of 26 registered components, 16 are a pure function of the request body and are
  exactly gateable; three call a model on it and are gateable only against recorded
  responses, which measures the plumbing rather than the savings; three depend on live
  cross-turn or cache state and cannot be measured at all. That last class **passes
  vacuously** rather than failing, which is why it needs naming: `extract_llm_sweep`
  needs the previous turn's forwarded body from the session stash
  (`proxy/prefixask.go:112`), a replay forwards nothing, so every record is a first
  turn — `ErrNoPrefix`, refused locally, no request made (`extract_sweep.go:795`). It
  declines on 100% of a corpus and removes 0 tokens, so a gate including it reports
  `0 -> 0, unchanged, pass` on a component that could be entirely broken. `cachesplit`
  is a marker that always skips (the edit is body-level in `apply/prefixsplit.go`) and
  `cacheinject` places breakpoints, so both have effects that exist only in provider
  cache accounting.

  Consequently tier 1 is described as the savings gate for the deterministic
  offloaders plus a universal integrity gate — not as "the expensiveness gate" — and
  the cache lever, which carries the largest measured effect in the product (−34.1%
  cost, 0% -> 96.7% hit in isolated A/B), sits outside it.

**Baselines rot for reasons that are not us** — model, gateway, task images, price
list. The recommendation is a single arm plus a cheap live drift canary that marks the
baseline *stale* when the upstream moves, rather than paying 2x for paired arms every
run; plus a ratchet rule so "progress moved the baseline" and "a regression moved the
baseline" do not look the same in the log.

The proposal also requires a `cg-gate selftest` that mutates each subject and asserts
the corresponding check fails, and three verdicts (`pass` / `fail` / `unmeasured`), so
a corpus that failed to load never reads as "nothing broke".

## Two findings noted in passing

Recorded in the doc (§1, §9) so they are not lost, not fixed here:

- A grep suggests the tree reads 38 operator-facing environment variables, 10 of which
  appear nowhere under `docs/` (`CG_BASE`, `CG_FILTER_REMOVE`, `CG_LIVE*`,
  `CG_SMTP_LIVE_TO`, `CG_TRIGGER_CF_MAX`, `CHEAP_MODEL_AUTH`, `KVCACHE_PYTHON`). That
  is a grep and not the AST inventory §3.2 proposes, so treat the exact list as
  indicative.
- `deploy/eval-containers/sweep.py` hardcodes `ROOT` to one engineer's laptop path, so
  it runs nowhere else as written.

## Open decisions

§11 lists four. The first blocks phase 2: the corpus is real traffic, so where it is
hosted, what scrubbing it gets and who approves its use needs an answer before any of
it is built.
