### PR TITLE
fix(plugin): make the printed recovery command the real launch path

### DIFF
--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -950,7 +950,17 @@ func TestCheckHookFinishesInsideItsOwnTimeout(t *testing.T) {
 	for _, want := range []string{
 		"nothing is answering there",
 		"Your request will hang with no error message",
-		"--dashboard", // the printed recovery command must not recreate the 404 dashboard
+		// This used to assert the literal "--dashboard", because the note restated the proxy's whole
+		// command line and a copy of it that forgot those flags left the user with a 404 dashboard.
+		// The note no longer restates anything — it points at start-proxy.sh, which always passes them
+		// — so the string is gone by design rather than by regression.
+		//
+		// The property itself did not move to prose: TestCheckProxyRecoveryCommandIsTheRealLaunchPath
+		// RUNS the printed command and asserts --dashboard in the argv the proxy is actually launched
+		// with, which is strictly stronger than finding the word in a paragraph. What is left to check
+		// here is that this path still hands the user something runnable at all.
+		"start-proxy.sh",
+		"--unrouted",
 	} {
 		if !strings.Contains(flat, want) {
 			t.Errorf("the diagnostic is missing %q; output was:\n%s", want, out)
@@ -2940,6 +2950,224 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 		t.Fatal("no skills were scanned, so this guard proved nothing")
 	}
 	t.Logf("scanned %d skills", checked)
+}
+
+// TestCheckProxyRecoveryCommandIsTheRealLaunchPath: the note printed when nothing answers on the port
+// used to carry a hand-rolled `context-guru-proxy --listen … --preset …`, and that duplicate had drifted
+// from what start-proxy.sh actually launches in four ways at once — it named the plugin option's preset
+// (which --config replaces anyway) and omitted --config, --anthropic-upstream and --idle-exit.
+//
+// Pasting it therefore turned keep-alive OFF for somebody who had enabled it and was paying for the
+// pings, bypassed a configured gateway, and left a proxy that never idle-exits. All silently, while the
+// user was already troubleshooting.
+//
+// So this does not assert on the note's WORDING. It extracts the command the note prints and RUNS it,
+// then asserts on the argv the proxy was launched with. A flag list can be repaired and drift again; what
+// has to hold is that the printed command produces the same proxy the hook would have started.
+func TestCheckProxyRecoveryCommandIsTheRealLaunchPath(t *testing.T) {
+	requireTool(t, "bash")
+	const preset, idle, upstream = "house", "90m", "http://gw.example:4000"
+
+	dir := t.TempDir()
+	state := filepath.Join(dir, "state")
+	stateDir := filepath.Join(state, "context-guru")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	port := freePort(t)
+	// A keep-alive config exists, which is the case the old command silently discarded.
+	keepalive := filepath.Join(stateDir, "keepalive-"+port+".yaml")
+	if err := os.WriteFile(keepalive, []byte("preset: "+preset+"\ncache:\n  keepalive: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: get the note. Auto-recovery has to FAIL for it to print, so the binary does not exist.
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := append(os.Environ(),
+		"CLAUDE_PLUGIN_ROOT="+root,
+		"CLAUDE_PLUGIN_OPTION_PORT="+port,
+		"CLAUDE_PLUGIN_OPTION_PRESET="+preset,
+		"CLAUDE_PLUGIN_OPTION_IDLE_EXIT="+idle,
+		"CLAUDE_PLUGIN_OPTION_UPSTREAM="+upstream,
+		"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+		"CONTEXT_GURU_BIN="+filepath.Join(dir, "does-not-exist"),
+		"CONTEXT_GURU_HEALTH_BUDGET=1",
+		"XDG_STATE_HOME="+state,
+		"TMPDIR="+dir)
+	cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "check-proxy.sh"))
+	cmd.Env = env
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-proxy.sh must never fail a prompt: %v\n%s", err, b)
+	}
+	note := string(b)
+	t.Logf("note ->\n%s", note)
+
+	// The duplicated command line must be gone, not merely corrected.
+	if strings.Contains(note, "context-guru-proxy --listen") {
+		t.Errorf("the note still prints a hand-rolled proxy command line; that duplicate is what drifted "+
+			"from the real launch path four times:\n%s", note)
+	}
+
+	// Step 2: pull the command out of the note and run it, this time with a proxy binary that works.
+	var recover string
+	for _, line := range strings.Split(note, "\n") {
+		if strings.Contains(line, "start-proxy.sh") && strings.Contains(line, "--unrouted") {
+			recover = strings.TrimSpace(line)
+			break
+		}
+	}
+	if recover == "" {
+		t.Fatalf("the note offers no runnable recovery command:\n%s", note)
+	}
+
+	argvFile := filepath.Join(dir, "argv")
+	fake := filepath.Join(dir, "fake-proxy")
+	py := requireTool(t, "python3")
+	script := "#!/usr/bin/env bash\n" +
+		"printf '%s\\n' \"$*\" > " + argvFile + "\n" +
+		"exec " + py + " -c '\n" +
+		"import http.server\n" +
+		"class H(http.server.BaseHTTPRequestHandler):\n" +
+		"    def do_GET(self):\n" +
+		"        self.send_response(200); self.end_headers(); self.wfile.write(b\"ok\")\n" +
+		"    def log_message(self, *a): pass\n" +
+		"http.server.HTTPServer((\"127.0.0.1\", " + port + "), H).serve_forever()\n'\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately NOT carrying the CLAUDE_PLUGIN_OPTION_* values: a terminal does not have them, which
+	// is the whole reason the printed command has to pass them as flags. Only CONTEXT_GURU_BIN and the
+	// state/tmp redirections are kept, because the test cannot install a real binary.
+	run := exec.Command("bash", "-c", recover)
+	run.Env = append(os.Environ(),
+		"CLAUDE_PLUGIN_OPTION_PORT=", "CLAUDE_PLUGIN_OPTION_PRESET=", "CLAUDE_PLUGIN_OPTION_IDLE_EXIT=",
+		"CLAUDE_PLUGIN_OPTION_UPSTREAM=", "ANTHROPIC_BASE_URL=", "ANTHROPIC_UPSTREAM=",
+		"CONTEXT_GURU_BIN="+fake,
+		"XDG_STATE_HOME="+state,
+		"TMPDIR="+dir)
+	out2, err := run.CombinedOutput()
+	t.Cleanup(func() {
+		if pb, e := os.ReadFile(filepath.Join(stateDir, "proxy-"+port+".pid")); e == nil {
+			exec.Command("kill", strings.TrimSpace(string(pb))).Run() //nolint:errcheck
+		}
+	})
+	if err != nil {
+		t.Fatalf("the printed recovery command failed: %v\n%s", err, out2)
+	}
+	argv, rerr := os.ReadFile(argvFile)
+	if rerr != nil {
+		t.Fatalf("the printed recovery command never launched a proxy: %v\nnote:\n%s\nrun:\n%s",
+			rerr, note, out2)
+	}
+	got := string(argv)
+	t.Logf("recovery command launched: %s", got)
+
+	for _, want := range []struct{ what, needle string }{
+		{"the configured port", "--listen 127.0.0.1:" + port},
+		{"the keep-alive config (omitting it turns off keep-alive the user is paying for)", "--config " + keepalive},
+		{"the configured upstream (omitting it bypasses the gateway holding their credential)", "--anthropic-upstream " + upstream},
+		{"the configured idle-exit (omitting it leaves a proxy that never exits)", "--idle-exit=" + idle},
+		{"the dashboard flags", "--dashboard"},
+	} {
+		if !strings.Contains(got, want.needle) {
+			t.Errorf("the recovered proxy is missing %s: wanted %q in\n\t%s", want.what, want.needle, got)
+		}
+	}
+	// The pidfile is what uninstall uses; a recovery proxy it cannot find is unstoppable.
+	if _, err := os.Stat(filepath.Join(stateDir, "proxy-"+port+".pid")); err != nil {
+		t.Errorf("no pidfile, so uninstall could not stop the recovered proxy: %v", err)
+	}
+}
+
+// TestCheckProxySaysSoWhenThereIsNoStarterToPointAt: with CLAUDE_PLUGIN_ROOT wrong or the plugin
+// half-installed there is no script to delegate to. The note must say that rather than fall back to a
+// hand-written command line — reintroducing the duplicate in the one case where nothing is verifiable is
+// how the original defect would come back.
+func TestCheckProxySaysSoWhenThereIsNoStarterToPointAt(t *testing.T) {
+	requireTool(t, "bash")
+	dir := t.TempDir()
+	port := freePort(t)
+	cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "check-proxy.sh"))
+	cmd.Env = append(os.Environ(),
+		"CLAUDE_PLUGIN_ROOT="+filepath.Join(dir, "not-the-plugin"),
+		"CLAUDE_PLUGIN_OPTION_PORT="+port,
+		"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+		"CONTEXT_GURU_HEALTH_BUDGET=1",
+		"XDG_STATE_HOME="+filepath.Join(dir, "state"),
+		"TMPDIR="+dir)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("must never fail a prompt: %v\n%s", err, b)
+	}
+	note := string(b)
+	t.Logf("note ->\n%s", note)
+	if strings.Contains(note, "context-guru-proxy --listen") {
+		t.Errorf("fell back to a hand-rolled command line, which is the defect this replaced:\n%s", note)
+	}
+	if !strings.Contains(note, "not where this hook expects it") {
+		t.Errorf("the missing starter is not reported:\n%s", note)
+	}
+	if !strings.Contains(note, "/context-guru:install") {
+		t.Errorf("no way forward is offered:\n%s", note)
+	}
+}
+
+// TestStartProxyTakesPresetAndIdleExitAsArguments: both existed only as CLAUDE_PLUGIN_OPTION_* reads,
+// which a terminal does not have — so the command check-proxy.sh prints could not carry them without an
+// env prefix, and this file's own gate comment records a human losing three rounds of debugging to a
+// pasted env prefix that split across lines and became a no-op.
+func TestStartProxyTakesPresetAndIdleExitAsArguments(t *testing.T) {
+	requireTool(t, "bash")
+	dir := t.TempDir()
+	argvFile := filepath.Join(dir, "argv")
+	fake := filepath.Join(dir, "fake-proxy")
+	body := "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > " + argvFile + "\nprintenv PRESET >> " +
+		argvFile + "\nsleep 30\n"
+	if err := os.WriteFile(fake, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	port := freePort(t)
+	state := filepath.Join(dir, "state")
+	cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "start-proxy.sh"),
+		"--unrouted", "--bin", fake, "--port", port, "--preset", "house", "--idle-exit", "90m")
+	// The options say something DIFFERENT, so a passing test cannot be reading them instead.
+	cmd.Env = append(os.Environ(),
+		"CLAUDE_PLUGIN_OPTION_PRESET=codesmart",
+		"CLAUDE_PLUGIN_OPTION_IDLE_EXIT=24h",
+		"ANTHROPIC_BASE_URL=",
+		"CONTEXT_GURU_BIN=",
+		"CONTEXT_GURU_HEALTH_BUDGET=1",
+		"XDG_STATE_HOME="+state,
+		"TMPDIR="+dir)
+	out, err := cmd.CombinedOutput()
+	t.Cleanup(func() { exec.Command("pkill", "-f", fake).Run() }) //nolint:errcheck
+	if err != nil {
+		t.Fatalf("must never fail a session: %v\n%s", err, out)
+	}
+	got, rerr := os.ReadFile(argvFile)
+	if rerr != nil {
+		t.Fatalf("the proxy never ran: %v\n%s", rerr, out)
+	}
+	launched := string(got)
+	t.Logf("launched: %s", launched)
+	if !strings.Contains(launched, "--idle-exit=90m") {
+		t.Errorf("--idle-exit was not honoured as an argument: %s", launched)
+	}
+	if strings.Contains(launched, "--idle-exit=24h") {
+		t.Errorf("the option beat the argument for idle-exit: %s", launched)
+	}
+	// PRESET reaches the proxy as an environment variable, so it is printed by the fake rather than argv.
+	if !strings.Contains(launched, "house") {
+		t.Errorf("--preset was not honoured as an argument: %s", launched)
+	}
+	if strings.Contains(launched, "codesmart") {
+		t.Errorf("the option beat the argument for preset: %s", launched)
+	}
 }
 
 // TestStartProxyReportsThePresetActuallyInEffect: the success note used to print $PRESET, which comes

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -2952,6 +2952,30 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 	t.Logf("scanned %d skills", checked)
 }
 
+// hasArgvFlag reports whether argv contains flag as a WHOLE token, and flagValue returns the token
+// after it. Substring matching is not good enough here and the difference is not academic:
+// `--dashboard` is a PREFIX of `--dashboard-db`, so `strings.Contains(argv, "--dashboard")` is
+// satisfied by the flag that follows it. Review deleted `--dashboard` from start-proxy.sh's launch
+// line and the assertion that exists to catch exactly that stayed green, with the dashboard off and
+// /dashboard/ returning 404.
+func hasArgvFlag(argv []string, flag string) bool {
+	for _, f := range argv {
+		if f == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func argvFlagValue(argv []string, flag string) (string, bool) {
+	for i, f := range argv {
+		if f == flag && i+1 < len(argv) {
+			return argv[i+1], true
+		}
+	}
+	return "", false
+}
+
 // TestCheckProxyRecoveryCommandIsTheRealLaunchPath: the note printed when nothing answers on the port
 // used to carry a hand-rolled `context-guru-proxy --listen … --preset …`, and that duplicate had drifted
 // from what start-proxy.sh actually launches in four ways at once — it named the plugin option's preset
@@ -2965,122 +2989,146 @@ func TestNoSkillBlockReadsAPluginOption(t *testing.T) {
 // then asserts on the argv the proxy was launched with. A flag list can be repaired and drift again; what
 // has to hold is that the printed command produces the same proxy the hook would have started.
 func TestCheckProxyRecoveryCommandIsTheRealLaunchPath(t *testing.T) {
-	requireTool(t, "bash")
-	const preset, idle, upstream = "house", "90m", "http://gw.example:4000"
-
-	dir := t.TempDir()
-	state := filepath.Join(dir, "state")
-	stateDir := filepath.Join(state, "context-guru")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	port := freePort(t)
-	// A keep-alive config exists, which is the case the old command silently discarded.
-	keepalive := filepath.Join(stateDir, "keepalive-"+port+".yaml")
-	if err := os.WriteFile(keepalive, []byte("preset: "+preset+"\ncache:\n  keepalive: true\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Step 1: get the note. Auto-recovery has to FAIL for it to print, so the binary does not exist.
-	root, err := filepath.Abs(".")
-	if err != nil {
-		t.Fatal(err)
-	}
-	env := append(os.Environ(),
-		"CLAUDE_PLUGIN_ROOT="+root,
-		"CLAUDE_PLUGIN_OPTION_PORT="+port,
-		"CLAUDE_PLUGIN_OPTION_PRESET="+preset,
-		"CLAUDE_PLUGIN_OPTION_IDLE_EXIT="+idle,
-		"CLAUDE_PLUGIN_OPTION_UPSTREAM="+upstream,
-		"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
-		"CONTEXT_GURU_BIN="+filepath.Join(dir, "does-not-exist"),
-		"CONTEXT_GURU_HEALTH_BUDGET=1",
-		"XDG_STATE_HOME="+state,
-		"TMPDIR="+dir)
-	cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "check-proxy.sh"))
-	cmd.Env = env
-	b, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("check-proxy.sh must never fail a prompt: %v\n%s", err, b)
-	}
-	note := string(b)
-	t.Logf("note ->\n%s", note)
-
-	// The duplicated command line must be gone, not merely corrected.
-	if strings.Contains(note, "context-guru-proxy --listen") {
-		t.Errorf("the note still prints a hand-rolled proxy command line; that duplicate is what drifted "+
-			"from the real launch path four times:\n%s", note)
-	}
-
-	// Step 2: pull the command out of the note and run it, this time with a proxy binary that works.
-	var recover string
-	for _, line := range strings.Split(note, "\n") {
-		if strings.Contains(line, "start-proxy.sh") && strings.Contains(line, "--unrouted") {
-			recover = strings.TrimSpace(line)
-			break
-		}
-	}
-	if recover == "" {
-		t.Fatalf("the note offers no runnable recovery command:\n%s", note)
-	}
-
-	argvFile := filepath.Join(dir, "argv")
-	fake := filepath.Join(dir, "fake-proxy")
-	py := requireTool(t, "python3")
-	script := "#!/usr/bin/env bash\n" +
-		"printf '%s\\n' \"$*\" > " + argvFile + "\n" +
-		"exec " + py + " -c '\n" +
-		"import http.server\n" +
-		"class H(http.server.BaseHTTPRequestHandler):\n" +
-		"    def do_GET(self):\n" +
-		"        self.send_response(200); self.end_headers(); self.wfile.write(b\"ok\")\n" +
-		"    def log_message(self, *a): pass\n" +
-		"http.server.HTTPServer((\"127.0.0.1\", " + port + "), H).serve_forever()\n'\n"
-	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Deliberately NOT carrying the CLAUDE_PLUGIN_OPTION_* values: a terminal does not have them, which
-	// is the whole reason the printed command has to pass them as flags. Only CONTEXT_GURU_BIN and the
-	// state/tmp redirections are kept, because the test cannot install a real binary.
-	run := exec.Command("bash", "-c", recover)
-	run.Env = append(os.Environ(),
-		"CLAUDE_PLUGIN_OPTION_PORT=", "CLAUDE_PLUGIN_OPTION_PRESET=", "CLAUDE_PLUGIN_OPTION_IDLE_EXIT=",
-		"CLAUDE_PLUGIN_OPTION_UPSTREAM=", "ANTHROPIC_BASE_URL=", "ANTHROPIC_UPSTREAM=",
-		"CONTEXT_GURU_BIN="+fake,
-		"XDG_STATE_HOME="+state,
-		"TMPDIR="+dir)
-	out2, err := run.CombinedOutput()
-	t.Cleanup(func() {
-		if pb, e := os.ReadFile(filepath.Join(stateDir, "proxy-"+port+".pid")); e == nil {
-			exec.Command("kill", strings.TrimSpace(string(pb))).Run() //nolint:errcheck
-		}
-	})
-	if err != nil {
-		t.Fatalf("the printed recovery command failed: %v\n%s", err, out2)
-	}
-	argv, rerr := os.ReadFile(argvFile)
-	if rerr != nil {
-		t.Fatalf("the printed recovery command never launched a proxy: %v\nnote:\n%s\nrun:\n%s",
-			rerr, note, out2)
-	}
-	got := string(argv)
-	t.Logf("recovery command launched: %s", got)
-
-	for _, want := range []struct{ what, needle string }{
-		{"the configured port", "--listen 127.0.0.1:" + port},
-		{"the keep-alive config (omitting it turns off keep-alive the user is paying for)", "--config " + keepalive},
-		{"the configured upstream (omitting it bypasses the gateway holding their credential)", "--anthropic-upstream " + upstream},
-		{"the configured idle-exit (omitting it leaves a proxy that never exits)", "--idle-exit=" + idle},
-		{"the dashboard flags", "--dashboard"},
+	// The upstream cases matter because the printed command is re-parsed by the user's shell. An
+	// unquoted `&` backgrounds the command mid-way, so the paste succeeds, starts a proxy, and chains it
+	// to a TRUNCATED upstream with nothing said — a silent partial success, which is the same failure
+	// mode as everything else in this file.
+	for _, c := range []struct{ name, upstream string }{
+		{"a plain upstream", "http://gw.example:4000"},
+		{"an upstream whose query string contains &", "http://gw.example:4000/v1?tenant=acme&mode=chain"},
 	} {
-		if !strings.Contains(got, want.needle) {
-			t.Errorf("the recovered proxy is missing %s: wanted %q in\n\t%s", want.what, want.needle, got)
-		}
-	}
-	// The pidfile is what uninstall uses; a recovery proxy it cannot find is unstoppable.
-	if _, err := os.Stat(filepath.Join(stateDir, "proxy-"+port+".pid")); err != nil {
-		t.Errorf("no pidfile, so uninstall could not stop the recovered proxy: %v", err)
+		t.Run(c.name, func(t *testing.T) {
+			requireTool(t, "bash")
+			const preset, idle = "house", "90m"
+
+			dir := t.TempDir()
+			state := filepath.Join(dir, "state")
+			stateDir := filepath.Join(state, "context-guru")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			port := freePort(t)
+			// A keep-alive config exists, which is the case the old command silently discarded.
+			keepalive := filepath.Join(stateDir, "keepalive-"+port+".yaml")
+			if err := os.WriteFile(keepalive, []byte("preset: "+preset+"\ncache:\n  keepalive: true\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: get the note. Auto-recovery has to FAIL for it to print, so the binary is absent.
+			root, err := filepath.Abs(".")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "check-proxy.sh"))
+			cmd.Env = append(os.Environ(),
+				"CLAUDE_PLUGIN_ROOT="+root,
+				"CLAUDE_PLUGIN_OPTION_PORT="+port,
+				"CLAUDE_PLUGIN_OPTION_PRESET="+preset,
+				"CLAUDE_PLUGIN_OPTION_IDLE_EXIT="+idle,
+				"CLAUDE_PLUGIN_OPTION_UPSTREAM="+c.upstream,
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+				"CONTEXT_GURU_BIN="+filepath.Join(dir, "does-not-exist"),
+				"CONTEXT_GURU_HEALTH_BUDGET=1",
+				"XDG_STATE_HOME="+state,
+				"TMPDIR="+dir)
+			b, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("check-proxy.sh must never fail a prompt: %v\n%s", err, b)
+			}
+			note := string(b)
+			t.Logf("note ->\n%s", note)
+
+			// The duplicated command line must be gone, not merely corrected.
+			if strings.Contains(note, "context-guru-proxy --listen") {
+				t.Errorf("the note still prints a hand-rolled proxy command line; that duplicate is what "+
+					"drifted from the real launch path four times:\n%s", note)
+			}
+
+			// Step 2: pull the command out of the note and run it, with a proxy binary that works.
+			var recover string
+			for _, line := range strings.Split(note, "\n") {
+				if strings.Contains(line, "start-proxy.sh") && strings.Contains(line, "--unrouted") {
+					recover = strings.TrimSpace(line)
+					break
+				}
+			}
+			if recover == "" {
+				t.Fatalf("the note offers no runnable recovery command:\n%s", note)
+			}
+
+			argvFile := filepath.Join(dir, "argv")
+			fake := filepath.Join(dir, "fake-proxy")
+			py := requireTool(t, "python3")
+			script := "#!/usr/bin/env bash\n" +
+				"printf '%s\\n' \"$*\" > " + argvFile + "\n" +
+				"exec " + py + " -c '\n" +
+				"import http.server\n" +
+				"class H(http.server.BaseHTTPRequestHandler):\n" +
+				"    def do_GET(self):\n" +
+				"        self.send_response(200); self.end_headers(); self.wfile.write(b\"ok\")\n" +
+				"    def log_message(self, *a): pass\n" +
+				"http.server.HTTPServer((\"127.0.0.1\", " + port + "), H).serve_forever()\n'\n"
+			if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			// Deliberately NOT carrying the CLAUDE_PLUGIN_OPTION_* values: a terminal does not have them,
+			// which is the whole reason the printed command has to pass them as flags. Only CONTEXT_GURU_BIN
+			// and the state/tmp redirections are kept, because the test cannot install a real binary.
+			run := exec.Command("bash", "-c", recover)
+			run.Env = append(os.Environ(),
+				"CLAUDE_PLUGIN_OPTION_PORT=", "CLAUDE_PLUGIN_OPTION_PRESET=", "CLAUDE_PLUGIN_OPTION_IDLE_EXIT=",
+				"CLAUDE_PLUGIN_OPTION_UPSTREAM=", "ANTHROPIC_BASE_URL=", "ANTHROPIC_UPSTREAM=",
+				"CONTEXT_GURU_BIN="+fake,
+				"XDG_STATE_HOME="+state,
+				"TMPDIR="+dir)
+			out2, err := run.CombinedOutput()
+			t.Cleanup(func() {
+				if pb, e := os.ReadFile(filepath.Join(stateDir, "proxy-"+port+".pid")); e == nil {
+					exec.Command("kill", strings.TrimSpace(string(pb))).Run() //nolint:errcheck
+				}
+			})
+			if err != nil {
+				t.Fatalf("the printed recovery command failed: %v\n%s", err, out2)
+			}
+			raw, rerr := os.ReadFile(argvFile)
+			if rerr != nil {
+				t.Fatalf("the printed recovery command never launched a proxy: %v\nnote:\n%s\nrun:\n%s",
+					rerr, note, out2)
+			}
+			argv := strings.Fields(string(raw))
+			t.Logf("recovery command launched: %s", strings.TrimSpace(string(raw)))
+
+			// Flags carrying a value: assert the VALUE, so a truncated one fails.
+			for _, want := range []struct{ what, flag, value string }{
+				{"the configured port", "--listen", "127.0.0.1:" + port},
+				{"the keep-alive config (omitting it turns off keep-alive the user is paying for)",
+					"--config", keepalive},
+				{"the configured upstream (a truncated one bypasses the gateway holding their credential)",
+					"--anthropic-upstream", c.upstream},
+			} {
+				got, ok := argvFlagValue(argv, want.flag)
+				if !ok {
+					t.Errorf("the recovered proxy never got %s (%s missing): %v", want.what, want.flag, argv)
+					continue
+				}
+				if got != want.value {
+					t.Errorf("%s is wrong: %s = %q, want %q", want.what, want.flag, got, want.value)
+				}
+			}
+			// Whole-token flags. --dashboard MUST be matched as a token: it is a prefix of --dashboard-db,
+			// and a substring check here passed with the bare flag deleted and the dashboard off.
+			for _, flag := range []string{"--dashboard", "--idle-exit=" + idle} {
+				if !hasArgvFlag(argv, flag) {
+					t.Errorf("the recovered proxy is missing %s, so it is not the proxy the hook would have "+
+						"started: %v", flag, argv)
+				}
+			}
+			// The pidfile is what uninstall uses; a recovery proxy it cannot find is unstoppable.
+			if _, err := os.Stat(filepath.Join(stateDir, "proxy-"+port+".pid")); err != nil {
+				t.Errorf("no pidfile, so uninstall could not stop the recovered proxy: %v", err)
+			}
+		})
 	}
 }
 

--- a/context-guru-plugin/scripts/check-proxy.sh
+++ b/context-guru-plugin/scripts/check-proxy.sh
@@ -89,9 +89,18 @@ PRESET="${CLAUDE_PLUGIN_OPTION_PRESET:-cache}"
 IDLE_EXIT="${CLAUDE_PLUGIN_OPTION_IDLE_EXIT:-24h}"
 UPSTREAM="${CLAUDE_PLUGIN_OPTION_UPSTREAM:-${ANTHROPIC_UPSTREAM:-}}"
 if [ -x "$STARTER" ]; then
-  RECOVER="\"${STARTER}\" --unrouted --port ${PORT} --preset ${PRESET} --idle-exit ${IDLE_EXIT}"
+  # Every interpolated value is SINGLE-quoted in the printed text, because this string is not run here
+  # — it is pasted into a human's shell, where it is re-parsed. An upstream is the realistic case:
+  # `http://gw.example:4000/v1?tenant=acme&mode=chain` unquoted makes the `&` background the command at
+  # that point, so the paste exits 0, starts a proxy, and chains it to a TRUNCATED upstream
+  # (…?tenant=acme) with nothing said. A space truncates the same way, and `;` would run the remainder.
+  #
+  # Single quotes rather than double: double quotes still expand `$` and backticks in the user's shell,
+  # so a value containing either would be silently rewritten at paste time. Single quotes suppress all
+  # of it, and none of these values can legitimately contain an apostrophe.
+  RECOVER="\"${STARTER}\" --unrouted --port '${PORT}' --preset '${PRESET}' --idle-exit '${IDLE_EXIT}'"
   if [ -n "$UPSTREAM" ]; then
-    RECOVER="${RECOVER} --upstream ${UPSTREAM}"
+    RECOVER="${RECOVER} --upstream '${UPSTREAM}'"
   fi
   HOW="To fix it now, in a terminal. This is the same script the hook runs, so it picks up your
 keep-alive config, the dashboard flags and the pidfile uninstall looks for, without you restating any

--- a/context-guru-plugin/scripts/check-proxy.sh
+++ b/context-guru-plugin/scripts/check-proxy.sh
@@ -60,19 +60,62 @@ if [ -x "${CLAUDE_PLUGIN_ROOT:-}/scripts/start-proxy.sh" ]; then
 fi
 
 LOG="${TMPDIR:-/tmp}/context-guru-proxy-${PORT}.log"
-# Same state directory the starter uses, so the command printed below writes its dashboard DB
-# where the hook-started proxy would have, and not into the user's repository.
-STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/context-guru"
+STARTER="${CLAUDE_PLUGIN_ROOT:-}/scripts/start-proxy.sh"
+
+# The recovery command DELEGATES to start-proxy.sh instead of restating its command line.
+#
+# It used to print a hand-rolled `context-guru-proxy --listen … --preset …`, and that duplicate had
+# drifted from the real launch path in four ways at once. It named CLAUDE_PLUGIN_OPTION_PRESET, which
+# --config replaces anyway; and it omitted --config, --anthropic-upstream and --idle-exit. Pasting it
+# therefore turned keep-alive OFF for somebody who had explicitly enabled it and was paying for the
+# pings, bypassed a configured gateway (which on a platform whose gateway rewrites model names makes
+# every request fail), and left a proxy that never idle-exits holding the port. Every one of those was
+# silent, at the moment the user is already troubleshooting.
+#
+# A repaired flag list would drift again the next time start-proxy.sh gains one — which is exactly how
+# those four were each missed in turn. Delegation cannot.
+#
+# Everything is passed as FLAGS, never as an env prefix. start-proxy.sh's own gate comment records what
+# an env prefix costs a human: a pasted invocation split across two lines, the assignments became a
+# no-op statement, the script ran unrouted and exited without a word. That is why --preset and
+# --idle-exit gained argument forms alongside --port and --upstream.
+#
+# --unrouted is required, not optional: settings `env` values reach hook processes, not interactive
+# shells, so ANTHROPIC_BASE_URL is absent in the user's terminal and start-proxy.sh's gate would
+# otherwise decline and do nothing. The port and preset must be passed for the same reason — the
+# CLAUDE_PLUGIN_OPTION_* values this hook can see are invisible there, so a bare invocation would
+# start on 8787 with the default preset.
+PRESET="${CLAUDE_PLUGIN_OPTION_PRESET:-cache}"
+IDLE_EXIT="${CLAUDE_PLUGIN_OPTION_IDLE_EXIT:-24h}"
+UPSTREAM="${CLAUDE_PLUGIN_OPTION_UPSTREAM:-${ANTHROPIC_UPSTREAM:-}}"
+if [ -x "$STARTER" ]; then
+  RECOVER="\"${STARTER}\" --unrouted --port ${PORT} --preset ${PRESET} --idle-exit ${IDLE_EXIT}"
+  if [ -n "$UPSTREAM" ]; then
+    RECOVER="${RECOVER} --upstream ${UPSTREAM}"
+  fi
+  HOW="To fix it now, in a terminal. This is the same script the hook runs, so it picks up your
+keep-alive config, the dashboard flags and the pidfile uninstall looks for, without you restating any
+of them:
+  ${RECOVER}
+Log from the last attempt: ${LOG}"
+else
+  # No starter to point at means the install is broken in a way the user has to fix anyway. Say that,
+  # rather than falling back to a hand-written command line — reintroducing the duplicate here would
+  # reintroduce the drift, in the one situation where nothing can be verified.
+  HOW="This plugin's start-proxy.sh is not where this hook expects it:
+  ${STARTER}
+so there is no command to hand you that would be safe to run — writing one out would mean restating
+the proxy's flags, and a stale copy of that list is what made this note wrong before. Reinstall with
+/context-guru:install from a session that still works.
+Log from the last attempt: ${LOG}"
+fi
+
 cat <<EOF
 context-guru: this project is routed through http://127.0.0.1:${PORT}/anthropic, and nothing is
 answering there. **Your request will hang with no error message** — that is what a dead proxy looks
 like from inside Claude Code, and it is why this note exists rather than a skill.
 
-To fix it now, in a terminal (the dashboard flags matter: without them /dashboard/ is a 404, and
-this proxy would then hold the port for the whole --idle-exit window with no way to notice why):
-  context-guru-proxy --listen 127.0.0.1:${PORT} --preset ${CLAUDE_PLUGIN_OPTION_PRESET:-cache} \\
-    --dashboard --dashboard-db "${STATE_DIR}/dashboard-${PORT}.db"
-Log from the last attempt: ${LOG}
+${HOW}
 
 To stop routing entirely and get working immediately, remove env.ANTHROPIC_BASE_URL from
 .claude/settings.local.json (or run /context-guru:uninstall from a session that still works).

--- a/context-guru-plugin/scripts/start-proxy.sh
+++ b/context-guru-plugin/scripts/start-proxy.sh
@@ -98,6 +98,15 @@ UPSTREAM_ARG=""
 # covered by the same permission rule as the rest of the command, and needs no symlink.
 BIN_ARG=""
 PORT_ARG=""
+# --preset and --idle-exit, the last two options that existed only as CLAUDE_PLUGIN_OPTION_* reads.
+#
+# They are here so a command handed to a HUMAN can carry them as flags. The alternative is an env
+# prefix, and this file already records what that costs: a pasted env-prefixed invocation split
+# across two lines, the assignments became a no-op statement, the script ran unrouted and exited
+# without a word, and three rounds of guessing followed. check-proxy.sh prints exactly such a
+# recovery command, so every value it needs to pass must have an argument form.
+PRESET_ARG=""
+IDLE_EXIT_ARG=""
 # Every discarded or malformed argument is REPORTED, never swallowed.
 #
 # The first version of this loop had no `*)` branch and took `$2` for `--upstream` on faith. All three
@@ -144,6 +153,10 @@ while [ $# -gt 0 ]; do
     # form twice over; this one was missed both times.
     --port) if takes_value --port "${2:-}"; then PORT_ARG="$2"; shift; fi ;;
     --port=*) if takes_value --port "${1#--port=}"; then PORT_ARG="${1#--port=}"; fi ;;
+    --preset) if takes_value --preset "${2:-}"; then PRESET_ARG="$2"; shift; fi ;;
+    --preset=*) if takes_value --preset "${1#--preset=}"; then PRESET_ARG="${1#--preset=}"; fi ;;
+    --idle-exit) if takes_value --idle-exit "${2:-}"; then IDLE_EXIT_ARG="$2"; shift; fi ;;
+    --idle-exit=*) if takes_value --idle-exit "${1#--idle-exit=}"; then IDLE_EXIT_ARG="${1#--idle-exit=}"; fi ;;
     *) note "ignoring unrecognised argument '$1'" ;;
   esac
   shift
@@ -152,6 +165,15 @@ FORCE="$START_UNROUTED"
 # BIN was resolved at the top from CONTEXT_GURU_BIN or the bare name; an explicit --bin overrides both.
 if [ -n "$BIN_ARG" ]; then
   BIN="$BIN_ARG"
+fi
+# An explicit --preset / --idle-exit overrides the option read at the top, same precedence as --bin.
+# Note this does NOT override a keepalive --config: that file states its own preset and --config
+# replaces the preset entirely, which is why the success note reports what the config says.
+if [ -n "$PRESET_ARG" ]; then
+  PRESET="$PRESET_ARG"
+fi
+if [ -n "$IDLE_EXIT_ARG" ]; then
+  IDLE_EXIT="$IDLE_EXIT_ARG"
 fi
 # PORT likewise, and everything derived from it has to be recomputed — the gate below compares against
 # it, and the log, pidfile, health URL and dashboard DB are all named after it. Re-deriving them here


### PR DESCRIPTION
Closes #225. Closes #226.

`check-proxy.sh` runs on `UserPromptSubmit` and, when nothing answers on the routed port, prints a command for the user to run in a terminal. That command was a hand-rolled `context-guru-proxy --listen … --preset …` — a second copy of what `start-proxy.sh` builds — and it had drifted from the real launch path **four ways at once**:

| Omission | What pasting it did |
|---|---|
| named `CLAUDE_PLUGIN_OPTION_PRESET` | reported a preset `--config` replaces anyway |
| no `--config` | **turned keep-alive off** for someone who enabled it and was paying for the pings |
| no `--anthropic-upstream` | **bypassed a configured gateway** — on a platform whose gateway rewrites model names, every request then fails |
| no `--idle-exit` | left a proxy that **never exits**, holding the port |

All silent, at the moment the user is already troubleshooting a hung session.

## Delegation, not a repaired flag list

A corrected list would still be a second copy of `start-proxy.sh`'s command line — and a second copy is precisely what drifted, since those four flags were each missed as they were added. The note now points at `start-proxy.sh`, which this script already invokes fourteen lines earlier for its automatic recovery attempt. Anything that script gains is picked up for free.

Where there is no starter to point at (wrong `CLAUDE_PLUGIN_ROOT`, half-installed plugin), the note says so and directs the user at `/context-guru:install`. It deliberately does **not** fall back to a hand-written command: reintroducing the duplicate in the one case where nothing can be verified is how this defect would come back.

## Why `--preset` and `--idle-exit` gained argument forms

A bare `start-proxy.sh` would **silently do nothing** from a terminal. Settings `env` values reach hook processes, not interactive shells, so `ANTHROPIC_BASE_URL` is absent there and the script's own gate declines and exits 0. Every `CLAUDE_PLUGIN_OPTION_*` is absent for the same reason, so it would also start on 8787 with the default preset — #221's class, reintroduced by the fix.

So the printed command must carry `--unrouted`, the port, and the preset explicitly. An env prefix was the obvious alternative and is the wrong shape — `start-proxy.sh`'s own gate comment records what it cost a human:

> A human pasted a long env-prefixed invocation, the paste split across two lines so the assignments became a no-op statement, the script ran unrouted and exited here without a word — no output, no log, no pidfile. Three rounds of guessing followed.

`--port`, `--upstream` and `--bin` already existed as arguments for that reason. `--preset` and `--idle-exit` were the two left, and now match, with the same `takes_value` validation and the same argument-beats-option precedence as `--bin`.

## The test runs the command, it doesn't read it

`TestCheckProxyRecoveryCommandIsTheRealLaunchPath` extracts the printed command and **executes** it — against a keep-alive config and a configured upstream — then asserts on the argv the proxy is actually launched with, plus the pidfile (a recovery proxy `uninstall` can't find is unstoppable). The second run clears every `CLAUDE_PLUGIN_OPTION_*`, because that is what a terminal looks like and is the whole reason the flags must be there.

```
--listen 127.0.0.1:40053  --idle-exit=90m  --dashboard  --dashboard-db …
--anthropic-upstream http://gw.example:4000  --config …/keepalive-40053.yaml
```

A wording assertion would have passed on all four original omissions.

## One existing test changed, not deleted

`TestCheckHookFinishesInsideItsOwnTimeout` asserted the literal `--dashboard`, commented *"the printed recovery command must not recreate the 404 dashboard"*. The note no longer restates flags, so that string is gone **by design** — and a failing assertion is the right place to be made to justify a change like this.

The property did not move to prose. It moved somewhere stronger: the new test asserts `--dashboard` in the **launched argv**. What the timeout test checks now is that this path still hands the user something runnable (`start-proxy.sh`, `--unrouted`), which is what it can observe from where it stands.

## Verification

Eval box, Go 1.26.4, `go test -race -count=1`, `CGO_ENABLED=1`. `-count=1` throughout, since the test cache does not track shell scripts read at runtime. **Eight mutations**, each proven to land, each failing the test named for it, each file restored byte-identical (`cmp`):

```
hand-rolled command line restored     -> the-real-launch-path        FAILED
--unrouted dropped                    -> FAILED (self-gates, launches nothing)
--port dropped                        -> FAILED (recovers on 8787, not the configured port)
--upstream branch dropped             -> FAILED (missing --anthropic-upstream)
--idle-exit dropped                   -> FAILED (missing --idle-exit)
start-proxy --idle-exit arg removed   -> takes-preset-and-idle-exit  FAILED (option beat argument)
start-proxy --preset arg removed      -> takes-preset-and-idle-exit  FAILED
no-starter branch given a fallback    -> no-starter-to-point-at      FAILED
```

Full suite: **29 packages ok, 0 failures, exit 0**. `gofmt -l` empty, `go vet` clean.

## On the two issues

#226 is my own duplicate of #225, filed before I saw it. #225 is the better of the two — it caught `--idle-exit`, which I had missed. Both are closed here and now cross-reference each other.
