### PR TITLE
feat(plugin): add a Claude Code status line for cache TTL and savings

### DIFF
--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -1746,5 +1747,722 @@ func TestRejectingAValueDoesNotEatTheNextFlag(t *testing.T) {
 	}
 	if strings.Contains(string(launched), "--anthropic-upstream") {
 		t.Errorf("an upstream reached argv from a rejected value: %s", launched)
+	}
+}
+
+// --- settings.py's statusLine key ---------------------------------------------------------
+
+// TestSettingsStatuslineRoundTrips: add --statusline writes the top-level key alongside the
+// existing env changes in ONE atomic save, and remove takes back only what it recorded writing —
+// the exact shape already proven for env.CONTEXT_GURU_BIN and env.ANTHROPIC_UPSTREAM above,
+// applied to a key that lives outside `env` entirely.
+func TestSettingsStatuslineRoundTrips(t *testing.T) {
+	const cmdPath = "/opt/cg/statusline.py"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+
+	facts, code := settings(t, "add", "--file", path, "--url", ourURL, "--statusline", cmdPath)
+	if code != 0 || facts["result"] != "added" {
+		t.Fatalf("add --statusline failed: exit %d, %v", code, facts)
+	}
+	got := readJSON(t, path)
+	sl, _ := got["statusLine"].(map[string]any)
+	if sl["type"] != "command" || sl["command"] != cmdPath {
+		t.Fatalf("statusLine = %v, want {type: command, command: %q}", got["statusLine"], cmdPath)
+	}
+	if got["theme"] != "dark" {
+		t.Error("an unrelated top-level setting was lost")
+	}
+
+	// Re-adding the identical install is a no-op, same as the base_url side.
+	facts, code = settings(t, "add", "--file", path, "--url", ourURL, "--statusline", cmdPath)
+	if code != 0 || facts["result"] != "unchanged" {
+		t.Fatalf("re-adding the same statusline should be unchanged: exit %d, %v", code, facts)
+	}
+
+	facts, code = settings(t, "remove", "--file", path, "--url", ourURL)
+	if code != 0 || facts["result"] != "removed" {
+		t.Fatalf("remove failed: exit %d, %v", code, facts)
+	}
+	if _, still := readJSON(t, path)["statusLine"]; still {
+		t.Error("the statusLine key survived removal")
+	}
+	if readJSON(t, path)["theme"] != "dark" {
+		t.Error("removal took more than its own keys")
+	}
+}
+
+// TestSettingsStatuslineRefusesToStealAnExisting mirrors
+// TestSettingsAddRefusesToStealAnExistingBaseURL for the statusLine key: a statusLine already in
+// the file may be the user's own, or another plugin's, and taking it over silently would break
+// whatever it drives while reporting success.
+func TestSettingsStatuslineRefusesToStealAnExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	theirs := map[string]any{"type": "command", "command": "~/.claude/my-own-statusline.sh"}
+	writeJSON(t, path, map[string]any{"statusLine": theirs})
+
+	facts, code := settings(t, "add", "--file", path, "--url", ourURL, "--statusline", "/opt/cg/statusline.py")
+	if code != 2 || facts["result"] != "conflict" {
+		t.Fatalf("expected a conflict (exit 2), got exit %d, %v", code, facts)
+	}
+	got := readJSON(t, path)
+	if sl, _ := got["statusLine"].(map[string]any); sl["command"] != theirs["command"] {
+		t.Fatalf("the file was modified despite the conflict: %v", got["statusLine"])
+	}
+	// The base_url side must not have been written either — one conflict stops the WHOLE call.
+	if env, _ := got["env"].(map[string]any); env != nil {
+		t.Errorf("env was written even though the statusline conflict should have stopped everything: %v", env)
+	}
+
+	// --force is the explicit decision, same as the base_url side, and it must be recoverable.
+	facts, code = settings(t, "add", "--file", path, "--url", ourURL, "--statusline", "/opt/cg/statusline.py", "--force")
+	if code != 0 || facts["result"] != "added" {
+		t.Fatalf("--force did not proceed: exit %d, %v", code, facts)
+	}
+	facts, code = settings(t, "remove", "--file", path, "--url", ourURL)
+	if code != 0 {
+		t.Fatalf("remove failed: %v", facts)
+	}
+	got = readJSON(t, path)
+	if sl, _ := got["statusLine"].(map[string]any); sl["command"] != theirs["command"] {
+		t.Errorf("uninstall did not restore the statusLine it replaced: %v", got["statusLine"])
+	}
+}
+
+// TestSettingsStatuslineOmittedWhenFlagAbsent proves the feature is fully additive: every
+// existing call site that never passes --statusline (which is most of them, including every
+// pre-existing test in this file) must behave exactly as it did before this key existed.
+func TestSettingsStatuslineOmittedWhenFlagAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{"env": map[string]any{}})
+	if _, code := settings(t, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	if _, ok := readJSON(t, path)["statusLine"]; ok {
+		t.Error("a statusLine key appeared without --statusline ever being passed")
+	}
+}
+
+// TestSettingsStatuslineOnlyInstallTouchesNoRouting covers the /context-guru:statusline skill's
+// own call shape: --statusline with NO --url, so a user who wants the status line (typically at
+// USER scope, since it renders regardless of which project is open) does not accidentally start
+// routing that scope's sessions through the proxy as a side effect.
+func TestSettingsStatuslineOnlyInstallTouchesNoRouting(t *testing.T) {
+	const cmdPath = "/opt/cg/statusline.py"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+
+	facts, code := settings(t, "add", "--file", path, "--statusline", cmdPath)
+	if code != 0 || facts["result"] != "added" {
+		t.Fatalf("statusline-only add failed: exit %d, %v", code, facts)
+	}
+	got := readJSON(t, path)
+	if _, hasEnv := got["env"]; hasEnv {
+		t.Errorf("env appeared from a call that never passed --url: %v", got)
+	}
+	sl, _ := got["statusLine"].(map[string]any)
+	if sl["command"] != cmdPath {
+		t.Fatalf("statusLine = %v, want command %q", got["statusLine"], cmdPath)
+	}
+
+	// Re-running is a no-op.
+	if _, code := settings(t, "add", "--file", path, "--statusline", cmdPath); code != 0 {
+		t.Fatal("re-add failed")
+	}
+
+	// Removing it with no --url must find it anyway — there is no env.ANTHROPIC_BASE_URL to key
+	// off, which is exactly the shape the base_url removal path's early return would otherwise
+	// mistake for "nothing installed here".
+	facts, code = settings(t, "remove", "--file", path)
+	if code != 0 || facts["result"] != "removed" {
+		t.Fatalf("statusline-only remove failed: exit %d, %v", code, facts)
+	}
+	if _, still := readJSON(t, path)["statusLine"]; still {
+		t.Error("the statusLine key survived a statusline-only removal")
+	}
+	if readJSON(t, path)["theme"] != "dark" {
+		t.Error("removal took more than its own key")
+	}
+}
+
+// TestSettingsAddRequiresUrlOrStatusline: with neither flag, `add` has nothing to do and must
+// say so rather than silently writing an empty ANTHROPIC_BASE_URL.
+func TestSettingsAddRequiresUrlOrStatusline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	py := requireTool(t, "python3")
+	cmd := exec.Command(py, filepath.Join(scriptsDir(t), "settings.py"), "add", "--file", path)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("add with neither --url nor --statusline should fail, got: %s", out)
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		t.Error("a file was created by a call that should have refused before writing anything")
+	}
+}
+
+// --- the statusLine command --------------------------------------------------------------
+
+// runStatusline runs statusline.py with a controlled environment and stdin, and returns its
+// output, exit code and wall-clock time.
+//
+// TMPDIR is pinned to a fresh t.TempDir() so the /api/stats response cache the script keeps
+// there (keyed only by port) cannot leak between tests that happen to reuse a port number.
+func runStatusline(t *testing.T, env map[string]string, stdin string) (out string, code int, elapsed time.Duration) {
+	t.Helper()
+	py := requireTool(t, "python3")
+	cmd := exec.Command(py, filepath.Join(scriptsDir(t), "statusline.py"))
+	cmd.Env = append(os.Environ(), "TMPDIR="+t.TempDir())
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	cmd.Stdin = strings.NewReader(stdin)
+	start := time.Now()
+	b, err := cmd.CombinedOutput()
+	elapsed = time.Since(start)
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("running statusline.py: %v (%s)", err, b)
+	}
+	t.Logf("statusline.py env=%v stdin=%q -> exit %d in %v, output %q",
+		env, stdin, code, elapsed.Round(time.Millisecond), b)
+	return string(b), code, elapsed
+}
+
+// statsStub is a stand-in /api/stats that always answers the same JSON body, so tests can drive
+// statusline.py against a controlled savings/keepalive shape without a real proxy.
+func statsStub(t *testing.T, body string) (port string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/stats", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() { srv.Close() })
+	return fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)
+}
+
+// routedEnv is the one env var that makes statusline.py act at all: it self-gates on
+// ANTHROPIC_BASE_URL naming our own port, exactly like the two hooks above.
+func routedEnv(port string) map[string]string {
+	return map[string]string{
+		"ANTHROPIC_BASE_URL":        "http://127.0.0.1:" + port + "/anthropic",
+		"CLAUDE_PLUGIN_OPTION_PORT": port,
+	}
+}
+
+// TestStatuslineIsSilentWhereRoutingIsNotConfigured is the same property the two hooks have,
+// and for the same reason: this plugin installs a statusLine at USER scope (see
+// skills/statusline/SKILL.md), so it renders in every project on the machine, including every one
+// that never routed through context-guru. Printing anything there — even "not routed" — would be
+// permanent noise in somebody's terminal for a plugin they are not using in that project.
+func TestStatuslineIsSilentWhereRoutingIsNotConfigured(t *testing.T) {
+	for _, c := range []struct {
+		name, baseURL string
+	}{
+		{"unset", ""},
+		{"another local proxy on a different port (e.g. litellm)", "http://localhost:4000/anthropic"},
+		{"a remote gateway", "https://gateway.corp.example/anthropic"},
+		{"our port number appearing in a REMOTE host", "https://8787.example.com/anthropic"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			out, code, _ := runStatusline(t, map[string]string{"ANTHROPIC_BASE_URL": c.baseURL}, "{}")
+			if code != 0 {
+				t.Errorf("exit %d; the status line command must never fail a render", code)
+			}
+			if strings.TrimSpace(out) != "" {
+				t.Errorf("printed %q for a project that is not routed through us", out)
+			}
+		})
+	}
+}
+
+// TestStatuslineReportsADownProxyInThreeCharacters covers the ACCEPT-AND-STALL shape, the same
+// one stallingPort exists for above: a hung proxy, a half-open socket, or an unrelated service on
+// the port all look like this to a client, and none of them are exotic. The render path must
+// notice inside its own short timeout rather than hang the status line.
+func TestStatuslineReportsADownProxyInThreeCharacters(t *testing.T) {
+	port := stallingPort(t)
+	out, code, elapsed := runStatusline(t, routedEnv(port), "{}")
+	if code != 0 {
+		t.Errorf("exit %d; must never fail a render", code)
+	}
+	if strings.TrimSpace(out) != "cg!" {
+		t.Errorf("got %q, want the down indicator %q", strings.TrimSpace(out), "cg!")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("took %v against a stalling port; the HTTP fetch carries its own ~0.6s timeout, "+
+			"so this should return in well under the script's own 2s backstop", elapsed)
+	}
+}
+
+// TestStatuslineNeverFailsOnAConnectionRefusal is the cheap, common shape of "down" — nothing
+// listening at all — kept distinct from the stalling-port test above because a refused
+// connection returns instantly and must not be confused with a slow one in the code path.
+func TestStatuslineNeverFailsOnAConnectionRefusal(t *testing.T) {
+	port := freePort(t) // freed immediately: nothing is listening
+	out, code, _ := runStatusline(t, routedEnv(port), "{}")
+	if code != 0 {
+		t.Errorf("exit %d; must never fail a render", code)
+	}
+	if strings.TrimSpace(out) != "cg!" {
+		t.Errorf("got %q, want %q", strings.TrimSpace(out), "cg!")
+	}
+}
+
+// TestStatuslineSurvivesMalformedStdin: Claude Code's own payload shape is trusted, but this
+// script must not crash if it is ever handed something else — a truncated pipe, a future
+// incompatible change, a manual invocation while testing.
+func TestStatuslineSurvivesMalformedStdin(t *testing.T) {
+	port := statsStub(t, `{"total_saved_usd": 0, "saved_unique": 0}`)
+	for _, stdin := range []string{"", "not json{{{", "null", "[1,2,3]", `{"prompt_cache": "not an object"}`} {
+		out, code, _ := runStatusline(t, routedEnv(port), stdin)
+		if code != 0 {
+			t.Errorf("stdin %q: exit %d; must never fail a render", stdin, code)
+		}
+		if !strings.Contains(out, "cache") {
+			t.Errorf("stdin %q: expected a graceful fallback cache segment, got %q", stdin, out)
+		}
+	}
+}
+
+// TestStatuslineSurvivesAMalformedStatsResponse: the proxy answered, but not with anything this
+// script can parse (a future field-shape change, a body truncated by an intermediary). The cache
+// stopper comes from stdin and owes the network nothing, so it must still render.
+func TestStatuslineSurvivesAMalformedStatsResponse(t *testing.T) {
+	port := statsStub(t, `not valid json at all`)
+	stdin := `{"prompt_cache": {"warm": true, "expires_at": ` +
+		fmt.Sprint(time.Now().Add(90*time.Second).Unix()) + `}}`
+	out, code, _ := runStatusline(t, routedEnv(port), stdin)
+	if code != 0 {
+		t.Errorf("exit %d; must never fail a render", code)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "cache 1:") {
+		t.Errorf("got %q; the cache stopper must still render off a malformed /api/stats body", out)
+	}
+	if strings.Contains(out, "saved") {
+		t.Errorf("a savings segment appeared from an unparseable stats body: %q", out)
+	}
+}
+
+// parseCacheSeconds reads back "cache M:SS" as a second count, for boundary assertions that have
+// to tolerate the real (small, sub-second) delay between this test computing `expires_at` and the
+// subprocess evaluating `time.time()` against it — a fixed-string comparison at a tight margin is
+// flaky by construction, not a property of the script.
+func parseCacheSeconds(t *testing.T, seg string) int {
+	t.Helper()
+	m, s := 0, 0
+	if _, err := fmt.Sscanf(seg, "cache %d:%d", &m, &s); err != nil {
+		t.Fatalf("%q does not parse as a cache countdown: %v", seg, err)
+	}
+	return m*60 + s
+}
+
+// TestStatuslineCacheCountdownMath is the boundary table for the TTL "stopper" — the single most
+// valuable element of this whole feature, per its own design brief. Every row is a way the
+// countdown could be wrong, including the one a naive `remaining < 0` check gets backwards: a
+// prefix that expires AT this exact instant (remaining == 0) has already gone cold, not "still
+// has zero seconds left".
+func TestStatuslineCacheCountdownMath(t *testing.T) {
+	port := statsStub(t, `{}`)
+	for _, c := range []struct {
+		name         string
+		remainingSec float64
+		wantCold     bool
+	}{
+		{"fresh: about 4m50s left", 290, false},
+		{"a few seconds left", 3, false},
+		{"boundary: expires exactly now", 0, true},
+		{"just expired", -5, true},
+		{"clock skew: far in the past", -100000, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			expiresAt := time.Now().Add(time.Duration(c.remainingSec * float64(time.Second))).Unix()
+			stdin := fmt.Sprintf(`{"prompt_cache": {"warm": true, "expires_at": %d}}`, expiresAt)
+			out, code, _ := runStatusline(t, routedEnv(port), stdin)
+			if code != 0 {
+				t.Fatalf("exit %d", code)
+			}
+			got := strings.SplitN(strings.TrimSpace(out), " | ", 2)[0]
+			if c.wantCold {
+				if got != "cache cold" {
+					t.Errorf("remaining=%.0fs: got %q, want %q", c.remainingSec, got, "cache cold")
+				}
+				return
+			}
+			if got == "cache cold" {
+				t.Fatalf("remaining=%.0fs: reported cold while still positive", c.remainingSec)
+			}
+			gotSec := parseCacheSeconds(t, got)
+			// Truncation only ever rounds DOWN (never up, never negative here), so the tolerance
+			// is asymmetric: at most the subprocess's own wall-clock overhead behind the expected
+			// value, never ahead of it.
+			if gotSec > int(c.remainingSec) || gotSec < int(c.remainingSec)-2 {
+				t.Errorf("remaining=%.0fs: got %q (%ds), want within 2s below that", c.remainingSec, got, gotSec)
+			}
+		})
+	}
+}
+
+// TestStatuslineOmitsPromptCacheWhenAbsent covers the normal, expected "no data yet" state —
+// before a session's first response has usage to track — as distinct from an error. It must
+// read calmly, never as a hang or a missing feature.
+// TestStatuslineCacheCountdownExactBoundary isolates remaining==0 EXACTLY, which the table test
+// above cannot reliably do: a subprocess always burns some real wall-clock time between this test
+// computing `expires_at` and the script evaluating `time.time()` against it, so "expires right
+// now" always lands very slightly negative in practice by the time it's checked — which happens
+// to satisfy BOTH `remaining <= 0` and the off-by-one `remaining < 0`, so that table row cannot
+// catch the boundary bug on its own. This freezes time.time() inside the interpreter instead, so
+// remaining is exactly 0.0, not "usually a hair negative".
+func TestStatuslineCacheCountdownExactBoundary(t *testing.T) {
+	py := requireTool(t, "python3")
+	script := `
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("statusline", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+m.time.time = lambda: 1_700_000_000.0
+print(m._cache_stopper({"prompt_cache": {"expires_at": 1_700_000_000.0}}))        # remaining == 0
+print(m._cache_stopper({"prompt_cache": {"expires_at": 1_700_000_000.5}}))        # remaining +0.5s
+print(m._cache_stopper({"prompt_cache": {"expires_at": 1_700_000_000.0 - 0.5}}))  # remaining -0.5s
+`
+	out, err := exec.Command(py, "-c", script, filepath.Join(scriptsDir(t), "statusline.py")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running the boundary check: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	want := []string{"cache cold", "cache 0:00", "cache cold"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d:\n%s", len(lines), len(want), out)
+	}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("line %d: got %q, want %q (remaining==0 must already read cold, not "+
+				"\"0:00\" — a prefix that expires AT this instant has no time left)", i, lines[i], w)
+		}
+	}
+}
+
+func TestStatuslineOmitsPromptCacheWhenAbsent(t *testing.T) {
+	port := statsStub(t, `{}`)
+	out, code, _ := runStatusline(t, routedEnv(port), `{}`)
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if strings.TrimSpace(out) != "cache –" {
+		t.Errorf("got %q, want the neutral placeholder %q", strings.TrimSpace(out), "cache –")
+	}
+}
+
+// TestStatuslineOmitsZeroSavings matches the dashboard's own convention (metrics.Snapshot's
+// keepalive field is `omitempty`): a fresh install has genuinely nothing to report yet, and a
+// segment reading "$0.00/0 saved" looks like a broken feature rather than an honest zero — the
+// exact failure the /context-guru:status skill's own docs warn against for the sibling numbers.
+func TestStatuslineOmitsZeroSavings(t *testing.T) {
+	port := statsStub(t, `{"total_saved_usd": 0, "saved_unique": 0, "keepalive_pings": 0}`)
+	out, code, _ := runStatusline(t, routedEnv(port), `{}`)
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if strings.Contains(out, "saved") || strings.Contains(out, "ka ") {
+		t.Errorf("a zero-valued segment was shown: %q", out)
+	}
+}
+
+// TestStatuslineShowsANegativeNetHonestly: total_saved_usd can go genuinely negative — an idle
+// keep-alive spending more than it recovers nets the whole figure negative (dash/overview.go's
+// own waterfall calls this "a real outcome the dashboard will not hide"). A savings segment must
+// not fold that into the same omission as a fresh install with nothing to report yet: `<= 0` and
+// `== 0` agree at exactly zero, but only the latter tells a real loss from "nothing happened".
+func TestStatuslineShowsANegativeNetHonestly(t *testing.T) {
+	port := statsStub(t, `{"total_saved_usd": -0.05, "saved_unique": 0}`)
+	out, code, _ := runStatusline(t, routedEnv(port), `{}`)
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out, "$-0.05/0 saved") {
+		t.Errorf("got %q, want a segment showing the negative net, not an omission", out)
+	}
+}
+
+// TestStatuslineShowsSavingsAndKeepalive is the positive control for the omission tests above:
+// without it, a statusline.py that never rendered ANY savings segment would pass both.
+func TestStatuslineShowsSavingsAndKeepalive(t *testing.T) {
+	port := statsStub(t, `{"total_saved_usd": 1.5, "saved_unique": 2500, "keepalive_pings": 4}`)
+	out, code, _ := runStatusline(t, routedEnv(port), `{}`)
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out, "$1.50/2.5k saved") {
+		t.Errorf("got %q, want a segment containing %q", out, "$1.50/2.5k saved")
+	}
+	if !strings.Contains(out, "ka 4p") {
+		t.Errorf("got %q, want a segment containing %q", out, "ka 4p")
+	}
+}
+
+// TestStatuslineCachesStatsAcrossQuickRenders is the "cheap" requirement made concrete: Claude
+// Code can re-render on every token of a streamed response, and without a cache this would be
+// one HTTP request per render against the user's own local proxy.
+func TestStatuslineCachesStatsAcrossQuickRenders(t *testing.T) {
+	var hits int64
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/stats", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"total_saved_usd": 0.01, "saved_unique": 1}`))
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() { srv.Close() })
+	port := fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)
+
+	// Same TMPDIR for every call in this test, deliberately — that is what makes the on-disk
+	// cache file shared between them. runStatusline gives each call a FRESH TMPDIR (correct
+	// isolation between different tests), so this test drives the script directly instead.
+	py := requireTool(t, "python3")
+	tmp := t.TempDir()
+	run := func() string {
+		cmd := exec.Command(py, filepath.Join(scriptsDir(t), "statusline.py"))
+		cmd.Env = append(os.Environ(), "TMPDIR="+tmp,
+			"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+			"CLAUDE_PLUGIN_OPTION_PORT="+port)
+		cmd.Stdin = strings.NewReader("{}")
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("statusline.py: %v (%s)", err, b)
+		}
+		return string(b)
+	}
+	for i := 0; i < 5; i++ {
+		run()
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("5 renders inside the cache TTL produced %d requests to /api/stats, want 1", got)
+	}
+}
+
+// --- the keep-alive opt-in toggle -----------------------------------------------------------
+
+// runKeepaliveBlock executes one bash block from skills/keepalive/SKILL.md with a controlled
+// environment, the same way runCheck/skillBlock drive the other skills' destructive snippets.
+func runKeepaliveBlock(t *testing.T, needle string, env map[string]string) (out string, code int) {
+	t.Helper()
+	requireTool(t, "bash")
+	block := skillBlock(t, "keepalive", needle)
+	cmd := exec.Command("bash", "-c", block)
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	b, err := cmd.CombinedOutput()
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("running keepalive block: %v (%s)", err, b)
+	}
+	t.Logf("keepalive block (needle %q) env=%v -> exit %d, output:\n%s", needle, env, code, b)
+	return string(b), code
+}
+
+// TestKeepaliveEnableWritesAPresetPreservingConfig is the fix for the defect the config toggle
+// would otherwise reintroduce: --config REPLACES --preset entirely (loadConfig in
+// cmd/context-guru-proxy/main.go only reads --preset when --config is ABSENT), so a keep-alive
+// config that omitted its own `preset:` line would silently turn compaction off the moment
+// keep-alive turned on — the opposite of what enabling it is supposed to do.
+func TestKeepaliveEnableWritesAPresetPreservingConfig(t *testing.T) {
+	state := t.TempDir()
+	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, map[string]string{
+		"CLAUDE_PLUGIN_OPTION_PORT":   "8787",
+		"CLAUDE_PLUGIN_OPTION_PRESET": "codesmart",
+		"XDG_STATE_HOME":              state,
+	})
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, out)
+	}
+	cfg := filepath.Join(state, "context-guru", "keepalive-8787.yaml")
+	b, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("config was not written at %s: %v", cfg, err)
+	}
+	if !strings.Contains(string(b), "preset: codesmart") {
+		t.Errorf("the configured PRESET did not survive into the config file, which would "+
+			"silently drop compaction the moment --config is passed:\n%s", b)
+	}
+	if !strings.Contains(string(b), "keepalive: true") {
+		t.Errorf("cache.keepalive: true is missing from the written config:\n%s", b)
+	}
+}
+
+// TestKeepaliveEnableRefusesToClobberAForeignFile: a file at the same path that this skill did
+// not write (no marker) might be something else entirely — refuse rather than overwrite it.
+func TestKeepaliveEnableRefusesToClobberAForeignFile(t *testing.T) {
+	state := t.TempDir()
+	stateDir := filepath.Join(state, "context-guru")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+	foreign := "# hand-written, not ours\npreset: cache\n"
+	if err := os.WriteFile(cfg, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, map[string]string{
+		"CLAUDE_PLUGIN_OPTION_PORT": "8787",
+		"XDG_STATE_HOME":            state,
+	})
+	if code != 0 {
+		t.Fatalf("must not fail outright, just refuse: exit %d: %s", code, out)
+	}
+	if !strings.Contains(out, "REFUSING") {
+		t.Errorf("no refusal reported for a foreign file: %s", out)
+	}
+	got, err := os.ReadFile(cfg)
+	if err != nil || string(got) != foreign {
+		t.Errorf("the foreign file was modified: %v, %q", err, got)
+	}
+}
+
+// TestKeepaliveDisableOnlyRemovesOurOwnFile mirrors the same ownership discipline
+// settings.py enforces for everything else this plugin writes.
+func TestKeepaliveDisableOnlyRemovesOurOwnFile(t *testing.T) {
+	t.Run("removes what we wrote", func(t *testing.T) {
+		state := t.TempDir()
+		stateDir := filepath.Join(state, "context-guru")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+		ours := "# context-guru: written by /context-guru:keepalive\npreset: cache\ncache:\n  keepalive: true\n"
+		if err := os.WriteFile(cfg, []byte(ours), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, map[string]string{
+			"CLAUDE_PLUGIN_OPTION_PORT": "8787",
+			"XDG_STATE_HOME":            state,
+		})
+		if code != 0 {
+			t.Fatalf("exit %d: %s", code, out)
+		}
+		if _, err := os.Stat(cfg); err == nil {
+			t.Error("our own config survived the disable block")
+		}
+	})
+
+	t.Run("leaves a foreign file alone", func(t *testing.T) {
+		state := t.TempDir()
+		stateDir := filepath.Join(state, "context-guru")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+		foreign := "# hand-written\npreset: cache\n"
+		if err := os.WriteFile(cfg, []byte(foreign), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, map[string]string{
+			"CLAUDE_PLUGIN_OPTION_PORT": "8787",
+			"XDG_STATE_HOME":            state,
+		})
+		if code != 0 {
+			t.Fatalf("exit %d: %s", code, out)
+		}
+		got, err := os.ReadFile(cfg)
+		if err != nil || string(got) != foreign {
+			t.Errorf("a config this skill never wrote was removed: %v, %q, output: %s", err, got, out)
+		}
+	})
+}
+
+// TestStartProxyPicksUpAKeepaliveConfig proves the wiring between the opt-in toggle above and the
+// hook that actually launches the proxy: presence of the file is what decides, and it is the ONLY
+// thing that decides — nothing else about this test's environment names keep-alive at all.
+func TestStartProxyPicksUpAKeepaliveConfig(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		writeCfg   bool
+		wantConfig bool
+	}{
+		{"no keepalive config: --config is never passed", false, false},
+		{"a keepalive config exists: --config names it", true, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			requireTool(t, "bash")
+			dir := t.TempDir()
+			argvFile := filepath.Join(dir, "argv")
+			fake := filepath.Join(dir, "fake-proxy")
+			port := freePort(t)
+			py := requireTool(t, "python3")
+			script := "#!/usr/bin/env bash\n" +
+				"printf '%s\\n' \"$*\" > " + argvFile + "\n" +
+				"exec " + py + " -c '\n" +
+				"import http.server\n" +
+				"class H(http.server.BaseHTTPRequestHandler):\n" +
+				"    def do_GET(self):\n" +
+				"        self.send_response(200); self.end_headers(); self.wfile.write(b\"ok\")\n" +
+				"    def log_message(self, *a): pass\n" +
+				"http.server.HTTPServer((\"127.0.0.1\", " + port + "), H).serve_forever()\n'\n"
+			if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			state := filepath.Join(dir, "state")
+			var cfgPath string
+			if c.writeCfg {
+				stateDir := filepath.Join(state, "context-guru")
+				if err := os.MkdirAll(stateDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				cfgPath = filepath.Join(stateDir, "keepalive-"+port+".yaml")
+				if err := os.WriteFile(cfgPath, []byte("preset: cache\ncache:\n  keepalive: true\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "start-proxy.sh"))
+			cmd.Env = append(os.Environ(),
+				"CLAUDE_PLUGIN_OPTION_PORT="+port,
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+				"CONTEXT_GURU_BIN="+fake,
+				"XDG_STATE_HOME="+state,
+				"TMPDIR="+dir)
+			out, err := cmd.CombinedOutput()
+			t.Cleanup(func() {
+				if b, e := os.ReadFile(filepath.Join(state, "context-guru", "proxy-"+port+".pid")); e == nil {
+					exec.Command("kill", strings.TrimSpace(string(b))).Run() //nolint:errcheck
+				}
+			})
+			if err != nil {
+				t.Fatalf("start-proxy.sh failed: %v\n%s", err, out)
+			}
+			argv, rerr := os.ReadFile(argvFile)
+			if rerr != nil {
+				t.Fatalf("the fake proxy never ran: %v", rerr)
+			}
+			gotConfig := strings.Contains(string(argv), "--config "+cfgPath) ||
+				(c.writeCfg && strings.Contains(string(argv), "--config"))
+			hasAnyConfig := strings.Contains(string(argv), "--config")
+			if c.wantConfig && !gotConfig {
+				t.Errorf("wanted --config %s in argv, got %q", cfgPath, argv)
+			}
+			if !c.wantConfig && hasAnyConfig {
+				t.Errorf("no keepalive config was written, but --config appeared anyway: %q", argv)
+			}
+		})
 	}
 }

--- a/context-guru-plugin/scripts/settings.py
+++ b/context-guru-plugin/scripts/settings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Add or remove exactly ONE key in a Claude Code settings file: env.ANTHROPIC_BASE_URL.
+"""Add or remove settings keys for the context-guru plugin: env.ANTHROPIC_BASE_URL (routing) and,
+optionally, the top-level statusLine key.
 
 This is the deterministic half of the install. The skill decides WHICH file and what to do
 about a conflict; this script does the edit and refuses to guess.
@@ -19,7 +20,8 @@ Output is one `key=value` line per fact on stdout, so the skill can act on the r
 re-reading the file or parsing prose.
 
 Usage:
-  settings.py add    --file PATH --url URL [--force]
+  settings.py add    --file PATH --url URL [--force] [--upstream URL] [--bin PATH] [--statusline CMD]
+  settings.py add    --file PATH --statusline CMD [--force]   # statusline only, no routing change
   settings.py remove --file PATH [--url URL]
   settings.py show   --file PATH
 """
@@ -47,6 +49,16 @@ BIN_KEY = "CONTEXT_GURU_BIN"
 # keys where the user owned 1, and /context-guru:status repeated the wrong number back to them.
 OURS = (KEY, UPSTREAM_KEY, BIN_KEY)
 
+# statusLine is a TOP-LEVEL settings key — a sibling of `env`, not a member of it — so it needs its
+# own record rather than fitting into OURS/env above. --statusline is optional on `add`: most
+# installs never pass it, and every add/remove call that omits it must behave exactly as it did
+# before this key existed.
+STATUSLINE_KEY = "statusLine"
+STATUSLINE_META = "installed_statusline"      # the command string we wrote, so a later run
+                                               # recognises its own work even if it is about to
+                                               # write a DIFFERENT command (the plugin moved).
+STATUSLINE_PREV_META = "previous_statusline"  # what we replaced, so uninstall can hand it back.
+
 # Where this script records what it did, so a later run can tell its own work from the user's.
 META = "$context-guru"
 
@@ -66,6 +78,37 @@ def is_ours(data: dict, url: str) -> bool:
     if isinstance(meta, dict) and meta.get("installed_base_url"):
         return url == meta["installed_base_url"]
     return False
+
+
+def is_ours_statusline(data: dict, current: object) -> bool:
+    """Did WE write the CURRENT statusLine value? Same shape as is_ours() above and for the same
+    reason: answered from a record of what we wrote, never from guessing at the value's shape —
+    a hand-written statusLine that happens to run a script named similarly to ours is still the
+    user's, and uninstall must not take it.
+    """
+    meta = data.get(META)
+    if isinstance(meta, dict) and meta.get(STATUSLINE_META):
+        return current == {"type": "command", "command": meta[STATUSLINE_META]}
+    return False
+
+
+def apply_statusline(data: dict, command: str) -> None:
+    """Write our statusLine into `data`, in place. A no-op if `command` is empty (the flag was not
+    passed on this call) or the file already holds exactly what we would write. Records what it
+    replaced, but only when that value was not already ours (a re-run that only changes the
+    command path must not overwrite the ORIGINAL previous_statusline with our own prior value).
+    """
+    if not command:
+        return
+    desired = {"type": "command", "command": command}
+    current = data.get(STATUSLINE_KEY)
+    if current == desired:
+        return
+    meta = data.setdefault(META, {})
+    if current is not None and not is_ours_statusline(data, current):
+        meta[STATUSLINE_PREV_META] = current
+    data[STATUSLINE_KEY] = desired
+    meta[STATUSLINE_META] = command
 
 
 def emit(**facts: object) -> None:
@@ -198,6 +241,7 @@ def save(path: str, data: dict) -> None:
 def cmd_show(args: argparse.Namespace) -> int:
     data, existed = load(args.file)
     current = (data.get("env") or {}).get(KEY)
+    sl = data.get(STATUSLINE_KEY)
     emit(
         result="ok",
         file=args.file,
@@ -205,6 +249,7 @@ def cmd_show(args: argparse.Namespace) -> int:
         base_url=current if current else "(unset)",
         other_env_keys=len([k for k in (data.get("env") or {}) if k not in OURS]),
         top_level_keys=len(data),
+        statusline=json.dumps(sl, sort_keys=True) if sl else "(unset)",
     )
     return 0
 
@@ -238,8 +283,40 @@ def cmd_add(args: argparse.Namespace) -> int:
     if getattr(args, "bin", ""):
         desired[BIN_KEY] = args.bin
 
+    # --statusline is checked here, ahead of every base_url branch below, for the same reason the
+    # `desired` set above exists at all: a conflict on it must stop the WHOLE call, including the
+    # base_url side, rather than writing half an install and reporting success. It is a TOP-LEVEL
+    # key (see apply_statusline), so it cannot join `desired`/`env` above; this is its own gate.
+    sl_command = getattr(args, "statusline", "")
+    sl_desired = {"type": "command", "command": sl_command} if sl_command else None
+    if sl_command:
+        existing_sl = data.get(STATUSLINE_KEY)
+        if existing_sl is not None and not is_ours_statusline(data, existing_sl) and not args.force:
+            emit(result="conflict", file=args.file, existing=json.dumps(existing_sl, sort_keys=True),
+                 proposed=sl_command, conflict_on="statusline",
+                 note="a statusLine is already configured in this file; ask before replacing it, "
+                      "then re-run with --force")
+            return 2
+    sl_unchanged = sl_desired is None or data.get(STATUSLINE_KEY) == sl_desired
+
+    # --url is optional when --statusline is present WITHOUT it: this is a statusline-only call
+    # (the /context-guru:statusline skill uses it) and must touch nothing about routing — a
+    # missing --url must never fall through to the branches below, which all assume a real URL
+    # and would otherwise write env.ANTHROPIC_BASE_URL="" or treat an existing one as a conflict
+    # with an empty string neither the user nor this call asked to set.
+    if not args.url:
+        if sl_unchanged:
+            emit(result="unchanged", file=args.file,
+                 note="statusline already installed, nothing to add")
+            return 0
+        saved = backup(args.file) if existed else ""
+        apply_statusline(data, sl_command)
+        save(args.file, data)
+        emit(result="added", file=args.file, backup=saved or "(new file)", statusline=sl_command)
+        return 0
+
     current = env.get(KEY)
-    if current == args.url and all(env.get(k) == v for k, v in desired.items()):
+    if current == args.url and all(env.get(k) == v for k, v in desired.items()) and sl_unchanged:
         emit(result="unchanged", file=args.file, base_url=current,
              upstream=env.get(UPSTREAM_KEY, ""), bin=env.get(BIN_KEY, ""),
              note="already routed to this proxy, with nothing left to add")
@@ -249,6 +326,8 @@ def cmd_add(args: argparse.Namespace) -> int:
         # absent or different, and say which, since "added" would misdescribe it.
         saved = backup(args.file) if existed else ""
         changed = [k for k, v in desired.items() if env.get(k) != v]
+        if not sl_unchanged:
+            changed.append("statusLine")
         env.update(desired)
         data["env"] = env
         meta = data.setdefault(META, {})
@@ -257,6 +336,7 @@ def cmd_add(args: argparse.Namespace) -> int:
             meta["installed_upstream"] = args.upstream
         if getattr(args, "bin", ""):
             meta["installed_bin"] = args.bin
+        apply_statusline(data, sl_command)
         save(args.file, data)
         emit(result="completed", file=args.file, base_url=args.url, added_keys=",".join(changed),
              upstream=env.get(UPSTREAM_KEY, ""), bin=env.get(BIN_KEY, ""), backup=saved,
@@ -275,6 +355,7 @@ def cmd_add(args: argparse.Namespace) -> int:
             meta["installed_upstream"] = args.upstream
         if getattr(args, "bin", ""):
             meta["installed_bin"] = args.bin
+        apply_statusline(data, sl_command)
         save(args.file, data)
         emit(result="repointed", file=args.file, base_url=args.url, previous=current,
              upstream=env.get(UPSTREAM_KEY, ""), bin=env.get(BIN_KEY, ""),
@@ -333,6 +414,7 @@ def cmd_add(args: argparse.Namespace) -> int:
         meta["installed_bin"] = args.bin
     if current:
         meta["previous_base_url"] = current
+    apply_statusline(data, sl_command)
     save(args.file, data)
     emit(result="added", file=args.file, base_url=args.url,
          replaced=current if current else "", backup=saved or "(new file)",
@@ -347,6 +429,26 @@ def cmd_remove(args: argparse.Namespace) -> int:
         return 0
     env = data.get("env")
     if not isinstance(env, dict) or KEY not in env:
+        # No routing to remove here — but a STATUSLINE-ONLY install (the /context-guru:statusline
+        # skill's `add --statusline` with no --url) never touches env at all, so it must not be
+        # missed just because there is no base_url in this file to key off.
+        meta0 = data.get(META)
+        recorded_sl0 = meta0.get(STATUSLINE_META) if isinstance(meta0, dict) else None
+        if recorded_sl0 and data.get(STATUSLINE_KEY) == {"type": "command", "command": recorded_sl0}:
+            saved = backup(args.file)
+            restored_sl = ""
+            del data[STATUSLINE_KEY]
+            if meta0.get(STATUSLINE_PREV_META):
+                data[STATUSLINE_KEY] = meta0[STATUSLINE_PREV_META]
+                restored_sl = json.dumps(meta0[STATUSLINE_PREV_META], sort_keys=True)
+            meta0.pop(STATUSLINE_META, None)
+            meta0.pop(STATUSLINE_PREV_META, None)
+            if not meta0:
+                data.pop(META, None)
+            save(args.file, data)
+            emit(result="removed", file=args.file, backup=saved, statusline_restored=restored_sl,
+                 note="statusline-only removal; no routing was present to touch")
+            return 0
         emit(result="unchanged", file=args.file, note=f"no env.{KEY} here")
         return 0
     current = env[KEY]
@@ -391,6 +493,20 @@ def cmd_remove(args: argparse.Namespace) -> int:
         recorded_bin = _meta.get("installed_bin") or ""
     if recorded_bin and env.get(BIN_KEY) == recorded_bin:
         del env[BIN_KEY]
+    # statusLine is a TOP-LEVEL key (not part of `env`), tracked the same way upstream/bin are
+    # above: taken back only if it is exactly what we recorded writing, restored to whatever it
+    # replaced. NOTE: like upstream/bin, this only runs when env.KEY was present above — the
+    # normal case, since `add` always writes them together in one call — so a statusLine left
+    # behind by a base_url that was already removed some other way will not be found here.
+    recorded_sl = ""
+    if isinstance(_meta, dict):
+        recorded_sl = _meta.get(STATUSLINE_META) or ""
+    restored_sl = ""
+    if recorded_sl and data.get(STATUSLINE_KEY) == {"type": "command", "command": recorded_sl}:
+        del data[STATUSLINE_KEY]
+        if isinstance(_meta, dict) and _meta.get(STATUSLINE_PREV_META):
+            data[STATUSLINE_KEY] = _meta[STATUSLINE_PREV_META]
+            restored_sl = json.dumps(_meta[STATUSLINE_PREV_META], sort_keys=True)
     # Put back whatever we took over at install time. Deleting the key was leaving a user who had
     # a gateway configured with nothing at all — a worse state than before they installed.
     restored = ""
@@ -405,6 +521,8 @@ def cmd_remove(args: argparse.Namespace) -> int:
         meta.pop("installed_base_url", None)
         meta.pop("installed_upstream", None)
         meta.pop("installed_bin", None)
+        meta.pop(STATUSLINE_META, None)
+        meta.pop(STATUSLINE_PREV_META, None)
         if not meta:
             data.pop(META, None)
     # Leave no litter: an `env: {}` we created is removed with the key. An env block that
@@ -415,7 +533,8 @@ def cmd_remove(args: argparse.Namespace) -> int:
         data["env"] = env
     save(args.file, data)
     emit(result="removed", file=args.file, was=current, backup=saved,
-         restored=restored, env_block_left=str(bool(env)).lower())
+         restored=restored, env_block_left=str(bool(env)).lower(),
+         statusline_restored=restored_sl)
     return 0
 
 
@@ -433,9 +552,14 @@ def main() -> int:
         p.add_argument("--upstream", default="",
                        help="also write env.ANTHROPIC_UPSTREAM, so the proxy chains behind an "
                             "existing gateway in LATER sessions too (the hook reads this block)")
+        p.add_argument("--statusline", default="",
+                       help="on add: also write the TOP-LEVEL statusLine key ({\"type\": "
+                            "\"command\", \"command\": <this value>}), refusing to replace one "
+                            "that is not ours unless --force. on remove: taken back only if it "
+                            "is exactly what a previous --statusline install recorded writing.")
     args = ap.parse_args()
-    if args.cmd == "add" and not args.url:
-        ap.error("add needs --url")
+    if args.cmd == "add" and not args.url and not args.statusline:
+        ap.error("add needs --url, or --statusline on its own for a statusline-only call")
     return {"add": cmd_add, "remove": cmd_remove, "show": cmd_show}[args.cmd](args)
 
 

--- a/context-guru-plugin/scripts/start-proxy.sh
+++ b/context-guru-plugin/scripts/start-proxy.sh
@@ -227,6 +227,22 @@ if [ -n "$UPSTREAM" ]; then
   UPSTREAM_ARGS=(--anthropic-upstream "$UPSTREAM")
 fi
 
+# --config, ONLY when a keep-alive config exists for this port — the opt-in toggle
+# skills/keepalive/SKILL.md writes. Nothing on the RENDER path (statusline.py) ever creates or
+# touches this file; a display hook that fires on every keystroke must not be what decides to
+# start spending the caller's credential on idle pings.
+#
+# --config REPLACES the preset entirely rather than layering over it (see loadConfig in
+# cmd/context-guru-proxy/main.go: `--config` bypasses the `--preset` flag/PRESET env var above
+# completely once it is set). That is why the file the keepalive skill writes always states its
+# OWN `preset:` line — a config that forgot it would silently turn off cachesplit the moment
+# keep-alive was turned on, the exact opposite of what enabling it is supposed to do.
+CONFIG_ARGS=()
+KEEPALIVE_CFG="${STATE}/keepalive-${PORT}.yaml"
+if [ -f "$KEEPALIVE_CFG" ]; then
+  CONFIG_ARGS=(--config "$KEEPALIVE_CFG")
+fi
+
 PRESET="$PRESET" \
   "${STARTER[@]}" "$BIN" \
   --listen "127.0.0.1:${PORT}" \
@@ -234,6 +250,7 @@ PRESET="$PRESET" \
   --dashboard \
   --dashboard-db "${STATE}/dashboard-${PORT}.db" \
   "${UPSTREAM_ARGS[@]+"${UPSTREAM_ARGS[@]}"}" \
+  "${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"}" \
   >>"$LOG" 2>&1 &
 started=$!
 disown 2>/dev/null || true

--- a/context-guru-plugin/scripts/statusline.py
+++ b/context-guru-plugin/scripts/statusline.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Claude Code statusLine command: render what the local context-guru proxy's KV cache is doing.
+
+Why Python, not another shell script like the hooks: this reads JSON off stdin and makes one
+timeout-bounded HTTP call, and that is what Python's stdlib (`json`, `urllib.request`) does
+directly. Bash would need `jq` (not guaranteed installed) for the first and a `curl` subprocess
+for the second — two extra failure points for a script whose one job is to never fail.
+
+Claude Code invokes this on (almost) every render — a state change, or the configured
+`refreshInterval` — so it has to be cheap and it has to be silent about failure. Two hard rules
+follow from that, and both are enforced structurally rather than by discipline:
+
+* READ-ONLY. This never pings the proxy or writes anything the proxy would see. Sending a
+  keep-alive ping from a command that fires on every keystroke would turn a display hook into an
+  unbounded traffic generator billed to the user — see skills/keepalive/SKILL.md for the actual,
+  explicit, opt-in way to do that.
+* NEVER BLOCKS, NEVER FAILS THE RENDER. Two blocking calls exist: reading stdin, and the HTTP GET
+  to /api/stats. The GET carries its own short timeout. Reading stdin normally returns instantly
+  (Claude Code writes the payload and closes the pipe before running this), but a `signal.alarm`
+  backstop bounds it too, so a wedged parent cannot hang this script indefinitely. Worst case is
+  therefore the sum of the two bounds, a couple of seconds — not unbounded. Every exit is 0; on
+  any error this prints whatever partial line it already has, or nothing.
+
+Self-gating: exactly like the SessionStart/UserPromptSubmit hooks, this does nothing in a project
+that is not routed through OUR proxy. The gate reads CLAUDE_PLUGIN_OPTION_PORT the same way those
+two hooks do, but never TRUSTS it alone — it still checks $ANTHROPIC_BASE_URL for that exact port,
+because that env block is what actually routes the traffic and so cannot be wrong. Matching any
+loopback ".../anthropic" URL regardless of port would treat another local proxy on its own port
+(litellm defaults to 127.0.0.1:4000) as ours whenever it happened to be a project's real routing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+# How long the whole script may run before its own backstop fires. Generous relative to the
+# urlopen timeout below (0.6s) so that timeout is what normally fires first; this is the net
+# under it, covering a stuck stdin read or anything else unaccounted for.
+SCRIPT_BUDGET_SECONDS = 2
+
+# The HTTP call's own timeout. /api/stats on a healthy local proxy answers in single-digit
+# milliseconds; 0.6s is already generous and still leaves headroom under the script budget above.
+HTTP_TIMEOUT_SECONDS = 0.6
+
+# How long a cached /api/stats response is reused before a fresh fetch is attempted. Claude Code
+# can re-render on every token during a stream, and this is what stops that from becoming a
+# request-per-render storm against the proxy.
+STATS_CACHE_TTL_SECONDS = 2.0
+
+# The plugin's own default port, matching context-guru-plugin/.claude-plugin/plugin.json's
+# "port" option default — used only as a fallback when CLAUDE_PLUGIN_OPTION_PORT is absent.
+DEFAULT_PORT = "8787"
+
+
+class _Budget(Exception):
+    """Raised by the SIGALRM backstop; caught once, at the very top."""
+
+
+def _on_alarm(_signum, _frame):
+    raise _Budget()
+
+
+def _read_stdin_json() -> dict:
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _our_port() -> str | None:
+    """The port this project is routed to OUR proxy on, or None if it is not routed through us.
+
+    Reads CLAUDE_PLUGIN_OPTION_PORT the same way check-proxy.sh and start-proxy.sh do (default
+    8787), then checks the ACTUAL routing value: does $ANTHROPIC_BASE_URL name exactly that port.
+    Accepting ANY loopback ".../anthropic" URL here — instead of a SPECIFIC configured port —
+    would treat litellm's own default (127.0.0.1:4000/anthropic) as ours whenever it happens to
+    be a project's real routing, which is precisely the class of bug those two hooks' own tests
+    (matching the port, not merely "localhost") exist to catch.
+    """
+    port = (os.environ.get("CLAUDE_PLUGIN_OPTION_PORT") or DEFAULT_PORT).strip() or DEFAULT_PORT
+    if not port.isdigit():
+        return None
+    base = os.environ.get("ANTHROPIC_BASE_URL", "")
+    pattern = rf"^https?://(?:127\.0\.0\.1|localhost|\[::1\]):{re.escape(port)}/anthropic/?$"
+    return port if re.match(pattern, base) else None
+
+
+def _cache_stopper(payload: dict) -> str:
+    """The countdown to the prompt-cache going cold, from Claude Code's OWN cache tracker.
+
+    `prompt_cache` rides on the statusLine payload already — Claude Code tracks this itself from
+    the response usage of every request it sends, independent of context-guru, so it is free
+    (zero extra network calls) and it reflects the ACTUAL wire bytes regardless of what any
+    component rewrote. It is absent before the first response of a session has usage to track,
+    which is a normal state, not an error.
+    """
+    pc = payload.get("prompt_cache")
+    if not isinstance(pc, dict):
+        return "cache –"
+    expires_at = pc.get("expires_at")
+    if not isinstance(expires_at, (int, float)):
+        return "cache –"
+    remaining = expires_at - time.time()
+    if remaining <= 0:  # covers real expiry AND clock skew alike: never show negative time
+        return "cache cold"
+    mins, secs = divmod(int(remaining), 60)
+    return f"cache {mins}:{secs:02d}"
+
+
+def _human(n: float) -> str:
+    n = float(n)
+    for suffix, scale in (("M", 1_000_000), ("k", 1_000)):
+        if abs(n) >= scale:
+            return f"{n / scale:.1f}{suffix}"
+    return f"{n:.0f}"
+
+
+def _stats_cache_path(port: str) -> str:
+    return os.path.join(tempfile.gettempdir(), f"context-guru-statusline-{port}.json")
+
+
+def _fetch_stats(port: str) -> tuple[dict | None, bool]:
+    """Returns (stats, proxy_down). stats is None when unavailable for any reason; proxy_down is
+    True only when the proxy could not be reached at all (vs. answered but had nothing useful —
+    e.g. the dashboard flag is off, or sent something this script cannot parse)."""
+    cache_path = _stats_cache_path(port)
+    try:
+        st = os.stat(cache_path)
+        if time.time() - st.st_mtime < STATS_CACHE_TTL_SECONDS:
+            with open(cache_path, encoding="utf-8") as fh:
+                return json.load(fh), False
+    except (OSError, ValueError):
+        pass  # no usable cache; fetch for real
+
+    url = f"http://127.0.0.1:{port}/api/stats"
+    try:
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+            body = resp.read(1 << 20)  # bounded: the real payload is a few KB
+    except urllib.error.HTTPError:
+        return None, False  # reached the proxy; it just has nothing (e.g. --dashboard is off)
+    except (urllib.error.URLError, OSError):
+        return None, True  # refused, timed out, or otherwise unreachable: the proxy is down
+
+    try:
+        stats = json.loads(body)
+    except (ValueError, TypeError):
+        return None, False
+    if not isinstance(stats, dict):
+        return None, False
+
+    try:
+        tmp = cache_path + f".{os.getpid()}.tmp"
+        with open(tmp, "wb") as fh:
+            fh.write(body)
+        os.replace(tmp, cache_path)
+    except OSError:
+        pass  # caching is an optimization; failing to write one is not this script's problem
+    return stats, False
+
+
+def _savings_segment(stats: dict) -> str | None:
+    usd = stats.get("total_saved_usd", 0) or 0
+    tokens = stats.get("saved_unique", 0) or 0
+    if usd == 0 and tokens == 0:
+        # Omitted rather than shown as "$0.00/0 saved", matching the dashboard's own convention
+        # (see metrics.Snapshot.KeepAlive's omitempty): a fresh install has nothing to say yet,
+        # and a row of zeroes there reads as a broken feature rather than a quiet truth.
+        #
+        # NOT `<= 0`: total_saved_usd can go genuinely negative (an idle keep-alive spending more
+        # than it recovers nets the whole figure negative — see dash/overview.go's own waterfall,
+        # "a real outcome the dashboard will not hide"), and that is exactly the case this must
+        # keep showing rather than quietly folding into the same omission as a fresh install.
+        return None
+    return f"${usd:.2f}/{_human(tokens)} saved"
+
+
+def _keepalive_segment(stats: dict) -> str | None:
+    pings = stats.get("keepalive_pings", 0) or 0
+    if pings <= 0:
+        return None
+    return f"ka {int(pings)}p"
+
+
+def main() -> None:
+    port = _our_port()
+    if port is None:
+        return  # not routed through us: say nothing, exactly like the other hooks
+
+    payload = _read_stdin_json()
+    cache_seg = _cache_stopper(payload)
+
+    stats, proxy_down = _fetch_stats(port)
+    if proxy_down:
+        print("cg!")  # three characters: the proxy is unreachable, nothing else is worth saying
+        return
+
+    parts = [cache_seg]
+    if stats is not None:
+        savings = _savings_segment(stats)
+        if savings:
+            parts.append(savings)
+        keepalive = _keepalive_segment(stats)
+        if keepalive:
+            parts.append(keepalive)
+    print(" | ".join(parts))
+
+
+if __name__ == "__main__":
+    try:
+        if hasattr(signal, "SIGALRM"):  # POSIX only, same as the plugin's shell hooks
+            signal.signal(signal.SIGALRM, _on_alarm)
+            signal.alarm(SCRIPT_BUDGET_SECONDS)
+        main()
+    except Exception:
+        pass  # never a traceback on a user's terminal; silence is the correct failure mode here
+    finally:
+        if hasattr(signal, "SIGALRM"):
+            signal.alarm(0)
+    sys.exit(0)

--- a/context-guru-plugin/skills/keepalive/SKILL.md
+++ b/context-guru-plugin/skills/keepalive/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: keepalive
+description: Report whether the idle prompt-cache keep-alive is running, and turn it on or off. It spends the caller's own credential to hold the cache warm between turns, so it is off by default and this is the explicit, opt-in way to change that — never done automatically by the status line or any hook. Use when the user asks to enable/disable keep-alive, keep the cache warm, send a keep-alive ping, or stop idle pings from spending money.
+---
+
+# context-guru keep-alive
+
+The proxy already has a real idle keep-alive scheduler (`proxy/keepalive.go`): once turned on,
+it pings a session's cached prefix shortly before the provider's TTL would drop it, so a session
+that comes back inside the gap still hits cache. **This skill does not build a second one** — it
+is the one deterministic, explicit way to switch the existing mechanism on or off for the local
+proxy this plugin starts.
+
+**Why this is not automatic, and never will be from the status line.** A ping spends the caller's
+own money (or usage-limit budget) between turns, while nobody is at the keyboard. The status line
+renders on every keystroke; if IT could arm this, a display hook would double as an unbounded
+traffic generator. Turning it on is therefore always something a user asks for, here, once.
+
+## 1. Report current activity
+
+```bash
+PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
+curl -fsS --max-time 3 "http://127.0.0.1:${PORT}/api/stats" | \
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print({k: d[k] for k in d if k.startswith("keepalive_")})'
+```
+
+`keepalive_pings: 0` and no `--config` in effect means it has never been turned on for this
+proxy — that is the expected state for every install by default, not a fault. If pings are
+non-zero but the user expected it to be OFF, jump to step 3.
+
+## 2. Turn it on
+
+Ask once, plainly: this will spend the caller's credential on idle turns to keep the cache warm,
+and it applies to every session routed through this proxy, not just this one.
+
+Write the config this mechanism reads (never hand-edited — same "look before you write"
+conservatism as `settings.py`, just for a file that is ours alone rather than the user's
+`settings.json`):
+
+```bash
+PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
+PRESET="${CLAUDE_PLUGIN_OPTION_PRESET:-cache}"
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
+mkdir -p "$STATE"
+CFG="${STATE}/keepalive-${PORT}.yaml"
+MARKER="# context-guru: written by /context-guru:keepalive"
+if [ -f "$CFG" ] && ! head -1 "$CFG" | grep -qF "$MARKER"; then
+  echo "REFUSING: ${CFG} already exists and was not written by this skill; edit or remove it by hand first"
+else
+  cat > "$CFG" <<EOF
+$MARKER
+# Keeps the preset explicit on purpose: passing --config to context-guru-proxy REPLACES
+# --preset entirely rather than layering over it, so a config missing this line would silently
+# turn compaction off the moment keep-alive turned on.
+preset: ${PRESET}
+cache:
+  keepalive: true
+EOF
+  echo "wrote ${CFG}"
+fi
+```
+
+`start-proxy.sh` picks this file up automatically the next time it starts the proxy on this
+port — no settings.json change, no plugin option. But `start-proxy.sh` only STARTS a proxy that
+is not already answering `/healthz` (see its own idempotence comment), so a proxy already running
+has to be stopped first for the new config to take effect:
+
+Stop it exactly the way `/context-guru:uninstall`'s step 2 does — pidfile first, ownership
+CONFIRMED before any signal is sent, never a `pkill` pattern. Run `/context-guru:uninstall`'s stop
+block, or the plugin's own equivalent, then:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/start-proxy.sh" --unrouted
+```
+
+Confirm it actually picked the config up — `curl -fsS http://127.0.0.1:${PORT}/healthz` first,
+then check step 1's `keepalive_pings` again after a session has gone idle for a while.
+
+## 3. Turn it off
+
+```bash
+PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
+CFG="${STATE}/keepalive-${PORT}.yaml"
+MARKER="# context-guru: written by /context-guru:keepalive"
+if [ -f "$CFG" ] && head -1 "$CFG" | grep -qF "$MARKER"; then
+  rm -f "$CFG"
+  echo "removed ${CFG}; keep-alive turns off the next time the proxy (re)starts"
+else
+  echo "(no keepalive config of ours at ${CFG} — nothing to remove)"
+fi
+```
+
+Same restart requirement as step 2: a proxy already running keeps its CURRENT config until it is
+stopped and started again. Removing the file only changes what the NEXT start does.
+
+## Reading the numbers honestly
+
+- `keepalive_ping_usd` is what the pings spent; `keepalive_saved_usd` is the prefix re-creations
+  they avoided; `keepalive_net_usd` is the difference. A negative net means the mechanism is
+  costing more than it saves on this traffic — say so plainly rather than reporting pings as a
+  win by themselves.
+- The status line (`/context-guru:statusline` to enable it) shows `ka Np` once pings have
+  actually happened — never before, and it never triggers one itself.

--- a/context-guru-plugin/skills/statusline/SKILL.md
+++ b/context-guru-plugin/skills/statusline/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: statusline
+description: Enable or disable the context-guru status line — a terminal status line showing the prompt-cache TTL countdown and running savings for whichever project is routed through the local proxy. Use when the user asks to show cache status in the status line, add a status line for context-guru, see savings in the terminal, or turn the status line off.
+---
+
+# context-guru status line
+
+Wires `context-guru-plugin/scripts/statusline.py` into Claude Code's `statusLine` setting, through
+`settings.py` — the same deterministic, conservative script that installs routing, extended to
+manage this one additional top-level key (never a second settings editor, never a hand-edit).
+
+**What it shows, once enabled and this project is routed:** a countdown to the prompt-cache TTL
+going cold (`cache 4:12` / `cache cold`), followed by running savings in dollars and tokens once
+they are non-zero (`$0.42/3.1k saved`), and how many keep-alive pings have fired (`ka 2p`) once
+any have. **In every project that is NOT routed through context-guru, it renders nothing at
+all** — the script self-gates exactly like the plugin's two hooks, so installing it is safe even
+at user scope.
+
+**It never sends a keep-alive ping, and never will.** It only reads. Turning the keep-alive
+mechanism on is a separate, explicit action — see `/context-guru:keepalive`.
+
+## Where to install it
+
+Default to **user scope** (`~/.claude/settings.json`), unlike `/context-guru:install`'s
+project-first default: a status line is a property of the terminal, not of one repository, and
+because the script renders nothing in unrouted projects, installing it once at user scope is safe
+regardless of which projects you later route. Ask before a different scope only if the user
+names one.
+
+## 1. Look before you write
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" show --file ~/.claude/settings.json
+```
+
+Read the `statusline=` line. `(unset)` means nothing is configured there yet — continue. Anything
+else that is not ours (the next step will say so with `result=conflict`) means the user, or
+another plugin, already owns that setting; stop and ask before replacing it, exactly like a
+pre-existing `ANTHROPIC_BASE_URL` during install.
+
+## 2. Install it
+
+`--statusline` on its own (no `--url`) touches ONLY the `statusLine` key — it writes nothing to
+`env`, so this never starts routing a scope that was not already routed:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" add --file ~/.claude/settings.json \
+  --statusline "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/statusline.py\""
+```
+
+- `result=added` — report the `backup=` path as their undo, same as install.
+- `result=unchanged` — already installed with this exact command; nothing to do.
+- `result=conflict` — a statusLine already exists here and is not ours (`existing=` in the
+  output). Ask before `--force`; the previous value is recorded and comes back on removal.
+
+A new session (or `claude` restarted) is needed to see the change take effect, the same as
+`ANTHROPIC_BASE_URL` picking up live only mid-session.
+
+## 3. Confirm
+
+Open (or resume) a session in a project that IS routed through context-guru and watch the status
+line render. Nothing to see yet is normal on the first turn of a session — the cache stopper needs
+at least one response with usage to track, and the savings segment stays hidden until it has
+something non-zero to report (see `_savings_segment` in `statusline.py`).
+
+## 4. Remove it
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" remove --file ~/.claude/settings.json
+```
+
+Restores whatever `statusLine` (if anything) was there before, exactly like base-URL removal —
+never just deletes and leaves the user with nothing. If routing was ALSO configured in the same
+file, this same call removes both; if only the status line was ever installed there, it is the
+only thing this touches.

--- a/docs/how-to/install-plugin.md
+++ b/docs/how-to/install-plugin.md
@@ -305,6 +305,44 @@ repo. That is correct behaviour, but it means "clone and go" is really "clone, a
   signals that do move are `components.cachesplit.verdict` and the billed tiers.
 - `/context-guru:uninstall` — removes the one settings key (with a backup) and stops the proxy.
 
+## Status line
+
+`/context-guru:statusline` puts the cache TTL and running savings in your terminal's status line,
+so you see them on every turn instead of asking `/context-guru:status`:
+
+```
+cache 4:12 | $0.42/3.1k saved | ka 2p
+```
+
+- **`cache 4:12` / `cache cold`** is the stopper — a countdown to the prompt-cache going cold.
+  It comes from Claude Code's own client-side cache tracker (the same one behind its `/context`
+  view), not from the proxy, so it costs no extra network call and it reflects the *actual* wire
+  bytes regardless of what any component rewrote. `cache –` before the first response of a
+  session has anything to track is normal, not a fault.
+- **`$0.42/3.1k saved`** is the running total (`total_saved_usd` / unique tokens saved), read from
+  the proxy's own `/api/stats`. Hidden entirely while both are zero — a fresh install has nothing
+  to report yet, and a segment reading `$0.00/0 saved` would look like a broken feature rather than
+  an honest one. The same caveats as `/context-guru:status` apply: list-price on a subscription,
+  process-wide rather than per-project.
+- **`ka 2p`** is how many idle keep-alive pings have fired. Hidden while zero, which is the
+  default — keep-alive is off unless you turn it on (below).
+- **`cg!`** means the proxy this project routes to is not answering. Everything else about the
+  line is silent — including in every project that is not routed through context-guru at all.
+
+**It only reads.** The status line renders on nearly every keystroke; if it could also *arm*
+anything, a display hook would double as an unbounded traffic generator billed to you. Sending a
+keep-alive ping is a separate, explicit action:
+
+`/context-guru:keepalive` reports whether the mechanism is on, and turns it on or off. Turning it
+on means the proxy will spend your own credential on idle turns, between sessions, to keep the
+cache warm — worth knowing before you enable it, which is why this asks rather than infers.
+
+One nuance worth having straight: once keep-alive is on, `cache cold` in the status line no
+longer means the provider's own cached entry is actually cold. The countdown is Claude Code's
+own view of *its own* last request; it has no way to see a ping the proxy sent while you were not
+typing. Treat `ka Np` and the next turn's latency as the ground truth once keep-alive is running,
+not the countdown by itself.
+
 ## Troubleshooting
 
 **"Nothing happened after `/context-guru:install`."** The setting applies to a **new** session;
@@ -329,6 +367,14 @@ To get working again immediately, `/context-guru:uninstall`.
 
 **Port 8787 is taken.** Change it in the plugin's configuration. Do not use 4000; litellm
 defaults to it, and the installer's default avoids the collision on purpose.
+
+**The status line is blank in a routed project.** Blank is its normal state before the first
+response of a session (no cache data to show yet) and while there is nothing to report on the
+savings/keep-alive segments — check `/context-guru:status` for the same numbers to confirm it is
+not simply early. If it stays blank across a whole session with real traffic, confirm
+`/context-guru:statusline` actually installed (`settings.py show` reports `statusline=`), and that
+a *new* session was started after installing it — like the routing key, the setting is picked up
+live but only in a session that started after it was written.
 
 **`--idle-exit` is refused at startup.** A threshold below roughly 5h34m (2× the store's default
 entry lifetime) is rejected, because exiting clears in-memory cache state — including frozen


### PR DESCRIPTION
## Stacked on #160

This branch is `feat/plugin-statusline`, based on `feat/context-guru-plugin` (#160), and must
merge **after** #160. It adds nothing to that PR's own diff — everything here is new files plus
small, additive extensions to `settings.py` and `start-proxy.sh`.

## What this adds

A Claude Code **status line** (`context-guru-plugin/scripts/statusline.py`) that renders, for any
project routed through context-guru's proxy:

```
cache 4:12 | $0.42/3.1k saved | ka 2p
```

- `cache 4:12` / `cache cold` — a countdown to the prompt-cache TTL going cold. Sourced from
  Claude Code's own client-side cache tracker (`prompt_cache` in the statusLine stdin payload),
  not from the proxy — zero extra network cost, and it reflects the actual wire bytes regardless
  of what any component rewrote.
- `$0.42/3.1k saved` — running savings (`total_saved_usd` / `saved_unique`), one short-timeout,
  short-TTL-cached `GET /api/stats`. Omitted while exactly zero (a fresh install has nothing to
  report yet); **not** omitted when negative — an idle keep-alive spending more than it recovers
  is a real outcome this does not hide.
- `ka 2p` — idle keep-alive pings that have actually fired. Omitted while zero, which is the
  default.
- `cg!` — the proxy is unreachable. Nothing else about the line is silent, including every
  project that is not routed through context-guru at all.

Plus the explicit, opt-in way to turn the existing idle keep-alive mechanism on
(`/context-guru:keepalive`), and the settings-management extension the status line needed
(`--statusline` on `settings.py`).

## Confirmed field names, not memory

Grepped the installed CLI binary directly for the statusLine contract (a past session learned the
hard way that trusting a docs summary over the binary was wrong):

- **Settings schema**: `"statusLine": {"type": "command", "command": "...", "padding": 0,
  "refreshInterval": <seconds>, "hideVimModeIndicator": false}` — found the exact validator:
  `type:C("command"),command:s(),padding:w().optional(),refreshInterval:w().min(1).optional()...`
- **Stdin payload**: reconstructed from the function that builds it (`Elo`) and its base (`ba`).
  The useful find: Claude Code already tracks prompt-cache warmth itself — `prompt_cache:
  {warm, ttl, expires_at, requests, misses, hit_ratio, cache_write_tokens, ...}` — omitted while
  `requests === 0`. That is the "stopper" this feature needed, for free.
- **Proxy routes**: confirmed against a real running proxy (curl, no auth needed in this plugin's
  single-tenant mode) — `/stats` and `/api/stats` real field names quoted in the script's own
  comments, not invented. No `/config` route exists (confirmed 404). Keep-alive can only be turned
  on via `--config <yaml>`, which **replaces `--preset` entirely** (`loadConfig` in
  `cmd/context-guru-proxy/main.go`) — the one measurement trap this design works around by always
  writing the active preset into that config.

## Real rendered lines, from a real Claude Code session through this worktree's built proxy

Driven via `tmux` (a real interactive session, `CLAUDE_CONFIG_DIR` pointed at a throwaway config
dir, chained behind this box's real gateway — never port 4000, never the box's production
service). Real numbers, cross-checked against `/api/stats` directly each time:

```
before any response:      cache –
after the first response: cache 4:57
after a second turn:       cache 4:49 | $0.01/0 saved      (api/stats: total_saved_usd=0.012949, saved_unique=0)
```

Then, with the keep-alive toggle turned on and the proxy restarted (confirmed via `ps` that
`--config` was passed and `pipeline=[cachesplit]` — the preset survived), a real idle ping fired
after the default 280s idle window:

```
cache cold | $-0.02/0 saved | ka 1p
```

`/api/stats` at that moment: `keepalive_pings=1, keepalive_ping_usd=0.0169,
keepalive_net_usd=-0.0169` (nothing had yet come back to recoup it — a real negative net, shown
rather than hidden). **Worth calling out explicitly**: `cache cold` here does not mean the
provider's own cached entry is actually cold — it means *Claude Code's own tracker*, which cannot
see a ping the proxy sent while nobody was typing, thinks it is. Documented as a caveat rather
than something the render tries to paper over.

## Why the render path never pings

The only network call `statusline.py` makes is a `GET`. Turning keep-alive on is a separate skill
(`/context-guru:keepalive`) that writes a small YAML config, never something the status line
triggers — a display hook that fires on nearly every keystroke must not double as an unbounded
traffic generator billed to the user.

## Tests

`go test ./context-guru-plugin/... -v -count=1`: **86** `=== RUN` lines, all pass. New coverage:
self-gating (including the litellm-port-collision case), a stalling proxy reported as `cg!`
inside its own timeout, malformed stdin/stats survived gracefully, exact TTL boundary math (a
frozen-clock unit test isolates `remaining == 0` precisely, since a subprocess always burns real
wall-clock time and a naive table test cannot reliably hit that instant), zero- and
negative-savings segments, response caching (one real HTTP call across 5 rapid renders),
`settings.py`'s new `statusLine` key (round trip, conflict refusal + `--force`, statusline-only
install touching no routing), and the keep-alive config's write/refuse/remove/`start-proxy.sh`
pickup wiring.

Every load-bearing check was revert-verified: the defect reintroduced in the source (never the
test), confirmed the test failed naming its own subject, then reverted. Examples:

- self-gate accepting any loopback URL → `TestStatuslineIsSilentWhereRoutingIsNotConfigured/another_local_proxy...` failed with `printed "cache –\n" for a project that is not routed through us`
- down-detection mislabeled as merely-unavailable → both `TestStatuslineReportsADownProxyInThreeCharacters` and `TestStatuslineNeverFailsOnAConnectionRefusal` failed, `got "cache –", want the down indicator "cg!"`
- TTL boundary off-by-one (`remaining < 0` instead of `<= 0`) → `TestStatuslineCacheCountdownExactBoundary` failed: `got "cache 0:00", want "cache cold"`
- zero-savings omission removed → `TestStatuslineOmitsZeroSavings` failed: `a zero-valued segment was shown: "cache – | $0.00/0 saved\n"`
- negative-savings folded into the same omission → `TestStatuslineShowsANegativeNetHonestly` failed: `got "cache –\n", want a segment showing the negative net, not an omission`
- `settings.py` statusline conflict check disabled → `TestSettingsStatuslineRefusesToStealAnExisting` failed: `expected a conflict (exit 2), got exit 0`
- `apply_statusline` call dropped from the fresh-install branch → `TestSettingsStatuslineRoundTrips` failed: `statusLine = <nil>`
- statusline-only removal branch disabled → `TestSettingsStatuslineOnlyInstallTouchesNoRouting` failed: fell through to `note:no env.ANTHROPIC_BASE_URL here`
- `start-proxy.sh`'s `--config` auto-pickup removed → `TestStartProxyPicksUpAKeepaliveConfig` failed: `wanted --config .../keepalive-....yaml in argv, got "--listen ..."`

## Isolation

Built and ran everything under `/tmp/cgfix/pr160b` and `/tmp/cgfix/ccdir160b`
(`CLAUDE_CONFIG_DIR`, verified the CLI honours it), proxies only on ports 4055/4056. `sha256sum`
of the real `~/.claude/settings.json` is byte-identical before and after this entire session.
Ports 4050–4059 swept clean at the end; the throwaway state/dashboard DBs and config dirs are
under `/tmp/cgfix/`, outside any tracked repo path.

## What was deliberately not built

- **No render-path ping** — read-only, always; see above.
- **No second keep-alive scheduler** — the toggle switches on the existing `proxy/keepalive.go`
  mechanism via the config file the binary already reads; nothing new schedules a ping.
- **No settings.json wiring for the keep-alive toggle.** It lives in its own file under the
  plugin's existing state directory (alongside the pidfile and dashboard DB it already keeps
  there), picked up by `start-proxy.sh` on the next (re)start — simpler than a third settings.json
  key for a decision that is really "does this file exist."
- **No on-demand "ping now" button.** The local single-tenant proxy has no route for that (the
  multi-tenant `/api/me/keepalive/sessions` control routes need a web session cookie this mode has
  no login flow for); the only real mechanism is the idle scheduler, armed for future gaps.