### PR TITLE
fix(plugin): the keepalive skill can see the configured port and preset

### DIFF
--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2825,13 +2825,21 @@ func TestEverySkillStatesThePerOptionFallback(t *testing.T) {
 		checked++
 		// The positive alone is the reassurance I suspected it of being: review demonstrated that
 		// restoring the old sentence while KEEPING the new rule passes. So assert the absence of the old
-		// instruction shape too. The discriminating string is "or 8787 if it reports" and not
-		// `source=(none)`, because the corrected prose quotes that token legitimately while explaining
-		// the rule — asserting on the token would fail every fixed file.
-		if strings.Contains(body, "or 8787 if it reports") {
-			t.Errorf("skills/%s/SKILL.md still tells the model \"or 8787 if it reports …\", which is the "+
-				"fallback keyed on `source=` that this rule replaces. A skill can state the per-option "+
-				"rule and contradict it two lines later; that is what this assertion catches.", e.Name())
+		// instruction shape too.
+		//
+		// The needle is the CONDITION, "if it reports `source=(none)`", not "or 8787 if it reports". The
+		// narrower form was coupled to one phrasing and this repo had two: keepalive's own sentence said
+		// "or 8787 and `cache` if it reports …", which slipped straight through — the same failure as
+		// keying the fence scan on "```bash". Verified against both real phrasings (origin/main's status
+		// and e0ea8a9's keepalive: 1 each) and all five current skills (0).
+		//
+		// It cannot be `source=(none)` alone: the corrected prose says "reports `source=(none)` only
+		// when …", which is an explanation rather than a condition, so the token appears in every FIXED
+		// file. "if it reports" is what makes it an instruction to act on.
+		if strings.Contains(body, "if it reports `source=(none)`") {
+			t.Errorf("skills/%s/SKILL.md still tells the model to fall back \"if it reports "+
+				"`source=(none)`\", which is the condition this per-option rule replaces. A skill can "+
+				"state the rule and contradict it two lines later; that is what this catches.", e.Name())
 		}
 		if !strings.Contains(body, "is unconfigured") {
 			t.Errorf("skills/%s/SKILL.md reads `settings.py config` but never says that an option the "+

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2860,6 +2860,16 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 					e.Name(), i+1, strings.TrimSpace(line))
 			}
 		}
+		// An odd number of fence lines ends the loop still inside one, which means the scan lost its
+		// bearings partway through and everything after that point went unexamined. That is a false
+		// negative over the whole remainder rather than a misfire: round-2 review deleted one closing
+		// fence, re-added the defect to all four blocks, and this guard reported 0 of 4. A missing
+		// backtick line is an ordinary editing slip, so detect it — same argument as `checked == 0`
+		// below, and it costs nothing while every skill stays balanced.
+		if inFence {
+			t.Errorf("skills/%s/SKILL.md: fences are unbalanced, so the scan lost its bearings partway "+
+				"through and this guard proved nothing for the rest of the file", e.Name())
+		}
 		checked++
 	}
 	if checked == 0 {

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2511,14 +2511,40 @@ func TestStatuslineCachesStatsAcrossQuickRenders(t *testing.T) {
 
 // --- the keep-alive opt-in toggle -----------------------------------------------------------
 
+// keepalivePort is deliberately not 8787. These blocks name the config file after the port, so a
+// regression to `${CLAUDE_PLUGIN_OPTION_PORT:-8787}` writes a filename nothing reads — and at a
+// fixture port of 8787 that regression passes by coincidence, which is exactly how it shipped.
+const keepalivePort = "4041"
+
+// fillSkillPlaceholder substitutes one placeholder in an extracted skill block, failing loudly when
+// it is absent: an unsubstituted `PORT="<port>"` makes every path below look inert for the wrong
+// reason, which is what happened when the placeholder was introduced in the uninstall skill.
+func fillSkillPlaceholder(t *testing.T, skill, block, placeholder, value string) string {
+	t.Helper()
+	if !strings.Contains(block, placeholder) {
+		t.Fatalf("the %s block no longer carries %s; if that value is obtained differently now, this "+
+			"test needs to follow suit rather than execute a stale template:\n%s", skill, placeholder, block)
+	}
+	return strings.Replace(block, placeholder, value, 1)
+}
+
 // runKeepaliveBlock executes one bash block from skills/keepalive/SKILL.md with a controlled
 // environment, the same way runCheck/skillBlock drive the other skills' destructive snippets.
-func runKeepaliveBlock(t *testing.T, needle string, env map[string]string) (out string, code int) {
+//
+// The blocks are TEMPLATES: the skill tells the model to discover the port and preset with
+// `settings.py config` and substitute them, because CLAUDE_PLUGIN_OPTION_* never reaches a Bash tool
+// call. So fill the placeholders the way the model is instructed to, and run with those variables
+// EMPTY — that is the environment the blocks actually execute in.
+func runKeepaliveBlock(t *testing.T, needle, preset string, env map[string]string) (out string, code int) {
 	t.Helper()
 	requireTool(t, "bash")
 	block := skillBlock(t, "keepalive", needle)
+	block = fillSkillPlaceholder(t, "keepalive", block, `PORT="<port>"`, `PORT="`+keepalivePort+`"`)
+	if preset != "" {
+		block = fillSkillPlaceholder(t, "keepalive", block, `PRESET="<preset>"`, `PRESET="`+preset+`"`)
+	}
 	cmd := exec.Command("bash", "-c", block)
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), "CLAUDE_PLUGIN_OPTION_PORT=", "CLAUDE_PLUGIN_OPTION_PRESET=")
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
@@ -2539,15 +2565,13 @@ func runKeepaliveBlock(t *testing.T, needle string, env map[string]string) (out 
 // keep-alive turned on — the opposite of what enabling it is supposed to do.
 func TestKeepaliveEnableWritesAPresetPreservingConfig(t *testing.T) {
 	state := t.TempDir()
-	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, map[string]string{
-		"CLAUDE_PLUGIN_OPTION_PORT":   "8787",
-		"CLAUDE_PLUGIN_OPTION_PRESET": "codesmart",
-		"XDG_STATE_HOME":              state,
+	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, "codesmart", map[string]string{
+		"XDG_STATE_HOME": state,
 	})
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, out)
 	}
-	cfg := filepath.Join(state, "context-guru", "keepalive-8787.yaml")
+	cfg := filepath.Join(state, "context-guru", "keepalive-"+keepalivePort+".yaml")
 	b, err := os.ReadFile(cfg)
 	if err != nil {
 		t.Fatalf("config was not written at %s: %v", cfg, err)
@@ -2569,14 +2593,13 @@ func TestKeepaliveEnableRefusesToClobberAForeignFile(t *testing.T) {
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+	cfg := filepath.Join(stateDir, "keepalive-"+keepalivePort+".yaml")
 	foreign := "# hand-written, not ours\npreset: cache\n"
 	if err := os.WriteFile(cfg, []byte(foreign), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, map[string]string{
-		"CLAUDE_PLUGIN_OPTION_PORT": "8787",
-		"XDG_STATE_HOME":            state,
+	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, "cache", map[string]string{
+		"XDG_STATE_HOME": state,
 	})
 	if code != 0 {
 		t.Fatalf("must not fail outright, just refuse: exit %d: %s", code, out)
@@ -2599,14 +2622,13 @@ func TestKeepaliveDisableOnlyRemovesOurOwnFile(t *testing.T) {
 		if err := os.MkdirAll(stateDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+		cfg := filepath.Join(stateDir, "keepalive-"+keepalivePort+".yaml")
 		ours := "# context-guru: written by /context-guru:keepalive\npreset: cache\ncache:\n  keepalive: true\n"
 		if err := os.WriteFile(cfg, []byte(ours), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, map[string]string{
-			"CLAUDE_PLUGIN_OPTION_PORT": "8787",
-			"XDG_STATE_HOME":            state,
+		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, "", map[string]string{
+			"XDG_STATE_HOME": state,
 		})
 		if code != 0 {
 			t.Fatalf("exit %d: %s", code, out)
@@ -2622,14 +2644,13 @@ func TestKeepaliveDisableOnlyRemovesOurOwnFile(t *testing.T) {
 		if err := os.MkdirAll(stateDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		cfg := filepath.Join(stateDir, "keepalive-8787.yaml")
+		cfg := filepath.Join(stateDir, "keepalive-"+keepalivePort+".yaml")
 		foreign := "# hand-written\npreset: cache\n"
 		if err := os.WriteFile(cfg, []byte(foreign), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, map[string]string{
-			"CLAUDE_PLUGIN_OPTION_PORT": "8787",
-			"XDG_STATE_HOME":            state,
+		out, code := runKeepaliveBlock(t, `rm -f "$CFG"`, "", map[string]string{
+			"XDG_STATE_HOME": state,
 		})
 		if code != 0 {
 			t.Fatalf("exit %d: %s", code, out)
@@ -2717,6 +2738,57 @@ func TestStartProxyPicksUpAKeepaliveConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNoSkillBlockReadsAPluginOption is a guard, not a discovery: it is the same defect as
+// TestTheConfiguredPortCanActuallyBeHonoured, which was found once in install/status/uninstall, fixed
+// there, and then reintroduced wholesale by a later skill that was written from the older pattern.
+//
+// CLAUDE_PLUGIN_OPTION_* reaches HOOK environments only, never a Bash tool call, so any
+// `${CLAUDE_PLUGIN_OPTION_X:-default}` inside a skill's fenced bash block is a silent wrong answer —
+// it always yields the default, whatever the user configured, and reports success while doing it.
+// Skills must obtain these values from `settings.py config` and substitute them.
+//
+// Scoped to fenced bash blocks in skills/, on purpose: the hook SCRIPTS (start-proxy.sh,
+// check-proxy.sh) do run in a hook environment and read these variables legitimately, and the skills'
+// PROSE has to be able to name the variable in order to warn about it.
+func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
+	entries, err := os.ReadDir("skills")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join("skills", e.Name(), "SKILL.md"))
+		if err != nil {
+			t.Errorf("reading %s: %v", e.Name(), err)
+			continue
+		}
+		in := false
+		for i, line := range strings.Split(string(b), "\n") {
+			switch {
+			case !in && strings.HasPrefix(line, "```bash"):
+				in = true
+			case in && strings.HasPrefix(line, "```"):
+				in = false
+			case in:
+				if strings.Contains(line, "CLAUDE_PLUGIN_OPTION_") {
+					t.Errorf("skills/%s/SKILL.md:%d reads a plugin option inside an executable block, "+
+						"which always expands to the default in a Bash tool call:\n\t%s\n"+
+						"Obtain it from `settings.py config` and substitute a <placeholder> instead.",
+						e.Name(), i+1, strings.TrimSpace(line))
+				}
+			}
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no skills were scanned, so this guard proved nothing")
+	}
+	t.Logf("scanned %d skills", checked)
 }
 
 // --- findings from Osher's end-to-end review of #160 ------------------------------------------

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2791,6 +2791,52 @@ func TestStartProxyPicksUpAKeepaliveConfig(t *testing.T) {
 	}
 }
 
+// TestEverySkillStatesThePerOptionFallback guards the wording, because the wording is the whole fix.
+//
+// `settings.py config` prints an `option_<name>=` line only for keys the user actually set, and reports
+// `source=(none)` only when the options object is missing or empty. All four skills that call it used to
+// document the fallback as keyed on `source=(none)` — so a PARTIAL config (a real `source=`, one option
+// absent) fell through every documented branch and left the model inventing a value at the exact point
+// those sections warn against it. For `uninstall` that builds a URL matching nothing, so the removal
+// silently finds nothing to remove.
+//
+// This asserts prose, which is unusual here and deliberate: the skills ARE the program on this path, and
+// the defect was a sentence rather than a statement. Kept to one required phrase rather than exact text,
+// so rewording stays cheap and deleting the rule does not.
+func TestEverySkillStatesThePerOptionFallback(t *testing.T) {
+	entries, err := os.ReadDir("skills")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join("skills", e.Name(), "SKILL.md"))
+		if err != nil {
+			t.Errorf("reading %s: %v", e.Name(), err)
+			continue
+		}
+		body := string(b)
+		if !strings.Contains(body, `settings.py" config`) {
+			continue // this skill does not read the options, so it has no fallback to state
+		}
+		checked++
+		if !strings.Contains(body, "is unconfigured") {
+			t.Errorf("skills/%s/SKILL.md reads `settings.py config` but never says that an option the "+
+				"output does not list is UNCONFIGURED. Without that, a partial config (a real `source=` "+
+				"with one option missing) matches no documented branch and the model invents a value.",
+				e.Name())
+		}
+	}
+	if checked < 4 {
+		t.Fatalf("only %d skills were found to read `settings.py config`; expected at least the four "+
+			"(install, status, uninstall, keepalive), so this guard proved less than it claims", checked)
+	}
+	t.Logf("checked %d skills that read the configured options", checked)
+}
+
 // fenceOpener matches a markdown fence and captures its info string. Leading whitespace is allowed
 // because an indented fence is still a fence — a block indented as a list continuation is executed
 // exactly like one at column zero.
@@ -2876,6 +2922,145 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 		t.Fatal("no skills were scanned, so this guard proved nothing")
 	}
 	t.Logf("scanned %d skills", checked)
+}
+
+// TestStartProxyReportsThePresetActuallyInEffect: the success note used to print $PRESET, which comes
+// from the plugin option, even though --config REPLACES the preset entirely. So with a keep-alive config
+// in play the proxy ran whatever `preset:` that file recorded while the note named the option — and the
+// two diverge the moment somebody changes the option after enabling keep-alive. Same species as the
+// defect this branch started from: a confident report of a value that is not in effect.
+//
+// The reading of the file happens on the SessionStart path, so every degenerate config must still START
+// the proxy, and must not produce a note that is wrong in the other direction. "Reported nothing" beats
+// "reported wrong", and neither beats "did not start" — hence the exit-0 and launched checks on every
+// row, not just the happy one.
+func TestStartProxyReportsThePresetActuallyInEffect(t *testing.T) {
+	const optionPreset = "codesmart" // what the PLUGIN OPTION says, and what the note must not parrot
+	for _, c := range []struct {
+		name      string
+		writeCfg  bool
+		cfg       string
+		wantIn    []string
+		wantNotIn []string
+	}{
+		{
+			name:     "the config's preset is reported, not the plugin option's",
+			writeCfg: true, cfg: "preset: house\ncache:\n  keepalive: true\n",
+			wantIn:    []string{"preset house"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			name:     "a quoted and padded value is still read",
+			writeCfg: true, cfg: "preset:   \"house\"  \ncache:\n  keepalive: true\n",
+			wantIn:    []string{"preset house"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			// Older files predate the always-state-the-preset rule. Report it as unstated: a config may
+			// set `pipeline:` directly, so claiming compaction is OFF would be wrong in the other
+			// direction — the failure mode this whole test exists to prevent.
+			name:     "no preset line: unstated, and never claimed to be off",
+			writeCfg: true, cfg: "cache:\n  keepalive: true\n",
+			wantIn:    []string{"unstated"},
+			wantNotIn: []string{"preset " + optionPreset, "compaction is OFF"},
+		},
+		{
+			name:     "a comment-only config claims nothing",
+			writeCfg: true, cfg: "# written by hand, nothing else\n",
+			wantIn:    []string{"unstated"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			name:     "an empty config claims nothing",
+			writeCfg: true, cfg: "",
+			wantIn:    []string{"unstated"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			name:     "malformed junk still starts the proxy and claims nothing",
+			writeCfg: true, cfg: "\x00\x01 not: [yaml: at all\n",
+			wantIn:    []string{"unstated"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			// With no config there is no --config, so the plugin option IS what is in effect and the
+			// note should say so. Without this row the test would pass on a note that never reports a
+			// preset at all.
+			name:      "no keepalive config: the plugin option is the truth and is reported",
+			writeCfg:  false,
+			wantIn:    []string{"preset " + optionPreset},
+			wantNotIn: []string{"unstated"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			requireTool(t, "bash")
+			dir := t.TempDir()
+			argvFile := filepath.Join(dir, "argv")
+			fake := filepath.Join(dir, "fake-proxy")
+			port := freePort(t)
+			py := requireTool(t, "python3")
+			script := "#!/usr/bin/env bash\n" +
+				"printf '%s\\n' \"$*\" > " + argvFile + "\n" +
+				"exec " + py + " -c '\n" +
+				"import http.server\n" +
+				"class H(http.server.BaseHTTPRequestHandler):\n" +
+				"    def do_GET(self):\n" +
+				"        self.send_response(200); self.end_headers(); self.wfile.write(b\"ok\")\n" +
+				"    def log_message(self, *a): pass\n" +
+				"http.server.HTTPServer((\"127.0.0.1\", " + port + "), H).serve_forever()\n'\n"
+			if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			state := filepath.Join(dir, "state")
+			if c.writeCfg {
+				stateDir := filepath.Join(state, "context-guru")
+				if err := os.MkdirAll(stateDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				cfgPath := filepath.Join(stateDir, "keepalive-"+port+".yaml")
+				if err := os.WriteFile(cfgPath, []byte(c.cfg), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "start-proxy.sh"))
+			cmd.Env = append(os.Environ(),
+				"CLAUDE_PLUGIN_OPTION_PORT="+port,
+				"CLAUDE_PLUGIN_OPTION_PRESET="+optionPreset,
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+				"CONTEXT_GURU_BIN="+fake,
+				"XDG_STATE_HOME="+state,
+				"TMPDIR="+dir)
+			out, err := cmd.CombinedOutput()
+			t.Cleanup(func() {
+				if b, e := os.ReadFile(filepath.Join(state, "context-guru", "proxy-"+port+".pid")); e == nil {
+					exec.Command("kill", strings.TrimSpace(string(b))).Run() //nolint:errcheck
+				}
+			})
+			// Fails open: property 5 of this script is that it never fails a session, whatever the
+			// config on disk looks like.
+			if err != nil {
+				t.Fatalf("must never fail a session: %v\n%s", err, out)
+			}
+			if _, rerr := os.Stat(argvFile); rerr != nil {
+				t.Fatalf("the proxy was never launched, so this config stopped a session starting: %v\n%s",
+					rerr, out)
+			}
+			got := string(out)
+			t.Logf("note ->\n%s", got)
+			for _, w := range c.wantIn {
+				if !strings.Contains(got, w) {
+					t.Errorf("note does not contain %q:\n%s", w, got)
+				}
+			}
+			for _, w := range c.wantNotIn {
+				if strings.Contains(got, w) {
+					t.Errorf("note contains %q, which is not what is in effect:\n%s", w, got)
+				}
+			}
+		})
+	}
 }
 
 // --- findings from Osher's end-to-end review of #160 ------------------------------------------
@@ -2968,6 +3153,47 @@ func TestTheConfiguredPortCanActuallyBeHonoured(t *testing.T) {
 		}
 		if _, err := os.Stat(filepath.Join(dir, "context-guru-proxy-"+port+".log")); err != nil {
 			t.Errorf("the log is not named after the configured port: %v", err)
+		}
+	})
+
+	// The state none of the four skills was written for: SOME options set, others not. cmd_config
+	// prints a line only for keys actually present and falls back to `source=(none)` only when the
+	// whole options object is missing, so a partial config reports a real `source=` and simply omits
+	// the rest. Every skill documented its fallback as keyed on `source=(none)`, which does not apply
+	// here — leaving the model to invent a value at the exact point those sections warn is dangerous.
+	t.Run("a partial config reports a real source and omits the options not set", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := filepath.Join(dir, "cfg")
+		if err := os.MkdirAll(cfg, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// port set, preset never touched — the common case, and the one that used to mislead.
+		writeJSON(t, filepath.Join(cfg, "settings.json"), map[string]any{
+			"pluginConfigs": map[string]any{
+				"context-guru@context-guru": map[string]any{
+					"options": map[string]any{"port": 4041},
+				},
+			},
+		})
+		py := requireTool(t, "python3")
+		cmd := exec.Command(py, filepath.Join(scriptsDir(t), "settings.py"), "config")
+		cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+cfg)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("config failed: %v\n%s", err, out)
+		}
+		got := string(out)
+		t.Logf("config ->\n%s", got)
+		if !strings.Contains(got, "option_port=4041") {
+			t.Errorf("the configured port was not reported:\n%s", got)
+		}
+		if strings.Contains(got, "option_preset=") {
+			t.Errorf("an unconfigured option was reported as though it had a value:\n%s", got)
+		}
+		if strings.Contains(got, "source=(none)") {
+			t.Errorf("a partial config reported source=(none); the skills' per-option fallback rule "+
+				"exists precisely because this reports a real source:\n%s", got)
 		}
 	})
 

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2823,6 +2823,16 @@ func TestEverySkillStatesThePerOptionFallback(t *testing.T) {
 			continue // this skill does not read the options, so it has no fallback to state
 		}
 		checked++
+		// The positive alone is the reassurance I suspected it of being: review demonstrated that
+		// restoring the old sentence while KEEPING the new rule passes. So assert the absence of the old
+		// instruction shape too. The discriminating string is "or 8787 if it reports" and not
+		// `source=(none)`, because the corrected prose quotes that token legitimately while explaining
+		// the rule — asserting on the token would fail every fixed file.
+		if strings.Contains(body, "or 8787 if it reports") {
+			t.Errorf("skills/%s/SKILL.md still tells the model \"or 8787 if it reports …\", which is the "+
+				"fallback keyed on `source=` that this rule replaces. A skill can state the per-option "+
+				"rule and contradict it two lines later; that is what this assertion catches.", e.Name())
+		}
 		if !strings.Contains(body, "is unconfigured") {
 			t.Errorf("skills/%s/SKILL.md reads `settings.py config` but never says that an option the "+
 				"output does not list is UNCONFIGURED. Without that, a partial config (a real `source=` "+
@@ -2937,11 +2947,12 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 func TestStartProxyReportsThePresetActuallyInEffect(t *testing.T) {
 	const optionPreset = "codesmart" // what the PLUGIN OPTION says, and what the note must not parrot
 	for _, c := range []struct {
-		name      string
-		writeCfg  bool
-		cfg       string
-		wantIn    []string
-		wantNotIn []string
+		name       string
+		writeCfg   bool
+		cfg        string
+		unreadable bool // chmod 000 after writing: the ONLY config that makes sed itself fail
+		wantIn     []string
+		wantNotIn  []string
 	}{
 		{
 			name:     "the config's preset is reported, not the plugin option's",
@@ -2983,6 +2994,32 @@ func TestStartProxyReportsThePresetActuallyInEffect(t *testing.T) {
 			wantNotIn: []string{"preset " + optionPreset},
 		},
 		{
+			// The row that defends the fail-open property itself. Every other row has a config sed can
+			// READ — empty, comment-only and junk files all match nothing and exit 0 — so none of them
+			// can see `set -e` being added. This one can: with pipefail in force, an unreadable file
+			// makes the assignment non-zero, and -e would then kill the script before the proxy starts.
+			name:     "an unreadable config still starts the proxy (this is what -e would break)",
+			writeCfg: true, cfg: "preset: house\ncache:\n  keepalive: true\n", unreadable: true,
+			wantIn:    []string{"unstated"},
+			wantNotIn: []string{"preset " + optionPreset},
+		},
+		{
+			// Reachable by hand edit, not theoretical: this document LOADS, with a top-level preset of
+			// house and a full house pipeline, so a first-match-at-any-indentation read would name the
+			// inner value while the proxy ran the outer one.
+			name:      "a nested preset: does not shadow the top-level one",
+			writeCfg:  true,
+			cfg:       "components:\n  offload:\n    preset: inner\npreset: house\ncache:\n  keepalive: true\n",
+			wantIn:    []string{"preset house"},
+			wantNotIn: []string{"inner", "preset " + optionPreset},
+		},
+		{
+			name:     "an inline comment does not leak into the note",
+			writeCfg: true, cfg: "preset: house # kept for the split\ncache:\n  keepalive: true\n",
+			wantIn:    []string{"preset house"},
+			wantNotIn: []string{"kept for the split", "preset " + optionPreset},
+		},
+		{
 			// With no config there is no --config, so the plugin option IS what is in effect and the
 			// note should say so. Without this row the test would pass on a note that never reports a
 			// preset at all.
@@ -3021,6 +3058,14 @@ func TestStartProxyReportsThePresetActuallyInEffect(t *testing.T) {
 				cfgPath := filepath.Join(stateDir, "keepalive-"+port+".yaml")
 				if err := os.WriteFile(cfgPath, []byte(c.cfg), 0o644); err != nil {
 					t.Fatal(err)
+				}
+				if c.unreadable {
+					if os.Geteuid() == 0 {
+						t.Skip("root ignores mode 000, so this row cannot make the read fail")
+					}
+					if err := os.Chmod(cfgPath, 0o000); err != nil {
+						t.Fatal(err)
+					}
 				}
 			}
 

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -2516,6 +2517,15 @@ func TestStatuslineCachesStatsAcrossQuickRenders(t *testing.T) {
 // fixture port of 8787 that regression passes by coincidence, which is exactly how it shipped.
 const keepalivePort = "4041"
 
+// emptyPreset asks runKeepaliveBlock to substitute an EMPTY preset value, which is not the same as
+// passing "" — that means "this block has no <preset> line at all". Only the first models a model that
+// looked for `option_preset=` and found nothing to use.
+const emptyPreset = "\x00"
+
+// unfilledPlaceholder matches a `<lowercase>` placeholder left in an extracted block. Lower-case only
+// on purpose, so a heredoc delimiter (`<<EOF`) is not mistaken for one.
+var unfilledPlaceholder = regexp.MustCompile(`<[a-z][a-z_]*>`)
+
 // fillSkillPlaceholder substitutes one placeholder in an extracted skill block, failing loudly when
 // it is absent: an unsubstituted `PORT="<port>"` makes every path below look inert for the wrong
 // reason, which is what happened when the placeholder was introduced in the uninstall skill.
@@ -2541,7 +2551,19 @@ func runKeepaliveBlock(t *testing.T, needle, preset string, env map[string]strin
 	block := skillBlock(t, "keepalive", needle)
 	block = fillSkillPlaceholder(t, "keepalive", block, `PORT="<port>"`, `PORT="`+keepalivePort+`"`)
 	if preset != "" {
-		block = fillSkillPlaceholder(t, "keepalive", block, `PRESET="<preset>"`, `PRESET="`+preset+`"`)
+		v := preset
+		if v == emptyPreset {
+			v = ""
+		}
+		block = fillSkillPlaceholder(t, "keepalive", block, `PRESET="<preset>"`, `PRESET="`+v+`"`)
+	}
+	// Nothing below may execute a template. The per-call substitutions above are opt-in, so this is
+	// the check that does not have to be remembered: the day a block gains a placeholder no call site
+	// fills, it fails here instead of running literally and asserting on nothing.
+	if m := unfilledPlaceholder.FindString(block); m != "" {
+		t.Fatalf("the keepalive %q block still carries the placeholder %s after substitution; it would "+
+			"execute as a literal template and every assertion below would pass on nothing:\n%s",
+			needle, m, block)
 	}
 	cmd := exec.Command("bash", "-c", block)
 	cmd.Env = append(os.Environ(), "CLAUDE_PLUGIN_OPTION_PORT=", "CLAUDE_PLUGIN_OPTION_PRESET=")
@@ -2662,6 +2684,35 @@ func TestKeepaliveDisableOnlyRemovesOurOwnFile(t *testing.T) {
 	})
 }
 
+// TestKeepaliveEnableRefusesAnEmptyPreset closes the hole the placeholder flow itself opens.
+//
+// `settings.py config` prints `option_preset=` only when that key is actually configured, so a user who
+// set the port and never touched the preset leaves the model with nothing to substitute. Writing the
+// resulting `preset:` line empty is not an error anywhere downstream: applyPreset returns early on
+// `Preset == ""` (config/config.go), so Load reports success, no pipeline is filled, and compaction is
+// entirely OFF while the keep-alive keeps spending the caller's credential on idle pings.
+//
+// That is strictly worse than the defaulted-`cache` bug this branch fixes, since `cache` at least ran
+// the split. The block already refuses to write over a file that is not its own; an unresolved preset
+// earns the same conservatism, and must leave no file behind.
+func TestKeepaliveEnableRefusesAnEmptyPreset(t *testing.T) {
+	state := t.TempDir()
+	out, code := runKeepaliveBlock(t, `cat > "$CFG" <<EOF`, emptyPreset, map[string]string{
+		"XDG_STATE_HOME": state,
+	})
+	if code == 0 {
+		t.Errorf("an unresolved preset was accepted; that writes `preset:` empty, which turns "+
+			"compaction off while keep-alive keeps paying for pings:\n%s", out)
+	}
+	if !strings.Contains(out, "REFUSING") {
+		t.Errorf("the refusal was not reported as such:\n%s", out)
+	}
+	cfg := filepath.Join(state, "context-guru", "keepalive-"+keepalivePort+".yaml")
+	if _, err := os.Stat(cfg); err == nil {
+		t.Errorf("a config was written anyway at %s, so the proxy would start with compaction off", cfg)
+	}
+}
+
 // TestStartProxyPicksUpAKeepaliveConfig proves the wiring between the opt-in toggle above and the
 // hook that actually launches the proxy: presence of the file is what decides, and it is the ONLY
 // thing that decides — nothing else about this test's environment names keep-alive at all.
@@ -2740,6 +2791,22 @@ func TestStartProxyPicksUpAKeepaliveConfig(t *testing.T) {
 	}
 }
 
+// fenceOpener matches a markdown fence and captures its info string. Leading whitespace is allowed
+// because an indented fence is still a fence — a block indented as a list continuation is executed
+// exactly like one at column zero.
+var fenceOpener = regexp.MustCompile("^[ \t]*```+[ \t]*([A-Za-z0-9_.+-]*)")
+
+// isShellFence reports whether a fence's info string means "this is shell the model will run". The
+// label is not a semantic boundary: ```sh and a bare ``` are executed the same as ```bash, so keying
+// a guard on the literal "```bash" leaves the same defect reachable one keystroke away.
+func isShellFence(info string) bool {
+	switch strings.ToLower(info) {
+	case "", "bash", "sh", "shell", "zsh", "console", "shell-session":
+		return true
+	}
+	return false
+}
+
 // TestNoSkillBlockReadsAPluginOption is a guard, not a discovery: it is the same defect as
 // TestTheConfiguredPortCanActuallyBeHonoured, which was found once in install/status/uninstall, fixed
 // there, and then reintroduced wholesale by a later skill that was written from the older pattern.
@@ -2749,9 +2816,14 @@ func TestStartProxyPicksUpAKeepaliveConfig(t *testing.T) {
 // it always yields the default, whatever the user configured, and reports success while doing it.
 // Skills must obtain these values from `settings.py config` and substitute them.
 //
-// Scoped to fenced bash blocks in skills/, on purpose: the hook SCRIPTS (start-proxy.sh,
+// Scoped to fenced SHELL blocks in skills/, on purpose: the hook SCRIPTS (start-proxy.sh,
 // check-proxy.sh) do run in a hook environment and read these variables legitimately, and the skills'
 // PROSE has to be able to name the variable in order to warn about it.
+//
+// "Shell block" deliberately includes ```sh, a bare ```, and an indented fence, not just ```bash at
+// column zero. Round-1 review demonstrated both escapes: the same defect re-added under a ```sh fence,
+// and under a two-space-indented ```bash fence, each left this guard silent. A guard for a CLASS has
+// to match how the model reads a block, and the model does not care what the info string says.
 func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 	entries, err := os.ReadDir("skills")
 	if err != nil {
@@ -2767,20 +2839,25 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 			t.Errorf("reading %s: %v", e.Name(), err)
 			continue
 		}
-		in := false
+		// Two pieces of state, not one. Tracking only "am I in a block I care about" gets the
+		// PARITY wrong: a ```json fence would not open anything, so its CLOSING fence reads as an
+		// opener and every prose line after it looks like shell. That is not hypothetical — it
+		// misfired on install/SKILL.md's prose the first time this guard was widened.
+		inFence, isShell := false, false
 		for i, line := range strings.Split(string(b), "\n") {
-			switch {
-			case !in && strings.HasPrefix(line, "```bash"):
-				in = true
-			case in && strings.HasPrefix(line, "```"):
-				in = false
-			case in:
-				if strings.Contains(line, "CLAUDE_PLUGIN_OPTION_") {
-					t.Errorf("skills/%s/SKILL.md:%d reads a plugin option inside an executable block, "+
-						"which always expands to the default in a Bash tool call:\n\t%s\n"+
-						"Obtain it from `settings.py config` and substitute a <placeholder> instead.",
-						e.Name(), i+1, strings.TrimSpace(line))
+			if m := fenceOpener.FindStringSubmatch(line); m != nil {
+				if inFence {
+					inFence, isShell = false, false
+				} else {
+					inFence, isShell = true, isShellFence(m[1])
 				}
+				continue
+			}
+			if inFence && isShell && strings.Contains(line, "CLAUDE_PLUGIN_OPTION_") {
+				t.Errorf("skills/%s/SKILL.md:%d reads a plugin option inside an executable block, "+
+					"which always expands to the default in a Bash tool call:\n\t%s\n"+
+					"Obtain it from `settings.py config` and substitute a <placeholder> instead.",
+					e.Name(), i+1, strings.TrimSpace(line))
 			}
 		}
 		checked++

--- a/context-guru-plugin/scripts/start-proxy.sh
+++ b/context-guru-plugin/scripts/start-proxy.sh
@@ -263,8 +263,28 @@ fi
 # keep-alive was turned on, the exact opposite of what enabling it is supposed to do.
 CONFIG_ARGS=()
 KEEPALIVE_CFG="${STATE}/keepalive-${PORT}.yaml"
+
+# PRESET_NOTE is what the success note reports, and it is NOT $PRESET once --config is passed. Because
+# --config replaces the preset entirely (see above), the proxy runs whatever `preset:` the keep-alive
+# file recorded, while $PRESET still holds the plugin option. Reporting the option named a value that
+# was not in effect, and the two diverge the moment somebody changes the option after enabling
+# keep-alive — a confident report of something untrue, which is the failure this plugin exists to avoid.
+PRESET_NOTE="$PRESET"
 if [ -f "$KEEPALIVE_CFG" ]; then
   CONFIG_ARGS=(--config "$KEEPALIVE_CFG")
+  # Fails OPEN, and reports nothing rather than something wrong. This runs on the SessionStart path,
+  # so an unreadable, empty, comment-only or preset-less file must still start the proxy: `set -e` is
+  # deliberately not in force, so a failing pipeline here only leaves cfg_preset empty.
+  cfg_preset=$(sed -n 's/^[[:space:]]*preset:[[:space:]]*//p' "$KEEPALIVE_CFG" 2>/dev/null \
+                 | head -1 | tr -d "\"'" | sed 's/[[:space:]]*$//')
+  if [ -n "$cfg_preset" ]; then
+    PRESET_NOTE="${cfg_preset} (from keepalive-${PORT}.yaml)"
+  else
+    # No preset: line. Do NOT say "compaction is off" — a config may set `pipeline:` directly without
+    # naming a preset, and files written before the always-state-the-preset rule exist in the wild. So
+    # report only what is known: the config decides, and it did not name one.
+    PRESET_NOTE="unstated in keepalive-${PORT}.yaml"
+  fi
 fi
 
 PRESET="$PRESET" \
@@ -307,11 +327,11 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # and overwrites the pidfile with a pid that immediately exits), not on this one.
   if curl -fsS --max-time 1 "$HEALTH" >/dev/null 2>&1; then
       if [ -n "$UPSTREAM" ]; then
-      note "proxy up on 127.0.0.1:${PORT} (preset ${PRESET}, idle-exit ${IDLE_EXIT}), chained behind ${UPSTREAM}."
+      note "proxy up on 127.0.0.1:${PORT} (preset ${PRESET_NOTE}, idle-exit ${IDLE_EXIT}), chained behind ${UPSTREAM}."
       note "dashboard: http://127.0.0.1:${PORT}/dashboard/"
       exit 0
     fi
-    note "proxy up on 127.0.0.1:${PORT} (preset ${PRESET}, idle-exit ${IDLE_EXIT})."
+    note "proxy up on 127.0.0.1:${PORT} (preset ${PRESET_NOTE}, idle-exit ${IDLE_EXIT})."
     note "dashboard: http://127.0.0.1:${PORT}/dashboard/"
     exit 0
   fi

--- a/context-guru-plugin/scripts/start-proxy.sh
+++ b/context-guru-plugin/scripts/start-proxy.sh
@@ -272,11 +272,22 @@ KEEPALIVE_CFG="${STATE}/keepalive-${PORT}.yaml"
 PRESET_NOTE="$PRESET"
 if [ -f "$KEEPALIVE_CFG" ]; then
   CONFIG_ARGS=(--config "$KEEPALIVE_CFG")
-  # Fails OPEN, and reports nothing rather than something wrong. This runs on the SessionStart path,
-  # so an unreadable, empty, comment-only or preset-less file must still start the proxy: `set -e` is
-  # deliberately not in force, so a failing pipeline here only leaves cfg_preset empty.
-  cfg_preset=$(sed -n 's/^[[:space:]]*preset:[[:space:]]*//p' "$KEEPALIVE_CFG" 2>/dev/null \
-                 | head -1 | tr -d "\"'" | sed 's/[[:space:]]*$//')
+  # Fails OPEN, and reports nothing rather than something wrong. This runs on the SessionStart path, so
+  # an unreadable, empty, comment-only or preset-less file must still start the proxy.
+  #
+  # What keeps that true is the ABSENCE of `set -e` combined with the PRESENCE of `set -uo pipefail`
+  # (line 28) — and it is pipefail that makes the combination load-bearing, not -e alone. With pipefail,
+  # a failing `sed` (a config that exists but cannot be read) becomes this assignment's exit status; add
+  # -e and the script dies with status 2 BEFORE the proxy is launched, which is the failure this file's
+  # own header calls the biggest risk in the feature. Do not add -e here without reading
+  # TestStartProxyReportsThePresetActuallyInEffect's unreadable-config row, which exists to catch it.
+  #
+  # Anchored at column zero: `preset:` is a top-level key, and a nested one (e.g. components.offload.
+  # preset) in a hand-edited file both LOADS and would win a first-match-any-indentation search, so the
+  # note would name the inner value while the proxy ran the outer one. Inline comments are stripped for
+  # the same reason — `preset: cache # why` used to leak the comment into the note.
+  cfg_preset=$(sed -n 's/^preset:[[:space:]]*//p' "$KEEPALIVE_CFG" 2>/dev/null \
+                 | head -1 | sed 's/[[:space:]]*#.*$//' | tr -d "\"'" | sed 's/[[:space:]]*$//')
   if [ -n "$cfg_preset" ]; then
     PRESET_NOTE="${cfg_preset} (from keepalive-${PORT}.yaml)"
   else

--- a/context-guru-plugin/skills/install/SKILL.md
+++ b/context-guru-plugin/skills/install/SKILL.md
@@ -107,6 +107,11 @@ The values are on disk, so read them:
 
 - `option_port=…` / `option_preset=…` / `option_idle_exit=…` / `option_upstream=…` — use these
 - `source=(none)` — nothing configured; the `plugin.json` defaults apply (port 8787, preset `cache`)
+- **an option with no line of its own is unconfigured**, whatever `source=` says. Only keys the user
+  actually set are printed, so a partial config — the port set and the preset never touched, say —
+  reports a real `source=` and simply omits `option_preset=`. Take the `plugin.json` default for each
+  missing option individually; do not read one present option as meaning the rest are set, and do not
+  invent a value because `source=` was not `(none)`.
 
 Carry the port through **every** later step explicitly: `--port` when starting the proxy, and the same
 number in the URL you write. If it turns out to be anything other than 8787, say so in your summary —

--- a/context-guru-plugin/skills/keepalive/SKILL.md
+++ b/context-guru-plugin/skills/keepalive/SKILL.md
@@ -36,9 +36,15 @@ The values are on disk, so read them:
 "${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" config
 ```
 
-Use its `option_port=` and `option_preset=`, or 8787 and `cache` if it reports `source=(none)`. Then
-substitute both into the `<port>` / `<preset>` placeholders in every block below. If the port is
-anything other than 8787, say so in your summary.
+**Read the fallback per option, not from `source=`.** That command prints an `option_<name>=` line only
+for keys the user actually configured, and reports `source=(none)` only when nothing at all is set. So
+somebody who set the port and never touched the preset — the case this whole section exists for — gets a
+real `source=` and *no* `option_preset=` line. Any option the output does not list is unconfigured: use
+the `plugin.json` default for that one (port 8787, preset `cache`), whatever `source=` says.
+
+Substitute both values into the `<port>` / `<preset>` placeholders in every block below. Never leave a
+placeholder unfilled and never substitute an empty string — an empty preset is not a harmless default,
+it turns compaction off (see step 2). If the port is anything other than 8787, say so in your summary.
 
 ## 1. Report current activity
 
@@ -68,6 +74,13 @@ STATE="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
 mkdir -p "$STATE"
 CFG="${STATE}/keepalive-${PORT}.yaml"
 MARKER="# context-guru: written by /context-guru:keepalive"
+# An unresolved preset is NOT a harmless default. `preset:` written empty makes the proxy load a
+# config with no pipeline at all and report success, so compaction is off while keep-alive keeps
+# spending the caller's credential on idle pings — worse than the wrong-preset bug this replaced.
+if [ -z "$PRESET" ]; then
+  echo "REFUSING: no preset resolved; substitute option_preset= from \`settings.py config\`, or the plugin.json default \`cache\`"
+  exit 1
+fi
 if [ -f "$CFG" ] && ! head -1 "$CFG" | grep -qF "$MARKER"; then
   echo "REFUSING: ${CFG} already exists and was not written by this skill; edit or remove it by hand first"
 else
@@ -97,7 +110,7 @@ block, or the plugin's own equivalent, then:
 "${CLAUDE_PLUGIN_ROOT}/scripts/start-proxy.sh" --unrouted
 ```
 
-Confirm it actually picked the config up — `curl -fsS http://127.0.0.1:${PORT}/healthz` first,
+Confirm it actually picked the config up — `curl -fsS http://127.0.0.1:<port>/healthz` first,
 then check step 1's `keepalive_pings` again after a session has gone idle for a while.
 
 ## 3. Turn it off

--- a/context-guru-plugin/skills/keepalive/SKILL.md
+++ b/context-guru-plugin/skills/keepalive/SKILL.md
@@ -16,10 +16,34 @@ own money (or usage-limit budget) between turns, while nobody is at the keyboard
 renders on every keystroke; if IT could arm this, a display hook would double as an unbounded
 traffic generator. Turning it on is therefore always something a user asks for, here, once.
 
+## First: get the configured port and preset
+
+**You cannot read `$CLAUDE_PLUGIN_OPTION_PORT` or `$CLAUDE_PLUGIN_OPTION_PRESET` here.** Claude Code
+puts those variables into HOOK environments only, never into a Bash tool call, so
+`${CLAUDE_PLUGIN_OPTION_PORT:-8787}` in a command always expands to 8787 whatever the user configured.
+
+For this skill that is worse than a misreport, because both values decide what gets written:
+
+- the config file is **named after the port**, so on a proxy configured for 4041 the enable step would
+  write `keepalive-8787.yaml` — a file nothing ever reads. The toggle would report success and change
+  nothing, and step 1 would then report on 8787 and confirm it.
+- `--config` **replaces** `--preset` entirely, so a defaulted `cache` would silently turn a configured
+  `house` preset off at the moment keep-alive turned on.
+
+The values are on disk, so read them:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" config
+```
+
+Use its `option_port=` and `option_preset=`, or 8787 and `cache` if it reports `source=(none)`. Then
+substitute both into the `<port>` / `<preset>` placeholders in every block below. If the port is
+anything other than 8787, say so in your summary.
+
 ## 1. Report current activity
 
 ```bash
-PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
+PORT="<port>"
 curl -fsS --max-time 3 "http://127.0.0.1:${PORT}/api/stats" | \
   python3 -c 'import json,sys; d=json.load(sys.stdin); print({k: d[k] for k in d if k.startswith("keepalive_")})'
 ```
@@ -38,8 +62,8 @@ conservatism as `settings.py`, just for a file that is ours alone rather than th
 `settings.json`):
 
 ```bash
-PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
-PRESET="${CLAUDE_PLUGIN_OPTION_PRESET:-cache}"
+PORT="<port>"
+PRESET="<preset>"
 STATE="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
 mkdir -p "$STATE"
 CFG="${STATE}/keepalive-${PORT}.yaml"
@@ -79,7 +103,7 @@ then check step 1's `keepalive_pings` again after a session has gone idle for a 
 ## 3. Turn it off
 
 ```bash
-PORT="${CLAUDE_PLUGIN_OPTION_PORT:-8787}"
+PORT="<port>"
 STATE="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
 CFG="${STATE}/keepalive-${PORT}.yaml"
 MARKER="# context-guru: written by /context-guru:keepalive"

--- a/context-guru-plugin/skills/status/SKILL.md
+++ b/context-guru-plugin/skills/status/SKILL.md
@@ -20,7 +20,11 @@ First get the configured port, because you cannot read it from the environment h
 "${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" config
 ```
 
-Use its `option_port=`, or 8787 if it reports `source=(none)`. Then:
+Use its `option_port=`. **Read the fallback per option, not from `source=`:** that command prints an
+`option_<name>=` line only for keys the user actually configured, and reports `source=(none)` only when
+nothing at all is set — so somebody with a partial config gets a real `source=` and no `option_port=`
+line. Any option the output does not list is unconfigured; use the `plugin.json` default for that one
+(port 8787), whatever `source=` says. Then:
 
 ```bash
 PORT="<port>"

--- a/context-guru-plugin/skills/uninstall/SKILL.md
+++ b/context-guru-plugin/skills/uninstall/SKILL.md
@@ -24,7 +24,11 @@ default would build the wrong URL and the removal would find nothing to remove:
 "${CLAUDE_PLUGIN_ROOT}/scripts/settings.py" config
 ```
 
-Use its `option_port=`, or 8787 if it reports `source=(none)`. Then:
+Use its `option_port=`. **Read the fallback per option, not from `source=`:** that command prints an
+`option_<name>=` line only for keys the user actually configured, and reports `source=(none)` only when
+nothing at all is set — so somebody with a partial config gets a real `source=` and no `option_port=`
+line. Any option the output does not list is unconfigured; use the `plugin.json` default for that one
+(port 8787), whatever `source=` says. Then:
 
 ```bash
 PORT="<port>"


### PR DESCRIPTION
Closes #221.

`skills/keepalive/SKILL.md` read `CLAUDE_PLUGIN_OPTION_PORT` and `_PRESET` inside its executable blocks. Those variables reach **hook** environments only, never a Bash tool call, so all four expansions silently produced their defaults whatever the user had configured.

This is the defect #160 fixed in `install`/`status`/`uninstall` (`81ff51f`, covered by `TestTheConfiguredPortCanActuallyBeHonoured`). This skill was added afterwards, from the older pattern, and brought it back.

## What it did on a non-default port

The config file is named after the port, so on a proxy configured for `4041`:

- **enable** wrote `keepalive-8787.yaml`, which nothing reads — a silent no-op that printed `wrote …`
- **disable** removed that same unread file, so turning it off was equally a no-op
- **step 1** then reported `keepalive_pings` from 8787 and confirmed the wrong answer
- **`PRESET` defaulted to `cache`**, and since `--config` *replaces* `--preset` entirely (`loadConfig` reads `--preset` only when `--config` is absent), enabling keep-alive silently switched off a configured preset — the exact failure the block's own comment claims to prevent

Fixed the way the other three skills already do it: a discovery step reading the values from disk with `settings.py config`, and `<port>` / `<preset>` placeholders the model substitutes.

## Why the tests did not see it

`runKeepaliveBlock` injected `CLAUDE_PLUGIN_OPTION_PORT=8787` into the block's environment — the one environment these blocks never run in — and the fixtures asserted against `keepalive-8787.yaml`. The fiction agreed with the defect, so everything passed.

They now fill the placeholders the way the skill instructs the model to, run with those variables **empty**, and use port **4041**. At a fixture port of 8787 this regression passes by coincidence, which is how it shipped.

`TestNoSkillBlockReadsAPluginOption` covers the class, because this was its second occurrence. It is scoped to fenced bash blocks under `skills/`: the hook scripts (`start-proxy.sh`, `check-proxy.sh`) do run in a hook environment and read these variables legitimately, and the skills' prose has to be able to name the variable in order to warn about it.

## Verification

Eval box, Go 1.26.4, `go test -race`, `CGO_ENABLED=1`. Each mutation proven to land, each failing the test named for it, each file restored byte-identical:

```
revert the skill to ${CLAUDE_PLUGIN_OPTION_*:-default}
    -> TestNoSkillBlockReadsAPluginOption  FAILED  (names lines 46/65/66)
    -> TestKeepalive*                      FAILED  (template guard fires, not a stale block)
delete save()'s copymode/chmod block
    -> TestSettingsPreservesFileMode       FAILED  (mode after add = 600, want 640)
```

The last mutation is unrelated to this change. It was run only to confirm that test is no longer vacuous after `81ff51f` raised its fixture to `0640`; `settings.py` is untouched here.

Full suite green: **29 packages ok, 0 failures, exit 0**. `gofmt` and `go vet` clean.

## Note on provenance

This started from a report that #160 had merged with the port blocker unfixed and `TestSettingsPreservesFileMode` still vacuous. That turned out not to be the case — both were fixed on the branch by `81ff51f` before the merge. The *class* of the port defect was live, though, in this later skill, which is what this PR fixes.

---

## Also in this PR: #223 and #224

Closes #223. Closes #224.

Both were found while reviewing this branch and filed as separate issues, on the rule that an unrelated `main` defect gets its own branch. The operator has since directed them here, so they land in this PR and close with it. Worth flagging for reviewers: this branch was reviewed twice as a **test-only** diff and is no longer one — it now touches `scripts/start-proxy.sh` and three more skills.

### #223 — the option fallback was keyed on `source=`, which is the wrong question

`settings.py config` prints an `option_<name>=` line only for keys the user actually set, and reports `source=(none)` only when the options object is missing or empty (`scripts/settings.py:570-575`). All four skills that call it said *"use `option_port=`, or 8787 if it reports `source=(none)`"*.

So a **partial** config — port set, preset never touched, which is the common case and the one this discovery step exists for — reports a real `source=` and simply omits the missing option. That matches no documented branch, leaving the model to invent a value exactly where those sections warn against it. `uninstall` is the worst instance: the removal URL is built from the port, so an invented port matches nothing and the removal silently finds nothing to remove — #221's failure mode by another route.

The rule is now per option in `install`, `status` and `uninstall` (`keepalive` got it earlier on this branch): *an option with no line of its own is unconfigured, whatever `source=` says.*

Two tests, because wording alone is not enforceable:

- `TestTheConfiguredPortCanActuallyBeHonoured` gains a partial-config case asserting the **shape** the wording depends on — `option_port` present, `option_preset` absent, `source` **not** `(none)`.
- `TestEverySkillStatesThePerOptionFallback` asserts every skill that reads the options states the rule. It checks prose, which is unusual here and deliberate: on this path the skills *are* the program, and the defect was a sentence rather than a statement. One required phrase rather than exact text, with a floor of four skills so it cannot pass by matching nothing.

### #224 — the success note reported a preset that was not in effect

`start-proxy.sh` passes `--config` whenever a keep-alive config exists for the port, and `--config` **replaces** the preset entirely (`loadConfig` returns `config.Load(path)` and never reads `preset` once `--config` is set). The note still printed `(preset ${PRESET})` from `CLAUDE_PLUGIN_OPTION_PRESET`, so the proxy ran whatever `preset:` the file recorded while the note named the plugin option. They diverge the moment somebody changes the option after enabling keep-alive — the same species as the defect this branch started from.

`PRESET_NOTE` now carries what is actually in effect, read from the config when one is in play.

It **fails open**, because this is the SessionStart path: the read is `2>/dev/null` into a variable, `set -e` is deliberately not in force, and every degenerate file (unreadable, empty, comment-only, preset-less, malformed) still starts the proxy.

It also refuses to be wrong in the *other* direction, which review caught in my first draft. I had written `"compaction is OFF"` for a config with no `preset:` line — untrue when a config sets `pipeline:` directly, and files predating the always-state-the-preset rule exist in the wild. It now reports `"unstated in keepalive-<port>.yaml"` and asserts nothing about compaction: reported nothing beats reported wrong, and neither beats did not start.

`TestStartProxyReportsThePresetActuallyInEffect` covers seven rows, each asserting exit 0 **and** that the proxy actually launched — including a no-config row, without which the test would pass on a note that never reported a preset at all.

### Verification

Eval box, Go 1.26.4, `go test -race`, `CGO_ENABLED=1`. Eight mutations, each proven to land, each failing the test named for it, each file restored byte-identical (`cmp`) before the next:

```
note reverted to $PRESET                      -> TestStartProxyReportsThePresetActuallyInEffect  FAILED
"compaction is OFF" for a preset-less config  -> TestStartProxyReportsThePresetActuallyInEffect  FAILED
the -f guard dropped                          -> TestStartProxy*                                 FAILED
cmd_config invents defaults for unset options -> TestTheConfiguredPortCanActuallyBeHonoured      FAILED
per-option rule deleted from each of the four -> TestEverySkillStatesThePerOptionFallback        FAILED (x4)
```

Full suite: **29 packages ok, 0 failures, exit 0**. `gofmt -l` empty, `go vet` clean.
