### PR TITLE
feat(plugin): add an escape hatch that works when Claude Code cannot

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ needed on a Pro/Max subscription** ([details](docs/how-to/install-plugin.md)):
 /context-guru:install
 ```
 
+**If it ever breaks and Claude cannot fix it:** `~/.local/state/context-guru/context-guru-reset`
+undoes the routing from a plain terminal — no working Claude session, no proxy, no network. Routing
+every request through a local proxy means a failure there fails every request, including the ones the
+uninstall skill would need, so the way out cannot itself be a skill.
+
 `/reload-plugins` is what makes the `/context-guru:*` skills exist in this session; without it the
 last line answers `Unknown command`. A new session does the same thing.
 

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -4184,3 +4184,190 @@ func TestRemoveIsNeverGatedByScope(t *testing.T) {
 		t.Errorf("removal damaged the machine-wide file")
 	}
 }
+
+// --- fixes from review round 1 of #236 -----------------------------------------------------
+
+// TestRemoveFirstNeverProducesAnOriginalHoldingRouting is the assertion the reviewer asked to have
+// pinned, and it names the defect exactly: record_touch() runs from save(), and save() is ALSO
+// cmd_remove's write path — so when the first recorded touch of a file was a REMOVAL, the O_EXCL
+// "copy taken before the first edit" was a copy of the ROUTED file, permanently. The hatch then
+// faithfully restored routing into an unrouted project.
+//
+// Who reaches it: every pre-hatch install that upgrades and then uninstalls, and anyone whose state
+// directory was wiped between install and remove. That is the population this whole feature is for.
+func TestRemoveFirstNeverProducesAnOriginalHoldingRouting(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.local.json")
+	// A file as a PRE-HATCH install left it: routed, with the metadata that version recorded, and no
+	// pre-edit copy anywhere because that version did not take one.
+	writeJSON(t, path, map[string]any{
+		"env":           map[string]any{"ANTHROPIC_BASE_URL": ourURL},
+		"permissions":   map[string]any{"allow": []string{"Bash(ls:*)"}},
+		"$context-guru": map[string]any{"installed_base_url": ourURL},
+	})
+
+	if _, code := settingsIn(t, state, home, "remove", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("remove failed")
+	}
+	// Whatever the record holds, nothing calling itself a pre-edit copy may contain routing.
+	originals, _ := filepath.Glob(filepath.Join(state, "originals", "*.original"))
+	for _, o := range originals {
+		b, err := os.ReadFile(o)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(b), "ANTHROPIC_BASE_URL") {
+			t.Fatalf("%s is called a pre-edit copy and contains routing:\n%s", o, b)
+		}
+	}
+
+	// End to end: the hatch must not put back what the remove took out.
+	out, code := runHatch(t, state, home, proj, "--yes")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "ANTHROPIC_BASE_URL") {
+		t.Errorf("the recovery tool re-introduced routing (exit %d):\n%s\nfile:\n%s", code, out, b)
+	}
+	if !strings.Contains(string(b), "Bash(ls:*)") {
+		t.Errorf("the user's own permission grant was lost:\n%s", b)
+	}
+}
+
+// TestEmptyPlanNeverClaimsSuccessWhenNothingCouldBeRestored. An empty plan is reached from two very
+// different states — genuinely clean, and "this file is routed and I have no copy to fix it with" —
+// and both used to end on "already back to their pre-install state". Exit 3 was correct, but nobody
+// reads an exit code; they read the last line, and it said the opposite of the truth to the one user
+// who is locked out.
+func TestEmptyPlanNeverClaimsSuccessWhenNothingCouldBeRestored(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": ourURL}})
+	// Routed already, no record: the pre-hatch install picking up a hatch on a no-op re-run.
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("fixture: add failed")
+	}
+
+	out, code := runHatch(t, state, home, proj, "--yes")
+	if code != 3 {
+		t.Errorf("exit %d, want 3", code)
+	}
+	if strings.Contains(out, "already back to their pre-install state") {
+		t.Errorf("told the user they are unrouted while the file is still routed:\n%s", out)
+	}
+	for _, want := range []string{"NOT back to their pre-install state", "ANTHROPIC_BASE_URL"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the honest branch is missing %q:\n%s", want, out)
+		}
+	}
+	if b, _ := os.ReadFile(path); !strings.Contains(string(b), ourURL) {
+		t.Error("it modified a file it has no pre-edit copy of")
+	}
+}
+
+// TestARestoreWarnsThatItRevertsTheWholeFile. The primary path is `cp`, so it reverts everything in
+// the file — and Claude Code appends permission grants to settings.local.json as the user approves
+// tools, so a months-old install means months of grants. The confirmation prompt asked "restore
+// these files?" and said nothing about that, which makes it consent to something unstated.
+func TestARestoreWarnsThatItRevertsTheWholeFile(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"permissions": map[string]any{"allow": []string{"Bash(ls:*)"}}})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	// The user then approves another tool and sets a model, the way a real month of use looks.
+	cur := readJSON(t, path)
+	cur["model"] = "opus"
+	cur["permissions"] = map[string]any{"allow": []string{"Bash(ls:*)", "Bash(git push:*)"}}
+	writeJSON(t, path, cur)
+
+	out, code := runHatch(t, state, home, proj, "--dry-run")
+	if code != 0 {
+		t.Fatalf("dry run: exit %d\n%s", code, out)
+	}
+	flat := strings.Join(strings.Fields(out), " ")
+	for _, want := range []string{
+		"reverts the WHOLE file",
+		"prereset",             // and that it is undoable
+		"The two files differ", // shown as evidence, before the prompt
+	} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("the plan does not warn about %q before asking:\n%s", want, out)
+		}
+	}
+	// It must not claim a filtered count of "your" changes: settings.py rewrites the file with
+	// indent=2, so a compact original differs on every line, and our own metadata spans lines that
+	// carry none of the words such a filter greps out. The first version of this reported 16 lines
+	// of user changes for a file whose only real change was one permission grant.
+	if strings.Contains(flat, "that are NOT context-guru's") {
+		t.Errorf("re-introduced a filtered line count that cannot be computed without a JSON parser:\n%s", out)
+	}
+}
+
+// TestMissingCopyIsNotRenderedAsAPath: the record carries "-" when no copy was ever taken, and
+// printing it verbatim gave "the pre-edit copy is missing (-)" — which reads as a bug in the tool
+// rather than a known limit of what it holds, on the pre-hatch path that is now the common case.
+func TestMissingCopyIsNotRenderedAsAPath(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": ourURL}})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	out, _ := runHatch(t, state, home, proj, "--dry-run")
+	if strings.Contains(out, "missing (-)") {
+		t.Errorf("rendered the empty-copy marker as a path:\n%s", out)
+	}
+	if !strings.Contains(out, "no pre-edit copy was taken") {
+		t.Errorf("did not explain why there is no copy:\n%s", out)
+	}
+}
+
+// TestDryRunAgreesWithARealRunAboutWhatIsLeft: --dry-run exited 0 unconditionally, so it and a real
+// run disagreed about whether anything was left for a human.
+func TestDryRunAgreesWithARealRunAboutWhatIsLeft(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": ourURL}})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	_, dry := runHatch(t, state, home, proj, "--dry-run")
+	_, real := runHatch(t, state, home, proj, "--yes")
+	if dry != real {
+		t.Errorf("--dry-run exited %d but the real run exited %d; they must agree about whether "+
+			"anything is left for a human", dry, real)
+	}
+}
+
+// TestAnUnusableStateDirectoryNeverFailsTheInstall. "Fail open, always" is a hard boundary in this
+// repo, and the hatch machinery is the newest thing in the write path. An install that would
+// otherwise have worked must not be broken by the recovery bookkeeping — it must report that the
+// hatch is unavailable and carry on.
+func TestAnUnusableStateDirectoryNeverFailsTheInstall(t *testing.T) {
+	home, proj := t.TempDir(), t.TempDir()
+	// A FILE where the state directory should be, so every path inside it is unusable.
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+
+	facts, code := settingsIn(t, blocked, home, "add", "--file", path, "--url", ourURL)
+	if code != 0 || facts["result"] != "added" {
+		t.Fatalf("an unusable state dir broke the install: exit %d, %v", code, facts)
+	}
+	if facts["reset_hatch"] != "unavailable" {
+		t.Errorf("reset_hatch=%q; it must say so rather than imply a hatch exists", facts["reset_hatch"])
+	}
+	env, _ := readJSON(t, path)["env"].(map[string]any)
+	if env["ANTHROPIC_BASE_URL"] != ourURL {
+		t.Errorf("the routing itself did not get written: %v", env)
+	}
+	if readJSON(t, path)["theme"] != "dark" {
+		t.Error("the user's settings were damaged")
+	}
+}

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -4210,7 +4210,23 @@ func TestRemoveFirstNeverProducesAnOriginalHoldingRouting(t *testing.T) {
 		t.Fatal("remove failed")
 	}
 	// Whatever the record holds, nothing calling itself a pre-edit copy may contain routing.
+	//
+	// The loop below is VACUOUS on its own for this fixture — no copy is the expected outcome, and an
+	// empty glob asserts nothing — so the expected count is asserted explicitly and the record is
+	// checked to say so. Flagged in review as the pattern worth propagating: an absence assertion
+	// needs a companion that proves the path ran.
 	originals, _ := filepath.Glob(filepath.Join(state, "originals", "*.original"))
+	if len(originals) != 0 {
+		t.Errorf("took %d pre-edit copy/copies of a file that was already routed: %v",
+			len(originals), originals)
+	}
+	rec, err := os.ReadFile(filepath.Join(state, "reset-manifest.tsv"))
+	if err != nil {
+		t.Fatalf("no record was written at all, so the rest of this test proves little: %v", err)
+	}
+	if !strings.Contains(string(rec), path) {
+		t.Errorf("the record does not mention the file, so the hatch would not know about it:\n%s", rec)
+	}
 	for _, o := range originals {
 		b, err := os.ReadFile(o)
 		if err != nil {
@@ -4569,5 +4585,223 @@ func TestTroubleshootingLeadsWithTheCommand(t *testing.T) {
 		if !strings.Contains(head, want) {
 			t.Errorf("the first Troubleshooting entry does not cover %q:\n%s", want, head)
 		}
+	}
+}
+
+// --- fixes from review round 3 of #236 -----------------------------------------------------
+
+// redactShapes is the ledger behind reset.sh's `redact` filter, one row per credential shape.
+//
+// It exists because that filter is a DENYLIST on a recovery tool, and a denylist is a list that will
+// be wrong again — it has now been wrong three times in this PR alone, in three different shapes.
+// Inverting it to an allowlist is worse on a diff of arbitrary JSON (it would redact the
+// `permissions` entries the diff exists to show), so the discipline is this table instead: ADD A ROW
+// WHEN YOU ADD A RULE, and the next miss is a row somebody forgot rather than an invisible leak.
+//
+// The must-survive rows matter as much as the leak rows. A filter that redacts everything passes
+// every absence assertion and makes the diff useless, which is the failure this table also pins.
+var redactShapes = []struct {
+	name string
+	line string
+	// secret must not appear in the output. Empty means the line must pass through UNCHANGED.
+	secret string
+}{
+	{"ANTHROPIC_API_KEY", `  "ANTHROPIC_API_KEY": "sk-ant-REALKEY0000",`, "REALKEY0000"},
+	{"ANTHROPIC_AUTH_TOKEN", `  "ANTHROPIC_AUTH_TOKEN": "REALTOKENVALUE",`, "REALTOKENVALUE"},
+	// The one that matters most here, and not a shape invented for the test: this is how a Context
+	// Guru credential is carried on this project's own dev machines, so it is the single most likely
+	// credential to appear in a context-guru user's env block — and its name contains none of
+	// key/token/secret/password/credential, which is why the first two versions of the filter missed
+	// it. HEADER is in the name class because of this row.
+	{"ANTHROPIC_CUSTOM_HEADERS", `  "ANTHROPIC_CUSTOM_HEADERS": "x-context-guru-token: cg_live_REALGURU",`, "REALGURU"},
+	{"authorization bearer JWT", `  "authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.REALJWTBODY",`, "REALJWTBODY"},
+	{"github PAT", `  "GITHUB_PAT": "ghp_REALPAT00000000",`, "REALPAT00000000"},
+	{"credential in a query param", `  "ANTHROPIC_UPSTREAM": "https://gw/anthropic?api_key=REALQUERYKEY",`, "REALQUERYKEY"},
+	{"credential in URL userinfo", `  "MY_GW": "https://svc:REALURLPASS@gw.corp/anthropic",`, "REALURLPASS"},
+	{"slack token", `  "SLACK": "xoxb-REALSLACKTOKEN",`, "REALSLACKTOKEN"},
+	{"aws access key id", `  "AWS_ACCESS_KEY_ID": "AKIAREALAWSKEY0000",`, "REALAWSKEY"},
+	{"bare exported base URL with userinfo", `https://svc:REALURLPASS@gw.corp/anthropic`, "REALURLPASS"},
+
+	{"permission grant must survive", `      "Bash(git push:*)",`, ""},
+	{"model must survive", `  "model": "opus",`, ""},
+	{"theme must survive", `  "theme": "dark",`, ""},
+	{"a plain loopback base URL must survive", `  "ANTHROPIC_BASE_URL": "http://127.0.0.1:8787/anthropic",`, ""},
+}
+
+// TestRedactCoversEveryKnownCredentialShape drives the real filter, lifted out of reset.sh, rather
+// than a copy of it — a copy would drift from the thing that ships.
+func TestRedactCoversEveryKnownCredentialShape(t *testing.T) {
+	requireTool(t, "bash")
+	body, err := os.ReadFile(filepath.Join(scriptsDir(t), "reset.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Slice out REDACT_NAME through the end of the redact() function.
+	_, rest, ok := strings.Cut(string(body), "REDACT_NAME=")
+	if !ok {
+		t.Fatal("reset.sh no longer defines REDACT_NAME; this test is extracting the wrong thing")
+	}
+	fnEnd := strings.Index(rest, "\n}\n")
+	if fnEnd < 0 {
+		t.Fatal("could not find the end of redact(); extraction would be silently partial")
+	}
+	fn := "REDACT_NAME=" + rest[:fnEnd+3]
+	if !strings.Contains(fn, "redact()") || !strings.Contains(fn, "sed") {
+		t.Fatalf("extracted fragment does not look like the filter:\n%s", fn)
+	}
+	fnPath := filepath.Join(t.TempDir(), "redact.sh")
+	if err := os.WriteFile(fnPath, []byte(fn), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range redactShapes {
+		cmd := exec.Command("sh", "-c",
+			`. "$1"; printf '%s\n' "$2" | redact`, "_", fnPath, tc.line)
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s: running redact: %v (%s)", tc.name, err, b)
+		}
+		got := strings.TrimRight(string(b), "\n")
+		if tc.secret == "" {
+			if got != tc.line {
+				t.Errorf("%s: over-redacted, so the diff loses what it exists to show\n got:  %q\n want: %q",
+					tc.name, got, tc.line)
+			}
+			continue
+		}
+		if strings.Contains(got, tc.secret) {
+			t.Errorf("%s: LEAKED %q\n got: %q", tc.name, tc.secret, got)
+		}
+		if got == tc.line {
+			t.Errorf("%s: line passed through untouched, so no rule matched it at all\n got: %q",
+				tc.name, got)
+		}
+	}
+}
+
+// TestNoPrinterOfContentEscapesTheFilter walks every site in reset.sh that prints real content and
+// plants a credential in each. The round-2 fix covered the plan diff; the review then found a FOURTH
+// site inside report_environment itself — the function whose own header promises values are never
+// printed — because that test only exercised the diff. So this one is organised by SITE.
+func TestNoPrinterOfContentEscapesTheFilter(t *testing.T) {
+	const secret = "REALSECRET-do-not-print-me"
+
+	t.Run("the verify pass", func(t *testing.T) {
+		// A user's own gateway carrying credentials in the URL, taken over with --force and then
+		// handed back. Verify greps the restored file and prints the matching lines.
+		state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+		path := filepath.Join(proj, "settings.json")
+		theirs := "https://svc:" + secret + "@gw.corp.example/anthropic"
+		writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": theirs}})
+		if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL,
+			"--force"); code != 0 {
+			t.Fatal("add --force failed")
+		}
+		out, _ := runHatch(t, state, home, proj, "--yes")
+		if strings.Contains(out, secret) {
+			t.Errorf("the verify pass printed a credential:\n%s", out)
+		}
+		if !strings.Contains(out, "still mentions") {
+			t.Fatalf("the verify branch never ran, so this asserted nothing:\n%s", out)
+		}
+	})
+
+	t.Run("the environment report", func(t *testing.T) {
+		state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+		path := filepath.Join(proj, "settings.json")
+		writeJSON(t, path, map[string]any{"theme": "dark"})
+		if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+			t.Fatal("add failed")
+		}
+		cmd := exec.Command(hatchPath(t, state), "--dry-run")
+		cmd.Dir = proj
+		cmd.Env = []string{
+			"CONTEXT_GURU_STATE=" + state, "HOME=" + home, "PATH=" + os.Getenv("PATH"),
+			"ANTHROPIC_BASE_URL=https://svc:" + secret + "@gw.corp.example/anthropic",
+		}
+		b, _ := cmd.CombinedOutput()
+		out := string(b)
+		if strings.Contains(out, secret) {
+			t.Errorf("report_environment printed a credential:\n%s", out)
+		}
+		if !strings.Contains(out, "exported in this shell") {
+			t.Fatalf("the branch that prints $base never ran:\n%s", out)
+		}
+	})
+
+	t.Run("the no-record grep", func(t *testing.T) {
+		state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+		if err := os.MkdirAll(filepath.Join(proj, ".claude"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(proj, ".claude", "settings.local.json")
+		writeJSON(t, path, map[string]any{"theme": "dark"})
+		if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL,
+			"--upstream", "https://gw.corp/anthropic?api_key="+secret); code != 0 {
+			t.Fatal("add failed")
+		}
+		hatch := hatchPath(t, state)
+		if err := os.Remove(filepath.Join(state, "reset-manifest.tsv")); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command(hatch, "--yes")
+		cmd.Dir = proj
+		cmd.Env = []string{"CONTEXT_GURU_STATE=" + state, "HOME=" + home, "PATH=" + os.Getenv("PATH")}
+		b, _ := cmd.CombinedOutput()
+		out := string(b)
+		if strings.Contains(out, secret) {
+			t.Errorf("the no-record grep printed a credential:\n%s", out)
+		}
+		if !strings.Contains(out, "ANTHROPIC_UPSTREAM") {
+			t.Fatalf("the grep never printed the key line, so this asserted nothing:\n%s", out)
+		}
+	})
+}
+
+// TestASuccessfulRestoreSaysSoEvenWhenTheShellIsRouted. The final summary tested INCOMPLETE for a
+// question about files — the same bug fixed in the empty-plan branch, one branch further down. So a
+// COMPLETELY successful restore, verified unrouted, run from a shell with an exported base URL (a
+// hosted agent, or simply the shell they installed from) printed "Finished with something left for
+// you" and never printed the count: $RESTORED was thrown away on the one run where it is the good
+// news, and the user who had just recovered was told the run did not finish.
+//
+// It survived three rounds because NO test grepped for "Done." at all.
+func TestASuccessfulRestoreSaysSoEvenWhenTheShellIsRouted(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"permissions": map[string]any{"allow": []string{"Bash(ls:*)"}}})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+
+	// Non-empty plan (a real restore) AND a routed shell: the two conditions together.
+	cmd := exec.Command(hatchPath(t, state), "--yes")
+	cmd.Dir = proj
+	cmd.Env = []string{
+		"CONTEXT_GURU_STATE=" + state, "HOME=" + home, "PATH=" + os.Getenv("PATH"),
+		"ANTHROPIC_BASE_URL=" + ourURL,
+	}
+	b, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	out := string(b)
+	if !strings.Contains(out, "restored:") {
+		t.Fatalf("no restore happened, so this test asserted nothing:\n%s", out)
+	}
+	if !strings.Contains(out, "Done. 1 file(s) put back.") {
+		t.Errorf("a fully successful restore never reported its count:\n%s", out)
+	}
+	if strings.Contains(out, "Finished with something left for you") {
+		t.Errorf("told the user the run did not finish after a verified-clean restore:\n%s", out)
+	}
+	if code != 3 {
+		t.Errorf("exit %d, want 3: the exported base URL is still left for a human", code)
+	}
+	if !strings.Contains(out, "environment report above") {
+		t.Errorf("did not point at what is actually left:\n%s", out)
 	}
 }

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -4608,11 +4608,18 @@ var redactShapes = []struct {
 }{
 	{"ANTHROPIC_API_KEY", `  "ANTHROPIC_API_KEY": "sk-ant-REALKEY0000",`, "REALKEY0000"},
 	{"ANTHROPIC_AUTH_TOKEN", `  "ANTHROPIC_AUTH_TOKEN": "REALTOKENVALUE",`, "REALTOKENVALUE"},
-	// The one that matters most here, and not a shape invented for the test: this is how a Context
-	// Guru credential is carried on this project's own dev machines, so it is the single most likely
-	// credential to appear in a context-guru user's env block — and its name contains none of
-	// key/token/secret/password/credential, which is why the first two versions of the filter missed
-	// it. HEADER is in the name class because of this row.
+	// The one that matters most here, and not a shape invented for the test.
+	//
+	// PROVENANCE, recorded because it is the strongest argument for this whole table: this leak was
+	// LIVE, not theoretical. `ANTHROPIC_CUSTOM_HEADERS` carrying a `<header>: <token>` string is how a
+	// Context Guru credential is set on this project's own development machines — set for interactive
+	// sessions and explicitly unset for benchmark runs — and it was present in the real
+	// ~/.claude/settings.json of the machine this filter was written on, where the author had read
+	// that file earlier the same day and not connected it to the filter.
+	//
+	// So the single most likely credential to appear in a context-guru user's env block was the one
+	// the first two versions of the filter did not catch, and its name contains none of
+	// key/token/secret/password/credential. HEADER is in the name class because of this row.
 	{"ANTHROPIC_CUSTOM_HEADERS", `  "ANTHROPIC_CUSTOM_HEADERS": "x-context-guru-token: cg_live_REALGURU",`, "REALGURU"},
 	{"authorization bearer JWT", `  "authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.REALJWTBODY",`, "REALJWTBODY"},
 	{"github PAT", `  "GITHUB_PAT": "ghp_REALPAT00000000",`, "REALPAT00000000"},
@@ -4626,6 +4633,13 @@ var redactShapes = []struct {
 	{"model must survive", `  "model": "opus",`, ""},
 	{"theme must survive", `  "theme": "dark",`, ""},
 	{"a plain loopback base URL must survive", `  "ANTHROPIC_BASE_URL": "http://127.0.0.1:8787/anthropic",`, ""},
+	// These three are what the verify pass and the no-record grep exist to SHOW the user — they are
+	// the routing itself, not a credential. AUTH and HEADER in the name class match more broadly than
+	// the original five did, so each is pinned here: over-redacting these would leave a locked-out
+	// user reading "<value not shown>" where they need to see which port they are pointed at.
+	{"a corporate base URL must survive", `  "ANTHROPIC_BASE_URL": "https://gateway.corp.example/anthropic",`, ""},
+	{"ANTHROPIC_UPSTREAM must survive", `  "ANTHROPIC_UPSTREAM": "https://gateway.corp.example",`, ""},
+	{"CONTEXT_GURU_BIN must survive", `  "CONTEXT_GURU_BIN": "/home/user/.local/bin/context-guru-proxy",`, ""},
 }
 
 // TestRedactCoversEveryKnownCredentialShape drives the real filter, lifted out of reset.sh, rather

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -4371,3 +4371,203 @@ func TestAnUnusableStateDirectoryNeverFailsTheInstall(t *testing.T) {
 		t.Error("the user's settings were damaged")
 	}
 }
+
+// --- fixes from review round 2 of #236 -----------------------------------------------------
+
+// TestThePlanNeverPrintsACredential. The whole-file warning added in round 1 diffs the settings
+// file, and `env` is exactly where people keep ANTHROPIC_API_KEY — so `--dry-run`, the invocation the
+// docs tell people to run FIRST, printed a live key twice, once per side of the diff. It contradicted
+// the principle stated 150 lines above it in the same script.
+//
+// The audience is what makes it worse than a secret in a log: somebody debugging a 401, whose next
+// move is to paste the output into an issue or a screenshot, precisely because it is written to be
+// read and acted on. TestHatchReportsCredentialsByLocationAndNeverByValue covers the rc-file half and
+// did not cover this path, which is how it got through.
+func TestThePlanNeverPrintsACredential(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	const (
+		apiKey    = "sk-ant-SUPERSECRET-do-not-print-me"
+		oddlyName = "hunter2-also-secret" // a key-ish name that is not spelled ANTHROPIC_*
+		urlCreds  = "pw123"
+	)
+	// Written COMPACT, the way a hand-edited settings file actually looks, and not via writeJSON.
+	// That matters for what this test covers: writeJSON indents, settings.py rewrites with the same
+	// indent, so the credential lines came out byte-identical on both sides of the diff and never
+	// appeared in it. The secret-absence assertion then passed for the wrong reason — nothing to
+	// redact — which is exactly what the "no redaction marker" check below caught.
+	fixture := `{"env": {"ANTHROPIC_API_KEY": "` + apiKey + `", "authToken": "` + oddlyName +
+		`", "MY_GATEWAY": "https://alice:` + urlCreds + `@gw.example/v1"},` +
+		` "permissions": {"allow": ["Bash(ls:*)"]}}`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	// A later change, so the whole-file warning and its diff are reached at all.
+	cur := readJSON(t, path)
+	cur["permissions"] = map[string]any{"allow": []string{"Bash(ls:*)", "Bash(git push:*)"}}
+	writeJSON(t, path, cur)
+
+	for _, args := range [][]string{{"--dry-run"}, {"--yes"}} {
+		out, _ := runHatch(t, state, home, proj, args...)
+		for _, secret := range []string{apiKey, oddlyName, urlCreds} {
+			if strings.Contains(out, secret) {
+				t.Errorf("hatch %v printed a credential (%q):\n%s", args, secret, out)
+			}
+		}
+		if args[0] == "--dry-run" {
+			// The redaction must not gut the diff: showing THAT a line changed is its whole purpose.
+			if !strings.Contains(out, "git push") {
+				t.Errorf("redaction removed the change the diff exists to show:\n%s", out)
+			}
+			if !strings.Contains(out, "value not shown") {
+				t.Errorf("no redaction marker, so the diff may simply not have run:\n%s", out)
+			}
+		}
+	}
+}
+
+// TestNormalUninstallDoesNotClaimTheOriginalIsGone. An ordinary uninstall of an ordinarily-installed
+// project takes the "file already carries our keys" branch — correctly, since a copy of the file at
+// that moment would be meaningless. But it also SET reset_original=unavailable, while the good,
+// verified-clean copy from the install sat on disk. install/SKILL.md turns that fact into "the hatch
+// can unroute but not restore", so the skill would have told users their content was unrecoverable
+// when it was not: the same class of inverted reassurance as round 1's finding 2.
+func TestNormalUninstallDoesNotClaimTheOriginalIsGone(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"permissions": map[string]any{"allow": []string{"Bash(ls:*)"}}})
+
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	facts, code := settingsIn(t, state, home, "remove", "--file", path, "--url", ourURL)
+	if code != 0 {
+		t.Fatalf("remove: exit %d, %v", code, facts)
+	}
+	if facts["reset_original"] == "unavailable" {
+		t.Errorf("remove reported reset_original=unavailable; the record's copy is what matters, "+
+			"not whether THIS call could take one: %v", facts)
+	}
+	// And the copy really is there, really is clean.
+	originals, _ := filepath.Glob(filepath.Join(state, "originals", "*.original"))
+	if len(originals) != 1 {
+		t.Fatalf("want exactly one original, got %v", originals)
+	}
+	b, err := os.ReadFile(originals[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "ANTHROPIC_BASE_URL") {
+		t.Errorf("the original holds routing:\n%s", b)
+	}
+}
+
+// TestAnExportedBaseURLIsNotCalledAFileProblem. INCOMPLETE grew to include an environment condition
+// (a base URL exported in the user's shell, which no settings change can override), and wiring that
+// into the empty-plan branch made it lie in the other direction: with clean files and a routed shell
+// it printed "your settings files are NOT back to their pre-install state" plus instructions to
+// repair a file, two lines under a line saying that file already matched its pre-install copy.
+//
+// Which sentence to print is a question about files; the exit code is a question about whether
+// anything is left for a human. Two questions, two flags.
+func TestAnExportedBaseURLIsNotCalledAFileProblem(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"permissions": map[string]any{"allow": []string{"Bash(ls:*)"}}})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	if _, code := runHatch(t, state, home, proj, "--yes"); code != 0 {
+		t.Fatal("first run should be a clean restore")
+	}
+
+	// Same clean state, but the shell itself is routed.
+	cmd := exec.Command(hatchPath(t, state), "--yes")
+	cmd.Dir = proj
+	cmd.Env = []string{
+		"CONTEXT_GURU_STATE=" + state, "HOME=" + home, "PATH=" + os.Getenv("PATH"),
+		"ANTHROPIC_BASE_URL=" + ourURL,
+	}
+	b, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	out := string(b)
+	if code != 3 {
+		t.Errorf("exit %d, want 3: an exported loopback base URL is left for a human", code)
+	}
+	if strings.Contains(out, "NOT back to their pre-install state") {
+		t.Errorf("called a clean file a file problem:\n%s", out)
+	}
+	for _, want := range []string{"already back to their pre-install state", "Your FILES are fine",
+		"exported in THIS SHELL"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestLoopbackDetectionCoversTheShapesThatMatter. The predicate guarding round 1's severe finding
+// used a startswith tuple, and everything it missed was a false NEGATIVE — the direction that
+// re-introduces the defect, by taking a copy of an already-routed file and calling it an original.
+func TestLoopbackDetectionCoversTheShapesThatMatter(t *testing.T) {
+	for _, tc := range []struct {
+		url     string
+		ourFile bool
+	}{
+		{"http://127.0.0.1:8787/anthropic", true},
+		{"http://127.0.0.1/anthropic", true}, // no port
+		{"http://0.0.0.0:8787/anthropic", true},
+		{"http://[::1]/anthropic", true}, // v6, no port
+		{"https://localhost:8787/anthropic", true},
+		{"https://gateway.corp.example/anthropic", false},
+		{"https://not-localhost.example.com/v1", false}, // must not match on substring
+	} {
+		state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+		path := filepath.Join(proj, "settings.json")
+		// No metadata and none of our other keys, so the loopback clause is the only thing deciding.
+		writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": tc.url}})
+		if _, code := settingsIn(t, state, home, "remove", "--file", path, "--url", tc.url); code != 0 {
+			t.Fatalf("%s: remove failed", tc.url)
+		}
+		originals, _ := filepath.Glob(filepath.Join(state, "originals", "*.original"))
+		if tc.ourFile && len(originals) != 0 {
+			b, _ := os.ReadFile(originals[0])
+			t.Errorf("%s: took a pre-edit copy of an already-routed file:\n%s", tc.url, b)
+		}
+		if !tc.ourFile && len(originals) != 1 {
+			t.Errorf("%s: declined to copy a file that is not ours (want an original, got %v)",
+				tc.url, originals)
+		}
+	}
+}
+
+// TestTroubleshootingLeadsWithTheCommand. Discoverability is part of the feature, not documentation
+// polish: a user who needs the hatch is searching the docs with a Claude that cannot answer
+// questions. Troubleshooting is the section they open, and it did not name the hatch at all.
+func TestTroubleshootingLeadsWithTheCommand(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "docs", "how-to", "install-plugin.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, after, ok := strings.Cut(string(b), "## Troubleshooting")
+	if !ok {
+		t.Fatal("no Troubleshooting section")
+	}
+	// Within the first entry, not somewhere further down the section.
+	head := after
+	if len(head) > 900 {
+		head = head[:900]
+	}
+	for _, want := range []string{"context-guru-reset", "hangs", "cannot run"} {
+		if !strings.Contains(head, want) {
+			t.Errorf("the first Troubleshooting entry does not cover %q:\n%s", want, head)
+		}
+	}
+}

--- a/context-guru-plugin/plugin_test.go
+++ b/context-guru-plugin/plugin_test.go
@@ -61,8 +61,22 @@ func requireTool(t *testing.T, name string) string {
 // settings runs settings.py and returns its key=value output as a map, plus the exit code.
 func settings(t *testing.T, args ...string) (map[string]string, int) {
 	t.Helper()
+	return settingsIn(t, t.TempDir(), t.TempDir(), args...)
+}
+
+// settingsIn is settings() with the two directories settings.py now writes OUTSIDE the target file
+// made explicit: the state directory holding the escape hatch and its record, and HOME (the hatch
+// is also copied to ~/.local/bin when that exists).
+//
+// Every test goes through here, including the ones that predate the hatch, because otherwise
+// `go test` writes into the DEVELOPER'S real ~/.local/state/context-guru — recording temp paths in
+// the manifest their own hatch would later read, and rewriting the copy on their PATH. A test suite
+// for a recovery tool must not be able to disturb the developer's own recovery tool.
+func settingsIn(t *testing.T, state, home string, args ...string) (map[string]string, int) {
+	t.Helper()
 	py := requireTool(t, "python3")
 	cmd := exec.Command(py, append([]string{filepath.Join(scriptsDir(t), "settings.py")}, args...)...)
+	cmd.Env = append(os.Environ(), "CONTEXT_GURU_STATE="+state, "HOME="+home)
 	out, err := cmd.CombinedOutput()
 	code := 0
 	if ee, ok := err.(*exec.ExitError); ok {
@@ -3577,5 +3591,596 @@ func TestSettingsReportsOSErrorsAsData(t *testing.T) {
 	// And it must not have damaged the file it could not replace.
 	if env := readJSON(t, path)["env"].(map[string]any); env["MINE"] != "keep" {
 		t.Errorf("the original file was altered on a failed write: %v", env)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The escape hatch.
+//
+// These tests exist because of an incident rather than a design review. A colleague installed the
+// plugin, ended up with 401 on every request, and found that `/context-guru:uninstall` — the
+// documented undo — could not run: it is a skill, and a skill needs a session that can reach a
+// model. The undo path was unavailable for precisely the reason he needed it.
+//
+// So the properties below are not "the hatch works". They are "the hatch works when everything
+// this plugin provides is gone": no Claude, no proxy, no plugin directory, no interpreter beyond
+// POSIX sh. Each test removes one of those and asserts recovery anyway.
+// ---------------------------------------------------------------------------
+
+// hatchPath is where settings.py installs the hatch, and asserts the two properties that make it a
+// hatch at all: it is executable, and it is NOT inside the plugin.
+func hatchPath(t *testing.T, state string) string {
+	t.Helper()
+	p := filepath.Join(state, "context-guru-reset")
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("no escape hatch at %s: %v", p, err)
+	}
+	if runtime.GOOS != "windows" && fi.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("the hatch at %s is not executable (mode %v) — a user in trouble should not have "+
+			"to work out that they need to prefix it with `sh`", p, fi.Mode().Perm())
+	}
+	if strings.HasPrefix(p, scriptsDir(t)) {
+		t.Fatalf("the hatch was installed INSIDE the plugin (%s). `/plugin uninstall`, a "+
+			"marketplace refresh or a wiped plugin cache would take the recovery tool with it", p)
+	}
+	return p
+}
+
+// runHatch executes the installed hatch with a controlled environment. cwd matters: the no-record
+// path reports files relative to the project the user is in.
+func runHatch(t *testing.T, state, home, cwd string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(hatchPath(t, state), args...)
+	cmd.Dir = cwd
+	cmd.Env = []string{
+		"CONTEXT_GURU_STATE=" + state,
+		"HOME=" + home,
+		"PATH=" + os.Getenv("PATH"),
+	}
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("running the hatch: %v (%s)", err, out)
+	}
+	t.Logf("hatch %v -> exit %d\n%s", args, code, out)
+	return string(out), code
+}
+
+// TestInstallLeavesAWayBackOutsideThePlugin is the whole feature in one assertion: after an install
+// there is a runnable recovery tool that does not live in the plugin, its path was REPORTED so the
+// skill can tell the user, and it holds a record of the file that was edited.
+func TestInstallLeavesAWayBackOutsideThePlugin(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+
+	facts, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL)
+	if code != 0 {
+		t.Fatalf("add: exit %d, %v", code, facts)
+	}
+	// Reported, not merely present. The install skill has to hand the path to the user while the
+	// session still works, because afterwards it may not.
+	if facts["reset_hatch"] == "" || facts["reset_hatch"] == "unavailable" {
+		t.Errorf("add did not report a usable reset_hatch: %v", facts)
+	}
+	if got, want := facts["reset_hatch"], hatchPath(t, state); got != want {
+		t.Errorf("reported reset_hatch=%q, but the hatch is at %q", got, want)
+	}
+	record, err := os.ReadFile(filepath.Join(state, "reset-manifest.tsv"))
+	if err != nil {
+		t.Fatalf("no record for the hatch to read: %v", err)
+	}
+	if !strings.Contains(string(record), path) {
+		t.Errorf("the record does not name the file that was edited:\n%s", record)
+	}
+}
+
+// TestTheHatchNeedsNothingButPOSIXSh: the hatch runs in a state where the proxy is down and Claude
+// cannot talk, so anything it depends on is a way for it to be unavailable too. Asserted against
+// the script's text, since "it happened to work on this machine" is not the claim.
+func TestTheHatchNeedsNothingButPOSIXSh(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(scriptsDir(t), "reset.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(b)
+	if !strings.HasPrefix(body, "#!/bin/sh") {
+		t.Errorf("the hatch must be POSIX sh; its shebang is %q",
+			strings.SplitN(body, "\n", 2)[0])
+	}
+	// Line-by-line, with comments stripped, so a word that appears while EXPLAINING the absence of
+	// a dependency is not read as the dependency. `claude` is deliberately not in this list: the
+	// script names it in the prose it prints ("start a NEW claude session"), which is advice rather
+	// than an invocation — the first version of this test failed on exactly that line.
+	for i, line := range strings.Split(body, "\n") {
+		code := line
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			code = line[:idx]
+		}
+		for _, banned := range []string{"python", "curl ", "context-guru-proxy", "jq ", "$(claude"} {
+			if strings.Contains(code, banned) {
+				t.Errorf("reset.sh:%d depends on %q, which may be exactly what is missing:\n%s",
+					i+1, banned, line)
+			}
+		}
+	}
+}
+
+// TestTheOriginalCopyOutlivesTheRollingBackups is the reason the hatch keeps its own copy rather
+// than trusting the *.context-guru-backup-* files beside the settings file: those are capped at ten
+// and BOTH add and remove write one, so on a machine that has installed and uninstalled a few times
+// the backup holding the user's pre-context-guru state is the first one deleted. The copy recovery
+// depends on cannot be on a rolling window.
+func TestTheOriginalCopyOutlivesTheRollingBackups(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"env": map[string]any{"MY_OWN": "keepme"}})
+	pristine, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 12; i++ { // KEEP_BACKUPS is 10; twelve cycles writes 24 of them
+		if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+			t.Fatalf("cycle %d: add failed", i)
+		}
+		if _, code := settingsIn(t, state, home, "remove", "--file", path, "--url", ourURL); code != 0 {
+			t.Fatalf("cycle %d: remove failed", i)
+		}
+	}
+
+	entries, err := os.ReadDir(filepath.Join(state, "originals"))
+	if err != nil {
+		t.Fatalf("the originals directory is gone: %v", err)
+	}
+	var found string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".original") {
+			found = filepath.Join(state, "originals", e.Name())
+		}
+		// A leading dot would make the copy invisible to `ls` and to every glob — including a
+		// user's own, in a directory that exists to be read by hand. The natural name starts with
+		// one, because the parent directory of a real target is `.claude`.
+		if strings.HasPrefix(e.Name(), ".") {
+			t.Errorf("the pre-edit copy %q is a hidden file", e.Name())
+		}
+	}
+	if found == "" {
+		t.Fatalf("no pre-edit copy survived twelve install/uninstall cycles: %v", entries)
+	}
+	got, err := os.ReadFile(found)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(pristine) {
+		t.Errorf("the pre-edit copy is not the file as the user had it:\ngot:  %s\nwant: %s",
+			got, pristine)
+	}
+}
+
+// TestHatchRestoresWithThePluginDeleted is the scenario the hatch is for. The user's way out must
+// not be inside the thing they are trying to get away from, so: install, delete the plugin's own
+// copy of the script, and recover anyway.
+func TestHatchRestoresWithThePluginDeleted(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{
+		"theme":       "dark",
+		"env":         map[string]any{"MY_OWN": "keepme"},
+		"permissions": map[string]any{"allow": []string{"Bash(ls)"}},
+	})
+	pristine, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL,
+		"--upstream", "https://gateway.corp.example"); code != 0 {
+		t.Fatal("add failed")
+	}
+	// Prove the fixture: routing really is in the file, so the restore below is doing work.
+	if b, _ := os.ReadFile(path); !strings.Contains(string(b), "127.0.0.1:8787") {
+		t.Fatalf("fixture is wrong — no routing key was written:\n%s", b)
+	}
+
+	// The hatch's own copy is the one that runs. Delete the plugin's, restoring it afterwards, to
+	// prove the installed copy is not quietly delegating to a file that may no longer exist.
+	src := filepath.Join(scriptsDir(t), "reset.sh")
+	body, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.WriteFile(src, body, 0o755) })
+
+	out, code := runHatch(t, state, home, proj, "--yes")
+	if code != 0 {
+		t.Fatalf("hatch: exit %d\n%s", code, out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(pristine) {
+		t.Errorf("the file was not restored to its pre-install state:\ngot:  %s\nwant: %s",
+			got, pristine)
+	}
+	// Reversible in its own right: whatever was there before the restore is kept, for the user who
+	// runs this and then finds the routing was not their problem.
+	pre, err := filepath.Glob(path + ".context-guru-prereset-*")
+	if err != nil || len(pre) == 0 {
+		t.Errorf("the hatch overwrote the routed file without keeping a copy of it")
+	}
+}
+
+// TestHatchDeletesAFileTheInstallCreated: "put it back" means DELETE when the install is the reason
+// the file exists. Restoring an empty file instead would leave a stub in the user's project that
+// they did not write and would have no reason to suspect.
+func TestHatchDeletesAFileTheInstallCreated(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.local.json")
+
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("fixture: the install did not create the file: %v", err)
+	}
+	out, code := runHatch(t, state, home, proj, "--yes")
+	if code != 0 {
+		t.Fatalf("hatch: exit %d\n%s", code, out)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("a file the install created was left behind (err=%v)", err)
+	}
+}
+
+// TestHatchSecondRunChangesNothing: people re-run a recovery tool — the first run tells them to
+// start a new session, and they check. The second run must be a real no-op rather than another
+// copy, another backup file, and another "1 file put back".
+func TestHatchSecondRunChangesNothing(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	if _, code := runHatch(t, state, home, proj, "--yes"); code != 0 {
+		t.Fatal("first hatch run failed")
+	}
+	before, _ := filepath.Glob(path + ".context-guru-prereset-*")
+
+	out, code := runHatch(t, state, home, proj, "--yes")
+	if code != 0 {
+		t.Fatalf("second run: exit %d\n%s", code, out)
+	}
+	if !strings.Contains(out, "already matches") && !strings.Contains(out, "Nothing to restore") {
+		t.Errorf("the second run did not report itself as a no-op:\n%s", out)
+	}
+	after, _ := filepath.Glob(path + ".context-guru-prereset-*")
+	if len(after) != len(before) {
+		t.Errorf("the second run wrote %d more backup(s) for no reason", len(after)-len(before))
+	}
+}
+
+// TestHatchDryRunWritesNothing. The routed file is what the user may still need; a preview that
+// modifies it is not a preview.
+func TestHatchDryRunWritesNothing(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	routed, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runHatch(t, state, home, proj, "--dry-run")
+	if code != 0 {
+		t.Fatalf("dry run: exit %d\n%s", code, out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(routed) {
+		t.Errorf("--dry-run modified the file")
+	}
+	if !strings.Contains(out, "nothing written") {
+		t.Errorf("--dry-run did not say it wrote nothing:\n%s", out)
+	}
+}
+
+// TestHatchWithNoRecordTellsTheUserWhereToLook: a hand-edited settings file, or a wiped state
+// directory. "Nothing to do" is the least useful thing that could be said to somebody whose
+// sessions are down, so the absent-record path has to do the diagnosis a human would.
+func TestHatchWithNoRecordTellsTheUserWhereToLook(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	// The real target, at the real path, because this branch's whole job is to point a user at the
+	// places routing hides — and the paths it prints are project-relative.
+	if err := os.MkdirAll(filepath.Join(proj, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(proj, ".claude", "settings.local.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+	hatch := hatchPath(t, state)
+	// Keep the hatch, lose the record — the state directory is not sacred, and a user may well
+	// have cleaned it out on advice from the uninstall skill.
+	if err := os.Remove(filepath.Join(state, "reset-manifest.tsv")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(hatch, "--yes")
+	cmd.Dir = proj
+	cmd.Env = []string{"CONTEXT_GURU_STATE=" + state, "HOME=" + home, "PATH=" + os.Getenv("PATH")}
+	b, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	out := string(b)
+	if code != 3 {
+		t.Errorf("exit %d; want 3 (finished, with something left for a human)\n%s", code, out)
+	}
+	for _, want := range []string{"settings.local.json", "ANTHROPIC_BASE_URL", "127.0.0.1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the no-record path never mentions %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestHatchReportsCredentialsByLocationAndNeverByValue. The incident that produced this hatch was
+// not a routing fault at all: both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN were set, the gateway
+// rejected whichever won, and the export was one line in a shell rc. Restoring settings cannot
+// reach that, so the hatch reports it — and must do so without echoing a live key into a terminal
+// buffer, a log, or a pasted transcript.
+func TestHatchReportsCredentialsByLocationAndNeverByValue(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "dark"})
+	if _, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL); code != 0 {
+		t.Fatal("add failed")
+	}
+
+	const secret = "sk-THIS-MUST-NEVER-BE-PRINTED"
+	rc := "# a comment\nexport PATH=\"$HOME/bin:$PATH\"\nexport ANTHROPIC_API_KEY=" + secret + "\n"
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(rc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(hatchPath(t, state), "--dry-run")
+	cmd.Dir = proj
+	cmd.Env = []string{
+		"CONTEXT_GURU_STATE=" + state,
+		"HOME=" + home,
+		"PATH=" + os.Getenv("PATH"),
+		"ANTHROPIC_API_KEY=" + secret,
+		"ANTHROPIC_AUTH_TOKEN=sk-a-different-one",
+	}
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			t.Fatal(err)
+		}
+	}
+	out := string(b)
+	if strings.Contains(out, secret) {
+		t.Errorf("the hatch printed a credential value:\n%s", out)
+	}
+	if !strings.Contains(out, "BOTH set") {
+		t.Errorf("the hatch did not flag two credential variables being set at once:\n%s", out)
+	}
+	if !strings.Contains(out, ".zshrc:3") {
+		t.Errorf("the hatch did not report the file and line of the export:\n%s", out)
+	}
+}
+
+// TestDeadProxyNoteNamesTheEscapeHatch. This hook fires on the prompt that is ABOUT to hang, which
+// makes it the single best place to hand the user their way out — and the advice it used to end on
+// was "edit the JSON by hand, or run /context-guru:uninstall from a session that still works". The
+// second half is unavailable to the user this note is written for: if their projects route through
+// the same dead port, no session still works. That is how the incident behind the hatch played out.
+func TestDeadProxyNoteNamesTheEscapeHatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook is POSIX-only")
+	}
+	requireTool(t, "bash")
+	dir := t.TempDir()
+	state := filepath.Join(dir, "state", "context-guru")
+	if err := os.MkdirAll(state, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hatch := filepath.Join(state, "context-guru-reset")
+	if err := os.WriteFile(hatch, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A binary that cannot start, so the hook reaches its "I could not fix this" note.
+	fake := filepath.Join(dir, "fake-proxy")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := freePort(t) // nothing listening: refused fast, so the hook goes straight to the note
+
+	cmd := exec.Command("bash", filepath.Join(scriptsDir(t), "check-proxy.sh"))
+	cmd.Env = append(os.Environ(),
+		"CLAUDE_PLUGIN_ROOT="+root,
+		"CLAUDE_PLUGIN_OPTION_PORT="+port,
+		"ANTHROPIC_BASE_URL=http://127.0.0.1:"+port+"/anthropic",
+		"CONTEXT_GURU_BIN="+fake,
+		"XDG_STATE_HOME="+filepath.Join(dir, "state"),
+		"TMPDIR="+dir)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			t.Fatalf("running check-proxy.sh: %v (%s)", err, b)
+		}
+	}
+	out := string(b)
+	if !strings.Contains(out, hatch) {
+		t.Errorf("the dead-proxy note does not name the escape hatch at %s:\n%s", hatch, out)
+	}
+	if !strings.Contains(out, "no\nworking Claude session") &&
+		!strings.Contains(strings.Join(strings.Fields(out), " "), "no working Claude session") {
+		t.Errorf("the note names the hatch without saying it works when Claude cannot:\n%s", out)
+	}
+}
+
+// TestDeadProxyNoteFallsBackWhenThereIsNoHatch is the negative control for the test above: pointing
+// a stuck user at a path that does not exist would be worse than the manual instructions, so the
+// hatch is named only when it is on disk.
+func TestDeadProxyNoteFallsBackWhenThereIsNoHatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook is POSIX-only")
+	}
+	out, _, _ := runCheck(t, freePort(t), "#!/bin/sh\nexit 1\n")
+	flat := strings.Join(strings.Fields(out), " ")
+	if strings.Contains(flat, "context-guru-reset") {
+		t.Errorf("named a hatch that is not installed:\n%s", out)
+	}
+	if !strings.Contains(flat, "remove env.ANTHROPIC_BASE_URL from .claude/settings.local.json") {
+		t.Errorf("the fallback instructions are gone, so a user with no hatch is told nothing:\n%s", out)
+	}
+}
+
+// TestAnAlreadyRoutedProjectStillGetsAHatch covers the machines that need one most: everybody who
+// installed BEFORE the hatch existed. Their re-run of /context-guru:install reports
+// `result=unchanged` and writes nothing, so the code path that installs the hatch never runs — and
+// re-running the install is the first thing anyone does when something looks wrong.
+//
+// There is no pre-edit copy to invent, so the hatch must be honest rather than absent: it names the
+// file, and says the original content is not recoverable from its own record.
+func TestAnAlreadyRoutedProjectStillGetsAHatch(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	// Routed already, by a version of the plugin that kept no record — which is what the state
+	// directory being empty represents.
+	writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": ourURL}})
+
+	facts, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL)
+	if code != 0 || facts["result"] != "unchanged" {
+		t.Fatalf("fixture: wanted result=unchanged exit 0, got %v exit %d", facts, code)
+	}
+	if facts["reset_hatch"] == "" || facts["reset_hatch"] == "unavailable" {
+		t.Fatalf("a no-op re-run left the machine with no hatch: %v", facts)
+	}
+	if facts["reset_original"] != "unavailable" {
+		t.Errorf("reset_original=%q; the pre-install content genuinely is not recoverable here and "+
+			"claiming otherwise would promise a restore that cannot happen", facts["reset_original"])
+	}
+	out, code := runHatch(t, state, home, proj, "--yes")
+	if code != 3 {
+		t.Errorf("hatch exit %d; want 3 — it has a file to name but cannot restore it\n%s", code, out)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("the hatch does not name the routed file:\n%s", out)
+	}
+	if b, _ := os.ReadFile(path); !strings.Contains(string(b), ourURL) {
+		t.Errorf("the hatch modified a file it had no pre-edit copy of")
+	}
+}
+
+// TestAConflictIsNeverRecordedAsOurEdit is the guard on the branch above. `result=conflict` is
+// somebody else's base URL that this script refused to touch — a corporate gateway, a benchmark
+// endpoint. Recording it would tell the hatch that context-guru edited a file it never wrote to,
+// and the hatch's whole safety property is that it only touches files it has a record of editing.
+func TestAConflictIsNeverRecordedAsOurEdit(t *testing.T) {
+	state, home, proj := t.TempDir(), t.TempDir(), t.TempDir()
+	path := filepath.Join(proj, "settings.json")
+	theirs := "https://gateway.corp.example/anthropic"
+	writeJSON(t, path, map[string]any{"env": map[string]any{"ANTHROPIC_BASE_URL": theirs}})
+
+	facts, code := settingsIn(t, state, home, "add", "--file", path, "--url", ourURL)
+	if code != 2 || facts["result"] != "conflict" {
+		t.Fatalf("fixture: wanted result=conflict exit 2, got %v exit %d", facts, code)
+	}
+	if b, err := os.ReadFile(filepath.Join(state, "reset-manifest.tsv")); err == nil {
+		if strings.Contains(string(b), path) {
+			t.Errorf("a refused conflict was recorded as our own edit:\n%s", b)
+		}
+	}
+}
+
+// TestAddRefusesTheMachineWideFileWithoutBeingTold. The default scope was documented in the install
+// skill and nowhere else — the script wrote whatever --file it was handed. A prompt is not a
+// guardrail against a machine-wide lockout: it can be skipped, or read differently by the next
+// model, and the cost is every Claude Code session on the machine, including the ones the user would
+// use to recover. So the refusal lives in the script.
+func TestAddRefusesTheMachineWideFileWithoutBeingTold(t *testing.T) {
+	state, home := t.TempDir(), t.TempDir()
+	userScope := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(userScope), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, userScope, map[string]any{"theme": "dark"})
+	before, err := os.ReadFile(userScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	facts, code := settingsIn(t, state, home, "add", "--file", userScope, "--url", ourURL)
+	if code != 2 || facts["reason"] != "user_scope_needs_flag" {
+		t.Fatalf("wanted exit 2 reason=user_scope_needs_flag, got exit %d %v", code, facts)
+	}
+	after, err := os.ReadFile(userScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the machine-wide file was modified by a call that reported refusing:\n%s", after)
+	}
+
+	// With the flag — i.e. the user asked for --global and confirmed — it goes through.
+	facts, code = settingsIn(t, state, home, "add", "--file", userScope, "--url", ourURL, "--user-scope")
+	if code != 0 || facts["result"] != "added" {
+		t.Fatalf("--user-scope did not permit the write: exit %d %v", code, facts)
+	}
+	env, _ := readJSON(t, userScope)["env"].(map[string]any)
+	if env["ANTHROPIC_BASE_URL"] != ourURL {
+		t.Errorf("routing not written with --user-scope: %v", env)
+	}
+}
+
+// TestRemoveIsNeverGatedByScope: uninstall loops over all three scopes, and it is the recovery path.
+// Gating removal the way `add` is gated would make a machine-wide install unremovable by the tool
+// that installed it — erring on exactly the wrong side.
+func TestRemoveIsNeverGatedByScope(t *testing.T) {
+	state, home := t.TempDir(), t.TempDir()
+	userScope := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(userScope), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, userScope, map[string]any{"theme": "dark"})
+	if _, code := settingsIn(t, state, home, "add", "--file", userScope, "--url", ourURL,
+		"--user-scope"); code != 0 {
+		t.Fatal("fixture: --user-scope add failed")
+	}
+
+	facts, code := settingsIn(t, state, home, "remove", "--file", userScope, "--url", ourURL)
+	if code != 0 {
+		t.Fatalf("remove from user scope: exit %d %v", code, facts)
+	}
+	env, _ := readJSON(t, userScope)["env"].(map[string]any)
+	if _, still := env["ANTHROPIC_BASE_URL"]; still {
+		t.Errorf("routing survived removal from the machine-wide file: %v", env)
+	}
+	if readJSON(t, userScope)["theme"] != "dark" {
+		t.Errorf("removal damaged the machine-wide file")
 	}
 }

--- a/context-guru-plugin/scripts/check-proxy.sh
+++ b/context-guru-plugin/scripts/check-proxy.sh
@@ -119,6 +119,25 @@ the proxy's flags, and a stale copy of that list is what made this note wrong be
 Log from the last attempt: ${LOG}"
 fi
 
+# The escape hatch, named here because THIS is the moment it is for: the proxy is down, the next
+# request hangs, and the advice this note used to end on was "edit the JSON by hand, or run a skill
+# from a session that still works" — the second of which is unavailable to a user whose sessions are
+# all routed through the same dead port. Only named when it is actually on disk; pointing at a path
+# that is not there would be worse than saying nothing.
+HATCH="${CONTEXT_GURU_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/context-guru}/context-guru-reset"
+if [ -x "$HATCH" ]; then
+  ESCAPE="To stop routing entirely and get working immediately, run this in a terminal — it needs no
+working Claude session, restores every settings file this plugin edited from a copy taken before the
+first edit, and prints what it changed:
+
+  ${HATCH}
+
+Add --dry-run first if you would rather see the plan than take it."
+else
+  ESCAPE="To stop routing entirely and get working immediately, remove env.ANTHROPIC_BASE_URL from
+.claude/settings.local.json (or run /context-guru:uninstall from a session that still works)."
+fi
+
 cat <<EOF
 context-guru: this project is routed through http://127.0.0.1:${PORT}/anthropic, and nothing is
 answering there. **Your request will hang with no error message** — that is what a dead proxy looks
@@ -126,7 +145,6 @@ like from inside Claude Code, and it is why this note exists rather than a skill
 
 ${HOW}
 
-To stop routing entirely and get working immediately, remove env.ANTHROPIC_BASE_URL from
-.claude/settings.local.json (or run /context-guru:uninstall from a session that still works).
+${ESCAPE}
 EOF
 exit 0

--- a/context-guru-plugin/scripts/reset.sh
+++ b/context-guru-plugin/scripts/reset.sh
@@ -110,10 +110,25 @@ warn() { printf '%s\n' "$*" >&2; }
 # Case-insensitivity is spelled out with bracket classes on purpose: BSD sed (macOS, where this
 # script runs most) has no `I` flag on `s///`, so `[Kk][Ee][Yy]` is the portable spelling.
 # ---------------------------------------------------------------------------
-REDACT_NAME='[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll]'
+# This is a DENYLIST, and a denylist on a recovery tool is a list that will be wrong again — it has
+# now been wrong three times, each in a different shape. It is not inverted to an allowlist because
+# on a diff of arbitrary JSON that would redact the `permissions` entries the diff exists to show,
+# which is a worse failure. What keeps it honest instead is a table-driven test with one row per
+# shape (TestRedactCoversEveryKnownCredentialShape): the next miss should be a row somebody forgot
+# to add, not an invisible leak. ADD A ROW WHEN YOU ADD A RULE.
+#
+# Name half. HEADER is not decoration: ANTHROPIC_CUSTOM_HEADERS is how a Context Guru credential is
+# carried on this project's own dev machines, so the single most likely credential in a context-guru
+# user's env block had a name containing none of key/token/secret/password/credential. AUTH catches
+# `authorization: Bearer …`, the other natural way to put a credential in an env block, and
+# `authToken` for free.
+REDACT_NAME='[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll]|[Aa][Uu][Tt][Hh]|[Hh][Ee][Aa][Dd][Ee][Rr]|[Ss][Ee][Ss][Ss][Ii][Oo][Nn]|[Cc][Oo][Oo][Kk][Ii][Ee]|[Ss][Ii][Gg][Nn][Aa][Tt][Uu][Rr][Ee]'
 redact() {
   sed -E -e "s/(\"[A-Za-z0-9_-]*(${REDACT_NAME})[A-Za-z0-9_-]*\"[[:space:]]*:[[:space:]]*\")[^\"]*/\1<value not shown>/g" \
          -e 's/sk-[A-Za-z0-9_-]{6,}/sk-<value not shown>/g' \
+         -e 's#(ghp_|github_pat_|xox[baprs]-|AKIA|eyJ)[A-Za-z0-9_./+-]{6,}#\1<value not shown>#g' \
+         -e "s/([Bb]earer[[:space:]]+)[A-Za-z0-9_.~+/=-]{8,}/\1<value not shown>/g" \
+         -e "s/([?\&][A-Za-z0-9_-]*([Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt])=)[^\&\"[:space:]]*/\1<value not shown>/g" \
          -e 's#(://)[^/@[:space:]"]*:[^/@[:space:]"]*@#\1<credentials not shown>@#g'
 }
 
@@ -155,12 +170,16 @@ report_environment() {
     case "$base" in
       http://127.0.0.1:*|http://localhost:*|http://[::1]:*)
         say "  ! ANTHROPIC_BASE_URL is exported in THIS SHELL and points at a local proxy:"
-        say "      $base"
+        # Through redact, like every other printer of real content. This was the fourth site and the
+        # worst one: it sits in the function whose own header promises values are never printed, and
+        # it honoured that for the credential variables and the rc grep while echoing a base URL
+        # verbatim — so an exported https://svc:SECRET@gw/anthropic went straight to the terminal.
+        say "      $(printf '%s' "$base" | redact)"
         say "    A settings file cannot override an exported variable, so this shell stays"
         say "    routed until you unset it. Fix the line reported below, then open a new shell."
         INCOMPLETE=1 ;;
       *)
-        say "  - ANTHROPIC_BASE_URL is exported in this shell: $base" ;;
+        say "  - ANTHROPIC_BASE_URL is exported in this shell: $(printf '%s' "$base" | redact)" ;;
     esac
   fi
 
@@ -255,7 +274,9 @@ say ""
 say "Files context-guru edited:"
 
 PLAN="$(mktemp "${TMPDIR:-/tmp}/cg-reset-plan.XXXXXX")"
-trap 'rm -f "$PLAN"' EXIT INT TERM
+# ENV_TMP is in here too (set later, in the empty-plan branch): an interrupt between its mktemp and
+# its rm would otherwise leak a temp file into TMPDIR.
+trap 'rm -f "$PLAN" ${ENV_TMP:+"$ENV_TMP"}' EXIT INT TERM
 
 n=0
 while IFS='	' read -r existed original path; do
@@ -488,10 +509,22 @@ done < "$PLAN"
 report_environment
 final_advice
 
-if [ "$INCOMPLETE" = 0 ]; then
+# FILES_UNFIXED chooses the sentence, INCOMPLETE chooses the exit code — the same split as the
+# empty-plan branch, which is where this bug was fixed first and where it should have been fixed
+# both times. Testing INCOMPLETE here meant a COMPLETELY successful restore, verified unrouted, run
+# from a shell with an exported base URL (a hosted agent, or the shell they installed from) printed
+# "Finished with something left for you" and never printed the count at all: $RESTORED was computed
+# and thrown away on precisely the run where it is the good news, and the user who had just
+# recovered was told the run did not finish.
+if [ "$FILES_UNFIXED" = 0 ]; then
   say ""
   say "Done. $RESTORED file(s) put back."
-  exit 0
+  if [ "$INCOMPLETE" != 0 ]; then
+    say ""
+    say "The files are done. What is left is in the environment report above — a settings file"
+    say "cannot fix it, so read the ! line there before starting a new session."
+  fi
+  [ "$INCOMPLETE" = 0 ] && exit 0 || exit 3
 fi
 say ""
 say "Finished with something left for you — see the ! lines above."

--- a/context-guru-plugin/scripts/reset.sh
+++ b/context-guru-plugin/scripts/reset.sh
@@ -33,6 +33,16 @@ YES=0
 STAMP="$(date +%Y%m%d-%H%M%S)"
 # Set when any step could not finish, so the exit code tells a script what a human would see.
 INCOMPLETE=0
+# Set ONLY by a problem with a FILE, and kept separate from INCOMPLETE on purpose.
+#
+# INCOMPLETE grew to include an environment condition (an ANTHROPIC_BASE_URL exported in the user's
+# shell, which no settings change can override) and that immediately made the empty-plan branch lie
+# in the other direction: with clean files and a routed shell it printed "your settings files are NOT
+# back to their pre-install state" plus instructions to repair a file, two lines under a line saying
+# that same file already matched its pre-install copy. Which sentence to print is a question about
+# FILES; the exit code is a question about whether anything is left for a human. Two questions, two
+# flags.
+FILES_UNFIXED=0
 RESTORED=0
 
 usage() {
@@ -74,6 +84,38 @@ MANIFEST="$STATE/reset-manifest.tsv"
 
 say()  { printf '%s\n' "$*"; }
 warn() { printf '%s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# redact: a filter for anything that prints FILE CONTENT.
+#
+# Found in review, and it contradicted this script's own stated principle 150 lines below: the
+# whole-file warning diffs the settings file, `env` is exactly where people keep
+# ANTHROPIC_API_KEY, and so `--dry-run` — the invocation the docs tell people to run FIRST —
+# printed a live key twice, once per side of the diff.
+#
+# Who reads this output is what makes it worse than the usual secret-in-a-log: somebody debugging
+# a 401, whose next move is very likely to paste the whole thing into an issue, a chat or a
+# screenshot, precisely BECAUSE the output is designed to be read and acted on.
+#
+# Applied at every site that prints file content rather than at the one the reviewer found — the
+# diff, the verify pass and the no-record grep all echo lines from the user's settings — because
+# "remember to filter this one too" is how the first leak happened.
+#
+# Redacts the VALUE and keeps the line, so the diff still shows THAT a credential line changed,
+# which is the whole point of showing a diff. Three shapes:
+#   * any JSON key whose name contains key/token/secret/password/credential, in any case;
+#   * an Anthropic/OpenAI-style `sk-...` value, whatever the field is called;
+#   * credentials embedded in a URL (https://user:pass@host).
+#
+# Case-insensitivity is spelled out with bracket classes on purpose: BSD sed (macOS, where this
+# script runs most) has no `I` flag on `s///`, so `[Kk][Ee][Yy]` is the portable spelling.
+# ---------------------------------------------------------------------------
+REDACT_NAME='[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll]'
+redact() {
+  sed -E -e "s/(\"[A-Za-z0-9_-]*(${REDACT_NAME})[A-Za-z0-9_-]*\"[[:space:]]*:[[:space:]]*\")[^\"]*/\1<value not shown>/g" \
+         -e 's/sk-[A-Za-z0-9_-]{6,}/sk-<value not shown>/g' \
+         -e 's#(://)[^/@[:space:]"]*:[^/@[:space:]"]*@#\1<credentials not shown>@#g'
+}
 
 # ---------------------------------------------------------------------------
 # The credential / environment report.
@@ -181,7 +223,7 @@ if [ ! -f "$MANIFEST" ]; then
       say "  $f"
       hits="$(grep -n 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$f" 2>/dev/null || true)"
       if [ -n "$hits" ]; then
-        printf '%s\n' "$hits" | sed 's/^/      /'
+        printf '%s\n' "$hits" | redact | sed 's/^/      /'
         say "      ^ if one of those points at 127.0.0.1 and you did not set it, delete that key."
       else
         say "      (no context-guru keys — this one is fine)"
@@ -270,8 +312,12 @@ while IFS='	' read -r existed original path; do
           say ""
           say "        The two files differ (this includes context-guru's own keys, and the"
           say "        reformatting it applied when it wrote the file):"
-          diff "$original" "$path" 2>/dev/null | grep '^[<>]' | head -14 | sed 's/^/          /'
-          [ "${dl:-0}" -gt 14 ] && say "          ... and $((dl - 14)) more line(s)"
+          # 30, not 14. A hand-written settings file is usually compact and settings.py rewrites
+          # it pretty-printed, so the first dozen diff lines are pure reformatting — at 14 the cut
+          # landed BEFORE the user's own change (an added permission grant) in a test, which is the
+          # one line they actually needed to see. Still bounded, because this prints to a terminal.
+          diff "$original" "$path" 2>/dev/null | grep '^[<>]' | head -30 | redact | sed 's/^/          /'
+          [ "${dl:-0}" -gt 30 ] && say "          ... and $((dl - 30)) more line(s)"
           say "        (\"<\" is the pre-install copy, \">\" is your file now.)"
         fi
       fi
@@ -298,7 +344,7 @@ while IFS='	' read -r existed original path; do
       say "        compare it yourself, then: cp \"$newest\" \"$path\""
     fi
     say "        left untouched."
-    INCOMPLETE=1
+    INCOMPLETE=1; FILES_UNFIXED=1
   fi
 done < "$MANIFEST"
 
@@ -308,16 +354,30 @@ fi
 
 if [ ! -s "$PLAN" ]; then
   say ""
+  # report_environment sets INCOMPLETE, and this branch used to test INCOMPLETE BEFORE running it —
+  # so an ANTHROPIC_BASE_URL exported in the user's shell (the one condition no file restore can fix)
+  # printed its `!` and still exited 0, while the identical condition on a non-empty plan exited 3.
+  #
+  # Its output is captured rather than printed here so the summary sentence still comes first. A
+  # redirect does NOT create a subshell in POSIX sh, so INCOMPLETE set inside the function survives —
+  # which `ENV_OUT=$(report_environment)` would silently NOT do, and the bug would be invisible.
+  ENV_TMP="$(mktemp "${TMPDIR:-/tmp}/cg-reset-env.XXXXXX")"
+  report_environment > "$ENV_TMP"
   # An empty plan is reached from TWO very different states, and saying the reassuring one about
   # both was a review finding: the missing-copy branch above deliberately adds nothing to the plan,
   # so a routed file with no original produced the correct "! ..." block and then "already back to
   # their pre-install state" as the LAST line — the opposite of the truth, to the one user who is
   # locked out. Exit 3 was right; nobody reads an exit code, they read the last line.
-  if [ "$INCOMPLETE" = 0 ]; then
+  if [ "$FILES_UNFIXED" = 0 ]; then
     say "Nothing to restore — your settings files are already back to their pre-install state."
-    report_environment
+    if [ "$INCOMPLETE" != 0 ]; then
+      say ""
+      say "Your FILES are fine. What is left is in the environment report below, and a settings"
+      say "file cannot fix it — read the ! line there."
+    fi
+    cat "$ENV_TMP"; rm -f "$ENV_TMP"
     final_advice
-    exit 0
+    [ "$INCOMPLETE" = 0 ] && exit 0 || exit 3
   fi
   say "Nothing could be restored automatically — see the ! line(s) above. Your settings files are"
   say "NOT back to their pre-install state, and this tool has no copy that would put them there."
@@ -328,7 +388,7 @@ if [ ! -s "$PLAN" ]; then
   say "  2. or open the file and delete the ANTHROPIC_BASE_URL / ANTHROPIC_UPSTREAM /"
   say "     CONTEXT_GURU_BIN keys from its \"env\" block, leaving everything else alone."
   say "     That is all the routing is; nothing else has to change."
-  report_environment
+  cat "$ENV_TMP"; rm -f "$ENV_TMP"
   final_advice
   exit 3
 fi
@@ -374,7 +434,7 @@ while IFS='	' read -r action original path; do
       say "  saved current state: $pre"
     else
       warn "  ! could not copy $path aside; leaving it alone rather than restoring over it"
-      INCOMPLETE=1
+      INCOMPLETE=1; FILES_UNFIXED=1
       continue
     fi
   fi
@@ -384,7 +444,7 @@ while IFS='	' read -r action original path; do
         say "  deleted:  $path"
         RESTORED=$((RESTORED + 1))
       else
-        warn "  ! could not delete $path"; INCOMPLETE=1
+        warn "  ! could not delete $path"; INCOMPLETE=1; FILES_UNFIXED=1
       fi ;;
     restore)
       # cp onto the existing path, never `mv`: the settings file may be a symlink into a dotfiles
@@ -394,7 +454,7 @@ while IFS='	' read -r action original path; do
         say "  restored: $path"
         RESTORED=$((RESTORED + 1))
       else
-        warn "  ! could not restore $path from $original"; INCOMPLETE=1
+        warn "  ! could not restore $path from $original"; INCOMPLETE=1; FILES_UNFIXED=1
       fi ;;
   esac
 done < "$PLAN"
@@ -412,7 +472,7 @@ while IFS='	' read -r action original path; do
     # Not automatically a failure: a user whose own gateway was replaced with --force gets that
     # gateway back here, and it is SUPPOSED to be in the restored file.
     say "  ?   $path still mentions an ANTHROPIC_* key:"
-    grep -n 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$path" | sed 's/^/        /'
+    grep -n 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$path" | redact | sed 's/^/        /'
     if grep -q '127\.0\.0\.1\|localhost' "$path" 2>/dev/null; then
       say "        that points at a local proxy — if you did not set it yourself, delete the key."
       left=1
@@ -423,7 +483,7 @@ while IFS='	' read -r action original path; do
     say "  ok  $path (no context-guru keys)"
   fi
 done < "$PLAN"
-[ "$left" = 0 ] || INCOMPLETE=1
+[ "$left" = 0 ] || { INCOMPLETE=1; FILES_UNFIXED=1; }
 
 report_environment
 final_advice

--- a/context-guru-plugin/scripts/reset.sh
+++ b/context-guru-plugin/scripts/reset.sh
@@ -1,0 +1,368 @@
+#!/bin/sh
+# context-guru-reset — undo context-guru's routing when Claude Code cannot do it for you.
+#
+# WHY THIS EXISTS, AND WHY IT IS NOT A SKILL
+#
+# The plugin's undo path is `/context-guru:uninstall`, which is a SKILL: it needs a working
+# Claude Code session to run. The failure this script exists for takes that away. Routing every
+# request through a local proxy means a bad routing key, a dead port or a rejected credential
+# makes every API call fail — and then the agent that would have fixed it cannot talk to a model
+# to be asked. A colleague hit exactly that: 401 on every request, and `/context-guru:uninstall`
+# unavailable for the same reason he needed it.
+#
+# So this is deliberately the opposite of the rest of the plugin:
+#
+#   * plain POSIX sh, no python, no Go binary, no network, no plugin code;
+#   * it is INSTALLED OUTSIDE THE PLUGIN, into the state directory next to its own backups. A
+#     hatch that lives inside the thing that broke is unavailable exactly when it is needed —
+#     `/plugin uninstall`, a marketplace refresh or a wiped plugin cache all take it with them;
+#   * the primary path is `cp`, restoring a copy of each settings file taken BEFORE the first
+#     edit, so recovery does not depend on parsing anything;
+#   * it takes its own backup before it writes, so running it is itself reversible;
+#   * it prints what it will do and asks, unless told `--yes`.
+#
+# It restores ROUTING. It does not fix a credential — see the report it prints at the end, which
+# names the file and line an ANTHROPIC_* variable is exported from without ever printing a value.
+
+set -eu
+
+PROG="context-guru-reset"
+STATE="${CONTEXT_GURU_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/context-guru}"
+DRY=0
+YES=0
+STAMP="$(date +%Y%m%d-%H%M%S)"
+# Set when any step could not finish, so the exit code tells a script what a human would see.
+INCOMPLETE=0
+RESTORED=0
+
+usage() {
+  cat <<USAGE
+$PROG — put your Claude Code settings back the way they were before context-guru.
+
+usage: $PROG [--dry-run] [--yes] [--state DIR]
+
+  --dry-run   show what would change and exit without writing anything
+  --yes       do not ask for confirmation (for non-interactive use)
+  --state DIR read the record from DIR instead of
+              \${XDG_STATE_HOME:-\$HOME/.local/state}/context-guru
+
+What it does, in order:
+  1. reads the record of every settings file context-guru edited;
+  2. copies each of those aside (.context-guru-prereset-*) so this is reversible too;
+  3. restores each from the copy taken before context-guru's first edit — or deletes the
+     file, if context-guru is the reason it exists;
+  4. verifies no routing key is left, and reports anything it could not fix.
+
+It never stops processes, never touches the network, and never edits a file it has no record
+of editing.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY=1 ;;
+    --yes|-y) YES=1 ;;
+    --state) shift; [ $# -gt 0 ] || { echo "$PROG: --state needs a directory" >&2; exit 2; }; STATE="$1" ;;
+    --state=*) STATE="${1#--state=}" ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "$PROG: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+MANIFEST="$STATE/reset-manifest.tsv"
+
+say()  { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# The credential / environment report.
+#
+# Printed on EVERY path, including when there is nothing to restore, because the last real
+# incident in this plugin's history was not a routing fault at all: both ANTHROPIC_API_KEY and
+# ANTHROPIC_AUTH_TOKEN were set, the gateway rejected the one that won, and the export was one
+# line in a shell rc. No amount of settings surgery reaches that, and a hatch that stays silent
+# about it sends the user back to a session that still fails.
+#
+# Values are never printed. `grep -n` gives the line, and the value is replaced before output —
+# a recovery tool that echoes a live API key into a terminal buffer is not a recovery tool.
+# ---------------------------------------------------------------------------
+report_environment() {
+  say ""
+  say "Environment (this is not something restoring a file can fix):"
+
+  set +u
+  api_set=0; tok_set=0
+  [ -n "$ANTHROPIC_API_KEY" ] && api_set=1
+  [ -n "$ANTHROPIC_AUTH_TOKEN" ] && tok_set=1
+  base="$ANTHROPIC_BASE_URL"
+  set -u
+
+  if [ "$api_set" = 1 ] && [ "$tok_set" = 1 ]; then
+    say "  ! ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN are BOTH set in this shell."
+    say "    Claude Code warns about this at startup and it is a real fault: only one of them"
+    say "    wins, and if that is the stale one every request fails with 401 no matter how the"
+    say "    routing is configured. Unset the one your gateway does not know."
+  elif [ "$api_set" = 1 ] || [ "$tok_set" = 1 ]; then
+    say "  - one Anthropic credential variable is set in this shell (value not shown)"
+  else
+    say "  - no Anthropic credential variable is set in this shell"
+  fi
+
+  if [ -n "${base:-}" ]; then
+    case "$base" in
+      http://127.0.0.1:*|http://localhost:*|http://[::1]:*)
+        say "  ! ANTHROPIC_BASE_URL is exported in THIS SHELL and points at a local proxy:"
+        say "      $base"
+        say "    A settings file cannot override an exported variable, so this shell stays"
+        say "    routed until you unset it. Fix the line reported below, then open a new shell."
+        INCOMPLETE=1 ;;
+      *)
+        say "  - ANTHROPIC_BASE_URL is exported in this shell: $base" ;;
+    esac
+  fi
+
+  # Where those exports come from. Nothing here is modified — the file and line are the point,
+  # because the user has to decide which credential is the good one, and this script cannot.
+  found=0
+  for rc in "$HOME/.zshrc" "$HOME/.zshenv" "$HOME/.zprofile" "$HOME/.bashrc" \
+            "$HOME/.bash_profile" "$HOME/.profile"; do
+    [ -f "$rc" ] || continue
+    hits="$(grep -nE '^[[:space:]]*(export[[:space:]]+)?ANTHROPIC_(API_KEY|AUTH_TOKEN|BASE_URL|UPSTREAM)=' "$rc" 2>/dev/null \
+            | sed 's/=.*/=<value not shown>/' || true)"
+    [ -n "$hits" ] || continue
+    [ "$found" = 0 ] && say "" && say "  ANTHROPIC_* set from shell startup files:"
+    found=1
+    printf '%s\n' "$hits" | while IFS= read -r line; do
+      printf '    %s:%s\n' "$rc" "$line"
+    done
+  done
+  if [ "$found" = 0 ]; then
+    say ""
+    say "  No ANTHROPIC_* assignments found in your shell startup files."
+  else
+    say ""
+    say "  Those lines run in every new shell. If one of them is the credential your gateway"
+    say "  rejects, editing it is the fix; this script does not touch them."
+  fi
+}
+
+final_advice() {
+  say ""
+  if [ "$RESTORED" -gt 0 ]; then
+    say "Next: start a NEW claude session. A running one keeps the environment it started with,"
+    say "so the session you are recovering will keep failing until you restart it."
+  fi
+  say "The plugin's hooks stay installed and are inert once routing is gone — each one exits"
+  say "immediately in a project that is not routed. Nothing needs to be uninstalled to unblock you."
+  say "Any proxy still running exits on its own idle timeout; nothing here signals a process."
+}
+
+# ---------------------------------------------------------------------------
+# No record at all. This is a real state — a hand-edited settings file, an install that predates
+# the record, or a wiped state directory — and answering it with "nothing to do" would be the
+# most useless thing this script could say to somebody whose sessions are down.
+# ---------------------------------------------------------------------------
+if [ ! -f "$MANIFEST" ]; then
+  warn "$PROG: no record of any edit at $MANIFEST"
+  say ""
+  say "That means this script cannot restore anything automatically. Nothing is lost: check"
+  say "these files by hand for an \"ANTHROPIC_BASE_URL\" pointing at 127.0.0.1, and either"
+  say "delete that key or restore one of the timestamped backups beside the file"
+  say "(*.context-guru-backup-*, newest last):"
+  say ""
+  # EVERY candidate is printed, present or not. Printing only the ones that exist meant that in a
+  # directory that happened to hold none of them the output was the heading "check these files by
+  # hand:" followed by nothing at all — which is the precise uselessness this branch was written to
+  # avoid, delivered to somebody whose sessions are down. A named path they can check and rule out
+  # is worth more than silence, and the absent ones are also the answer to "is it the global one?".
+  for f in "./.claude/settings.local.json" "./.claude/settings.json" "$HOME/.claude/settings.json"; do
+    if [ -f "$f" ]; then
+      say "  $f"
+      hits="$(grep -n 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$f" 2>/dev/null || true)"
+      if [ -n "$hits" ]; then
+        printf '%s\n' "$hits" | sed 's/^/      /'
+        say "      ^ if one of those points at 127.0.0.1 and you did not set it, delete that key."
+      else
+        say "      (no context-guru keys — this one is fine)"
+      fi
+      ls -1t "$f".context-guru-backup-* 2>/dev/null | sed 's/^/      backup: /' || true
+    else
+      say "  $f"
+      say "      (not present)"
+    fi
+  done
+  say ""
+  say "  The first two are relative to the project you are in: $(pwd)"
+  say "  If you were routed from a different project, run this again from there."
+  report_environment
+  final_advice
+  exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Read the record and build the plan. Two passes on purpose: everything is shown before anything
+# is written, so the confirmation prompt is answered with the full picture rather than with trust.
+#
+# Format, one edited settings file per line:  <1|0 existed before>\t<original copy|->\t<path>
+# `0` means context-guru CREATED that file, so putting things back means deleting it.
+# ---------------------------------------------------------------------------
+say "$PROG"
+say "Record: $MANIFEST"
+say ""
+say "Files context-guru edited:"
+
+PLAN="$(mktemp "${TMPDIR:-/tmp}/cg-reset-plan.XXXXXX")"
+trap 'rm -f "$PLAN"' EXIT INT TERM
+
+n=0
+while IFS='	' read -r existed original path; do
+  case "$existed" in ''|'#'*) continue ;; esac
+  [ -n "${path:-}" ] || continue
+  n=$((n + 1))
+  if [ ! -e "$path" ]; then
+    say "  $path"
+    say "      gone already — nothing to restore"
+    continue
+  fi
+  if [ "$existed" = 0 ]; then
+    say "  $path"
+    say "      DELETE (context-guru created this file; it did not exist before)"
+    printf 'delete\t-\t%s\n' "$path" >> "$PLAN"
+  elif [ -f "$original" ]; then
+    say "  $path"
+    if cmp -s "$original" "$path"; then
+      # Already identical to the pre-install copy, so a restore would copy a file onto itself and
+      # leave another .context-guru-prereset-* behind for nothing. Running this twice is a normal
+      # thing to do — the first run tells you to open a new session, and people re-run it to check
+      # — so the second run has to be a genuine no-op rather than quiet extra work.
+      say "      already matches the pre-install copy — nothing to do"
+    else
+      say "      RESTORE from the copy taken before the first edit:"
+      say "      $original"
+      printf 'restore\t%s\t%s\n' "$original" "$path" >> "$PLAN"
+    fi
+  else
+    say "  $path"
+    say "      ! the pre-edit copy is missing ($original)"
+    newest="$(ls -1t "$path".context-guru-backup-* 2>/dev/null | head -1 || true)"
+    if [ -n "$newest" ]; then
+      say "        a timestamped backup exists and is NOT restored automatically, because it"
+      say "        may be a copy of a later state rather than of your original:"
+      say "          $newest"
+      say "        compare it yourself, then: cp \"$newest\" \"$path\""
+    fi
+    say "        left untouched."
+    INCOMPLETE=1
+  fi
+done < "$MANIFEST"
+
+if [ "$n" = 0 ]; then
+  say "  (none recorded)"
+fi
+
+if [ ! -s "$PLAN" ]; then
+  say ""
+  say "Nothing to restore — your settings files are already back to their pre-install state."
+  report_environment
+  final_advice
+  [ "$INCOMPLETE" = 0 ] && exit 0 || exit 3
+fi
+
+if [ "$DRY" = 1 ]; then
+  say ""
+  say "--dry-run: nothing written."
+  report_environment
+  exit 0
+fi
+
+if [ "$YES" = 0 ]; then
+  say ""
+  # </dev/tty rather than stdin: a `sh reset.sh` whose stdin is not a terminal must not read the
+  # answer out of a pipe, or out of the rest of a script.
+  if [ -r /dev/tty ]; then
+    printf 'Restore these files now? [y/N] '
+    read -r answer < /dev/tty || answer=""
+    case "$answer" in
+      y|Y|yes|YES) ;;
+      *) say "Aborted; nothing was written."; exit 1 ;;
+    esac
+  else
+    warn ""
+    warn "$PROG: not a terminal, so nothing was written. Re-run with --yes to proceed."
+    exit 2
+  fi
+fi
+
+say ""
+while IFS='	' read -r action original path; do
+  # Reversible in its own right: whatever is there NOW is copied aside first, so a user who runs
+  # this and then discovers the routing was not the problem has the routed version back.
+  pre="$path.context-guru-prereset-$STAMP"
+  if [ -e "$path" ] && [ ! -e "$pre" ]; then
+    if cp -p "$path" "$pre" 2>/dev/null || cp "$path" "$pre"; then
+      say "  saved current state: $pre"
+    else
+      warn "  ! could not copy $path aside; leaving it alone rather than restoring over it"
+      INCOMPLETE=1
+      continue
+    fi
+  fi
+  case "$action" in
+    delete)
+      if rm -f "$path"; then
+        say "  deleted:  $path"
+        RESTORED=$((RESTORED + 1))
+      else
+        warn "  ! could not delete $path"; INCOMPLETE=1
+      fi ;;
+    restore)
+      # cp onto the existing path, never `mv`: the settings file may be a symlink into a dotfiles
+      # repository, and replacing the link would silently take the edit away from the file the
+      # user actually manages. Same reason settings.py resolves the path before writing.
+      if cp "$original" "$path"; then
+        say "  restored: $path"
+        RESTORED=$((RESTORED + 1))
+      else
+        warn "  ! could not restore $path from $original"; INCOMPLETE=1
+      fi ;;
+  esac
+done < "$PLAN"
+
+# ---------------------------------------------------------------------------
+# Verify, rather than trusting that cp did what the plan said. This is the claim the user acts
+# on — "you are unrouted now" — so it is checked against the files on disk.
+# ---------------------------------------------------------------------------
+say ""
+say "Verifying:"
+left=0
+while IFS='	' read -r action original path; do
+  [ -e "$path" ] || { say "  ok  $path (absent)"; continue; }
+  if grep -q 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$path" 2>/dev/null; then
+    # Not automatically a failure: a user whose own gateway was replaced with --force gets that
+    # gateway back here, and it is SUPPOSED to be in the restored file.
+    say "  ?   $path still mentions an ANTHROPIC_* key:"
+    grep -n 'ANTHROPIC_BASE_URL\|ANTHROPIC_UPSTREAM\|CONTEXT_GURU_BIN' "$path" | sed 's/^/        /'
+    if grep -q '127\.0\.0\.1\|localhost' "$path" 2>/dev/null; then
+      say "        that points at a local proxy — if you did not set it yourself, delete the key."
+      left=1
+    else
+      say "        that is your own value, restored as it was before the install."
+    fi
+  else
+    say "  ok  $path (no context-guru keys)"
+  fi
+done < "$PLAN"
+[ "$left" = 0 ] || INCOMPLETE=1
+
+report_environment
+final_advice
+
+if [ "$INCOMPLETE" = 0 ]; then
+  say ""
+  say "Done. $RESTORED file(s) put back."
+  exit 0
+fi
+say ""
+say "Finished with something left for you — see the ! lines above."
+exit 3

--- a/context-guru-plugin/scripts/reset.sh
+++ b/context-guru-plugin/scripts/reset.sh
@@ -240,11 +240,56 @@ while IFS='	' read -r existed original path; do
     else
       say "      RESTORE from the copy taken before the first edit:"
       say "      $original"
+      # A whole-file restore reverts EVERYTHING in the file, not just the routing — and for
+      # .claude/settings.local.json that is not hypothetical, because Claude Code appends permission
+      # grants to it as the user approves tools. A months-old install means months of grants. The
+      # copy of the current file taken below makes it recoverable, but silently reverting a user's
+      # settings while a confirmation prompt says only "restore these files?" is not a choice they
+      # were given. So: show them, in the plan, before they answer.
+      #
+      # `diff` rather than a JSON-aware comparison on purpose: parsing JSON in sh is exactly the
+      # cleverness a recovery tool must not contain, and a plain diff of two small files answers the
+      # question the user actually has, which is "what am I about to lose".
+      say ""
+      say "      ! this reverts the WHOLE file, not just the routing. Anything you changed in it"
+      say "        since installing goes back too — permission grants Claude Code appended as you"
+      say "        approved tools, a model or theme you set. Your current version is copied to"
+      say "        *.context-guru-prereset-* first, so this is undoable."
+      # The diff is shown as EVIDENCE, with no claim about which side of it is the user's.
+      #
+      # The first version of this counted "lines that are not context-guru's" by grepping our key
+      # names out, and the number was false precision twice over: settings.py rewrites the file with
+      # indent=2, so a compact original diffs on every line, and our own metadata spans lines that
+      # carry none of the words being filtered. It reported 16 lines of "your" changes for a file
+      # whose only real change was two permission grants. Since sh cannot compare JSON semantically
+      # — and parsing it here is exactly the cleverness this script must not contain — the honest
+      # move is to show the difference and say plainly what it includes.
+      if command -v diff >/dev/null 2>&1; then
+        dl="$(diff "$original" "$path" 2>/dev/null | grep -c '^[<>]' || true)"
+        if [ "${dl:-0}" -gt 0 ]; then
+          say ""
+          say "        The two files differ (this includes context-guru's own keys, and the"
+          say "        reformatting it applied when it wrote the file):"
+          diff "$original" "$path" 2>/dev/null | grep '^[<>]' | head -14 | sed 's/^/          /'
+          [ "${dl:-0}" -gt 14 ] && say "          ... and $((dl - 14)) more line(s)"
+          say "        (\"<\" is the pre-install copy, \">\" is your file now.)"
+        fi
+      fi
+      say ""
       printf 'restore\t%s\t%s\n' "$original" "$path" >> "$PLAN"
     fi
   else
     say "  $path"
-    say "      ! the pre-edit copy is missing ($original)"
+    # `-` is what the record carries when no copy was ever taken (a project that was already
+    # routed when the record was created, or a file whose first recorded touch was a REMOVAL).
+    # Rendering it as a path — "the pre-edit copy is missing (-)" — reads like a bug in the tool
+    # rather than a known limit of what it holds, and it is the normal case for pre-hatch installs.
+    if [ "$original" = "-" ] || [ -z "$original" ]; then
+      say "      ! no pre-edit copy was taken for this file — it already carried context-guru's"
+      say "        keys when the record was created, so nothing here holds its original content."
+    else
+      say "      ! the pre-edit copy is missing ($original)"
+    fi
     newest="$(ls -1t "$path".context-guru-backup-* 2>/dev/null | head -1 || true)"
     if [ -n "$newest" ]; then
       say "        a timestamped backup exists and is NOT restored automatically, because it"
@@ -263,17 +308,42 @@ fi
 
 if [ ! -s "$PLAN" ]; then
   say ""
-  say "Nothing to restore — your settings files are already back to their pre-install state."
+  # An empty plan is reached from TWO very different states, and saying the reassuring one about
+  # both was a review finding: the missing-copy branch above deliberately adds nothing to the plan,
+  # so a routed file with no original produced the correct "! ..." block and then "already back to
+  # their pre-install state" as the LAST line — the opposite of the truth, to the one user who is
+  # locked out. Exit 3 was right; nobody reads an exit code, they read the last line.
+  if [ "$INCOMPLETE" = 0 ]; then
+    say "Nothing to restore — your settings files are already back to their pre-install state."
+    report_environment
+    final_advice
+    exit 0
+  fi
+  say "Nothing could be restored automatically — see the ! line(s) above. Your settings files are"
+  say "NOT back to their pre-install state, and this tool has no copy that would put them there."
+  say ""
+  say "What works, in order of least effort:"
+  say "  1. compare a timestamped backup beside the file and copy it back yourself:"
+  say "       cp <file>.context-guru-backup-<newest> <file>"
+  say "  2. or open the file and delete the ANTHROPIC_BASE_URL / ANTHROPIC_UPSTREAM /"
+  say "     CONTEXT_GURU_BIN keys from its \"env\" block, leaving everything else alone."
+  say "     That is all the routing is; nothing else has to change."
   report_environment
   final_advice
-  [ "$INCOMPLETE" = 0 ] && exit 0 || exit 3
+  exit 3
 fi
 
 if [ "$DRY" = 1 ]; then
   say ""
   say "--dry-run: nothing written."
   report_environment
-  exit 0
+  # Honour INCOMPLETE here too. It used to exit 0 unconditionally, so --dry-run and a real run
+  # disagreed about whether anything was left for a human — including when report_environment had
+  # just found an exported ANTHROPIC_BASE_URL that no settings change can override.
+  [ "$INCOMPLETE" = 0 ] && exit 0
+  say ""
+  say "(--dry-run found something a restore will not fix — see the ! lines above.)"
+  exit 3
 fi
 
 if [ "$YES" = 0 ]; then

--- a/context-guru-plugin/scripts/settings.py
+++ b/context-guru-plugin/scripts/settings.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import os
 import shutil
@@ -189,6 +190,250 @@ def prune_backups(path: str) -> None:
             pass
 
 
+# ---------------------------------------------------------------------------
+# The escape hatch: a pre-edit copy of every file we touch, a record of what we touched, and a
+# plain-sh script OUTSIDE THIS PLUGIN that puts it all back.
+#
+# The timestamped backups above are not enough on their own, and the reason is a real incident.
+# `/context-guru:uninstall` is a SKILL — it needs a working Claude Code session. But the failure
+# it exists for is "every request through the proxy fails", which is exactly the state in which
+# no skill can run: the agent that would undo the routing cannot reach a model to be asked. A
+# colleague hit that, 401 on every call, with the documented undo path unavailable for the same
+# reason he needed it.
+#
+# So three things are established BEFORE any routing key exists, in one choke point that no
+# write path can skip (see save()):
+#
+# 1. an ORIGINAL copy, taken once, never overwritten, never pruned. The backups beside the file
+#    are capped at KEEP_BACKUPS and every add AND remove writes one, so on a machine that has
+#    installed and uninstalled a few times the copy holding the user's pre-context-guru state is
+#    the FIRST to be deleted. The one copy recovery depends on cannot be on a rolling window.
+# 2. a record of which files we edited and whether each existed beforehand — a file we created
+#    is put back by deleting it, not by restoring it, and nothing else can tell the difference.
+# 3. the hatch script itself, copied out of the plugin into the state directory. A hatch that
+#    lives inside the thing that broke goes away with `/plugin uninstall`, a marketplace
+#    refresh, or a wiped plugin cache — i.e. it is missing in a fair share of the cases it is
+#    for. The copy under the state directory has no dependency on this plugin still existing.
+#
+# All of it is best-effort: a read-only or missing state directory must not fail an install that
+# would otherwise work. It is REPORTED instead (`reset_hatch=`), so the skill can tell the user
+# whether they have a hatch rather than assuming it.
+# ---------------------------------------------------------------------------
+
+HATCH_NAME = "context-guru-reset"
+MANIFEST_VERSION = 1
+
+# Facts collected during the run and printed once by main(), rather than from inside save() —
+# the caller reads `key=value` lines and the result line should come first.
+HATCH_FACTS: dict[str, str] = {}
+
+
+def state_dir() -> str:
+    """Where the hatch, the record and the original copies live. Overridable for tests."""
+    override = os.environ.get("CONTEXT_GURU_STATE")
+    if override:
+        return override
+    base = os.environ.get("XDG_STATE_HOME") or os.path.join(os.path.expanduser("~"), ".local", "state")
+    return os.path.join(base, "context-guru")
+
+
+def user_scope_files() -> list[str]:
+    """The settings file(s) that route EVERY project on the machine.
+
+    Kept as real paths so a symlinked ~/.claude (dotfiles) is still recognised as user scope.
+    """
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+    return [os.path.realpath(os.path.join(base, "settings.json"))]
+
+
+def is_user_scope(path: str) -> bool:
+    return os.path.realpath(path) in user_scope_files()
+
+
+def _slug(real: str) -> str:
+    """A filename for `real`'s original copy: readable, collision-free, path-shaped names flattened.
+
+    The hash is what makes it unique — two projects both called `web` have the same tail — and the
+    readable prefix is there because a user reading `ls` in a panic should be able to see which of
+    these is their global settings file and which is a project's.
+    """
+    tail = f"{os.path.basename(os.path.dirname(real))}-{os.path.basename(real)}"
+    safe = "".join(c if (c.isalnum() or c in "-._") else "_" for c in tail)
+    # Strip the leading dot, because the common case produces one: the parent directory is
+    # `.claude`, so the natural name is `.claude-settings.local.json.<hash>.original` — a HIDDEN
+    # file. A test caught it: `ls originals/*.original` matched nothing while the file sat right
+    # there. The directory exists to be read by a user whose sessions are down, and by any later
+    # glob over it; neither sees a dotfile.
+    safe = safe.lstrip(".") or "settings"
+    return f"{safe}.{hashlib.sha256(real.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _write_atomic(path: str, data: bytes, mode: int = 0o600) -> None:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), prefix=os.path.basename(path) + ".tmp-")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def install_hatch(state: str) -> str:
+    """Copy reset.sh out of the plugin and into `state`. Returns the installed path, or "".
+
+    Refreshed when the content differs, so a plugin update updates the hatch — the copy is the
+    one that will actually be run, and a stale copy of a recovery tool is its own hazard.
+    """
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "reset.sh")
+    dest = os.path.join(state, HATCH_NAME)
+    try:
+        with open(src, "rb") as fh:
+            new = fh.read()
+    except OSError:
+        # Source gone (a partial plugin install). An older copy already out here is still valid.
+        return dest if os.path.exists(dest) else ""
+    try:
+        current = None
+        if os.path.exists(dest):
+            with open(dest, "rb") as fh:
+                current = fh.read()
+        if current != new:
+            _write_atomic(dest, new, 0o700)
+        elif not os.access(dest, os.X_OK):
+            os.chmod(dest, 0o700)
+    except OSError:
+        return ""
+    # A second copy where the user's shell will find it by name. Only if the directory already
+    # exists — this is the proxy binary's own destination, so on a machine that ran the install it
+    # does; creating it would be a PATH change nobody asked for.
+    bindir = os.path.join(os.path.expanduser("~"), ".local", "bin")
+    if os.path.isdir(bindir):
+        try:
+            link = os.path.join(bindir, HATCH_NAME)
+            existing = None
+            if os.path.exists(link):
+                with open(link, "rb") as fh:
+                    existing = fh.read()
+            if existing != new:
+                _write_atomic(link, new, 0o700)
+        except OSError:
+            pass
+    return dest
+
+
+def _manifest_paths(state: str) -> tuple[str, str]:
+    return (os.path.join(state, "reset-manifest.json"),
+            os.path.join(state, "reset-manifest.tsv"))
+
+
+def _render_tsv(entries: list[dict]) -> bytes:
+    """The record in the form the hatch actually reads: one line per file, tab-separated.
+
+    Why not have the hatch parse the JSON: it is POSIX sh with no interpreter available on the
+    path that matters, and hand-rolled JSON parsing in sh is precisely the kind of cleverness a
+    recovery tool must not contain. The JSON is kept beside it for anything else that wants
+    structure.
+
+    A path containing a tab or a newline cannot be represented on a line, and rather than write a
+    line that would be misparsed into the wrong filename, such an entry is recorded as a comment
+    and the caller is told the record is partial. Deleting or overwriting the wrong file is a much
+    worse outcome than telling the user one path needs doing by hand.
+    """
+    out = [b"# context-guru reset record v%d - <existed_before 1|0>\t<original copy|->\t<path>" %
+           MANIFEST_VERSION]
+    for e in entries:
+        path = e["path"]
+        if "\t" in path or "\n" in path or "\r" in path:
+            out.append(b"# UNREPRESENTABLE PATH (tab or newline); restore this one by hand: "
+                       + repr(path).encode("utf-8"))
+            continue
+        out.append("\t".join(("1" if e["existed_before"] else "0",
+                             e.get("original") or "-", path)).encode("utf-8"))
+    return b"\n".join(out) + b"\n"
+
+
+def record_touch(real: str, existed: bool) -> None:
+    """Note that we are about to edit `real`, and make sure a way back exists.
+
+    Called from save() before the write, so `existed` is the truth about the file as the user had
+    it. Idempotent: the original copy is created with O_EXCL and a second call never replaces it,
+    which is the whole point — the tenth edit must not overwrite the record of the first.
+    """
+    state = state_dir()
+    try:
+        os.makedirs(os.path.join(state, "originals"), exist_ok=True)
+    except OSError as exc:
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"cannot write {state}: {exc}"
+        return
+
+    original = ""
+    if existed:
+        dest = os.path.join(state, "originals", _slug(real) + ".original")
+        try:
+            fd = os.open(dest, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            original = dest          # already recorded, by an earlier run; keep THAT one
+        except OSError:
+            original = ""
+        else:
+            try:
+                with os.fdopen(fd, "wb") as out, open(real, "rb") as srcf:
+                    shutil.copyfileobj(srcf, out)
+                original = dest
+            except OSError:
+                try:
+                    os.unlink(dest)  # a half copy is worse than none: it would restore garbage
+                except OSError:
+                    pass
+                original = ""
+
+    jsonp, tsvp = _manifest_paths(state)
+    entries: list[dict] = []
+    try:
+        with open(jsonp, encoding="utf-8") as fh:
+            prior = json.load(fh)
+        if isinstance(prior, dict) and isinstance(prior.get("files"), list):
+            entries = [e for e in prior["files"] if isinstance(e, dict) and e.get("path")]
+    except (OSError, json.JSONDecodeError):
+        entries = []
+
+    for e in entries:
+        if e.get("path") == real:
+            # Seen before. The first record is the authoritative one — `existed_before` describes
+            # the file as it was before context-guru ever touched it, and re-recording it from a
+            # later run would say "it existed" about a file we created ourselves.
+            if not e.get("original") and original:
+                e["original"] = original
+            break
+    else:
+        entries.append({"path": real, "existed_before": bool(existed),
+                        "original": original,
+                        "first_touched": _dt.datetime.now().astimezone().isoformat(timespec="seconds")})
+
+    hatch = install_hatch(state)
+    try:
+        _write_atomic(jsonp, (json.dumps({"version": MANIFEST_VERSION, "hatch": hatch,
+                                          "files": entries}, indent=2) + "\n").encode("utf-8"))
+        _write_atomic(tsvp, _render_tsv(entries))
+    except OSError as exc:
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"cannot write the record: {exc}"
+        return
+
+    HATCH_FACTS["reset_hatch"] = hatch or "unavailable"
+    HATCH_FACTS["reset_record"] = tsvp
+    if existed and not original:
+        # Worth its own line: routing can be removed from the record, but the file's original
+        # CONTENT is not recoverable from anything the hatch holds.
+        HATCH_FACTS["reset_original"] = "unavailable"
+
+
 def save(path: str, data: dict) -> None:
     """Write `data` to `path` atomically, preserving the file's identity and permissions.
 
@@ -206,6 +451,12 @@ def save(path: str, data: dict) -> None:
     """
     real = os.path.realpath(path)
     os.makedirs(os.path.dirname(os.path.abspath(real)) or ".", exist_ok=True)
+    # Every write in this script funnels through here, which is why the hatch is established here
+    # and not in the six callers: `add` alone has six exits that write, and one of them forgetting
+    # to record the file would produce a routed machine with no recorded way back — the one bug
+    # class this must not have. `real`, not `path`: a dotfiles symlink is restored by writing the
+    # file it points at, the same reason the write below resolves it.
+    record_touch(real, os.path.exists(real))
     # 0600 from the instant the file exists, not from copymode() below.
     #
     # `open(tmp, "w")` creates with 0666 & ~umask — typically 0644 — and the mode was corrected
@@ -254,7 +505,71 @@ def cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def ensure_hatch(file: str) -> None:
+    """Put a hatch in place for a project that is already routed, without editing anything.
+
+    There is no pre-edit copy to take — that moment passed, possibly in a version of this plugin
+    that did not take one. So the record gets the path with no original, and the hatch reports
+    honestly: it names the file, points at the timestamped backups beside it, and refuses to
+    restore one automatically because a rolling backup may hold a LATER state rather than the
+    user's original. That is strictly more use than "no record of any edit", which is what somebody
+    with a pre-hatch install would otherwise get while their sessions were down.
+    """
+    state = state_dir()
+    try:
+        os.makedirs(os.path.join(state, "originals"), exist_ok=True)
+    except OSError as exc:
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"cannot write {state}: {exc}"
+        return
+    real = os.path.realpath(file)
+    jsonp, tsvp = _manifest_paths(state)
+    entries: list[dict] = []
+    try:
+        with open(jsonp, encoding="utf-8") as fh:
+            prior = json.load(fh)
+        if isinstance(prior, dict) and isinstance(prior.get("files"), list):
+            entries = [e for e in prior["files"] if isinstance(e, dict) and e.get("path")]
+    except (OSError, json.JSONDecodeError):
+        entries = []
+    if not any(e.get("path") == real for e in entries):
+        entries.append({"path": real, "existed_before": True, "original": "",
+                        "first_touched": "(unknown: routed before this record existed)"})
+    hatch = install_hatch(state)
+    try:
+        _write_atomic(jsonp, (json.dumps({"version": MANIFEST_VERSION, "hatch": hatch,
+                                          "files": entries}, indent=2) + "\n").encode("utf-8"))
+        _write_atomic(tsvp, _render_tsv(entries))
+    except OSError as exc:
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"cannot write the record: {exc}"
+        return
+    HATCH_FACTS["reset_hatch"] = hatch or "unavailable"
+    HATCH_FACTS["reset_record"] = tsvp
+    HATCH_FACTS["reset_original"] = "unavailable"
+
+
 def cmd_add(args: argparse.Namespace) -> int:
+    # SCOPE GATE, before anything is read or written.
+    #
+    # A project-scope install that goes wrong breaks one project. The same mistake in
+    # ~/.claude/settings.json breaks EVERY Claude Code session on the machine — including the ones
+    # the user would use to fix it, and including every project that has nothing to do with
+    # context-guru. That asymmetry is why project scope is the documented default.
+    #
+    # It was ONLY documented, though: the default lived in the install skill's prose, and the script
+    # would write whatever --file it was handed. A prompt is not a guardrail — it can be skipped, or
+    # read differently by the next model, and the failure it guards against is a machine-wide
+    # lockout. So the refusal lives here, where nothing can talk it round, and takes an explicit
+    # flag that means the user was asked. Removal is deliberately NOT gated: uninstall must be able
+    # to clean every scope, and blocking recovery would be the wrong side to err on.
+    if is_user_scope(args.file) and not getattr(args, "user_scope", False):
+        emit(result="error", reason="user_scope_needs_flag", file=args.file,
+             note="this file routes EVERY project on the machine, so it needs --user-scope as "
+                  "well. Confirm with the user first, naming that blast radius; project scope "
+                  "(.claude/settings.local.json) is the default for a reason.")
+        return 2
+
     data, existed = load(args.file)
     env = data.get("env")
     if env is None:
@@ -590,6 +905,10 @@ def main() -> int:
         p.add_argument("--upstream", default="",
                        help="also write env.ANTHROPIC_UPSTREAM, so the proxy chains behind an "
                             "existing gateway in LATER sessions too (the hook reads this block)")
+        p.add_argument("--user-scope", action="store_true",
+                       help="permit writing the machine-wide settings file "
+                            "(~/.claude/settings.json), which routes EVERY project. Refused "
+                            "without this on `add`; never needed on `remove`.")
         p.add_argument("--statusline", default="",
                        help="on add: also write the TOP-LEVEL statusLine key ({\"type\": "
                             "\"command\", \"command\": <this value>}), refusing to replace one "
@@ -601,8 +920,32 @@ def main() -> int:
     args = ap.parse_args()
     if args.cmd == "add" and not args.url and not args.statusline:
         ap.error("add needs --url, or --statusline on its own for a statusline-only call")
-    return {"add": cmd_add, "remove": cmd_remove, "show": cmd_show,
-            "config": cmd_config}[args.cmd](args)
+    rc = {"add": cmd_add, "remove": cmd_remove, "show": cmd_show,
+          "config": cmd_config}[args.cmd](args)
+
+    # The hatch facts are printed HERE rather than from inside save(), so the `result=` line the
+    # caller keys on stays first, and so every writing path reports them without six call sites
+    # having to remember to.
+    #
+    # The fallback matters as much as the facts: a re-run that changes nothing (`result=unchanged`)
+    # never reaches save(), and the install skill would then have no path to hand the user. The
+    # hatch is on disk from the first install, so report it whenever it is there.
+    if HATCH_FACTS:
+        emit(**HATCH_FACTS)
+    elif args.cmd == "add" and rc == 0:
+        # A successful `add` that wrote NOTHING — `result=unchanged`, i.e. the project is already
+        # routed to this proxy. save() never ran, so without this branch the machines that most need
+        # a hatch are exactly the ones that never get one: everybody who installed before the hatch
+        # existed, whose re-run of /context-guru:install is a no-op. Re-running the install is also
+        # the first thing anyone does when something looks wrong, so it is the natural repair moment.
+        #
+        # Gated on rc == 0, which is what makes it safe to record the file: `result=conflict` exits
+        # 2, and that is somebody ELSE'S base URL we refused to touch — recording it here would tell
+        # the hatch that context-guru edited a file it never wrote to.
+        ensure_hatch(args.file)
+        if HATCH_FACTS:
+            emit(**HATCH_FACTS)
+    return rc
 
 
 if __name__ == "__main__":

--- a/context-guru-plugin/scripts/settings.py
+++ b/context-guru-plugin/scripts/settings.py
@@ -357,6 +357,29 @@ def _render_tsv(entries: list[dict]) -> bytes:
     return b"\n".join(out) + b"\n"
 
 
+def _is_loopback(url: str) -> bool:
+    """Does this URL name this machine? Used only as the weakest signal in _looks_routed_by_us.
+
+    Written out rather than a `startswith` tuple because every shape the tuple missed was a false
+    NEGATIVE — no port (`http://127.0.0.1/anthropic`), `0.0.0.0`, `[::1]` without a port, `https://`
+    — and a false negative here is the direction that re-introduces the defect the caller exists to
+    prevent: taking a copy of an already-routed file and calling it an original.
+    """
+    rest = url
+    for scheme in ("http://", "https://"):
+        if rest.startswith(scheme):
+            rest = rest[len(scheme):]
+            break
+    else:
+        return False
+    host = rest.split("/", 1)[0]
+    if host.startswith("["):                      # [::1] or [::1]:8787
+        host = host.split("]", 1)[0] + "]"
+    else:
+        host = host.split(":", 1)[0]
+    return host in ("127.0.0.1", "localhost", "[::1]", "0.0.0.0", "::1")
+
+
 def _looks_routed_by_us(real: str) -> bool:
     """Is this file ALREADY in our post-install state, so a copy of it is not an "original"?
 
@@ -400,8 +423,7 @@ def _looks_routed_by_us(real: str) -> bool:
     if UPSTREAM_KEY in env or BIN_KEY in env:
         return True   # nobody else writes these two
     url = env.get(KEY)
-    if isinstance(url, str) and url.startswith(("http://127.0.0.1:", "http://localhost:",
-                                                "http://[::1]:")):
+    if isinstance(url, str) and _is_loopback(url):
         # A pre-hatch install old enough to have no metadata. Ambiguous with a user's own loopback
         # proxy, and resolved toward the safer failure per the docstring.
         return True
@@ -440,11 +462,19 @@ def _record_touch(real: str, existed: bool) -> None:
         return
 
     original = ""
+    skipped_copy = False
     if existed and _looks_routed_by_us(real):
-        # Recorded, but with no original — which is exactly the state ensure_hatch() already
-        # produces, and the hatch's missing-copy branch already reports honestly.
-        HATCH_FACTS["reset_original"] = "unavailable"
-        HATCH_FACTS["reset_original_reason"] = "file already carried context-guru's keys"
+        # Recorded, but with no original from THIS call — which is exactly the state ensure_hatch()
+        # already produces, and the hatch's missing-copy branch already reports honestly.
+        #
+        # Deliberately not reported here. It was, and that was a review finding: an ordinary
+        # uninstall of an ordinarily-installed project takes this branch (the file IS ours by then),
+        # so `reset_original=unavailable` was printed while a good, verified-clean copy from the
+        # install sat on disk. install/SKILL.md turns that fact into "the hatch can unroute but not
+        # restore", so the skill would have told users their content was unrecoverable when it was
+        # not. The fact is a statement about what the hatch HOLDS, so it is decided below, after the
+        # manifest entry is known.
+        skipped_copy = True
     elif existed:
         dest = os.path.join(state, "originals", _slug(real) + ".original")
         try:
@@ -475,6 +505,7 @@ def _record_touch(real: str, existed: bool) -> None:
     except (OSError, json.JSONDecodeError):
         entries = []
 
+    held_original = ""
     for e in entries:
         if e.get("path") == real:
             # Seen before. The first record is the authoritative one — `existed_before` describes
@@ -482,11 +513,13 @@ def _record_touch(real: str, existed: bool) -> None:
             # later run would say "it existed" about a file we created ourselves.
             if not e.get("original") and original:
                 e["original"] = original
+            held_original = e.get("original") or ""
             break
     else:
         entries.append({"path": real, "existed_before": bool(existed),
                         "original": original,
                         "first_touched": _dt.datetime.now().astimezone().isoformat(timespec="seconds")})
+        held_original = original
 
     hatch = install_hatch(state)
     try:
@@ -500,11 +533,13 @@ def _record_touch(real: str, existed: bool) -> None:
 
     HATCH_FACTS["reset_hatch"] = hatch or "unavailable"
     HATCH_FACTS["reset_record"] = tsvp
-    if existed and not original:
-        # Worth its own line: routing can be removed from the record, but the file's original
-        # CONTENT is not recoverable from anything the hatch holds.
+    if existed and not held_original:
+        # Judged against what the RECORD ends up holding, not against this call: a file whose
+        # original was captured by an earlier install must not be reported as unrecoverable now.
         HATCH_FACTS["reset_original"] = "unavailable"
-        HATCH_FACTS.setdefault("reset_original_reason", "no pre-edit copy could be taken")
+        HATCH_FACTS["reset_original_reason"] = (
+            "the file already carried context-guru's keys when it was first recorded"
+            if skipped_copy else "no pre-edit copy could be taken")
 
 
 def save(path: str, data: dict) -> None:

--- a/context-guru-plugin/scripts/settings.py
+++ b/context-guru-plugin/scripts/settings.py
@@ -357,7 +357,74 @@ def _render_tsv(entries: list[dict]) -> bytes:
     return b"\n".join(out) + b"\n"
 
 
+def _looks_routed_by_us(real: str) -> bool:
+    """Is this file ALREADY in our post-install state, so a copy of it is not an "original"?
+
+    This is the guard on a severe defect found in review. `record_touch` runs from `save()`, and
+    `save()` is also `cmd_remove`'s write path — so when the FIRST recorded touch of a file was a
+    REMOVAL, the O_EXCL "copy taken before the first edit" was a copy of the ROUTED file, and being
+    O_EXCL it was permanent. The hatch then faithfully restored routing into an unrouted project:
+    the one behaviour a recovery tool cannot have, reproduced, and worst on exactly the population
+    this hatch is for — every pre-hatch install that upgrades and then uninstalls.
+
+    Content, not intent: `remove` is the obvious way in, but threading "this is an install" through
+    `save()` would still take a routed copy when an ADD runs against a file we had already routed
+    (a wiped state directory, a re-run with --force). What makes a copy meaningless is that the file
+    already carries our work, whoever is writing and why.
+
+    Erring is asymmetric, so this errs one way on purpose. A false positive costs the user a
+    whole-file restore they could have had, and the hatch says so honestly and points at the
+    timestamped backups. A false negative re-applies the routing they ran the hatch to escape.
+
+    A base URL that is NOT ours is deliberately not a signal — a user's own loopback gateway
+    (litellm's default is 127.0.0.1:4000) is precisely the value most worth having a copy of. Hence
+    the record and our own keys below, plus the narrow loopback test, rather than "any base URL".
+    """
+    try:
+        with open(real, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        # Unparseable never reaches a write (load() refuses first), so this is a file we are not
+        # going to touch anyway. Say "not ours" and let the O_EXCL copy happen: an unreadable file
+        # is the case where a byte-for-byte copy is worth most.
+        return False
+    if not isinstance(data, dict):
+        return False
+    if META in data:
+        # We have written this file before, and recorded it. The strongest signal there is, and the
+        # one the pre-hatch population carries: this metadata predates the hatch.
+        return True
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return False
+    if UPSTREAM_KEY in env or BIN_KEY in env:
+        return True   # nobody else writes these two
+    url = env.get(KEY)
+    if isinstance(url, str) and url.startswith(("http://127.0.0.1:", "http://localhost:",
+                                                "http://[::1]:")):
+        # A pre-hatch install old enough to have no metadata. Ambiguous with a user's own loopback
+        # proxy, and resolved toward the safer failure per the docstring.
+        return True
+    return False
+
+
 def record_touch(real: str, existed: bool) -> None:
+    """Fail-open wrapper. See _record_touch.
+
+    `except OSError` at three inner sites was nearly total and reviewed as not good enough: the body
+    also encodes paths to UTF-8, which raises UnicodeEncodeError (not an OSError) for a filename
+    carrying surrogates from surrogateescape. "Fail open, always" is a hard boundary in this repo, so
+    the hatch machinery must not be able to fail a settings write for ANY reason — the install it
+    would break is one that would otherwise have worked.
+    """
+    try:
+        _record_touch(real, existed)
+    except Exception as exc:                      # noqa: BLE001 - deliberate, see docstring
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"{type(exc).__name__}: {exc}"
+
+
+def _record_touch(real: str, existed: bool) -> None:
     """Note that we are about to edit `real`, and make sure a way back exists.
 
     Called from save() before the write, so `existed` is the truth about the file as the user had
@@ -373,7 +440,12 @@ def record_touch(real: str, existed: bool) -> None:
         return
 
     original = ""
-    if existed:
+    if existed and _looks_routed_by_us(real):
+        # Recorded, but with no original — which is exactly the state ensure_hatch() already
+        # produces, and the hatch's missing-copy branch already reports honestly.
+        HATCH_FACTS["reset_original"] = "unavailable"
+        HATCH_FACTS["reset_original_reason"] = "file already carried context-guru's keys"
+    elif existed:
         dest = os.path.join(state, "originals", _slug(real) + ".original")
         try:
             fd = os.open(dest, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -432,6 +504,7 @@ def record_touch(real: str, existed: bool) -> None:
         # Worth its own line: routing can be removed from the record, but the file's original
         # CONTENT is not recoverable from anything the hatch holds.
         HATCH_FACTS["reset_original"] = "unavailable"
+        HATCH_FACTS.setdefault("reset_original_reason", "no pre-edit copy could be taken")
 
 
 def save(path: str, data: dict) -> None:
@@ -506,6 +579,15 @@ def cmd_show(args: argparse.Namespace) -> int:
 
 
 def ensure_hatch(file: str) -> None:
+    """Fail-open wrapper. See _ensure_hatch, and record_touch for why this is not `except OSError`."""
+    try:
+        _ensure_hatch(file)
+    except Exception as exc:                      # noqa: BLE001 - deliberate, see record_touch
+        HATCH_FACTS["reset_hatch"] = "unavailable"
+        HATCH_FACTS["reset_hatch_detail"] = f"{type(exc).__name__}: {exc}"
+
+
+def _ensure_hatch(file: str) -> None:
     """Put a hatch in place for a project that is already routed, without editing anything.
 
     There is no pre-edit copy to take — that moment passed, possibly in a version of this plugin

--- a/context-guru-plugin/skills/install/SKILL.md
+++ b/context-guru-plugin/skills/install/SKILL.md
@@ -37,7 +37,9 @@ Three lines, not an essay. The user asked for an install; deliver one, and let t
 - **The real risk: if the proxy is down, requests HANG** rather than failing — no output, no error.
   A `UserPromptSubmit` hook detects that and restarts it. This is why the default scope is one
   project, not the machine.
-- `/context-guru:uninstall` reverses it, restoring any base URL it replaced.
+- `/context-guru:uninstall` reverses it, restoring any base URL it replaced. If the routing
+  itself is what breaks, a skill cannot run — so the install also drops a plain-sh escape hatch
+  outside the plugin, and step 6 tells them where it is.
 
 Fuller detail — preset behaviour, subscription vs metered billing, scope trade-offs — is in
 `docs/how-to/install-plugin.md`. Point at it; do not recite it.
@@ -128,9 +130,22 @@ trade-off in one line each:
 | This project, whole team | `.claude/settings.json` | breaks for everyone who clones the repo |
 | Every project (`--global`) | `~/.claude/settings.json` | **every Claude Code session on the machine breaks** |
 
-If the user passed `--global`, use the third and confirm once that they mean it, naming the
-blast radius. `env` blocks merge per key across scopes, so a user-scope install is not clobbered
-by a project that ships its own `env` block.
+Project scope is the default because of that third row, and the asymmetry is worth being concrete
+about: a project-scope mistake costs the user one project, while the same mistake machine-wide takes
+out every session they could use to fix it — including every project that has nothing to do with
+context-guru. Writing the project's own `.claude/settings.local.json` is also why overriding a
+machine-wide base URL is safe here: `env` blocks merge per key, most specific first, so the project
+file wins for this project and changes nothing anywhere else.
+
+**The script enforces this; it is not left to you.** `settings.py add` refuses the machine-wide file
+outright and exits 2 with `reason=user_scope_needs_flag` unless it is passed `--user-scope`. That
+refusal used to live only in this paragraph, and a default that exists only in a prompt is not a
+guardrail — it can be skipped or read differently, and what it guards against is a machine-wide
+lockout. So if the user passed `--global`: confirm once, naming the blast radius, and only then add
+`--user-scope` to the step 6 command. Never add it to satisfy an error you did not expect — an
+unexpected `user_scope_needs_flag` means you are about to write the wrong file.
+
+Removal is not gated, on purpose: `/context-guru:uninstall` has to be able to clean every scope.
 
 ### 4. Look before you write
 
@@ -305,6 +320,24 @@ which fixes it without touching the user's shell at all. Still mention the `PATH
 want `context-guru-proxy` on the command line too.
 
 - `result=added` — report the `backup=` path to the user. That is their undo.
+- `reset_hatch=<path>` — **print this path verbatim, on its own line, in your summary.** It is the
+  escape hatch, and this is the only moment the user is certain to be able to read it: the failure
+  it exists for is "every request through the proxy fails", and in that state no skill can run,
+  including `/context-guru:uninstall`. It happened — a colleague's install left him at 401 on every
+  call with the documented undo path unavailable for exactly the reason he needed it. Tell him the
+  command, not the concept:
+
+  ```
+  If Claude ever stops being able to talk after this, run: <the reset_hatch path>
+  ```
+
+  It restores every settings file this plugin edited, from a copy taken before the first edit, and
+  needs no Claude, no network, no proxy and no plugin. `reset_hatch=unavailable` means the state
+  directory could not be written — say so plainly, because then their only undo is the `backup=`
+  path above.
+- `reset_original=unavailable` — the routing is recorded but the file's original CONTENT is not.
+  Rare (an unreadable settings file). Worth one line, since the hatch can then unroute but not
+  restore.
 - `result=conflict` — you skipped step 4, or the file changed. Go back and ask; only pass
   `--force` once the user has said to replace that specific value. When they do, the replaced
   value is recorded and `/context-guru:uninstall` puts it back — say so, because "we will take
@@ -373,6 +406,8 @@ purpose — exiting clears in-memory cache state. If they want a shorter one, th
 - Dashboard: `http://127.0.0.1:<port>/dashboard/` — the four billed token tiers are where the
   cache effect is visible.
 - `/context-guru:status` for the numbers, `/context-guru:uninstall` to undo.
+- The escape hatch from step 6, once more, as the last line of your summary. A user who has to
+  find it will be looking at this transcript with a session that cannot answer questions.
 
 ## Do not
 

--- a/context-guru-plugin/skills/install/SKILL.md
+++ b/context-guru-plugin/skills/install/SKILL.md
@@ -335,9 +335,12 @@ want `context-guru-proxy` on the command line too.
   needs no Claude, no network, no proxy and no plugin. `reset_hatch=unavailable` means the state
   directory could not be written — say so plainly, because then their only undo is the `backup=`
   path above.
-- `reset_original=unavailable` — the routing is recorded but the file's original CONTENT is not.
-  Rare (an unreadable settings file). Worth one line, since the hatch can then unroute but not
-  restore.
+- `reset_original=unavailable` — the routing is recorded but the hatch holds no copy of the file's
+  original CONTENT, so it can name the file and point at the timestamped backups but cannot restore
+  it. **Read `reset_original_reason=` and pass it on rather than guessing** — the usual cause is not
+  a fault: the project was already routed when the record was first created (a pre-hatch install,
+  or a state directory that was cleaned), and no copy of an unrouted version was ever takeable.
+  Say that plainly; it is not a reason to stop, and it does not appear on a normal first install.
 - `result=conflict` — you skipped step 4, or the file changed. Go back and ask; only pass
   `--force` once the user has said to replace that specific value. When they do, the replaced
   value is recorded and `/context-guru:uninstall` puts it back — say so, because "we will take

--- a/context-guru-plugin/skills/uninstall/SKILL.md
+++ b/context-guru-plugin/skills/uninstall/SKILL.md
@@ -12,6 +12,15 @@ fails.
 
 If the user is here because something is broken, do step 1 first and explain afterwards.
 
+**If they are here because Claude could not talk at all, they got here by luck** — the routing this
+skill removes is what breaks the session that would run it. There is a plain-sh escape hatch for
+that, installed outside the plugin at
+`${XDG_STATE_HOME:-$HOME/.local/state}/context-guru/context-guru-reset` (also on `PATH` as
+`context-guru-reset` when `~/.local/bin` is there). It restores every settings file the install
+edited from a copy taken before the first edit, and needs no Claude, no network and no proxy. Point
+at it when a user reports being stuck, and prefer it to this skill for anyone who is currently
+locked out — it is `cp`, where this skill is a conversation.
+
 ## 1. Remove the routing key
 
 Check all three scopes: the install may have written any of them, and a `--global` install

--- a/docs/how-to/install-plugin.md
+++ b/docs/how-to/install-plugin.md
@@ -438,6 +438,19 @@ are down. Exit status is 3: finished, with something left for a human.
 
 ## Troubleshooting
 
+**Every request fails or hangs, and `/context-guru:uninstall` cannot run.** Run this:
+
+```bash
+~/.local/state/context-guru/context-guru-reset
+```
+
+That is the whole fix. It needs no working Claude session — which is the point, because when routing
+is what broke, the skill that would undo it cannot reach a model either. It restores every settings
+file this plugin edited, prints what it changed, and ends by naming anything a file restore cannot
+fix (a credential variable, an `ANTHROPIC_BASE_URL` exported in your shell). Add `--dry-run` first if
+you want the plan without the change. Full detail: [the escape
+hatch](#the-escape-hatch-when-claude-code-cannot-fix-it-for-you).
+
 **"Nothing happened after `/context-guru:install`."** The setting applies to a **new** session;
 the one you ran it in already has its environment. Start a new session.
 

--- a/docs/how-to/install-plugin.md
+++ b/docs/how-to/install-plugin.md
@@ -40,6 +40,16 @@ session works too; reloading is just quicker.
 
 ### Step 2 asks you to pick a scope — this is what it means
 
+**Project scope is the default, and the script now enforces it.** `settings.py add` refuses to write
+the machine-wide `~/.claude/settings.json` unless it is explicitly passed `--user-scope`, which the
+install skill adds only after you have asked for `--global` and confirmed it. The reason is the
+blast radius, not tidiness: a project-scope install that goes wrong costs you that project, while
+the same mistake machine-wide takes out every Claude Code session you have — including the ones you
+would use to fix it, and every project unrelated to context-guru. Routing per repo also means a
+machine-wide base URL of your own keeps working everywhere else, because `env` blocks merge per key
+with the most specific file winning.
+
+
 `/plugin install` offers three, and they decide who gets **the plugin**:
 
 | Option | Written to | Who gets it |
@@ -362,6 +372,69 @@ you have turned that segment on) no longer means the provider's own cached entry
 cold. The countdown is Claude Code's own view of *its own* last request; it has no way to see a
 ping the proxy sent while you were not typing. Treat `ka Np` and the next turn's latency as the
 ground truth once keep-alive is running, not the countdown by itself.
+
+## The escape hatch: when Claude Code cannot fix it for you
+
+`/context-guru:uninstall` is a skill, so it needs a working session. The failure this plugin can
+cause takes that away: every request goes through a local proxy, so a dead port, a stale routing
+key or a credential the upstream rejects makes *every* API call fail — and the agent that would
+undo the routing cannot reach a model to be asked. That is not hypothetical; it is the incident
+this section exists because of.
+
+So the install writes a hatch you can run yourself, and it lives **outside the plugin** — a
+recovery tool inside the thing that broke is gone the moment you `/plugin uninstall`, refresh the
+marketplace, or the plugin cache is wiped:
+
+```bash
+~/.local/state/context-guru/context-guru-reset          # always here
+context-guru-reset                                      # on PATH too, when ~/.local/bin exists
+```
+
+It is POSIX `sh`. No Claude, no network, no proxy, no Python, no Go binary, no plugin code.
+
+```bash
+context-guru-reset --dry-run    # show what it would change, write nothing
+context-guru-reset              # show the plan, ask, then restore
+context-guru-reset --yes        # no prompt, for a script
+```
+
+What it does:
+
+1. reads its record of every settings file the install edited — kept in
+   `~/.local/state/context-guru/reset-manifest.tsv`;
+2. copies each of those aside as `*.context-guru-prereset-*`, so running the hatch is itself
+   reversible;
+3. restores each one from a copy taken **before the first edit**, held in
+   `~/.local/state/context-guru/originals/` — or deletes the file, when the install is the reason
+   it exists;
+4. verifies no routing key is left, and reports anything it could not fix.
+
+Why a separate copy when every edit already writes a `*.context-guru-backup-*` beside the file:
+those are capped at ten and every add *and* remove writes one, so on a machine that has installed
+and uninstalled a few times the backup holding your pre-context-guru state is the first to be
+deleted. The copy under `originals/` is written once, with `O_EXCL`, and never pruned.
+
+It never signals a process, never touches the network, and never edits a file it has no record of
+editing. Any proxy still running exits on its own idle timeout.
+
+### It restores routing, not credentials
+
+Worth being blunt about, because the incident that prompted the hatch was **not** a routing fault.
+Both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` were set, the gateway rejected whichever one
+won, and the export was a single line in a shell rc. No amount of settings surgery reaches that.
+
+So the hatch ends with an environment report: whether both credential variables are set, whether
+`ANTHROPIC_BASE_URL` is exported in your *shell* (where no settings file can override it), and the
+`file:line` of every `ANTHROPIC_*` assignment in your shell startup files. It prints the locations
+and never the values — a recovery tool that echoes a live key into your terminal buffer is not one.
+Fixing those lines is yours to do; the hatch will not edit them.
+
+### If there is no record
+
+A hand-edited settings file, or a wiped state directory, and the hatch has nothing to restore
+from. It says so, prints the three files worth checking, greps each for the keys, and lists the
+timestamped backups beside them — rather than reporting "nothing to do" to somebody whose sessions
+are down. Exit status is 3: finished, with something left for a human.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Why

`/context-guru:uninstall` is a **skill**, so it needs a working session. The failure it exists for removes that: every request goes through a local proxy, so a dead port or a credential the upstream rejects fails *every* API call — and the agent that would remove the routing cannot reach a model to be asked.

That is not hypothetical. An install left a colleague at 401 on every request, with the documented undo path unavailable for exactly the reason he needed it. His actual fault turned out to be two credential variables set at once and one line in a shell rc — which a settings-file undo would not have fixed either.

## What this adds

**A plain-`sh` hatch, installed outside the plugin.** `settings.py` now establishes three things before any routing key exists, at the single choke point every write funnels through (`save()` — `add` alone has six exits that write):

1. an `O_EXCL` copy of each settings file, taken once, never overwritten, **never pruned**. The existing `*.context-guru-backup-*` files are capped at 10 and *both* add and remove write one — so on a machine that has installed and uninstalled a few times, the backup holding the user's pre-context-guru state is the **first** one deleted. A test runs twelve cycles and asserts the copy is still byte-identical.
2. a record of which files were edited and whether each existed beforehand. A file the install *created* is put back by deleting it; nothing else can tell the difference.
3. `reset.sh`, copied **out of the plugin** into `~/.local/state/context-guru/` (and `~/.local/bin` for `PATH`). A recovery tool that lives inside the thing that broke is gone with `/plugin uninstall`, a marketplace refresh, or a wiped plugin cache.

The hatch needs no Claude, no proxy, no network, no Python, no plugin code — asserted by a test that greps its own source. Restore is `cp`. It copies the current file aside first so running it is itself reversible, verifies afterwards instead of trusting `cp`, and a second run is a real no-op.

**It reports credentials, since that was the real fault.** Whether both credential variables are set, whether `ANTHROPIC_BASE_URL` is exported in the *shell* (where no settings file can override it), and the `file:line` of every `ANTHROPIC_*` assignment in the rc files — locations only, values replaced. A test plants a secret and greps the output for it.

**The dead-proxy hook now names the hatch.** That note prints on the prompt that is about to hang, and its advice used to end in "run `/context-guru:uninstall` from a session that still works" — precisely what its reader does not have.

**`add` refuses the machine-wide file without `--user-scope`.** Project scope was already the documented default, but *only* documented: the script wrote whatever `--file` it was handed. A prompt is not a guardrail against a machine-wide lockout, and the asymmetry is the whole point — a project-scope mistake costs one project, the same mistake in `~/.claude/settings.json` takes out every session the user would use to fix it. Removal is deliberately not gated; uninstall must be able to clean every scope.

**Already-routed installs get a hatch too.** A re-run of the install on a routed project reports `result=unchanged` and never reaches `save()` — so without this, the machines that most need a hatch (everyone who installed before it existed) would never get one. It is honest there: no pre-edit copy exists, so it names the file, points at the timestamped backups, and refuses to auto-restore one that may hold a later state.

## Two defects the tests caught while being written

- The pre-edit copies were created as **dotfiles** — the parent directory of a real target is `.claude`, so the natural name is `.claude-settings.local.json.<hash>.original`. Invisible to `ls` and to every glob, in a directory whose purpose is that a panicking human can read it.
- The no-record path printed the heading `check these files by hand:` followed by **nothing at all** when it matched none of its candidates — the exact uselessness that branch exists to prevent.

## Testing

- **80 tests** in the plugin package, `go vet` clean. 15 are new. Go is not installed on the laptop this was written on, so the suite ran in a `golang:1.26` container.
- The shared `settings()` helper now pins `CONTEXT_GURU_STATE` and `HOME`. Without that, `go test` wrote into the developer's own `~/.local/state/context-guru` and rewrote the copy on their `PATH` — a test suite for a recovery tool should not be able to disturb the developer's recovery tool.
- An **isolated end-to-end run against a real Claude Code 2.1.267** (its own `CLAUDE_CONFIG_DIR`, `HOME` and state dir, verified not to touch the real config): plugin installed from the local marketplace, install steps driven in order, routing landing in the project file with the machine-wide `env` block byte-identical throughout, the scope refusal, the proxy killed so the hook fires, then recovery by pasting the hatch path. Also re-verified on macOS `sh`, since the container runs `dash`.
- **No model calls anywhere.** The proxy binary is stubbed (no Go toolchain locally), which is sufficient because everything under test keys off `/healthz`. What is therefore *not* exercised is the install skill's own prose — the model's judgment about scope and chaining — and a real request through a real proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
