### PR TITLE
fix(extract_llm): book the saving the wire saw, not the projection's

### DIFF
--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -900,7 +900,14 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// that never happened — over-reporting the exact figure the iteration-024 re-run
 			// will be judged on.
 			if apply(i, content, cached.Projected, cached.Summary, true) {
-				if saved := schema.TextTokens(content) - schema.TextTokens(cached.Projected); saved > 0 {
+				// Measured against the message AS REPLAYED, for the same reason the fresh path is
+				// (#195): the text written is the projection PLUS the summary, the marker and the
+				// recovery hint, and the summary dominates that overhead. Correcting only the fresh
+				// path would leave this component contradicting itself — the same compaction valued
+				// higher on every replay turn than on the turn it was made, and replays are the
+				// steady state, so most of the reported value would come from the overstated side.
+				// That is the shape extract_llm_sweep was in for one commit; see its two sites.
+				if saved := schema.TextTokens(content) - schema.TextTokens(schema.MessageText(req.Input[i])); saved > 0 {
 					metrics.RecordExtractionValue(rep.Component, float64(saved)*val.repeatPerToken)
 				}
 				dbgReapply++
@@ -1352,7 +1359,16 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 				//
 				// Recorded in phase 3 instead, per candidate, once the splice is a fact. This
 				// runs in a goroutine, so the value simply rides in the slot phase 3 already reads.
-				out[k].saved = before - schema.TextTokens(res)
+				//
+				// `saved` is NOT computed here, and that is the second half of the same rule: the
+				// projection is not what the message becomes. apply splices
+				// `projected + "\n[" + summary + "] " + marker + hint`, so `before - TextTokens(res)`
+				// omits the summary, the marker and the recovery hint — and the summary is the
+				// dominant term by an order of magnitude, not the marker's ~23 tokens (a 900-token
+				// output compacted to 100 with a 60-token summary booked 800 where the message
+				// shrank by ~715). It is also a model output, so the overstatement varies per
+				// candidate and does not average out across a run. Phase 3 measures the spliced
+				// message instead — see #195. Only `before` rides along, as the ratio's denominator.
 				out[k].before = before
 			} else if !timedOut {
 				e.ratios.observe(0, before) // a miss is real evidence: ratio 0
@@ -1466,6 +1482,22 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if !apply(cands[k].i, cands[k].content, out[k].projected, out[k].summary, false) {
 				continue
 			}
+			// MEASURED AGAINST THE MESSAGE AS SPLICED, which is what the request actually shrank
+			// by — the figure an operator can check against their bill, and the basis
+			// extract_llm_sweep already books on. Carrying `before - TextTokens(projection)` out of
+			// runCall instead omitted the summary, the marker and the recovery hint, so the two
+			// extraction components' per-arm savings were not comparable (#195). Not merely a
+			// reporting artefact: this feeds e.ratios.observe, which is what the economic gate
+			// consults to decide whether the NEXT call is worth making, so an optimistic saving
+			// biased that decision towards spending.
+			//
+			// From cands[k].content rather than out[k].before, which is the same number for a slot
+			// that made a call but is 0 in a single-flight FOLLOWER's slot — and a follower does
+			// reach this splice, so the subtraction would go negative there. Nothing books it (the
+			// guard below is out[k].called), but a stored negative saving is one refactor away from
+			// being read by something that does.
+			out[k].saved = schema.TextTokens(cands[k].content) -
+				schema.TextTokens(schema.MessageText(req.Input[cands[k].i]))
 			// The splice is a fact, so the outcome may now be booked. `accepted` in the ledger row
 			// is documented as "the never-worse outcome — the same condition that spliced the
 			// result above, so the log cannot say accepted while the request kept the original",

--- a/components/offload/extract_llm.go
+++ b/components/offload/extract_llm.go
@@ -1191,17 +1191,21 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 		// overwhelming: a turn whose entire transcript re-bills at 1.25x fresh. On this warm
 		// per-output path the extra second buys a fraction of a cent, so it stays fully concurrent
 		// and the flag above is best-effort.
-		// saved/before carry the CALL's arithmetic to phase 3 rather than letting the goroutine
-		// that computed it book the outcome — see the accept branch in runCall.
+		// The outcome is carried to phase 3 rather than booked by the goroutine that produced it
+		// — see the accept branch in runCall.
 		type outT struct {
 			projected, summary string
-			saved, before      int
+			// saved is the WIRE saving, filled by phase 3 once the splice is a fact — not by the
+			// goroutine that made the call. There is no `before` beside it: phase 3 derives the
+			// denominator from cands[k].content, which is the same number. See the assignment.
+			saved int
 			// called marks a slot that actually issued a model call. A single-flight FOLLOWER
 			// returns before filling its slot, so the accounting in phase 3 must skip it.
 			//
-			// An explicit flag rather than a proxy. `before > 0` was indirect — `before` is in
-			// scope in the follower branch, so filling it there would silently re-enable the
-			// booking — and `calls[k].Component != ""` traded that for a worse coupling: it is
+			// An explicit flag rather than a proxy. `out[k].before > 0` was indirect — `before` was
+			// then a field of this struct and is in scope in the follower branch, so filling it
+			// there would silently re-enable the booking; the field itself is gone as of #195 —
+			// and `calls[k].Component != ""` traded that for a worse coupling: it is
 			// just rep.Component, which components/pipeline.go always sets in production but which
 			// most of this package's tests leave empty on a bare &components.Report{}. That made
 			// the whole booking block unreachable from those fixtures, so a future regression
@@ -1368,8 +1372,8 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 				// output compacted to 100 with a 60-token summary booked 800 where the message
 				// shrank by ~715). It is also a model output, so the overstatement varies per
 				// candidate and does not average out across a run. Phase 3 measures the spliced
-				// message instead — see #195. Only `before` rides along, as the ratio's denominator.
-				out[k].before = before
+				// message instead, and derives the ratio's denominator there too — see #195, and
+				// the assignment in phase 3 for why neither term rides in the slot.
 			} else if !timedOut {
 				e.ratios.observe(0, before) // a miss is real evidence: ratio 0
 			}
@@ -1482,22 +1486,23 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if !apply(cands[k].i, cands[k].content, out[k].projected, out[k].summary, false) {
 				continue
 			}
-			// MEASURED AGAINST THE MESSAGE AS SPLICED, which is what the request actually shrank
-			// by — the figure an operator can check against their bill, and the basis
-			// extract_llm_sweep already books on. Carrying `before - TextTokens(projection)` out of
-			// runCall instead omitted the summary, the marker and the recovery hint, so the two
-			// extraction components' per-arm savings were not comparable (#195). Not merely a
-			// reporting artefact: this feeds e.ratios.observe, which is what the economic gate
-			// consults to decide whether the NEXT call is worth making, so an optimistic saving
-			// biased that decision towards spending.
+			// MEASURED AGAINST THE MESSAGE AS SPLICED, which is what this request's message actually
+			// shrank by, and the basis extract_llm_sweep already books on. Carrying
+			// `before - TextTokens(projection)` out of runCall instead omitted the summary, the
+			// marker and the recovery hint, so the two extraction components' per-arm savings were
+			// not comparable (#195). Not merely a reporting artefact: this feeds e.ratios.observe,
+			// which is what the economic gate consults to decide whether the NEXT call is worth
+			// making, so an optimistic saving biased that decision towards spending.
 			//
-			// From cands[k].content rather than out[k].before, which is the same number for a slot
-			// that made a call but is 0 in a single-flight FOLLOWER's slot — and a follower does
-			// reach this splice, so the subtraction would go negative there. Nothing books it (the
-			// guard below is out[k].called), but a stored negative saving is one refactor away from
-			// being read by something that does.
-			out[k].saved = schema.TextTokens(cands[k].content) -
-				schema.TextTokens(schema.MessageText(req.Input[cands[k].i]))
+			// Both terms are derived HERE rather than carried in the slot. `before` is
+			// TextTokens(cands[k].content) — the same number runCall computes for
+			// calls[k].CandidateTokens — so once `saved` stopped riding along there was nothing
+			// left for the slot to hold but a denominator, and a field is a worse place for it: a
+			// single-flight FOLLOWER's slot has before == 0 while its message is spliced like any
+			// other, so the field's value did not mean what its name says on every slot that
+			// reaches this line.
+			before := schema.TextTokens(cands[k].content)
+			out[k].saved = before - schema.TextTokens(schema.MessageText(req.Input[cands[k].i]))
 			// The splice is a fact, so the outcome may now be booked. `accepted` in the ledger row
 			// is documented as "the never-worse outcome — the same condition that spliced the
 			// result above, so the log cannot say accepted while the request kept the original",
@@ -1540,13 +1545,25 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			// Only for a slot that actually MADE A CALL — see outT.called for why the condition is
 			// an explicit flag rather than a proxy.
 			//
-			// A DEFENCE, NOT A FIX: nothing was escaping before it. ratioTracker.observe returns
-			// early on totalTok <= 0, both recorders are no-ops at 0, out[k].saved is already 0 in
-			// a follower slot, and a follower's row is dropped by the Component filter on the
-			// append below. So this prevents no live defect, and saying otherwise would leave a
-			// future reader reasoning from a false premise. What it buys is that the booking no
-			// longer depends on three unrelated zero-guards staying zero-guards, and that the
-			// condition is stated where the booking happens.
+			// LOAD-BEARING AS OF #195, and it was a defence before that — the change is worth
+			// stating because the paragraph a reader consults before relaxing this guard used to
+			// say the opposite.
+			//
+			// It was written when `saved` was computed in runCall's accept branch, which a
+			// single-flight FOLLOWER returns before reaching, so a follower's slot carried
+			// saved == 0 and the guard prevented no live defect: three unrelated zero-guards
+			// already did (ratioTracker.observe returns early on totalTok <= 0, both recorders are
+			// no-ops at 0, and a follower's ledger row is dropped by the Component filter on the
+			// append below).
+			//
+			// The wire measurement moved to phase 3, and a follower DOES reach phase 3: its slot is
+			// filled with a non-empty `projected`, so it does not take the `projected == ""` skip,
+			// it splices, and the line above stores a POSITIVE saving for it (tryMark guarantees
+			// the spliced text is strictly smaller). Two of the three zero-guards therefore no
+			// longer apply, and this condition is the only thing between a follower's saving and
+			// RecordExtractionSaving, e.ratios.observe and calls[k].SavedTokens. Removing it books
+			// a saving for a request that made no call — and through the ratio, prices future calls
+			// on it.
 			//
 			// The follower's saving stays UNBOOKED — its leader books the shared result once, and
 			// attributing it twice would over-count. Booking per spliced message rather than per
@@ -1554,7 +1571,7 @@ func (e *ExtractLLM) Offload(req *bschemas.BifrostChatRequest, rep *components.R
 			if out[k].called {
 				calls[k].Accepted = true
 				calls[k].SavedTokens = out[k].saved
-				e.ratios.observe(out[k].saved, out[k].before)
+				e.ratios.observe(out[k].saved, before)
 				metrics.RecordExtractionSaving(rep.Component, out[k].saved)
 				// What the removal was WORTH, at this turn's regime. On a cold sweep that is the
 				// cache-write rate; the replays above are credited at the read rate.

--- a/components/offload/extract_llm_savedbasis_test.go
+++ b/components/offload/extract_llm_savedbasis_test.go
@@ -1,0 +1,194 @@
+package offload
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	bschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/rossoctl/context-guru/components"
+	"github.com/rossoctl/context-guru/schema"
+	"github.com/rossoctl/context-guru/store"
+)
+
+// summarizingModel returns a Starlark program that keeps the first lines of the body AND sets a
+// SUMMARY, so the splice takes the marker-plus-summary shape that `apply` actually writes:
+//
+//	projected + "\n[" + summary + "] " + marker + recovery hint
+//
+// shrinkingModel is not enough for these tests. Its reply defines a `transform` function and never
+// assigns OUTPUT, so the code leg produces nothing and the deterministic fallback supplies the
+// projection — with an empty summary. That fixture exercises the marker overhead (~23 tokens) but
+// not the SUMMARY, which is the dominant term in the gap under test (#195): exercising the shape
+// the splice writes is not the same as exercising it with the subject of the fix inside it.
+type summarizingModel struct {
+	calls   int
+	summary string
+}
+
+func (m *summarizingModel) Complete(_ context.Context, _ string) (string, error) {
+	m.calls++
+	// 40 of the body's 400 lines: enough to clear the acceptance check's keep-ratio floor (a
+	// result below ~5% of the body is refused as insane, which is what a one-line OUTPUT hit),
+	// small enough that the compaction is large and the fixture's numbers are unambiguous.
+	return "```python\nOUTPUT = \"\\n\".join(INPUT.split(\"\\n\")[0:40])\nSUMMARY = \"" +
+		m.summary + "\"\n```", nil
+}
+
+// A realistic one-line digest, kept just under clipSummary's 120-rune bound so the assertions can
+// look for it verbatim in the spliced text — a longer one comes back clipped with an ellipsis and
+// `Contains` would fail for a reason that has nothing to do with the subject. Tens of tokens, an
+// order of magnitude more than the marker and hint the sweep's fix was about.
+const basisSummary = "worker log: 400 identical INFO batch lines, no ERROR or WARN anywhere, " +
+	"no batch reported a failure"
+
+// THE FRESH PATH must book the saving the WIRE saw: the candidate minus the message as spliced.
+//
+// It booked `before - TextTokens(projection)` instead, carried out of runCall. The message that
+// goes upstream is the projection PLUS the summary, the marker and the recovery hint, so the figure
+// overstated every candidate by all three — and the summary dominates that, so the overstatement is
+// variable per candidate and does not average out. #195.
+//
+// What the broken version did, so this test can be audited from outside: on the fixture below it
+// booked TextTokens(body) - TextTokens("<first line>\n"), while the message it sent was
+// "<first line>\n[<summary>] <<cg:HASH>> [full output: call cg_expand]". Both figures are large and
+// positive; they differ by the summary + marker + hint, which is what the assertions below pin.
+//
+// Two consumers make it more than a reporting artefact: metrics.RecordExtractionSaving (the /stats
+// figure two arms of a comparison are read from) and e.ratios.observe, which prices the NEXT call —
+// so an optimistic saving argued for spending more.
+func TestExtractLLMBooksWhatTheSplicedMessageActuallySaved(t *testing.T) {
+	model := &summarizingModel{summary: basisSummary}
+	e := newTimeoutTestComponent(t, model) // min_tokens: 1, strategy: code, gate off
+	st := store.NewMemory(store.Options{MaxEntries: 400})
+	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 400)
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("summarize the worker log"), toolResultMsg(body),
+	}}
+	c := pricedCtx("saved-basis-fresh", st, model)
+	rep := &components.Report{Component: "extract_llm"}
+	savedBefore := extractGrossSaved("extract_llm")
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload must fail open: %v", err)
+	}
+
+	// PRECONDITIONS. The call happened, the splice happened, and the spliced text carries the
+	// SUMMARY — without the last one the fixture measures the marker overhead alone and the gap
+	// this test exists for is not in it.
+	if model.calls == 0 {
+		t.Fatal("the extraction model was never called, so nothing was booked")
+	}
+	spliced := schema.MessageText(req.Input[1])
+	if spliced == body {
+		t.Fatal("the candidate was not spliced, so there is no saving to attribute")
+	}
+	if !strings.Contains(spliced, basisSummary) {
+		t.Fatalf("the spliced message carries no summary segment, so the dominant term in the "+
+			"projection-vs-wire gap is absent from this fixture: %.200q", spliced)
+	}
+	// The projection is exactly what the splice put before the summary segment, i.e. the model's
+	// own result — the text the broken version subtracted. LastIndex, not Index: markElisions may
+	// have added "... N lines elided ..." notes inside the projection, and the summary segment is
+	// the final line by construction.
+	projection := spliced[:strings.LastIndex(spliced, "\n[")]
+	wire := schema.TextTokens(body) - schema.TextTokens(spliced)
+	projected := schema.TextTokens(body) - schema.TextTokens(projection)
+	if wire <= 0 {
+		t.Fatal("the message did not shrink, so there is no wire figure to compare against")
+	}
+	// THE FIXTURE MUST SEPARATE THE TWO IMPLEMENTATIONS. If the summary, marker and hint were
+	// free, both bases would produce the same number and every assertion below would hold for
+	// the projection-based code too.
+	if projected <= wire {
+		t.Fatalf("the projection-based figure (%d) is not larger than the wire figure (%d), so "+
+			"this fixture cannot tell the two bases apart", projected, wire)
+	}
+
+	// THE POSITIVE: the booked figure is the wire's, to the token.
+	if got := int(extractGrossSaved("extract_llm") - savedBefore); got != wire {
+		t.Errorf("RecordExtractionSaving booked %d tokens; the message it sent shrank by %d "+
+			"(the projection-only figure is %d). extract_llm_sweep books the spliced message, so "+
+			"two arms of a comparison were not measuring the same thing — and this figure also "+
+			"feeds the ratio tracker the economic gate spends against", got, wire, projected)
+	}
+	if len(rep.Calls) == 0 {
+		t.Fatal("no ModelCall row was reported, so the ledger's figure cannot be checked")
+	}
+	ledger := 0
+	for _, call := range rep.Calls {
+		ledger += call.SavedTokens
+	}
+	if ledger != wire {
+		t.Errorf("the ledger claims %d saved tokens; the message sent shrank by %d (projection "+
+			"only: %d)", ledger, wire, projected)
+	}
+}
+
+// A REPLAY must be valued on the same basis as the turn that made the decision.
+//
+// The replay path credited `content - TextTokens(cached.Projected)` at the repeat rate. Correcting
+// only the fresh path would leave the component contradicting ITSELF — the same compaction worth
+// more on every replay turn than on the turn it was made — and replays are the steady state, so
+// most of the reported value would come from the overstated side. The sweep was in exactly that
+// state for one commit (c442670).
+func TestExtractLLMReplayBooksWhatTheReplayedMessageActuallySaved(t *testing.T) {
+	model := &summarizingModel{summary: basisSummary}
+	e := newTimeoutTestComponent(t, model)
+	st := store.NewMemory(store.Options{MaxEntries: 400})
+	c := pricedCtx("saved-basis-replay", st, model)
+	// CacheRead is 1 USD/token in pricedCtx, so the credited value equals the token count and
+	// clears round4's 1e-4 step. repeatPerToken is the read rate on a warm cache-aware turn,
+	// which is what the replay path credits at.
+	body := strings.Repeat("2026-08-31T10:00:00Z INFO worker: processed batch\n", 400)
+	newReq := func() *bschemas.BifrostChatRequest {
+		return &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+			userMsg("summarize the worker log"), toolResultMsg(body),
+		}}
+	}
+
+	// Turn 1 takes the decision.
+	r1 := components.Report{Component: "extract_llm"}
+	if _, err := e.Offload(newReq(), &r1, c); err != nil {
+		t.Fatal(err)
+	}
+	if model.calls == 0 {
+		t.Fatal("turn 1 made no call, so turn 2 has no frozen decision to replay")
+	}
+
+	// Turn 2 replays it, and only turn 2's booking is measured.
+	req2 := newReq()
+	before := capturedText(req2)
+	valueBefore := extractGrossValue("extract_llm")
+	r2 := components.Report{Component: "extract_llm"}
+	if _, err := e.Offload(req2, &r2, c); err != nil {
+		t.Fatal(err)
+	}
+	if r2.Replays == 0 {
+		t.Fatalf("turn 2 replayed nothing (gates: %v, events: %v)", r2.Gates, r2.Events)
+	}
+	spliced := schema.MessageText(req2.Input[1])
+	if spliced == before[1] {
+		t.Fatal("the replay rewrote nothing, so there is no wire figure to compare against")
+	}
+	if !strings.Contains(spliced, basisSummary) {
+		t.Fatalf("the replayed message carries no summary segment, so the dominant term in the "+
+			"gap under test is absent: %.200q", spliced)
+	}
+	projection := spliced[:strings.LastIndex(spliced, "\n[")]
+	wire := schema.TextTokens(before[1]) - schema.TextTokens(spliced)
+	projected := schema.TextTokens(before[1]) - schema.TextTokens(projection)
+	if wire <= 0 {
+		t.Fatal("the replayed message did not shrink, so there is no wire figure to compare")
+	}
+	if projected <= wire {
+		t.Fatalf("the projection-based figure (%d) is not larger than the wire figure (%d), so "+
+			"this fixture cannot tell the two bases apart", projected, wire)
+	}
+	booked := extractGrossValue("extract_llm") - valueBefore
+	if int(booked+0.5) != wire {
+		t.Errorf("the replay credited %v tokens of value; the message it sent shrank by %d "+
+			"(projection only: %d). Valuing a replay against the stored projection makes the same "+
+			"compaction worth more on every replay turn than on the turn it was made — and "+
+			"replays are the steady state", booked, wire, projected)
+	}
+}

--- a/components/offload/extract_llm_savedbasis_test.go
+++ b/components/offload/extract_llm_savedbasis_test.go
@@ -192,3 +192,85 @@ func TestExtractLLMReplayBooksWhatTheReplayedMessageActuallySaved(t *testing.T) 
 			"replays are the steady state", booked, wire, projected)
 	}
 }
+
+// A SINGLE-FLIGHT FOLLOWER's message shrinks too, and its saving must NOT be booked a second time.
+//
+// This test exists because of what the wire measurement did to the `out[k].called` guard. While
+// `saved` was computed in runCall's accept branch, a follower — which returns before that branch —
+// carried saved == 0, so the guard prevented nothing and its own comment said as much. Phase 3 is a
+// different matter: a follower's slot holds a non-empty `projected`, so it does not take the
+// `projected == ""` skip, it splices, and the wire measurement stores a POSITIVE saving for it.
+// `called` is now the only thing between that number and RecordExtractionSaving, e.ratios.observe
+// and calls[k].SavedTokens — so the guard needs a test, and it had none.
+//
+// The contract it upholds is metrics.RecordExtractionSaving's own: "count each distinct compaction
+// once — the caller dedups by content key". Four byte-identical outputs are one compaction derived
+// by one call, spliced into four messages. Booking four would quadruple the reported saving of one
+// model call, and would feed the ratio tracker four observations of work done once.
+func TestExtractLLMDoesNotBookASingleFlightFollowersSaving(t *testing.T) {
+	// Byte-identical bodies, so all four share one extraction key and three become followers.
+	// The text is distinct from every other fixture here because extractInflight's group is
+	// process-wide and a collision would make this test measure another test's call.
+	body := strings.Repeat("savedbasis follower fixture, identical across all four candidates\n", 400)
+	const identical = 4
+	req := &bschemas.BifrostChatRequest{Input: []bschemas.ChatMessage{
+		userMsg("summarize these four identical outputs"),
+	}}
+	for i := 0; i < identical; i++ {
+		req.Input = append(req.Input, toolResultMsg(body))
+	}
+	model := &summarizingModel{summary: basisSummary}
+	e := newTimeoutTestComponent(t, model)
+	rep := &components.Report{Component: "extract_llm"}
+	c := &components.Ctx{
+		Session: "savedbasis-follower", Ctx: context.Background(),
+		Store: store.NewMemory(store.Options{MaxEntries: 400}), CtxWindow: 1_000_000,
+		Model: components.ModelSpec{Static: model, Incoming: model},
+		// Caching off, so the tail gate lets every candidate through and all four reach the
+		// concurrent phase — the same reason TestConcurrentCallsDoNotRaceOnTheGateHistogram does it.
+		CacheAware: false, MaxCachedIdx: -1,
+	}
+	savedBefore := extractGrossSaved("extract_llm")
+	if _, err := e.Offload(req, rep, c); err != nil {
+		t.Fatalf("Offload must fail open: %v", err)
+	}
+
+	// PRECONDITIONS. Followers ran, one call was made, and — the one that makes this test about
+	// phase 3 rather than about a slot that never got there — EVERY message was spliced,
+	// followers included.
+	if got := rep.Gates["deduped_inflight_extraction"]; got != identical-1 {
+		t.Fatalf("deduped_inflight_extraction = %d, want %d: without followers there is no "+
+			"double-booking to prevent (gates: %v)", got, identical-1, rep.Gates)
+	}
+	if model.calls != 1 {
+		t.Fatalf("the model was called %d times; single-flight was supposed to collapse the four "+
+			"identical candidates into one call", model.calls)
+	}
+	spliced := schema.MessageText(req.Input[1])
+	for i := 1; i <= identical; i++ {
+		if got := schema.MessageText(req.Input[i]); got == body {
+			t.Fatalf("message %d went upstream verbatim, so this fixture does not exercise a "+
+				"follower whose message shrank", i)
+		}
+	}
+	oneWire := schema.TextTokens(body) - schema.TextTokens(spliced)
+	if oneWire <= 0 {
+		t.Fatal("no message shrank, so there is no saving to book once or four times")
+	}
+
+	// THE POSITIVE: one compaction's worth is booked, from four spliced messages.
+	if got := int(extractGrossSaved("extract_llm") - savedBefore); got != oneWire {
+		t.Errorf("RecordExtractionSaving booked %d tokens for %d messages spliced from ONE model "+
+			"call; one compaction is worth %d. RecordExtractionSaving's contract is to count each "+
+			"distinct compaction once, and the ratio tracker that prices future calls is fed from "+
+			"the same place — so booking a follower's saving both inflates the reported figure and "+
+			"argues for making more calls on evidence of work done once", got, identical, oneWire)
+	}
+	if len(rep.Calls) != 1 {
+		t.Fatalf("got %d ledger rows for one model call: %+v", len(rep.Calls), rep.Calls)
+	}
+	if rep.Calls[0].SavedTokens != oneWire {
+		t.Errorf("the ledger row claims %d saved tokens; the message its call compacted shrank by "+
+			"%d", rep.Calls[0].SavedTokens, oneWire)
+	}
+}

--- a/components/offload/extract_llm_savedbasis_test.go
+++ b/components/offload/extract_llm_savedbasis_test.go
@@ -207,6 +207,18 @@ func TestExtractLLMReplayBooksWhatTheReplayedMessageActuallySaved(t *testing.T) 
 // once — the caller dedups by content key". Four byte-identical outputs are one compaction derived
 // by one call, spliced into four messages. Booking four would quadruple the reported saving of one
 // model call, and would feed the ratio tracker four observations of work done once.
+//
+// IT ALSO GUARDS THE BASIS, beyond the purpose stated above, and that is worth writing down because
+// a reader deciding what this test protects will otherwise under-read it: changing phase 3's basis
+// in place — `before - TextTokens(out[k].projected)` rather than the spliced message — fails this
+// test too, at 3,953 against 3,907. Found by the reviewing session on #216 with a variant mutation.
+//
+// AND THE DEDUP RIDES A SCHEDULING RACE: the leader must still hold the single-flight key when the
+// three followers reach extractInflight.Do, and summarizingModel.Complete is pure string work that
+// returns immediately. Verified 50/50 at -count=50. Deliberately left as is, because a lost race
+// FATALS on the deduped_inflight_extraction and model.calls preconditions rather than passing
+// vacuously — so a red here says whether the guard broke or the race was simply lost, which is the
+// property that matters. Do not read a failure on those two lines as a defect in the guard.
 func TestExtractLLMDoesNotBookASingleFlightFollowersSaving(t *testing.T) {
 	// Byte-identical bodies, so all four share one extraction key and three become followers.
 	// The text is distinct from every other fixture here because extractInflight's group is

--- a/components/offload/extract_llm_savedbasis_test.go
+++ b/components/offload/extract_llm_savedbasis_test.go
@@ -217,8 +217,12 @@ func TestExtractLLMReplayBooksWhatTheReplayedMessageActuallySaved(t *testing.T) 
 // three followers reach extractInflight.Do, and summarizingModel.Complete is pure string work that
 // returns immediately. Verified 50/50 at -count=50. Deliberately left as is, because a lost race
 // FATALS on the deduped_inflight_extraction and model.calls preconditions rather than passing
-// vacuously — so a red here says whether the guard broke or the race was simply lost, which is the
-// property that matters. Do not read a failure on those two lines as a defect in the guard.
+// vacuously — so a red here says whether the guard broke or the fixture produced no followers, which
+// is the property that matters. A failure on those two lines means the latter, and it has two very
+// different causes: the race was lost, or SINGLE-FLIGHT DEDUP ITSELF REGRESSED — a changed result
+// key, a concurrency semaphore that now serialises the candidates, getResultGlobal starting to
+// answer them. Neither is a defect in out[k].called, but the second is a defect worth chasing, so do
+// not read those two lines going red as nothing having happened.
 func TestExtractLLMDoesNotBookASingleFlightFollowersSaving(t *testing.T) {
 	// Byte-identical bodies, so all four share one extraction key and three become followers.
 	// The text is distinct from every other fixture here because extractInflight's group is

--- a/docs/components/extract_llm.md
+++ b/docs/components/extract_llm.md
@@ -724,10 +724,17 @@ booked the candidate minus the model's PROJECTION, while the text written is the
 summary segment, the marker and the recovery hint — so its figure overstated by all three, with the
 summary the dominant term. Since the summary is a model output, the overstatement varied per
 candidate rather than averaging out, and two arms of a comparison read side by side were not
-measuring the same thing (#195). Both components now subtract the message that was actually sent,
-which is the number an operator can check against their bill. It matters beyond reporting: the same
-figure feeds the ratio tracker the economic gate spends against, so an optimistic saving argued for
-making more calls.
+measuring the same thing (#195). Both components now subtract the message that was actually sent, so
+the row is the number of tokens the requests it counts genuinely shrank by. **It is not the bill
+delta**, for two reasons that predate that fix and are unchanged by it: `RecordExtractionSaving`
+counts each *distinct* compaction once, so when single-flight hands two concurrent requests the same
+result two messages shrink and one saving is booked; and replays feed `gross_value_usd` but never
+this row, so the tokens are fresh removals only while the dollars beside them are fresh plus replay
+— the same `acted_fresh` / `acted_replay` split, one column over. Take the money question to
+`gross_value_usd` and `net_value_usd`.
+
+The basis matters beyond reporting: the same figure feeds the ratio tracker the economic gate spends
+against, so an optimistic saving argued for making more calls.
 
 Plus, at the top level of `/stats`: **`llm_truncated`** — replies that stopped at the model's
 output cap. That is the worst outcome available, full price for zero result, and it used to be

--- a/docs/components/extract_llm.md
+++ b/docs/components/extract_llm.md
@@ -711,13 +711,23 @@ questions at a flat rate.
 | `gross_value_usd` | What its saved tokens are worth at the rate they'd have been billed |
 | **`net_value_usd`** | **The honest headline. Negative = underwater.** `null` when the spend is not known |
 | `avg_latency_ms` | Mean wall time per call (latency cost on the hot path) |
-| `gross_saved_tokens` | Tokens removed |
+| `gross_saved_tokens` | Tokens removed, measured on the message **as spliced** — the candidate minus what actually went upstream, marker and summary segment included |
 | `reasons` / `top_reason` | Why extraction ran or was suppressed |
 
 Per-component, in `components.extract_llm`: **`acted` counts free replays.** A frozen decision
 re-spliced on a later turn saves tokens and costs nothing, and it landed in the same counter as the
 call that derived it — `acted: 239` beside `reapplied_same_session: 2,291` was read as 239 paid
 extractions. Use `acted_fresh` (paid work) and `acted_replay` (free) instead.
+
+**Both extraction components measure a saving the same way**, and they did not always. `extract_llm`
+booked the candidate minus the model's PROJECTION, while the text written is the projection plus the
+summary segment, the marker and the recovery hint — so its figure overstated by all three, with the
+summary the dominant term. Since the summary is a model output, the overstatement varied per
+candidate rather than averaging out, and two arms of a comparison read side by side were not
+measuring the same thing (#195). Both components now subtract the message that was actually sent,
+which is the number an operator can check against their bill. It matters beyond reporting: the same
+figure feeds the ratio tracker the economic gate spends against, so an optimistic saving argued for
+making more calls.
 
 Plus, at the top level of `/stats`: **`llm_truncated`** — replies that stopped at the model's
 output cap. That is the worst outcome available, full price for zero result, and it used to be


### PR DESCRIPTION
Closes #195.

`extract_llm` booked `candidate − TextTokens(projection)` for every removal, on both the fresh and
the replay path. What `apply` writes is

```
projected + "\n[" + summary + "] " + marker + recovery hint
```

so the figure omitted the summary segment, the marker and the recovery hint. `extract_llm_sweep`
already subtracts the message **as spliced**, so the two extraction components were measuring
"saved tokens" against different baselines while both feeding `metrics.RecordExtractionSaving` /
`RecordExtractionValue` and both surfacing in `/stats` under `by_component`.

Both sites move to the sweep's basis.

| Site | Booked before | Books now |
|---|---|---|
| fresh (`out[k].saved`) | the projection, carried out of `runCall` | `cands[k].content − MessageText(req.Input[i])`, in phase 3, once the splice is a fact |
| replay | `content − cached.Projected` | `content − MessageText(req.Input[i])` |

### The gap is summary-dominated, not the marker's ~23 tokens

#195's description put the overhead at the marker's; that is true of the sweep's old figure and
wrong for this component. The summary is the dominant term and it is a **model output**, so the
overstatement varies per candidate and does not average out across a run. On this change's fixture:
**6,833 booked against 6,787 actually sent** — 46 tokens on one candidate whose summary is 98
characters, and a full 120-rune summary on a smaller candidate is a far larger fraction.

### It is not only reporting

`out[k].saved` feeds `e.ratios.observe`, and the ratio tracker is what the economic gate consults to
decide whether a call is worth making at all. An optimistic saving biased the decision to spend, in
the direction of spending more.

### Sequencing — a maintainer's call, flagged rather than decided

#195 asks for this to land **after** the iteration-024 re-run, or with an explicit note beside its
results, so a savings-basis change does not land in the middle of the comparison it would
invalidate. Iteration 024's numbers are not in the tree, so the durable note went into
`docs/components/extract_llm.md`: the `gross_saved_tokens` row now states the basis, and a paragraph
records why it moved. **Anyone reading 024's two arms across this commit needs to know
`extract_llm`'s figure got smaller without the mechanism getting worse.** Hold the merge if the
re-run is still open.

### Also in the diff, and why

- `runCall` no longer computes `saved` at all; only `before` rides along in the slot, as the ratio's
  denominator.
- Phase 3 subtracts from `cands[k].content` rather than `out[k].before`, which is `0` in a
  single-flight **follower**'s slot — and a follower does reach the splice, so that subtraction
  would store a negative. Nothing books it today (the guard is `out[k].called`), but a stored
  negative saving is one refactor away from being read.
- The replay path had to move with the fresh one. Correcting only the fresh path would leave the
  component contradicting itself — the same compaction worth more on every replay turn than on the
  turn it was made — and replays are the steady state, so most of the reported value would come from
  the overstated side. That is the shape the sweep was in for exactly one commit (`c442670`).

### What the broken version did

So the tests can be audited from outside: on the new fixture it booked
`TextTokens(body) − TextTokens("<40 body lines + elision notes>")` = 6,833, while the message it
sent was those lines plus `\n[worker log: 400 identical INFO batch lines, …] <<cg:HASH>> [full
output: call cg_expand]`, which is 6,787 smaller than the body. Both figures are large and positive;
they differ by summary + marker + hint.

### Verification

Go 1.26.4, eval box: `gofmt -l` clean, `go vet ./...` clean, `go test ./...` **28/28 packages pass**.

Two mutations, each reverting ONE site, each confirmed to **build** first (`go build ./...` +
`go vet`), each asserted to land exactly once, each failing on its own test's own assertion with the
other test still green:

| Mutation | Result |
|---|---|
| **M1** fresh path books the projection again (`out[k].saved = before - TextTokens(res)`, phase 3's measurement removed) | FAIL — *"RecordExtractionSaving booked 6833 tokens; the message it sent shrank by 6787"*. Replay test still PASSES |
| **M2** replay books `cached.Projected` again | FAIL — *"the replay credited 6833 tokens of value; the message it sent shrank by 6787"*. Fresh test still PASSES |

M1 was also run against the whole `components/offload` package: it fails **only** the new fresh
test, so no existing test was silently depending on either basis.

### The fixture, and what it took to make it able to fail

The tests needed a model that sets both `OUTPUT` and `SUMMARY`. `shrinkingModel` does not — its
reply defines a `transform` function, never assigns `OUTPUT`, and the deterministic fallback then
supplies the projection with an **empty summary**, which exercises the marker overhead but not the
term this change is about. Two things the new fixture had to clear to put the subject inside the
shape:

- a one-line `OUTPUT` is refused by the acceptance check's keep-ratio floor (~5% of the body), so
  the program keeps 40 of 400 lines;
- a summary over `clipSummary`'s 120 runes comes back ellipsized, so a verbatim `Contains` check
  would fail for a reason unrelated to the subject.

Both are asserted as preconditions rather than assumed, and each test fatals if the projection-based
figure is not strictly larger than the wire figure — without that guard the fixture could not tell
the two implementations apart.

### Not touched here

The other components' savings paths were checked: `RecordExtractionSaving` / `RecordExtractionValue`
have exactly four call sites, two in each extraction component, and all four now measure the
message.
